### PR TITLE
Fixes for mathlib update (spell out `Mathlib.Vector`)

### DIFF
--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -23,15 +23,15 @@ lemma Fintype.sum_inv_card (α : Type) [Fintype α] [Nonempty α] :
     nsmul_eq_mul, ENNReal.mul_inv_cancel] <;> simp
 
 @[simp] -- mathlib?
-lemma vector_eq_nil {α : Type} (xs : Vector α 0) : xs = Vector.nil :=
-  Vector.ext (IsEmpty.forall_iff.2 True.intro)
+lemma vector_eq_nil {α : Type} (xs : Mathlib.Vector α 0) : xs = Mathlib.Vector.nil :=
+  Mathlib.Vector.ext (IsEmpty.forall_iff.2 True.intro)
 
 lemma List.injective2_cons {α : Type} : Function.Injective2 (List.cons (α := α)) := by
   simp [Function.Injective2]
 
 lemma Vector.injective2_cons {α : Type} {n : ℕ} :
-    Function.Injective2 (Vector.cons : α → Vector α n → Vector α (n + 1)) := by
-  simp [Function.Injective2, Vector.eq_cons_iff]
+    Function.Injective2 (Vector.cons : α → Mathlib.Vector α n → Mathlib.Vector α (n + 1)) := by
+  simp [Function.Injective2, Mathlib.Vector.eq_cons_iff]
 
 lemma Prod.mk.injective2 {α β : Type} :
     Function.Injective2 (Prod.mk : α → β → α × β) := by
@@ -64,7 +64,11 @@ lemma List.card_filter_getElem_eq {α : Type} [DecidableEq α]
   simp only [Fin.getElem_fin, beq_iff_eq, Finset.sum_boole, Nat.cast_id]
 
 @[simp]
-lemma Vector.getElem_eq_get {α n} (xs : Vector α n) (i : ℕ) (h : i < n) :
+lemma Vector.getElem_eq_get {α n} (xs : _root_.Vector α n) (i : ℕ) (h : i < n) :
+  xs[i]'h = xs.get ⟨i, h⟩ := rfl
+
+@[simp]
+lemma Mathlib.Vector.getElem_eq_get {α n} (xs : Mathlib.Vector α n) (i : ℕ) (h : i < n) :
   xs[i]'h = xs.get ⟨i, h⟩ := rfl
 
 @[simp] lemma Finset.sum_boole' {ι β : Type} [AddCommMonoid β] (r : β)

--- a/VCVio/OracleComp/Constructions/Replicate.lean
+++ b/VCVio/OracleComp/Constructions/Replicate.lean
@@ -23,8 +23,8 @@ namespace OracleComp
 variable {ι : Type} {spec : OracleSpec ι} {α β : Type}
 
 /-- Run the computation `oa` repeatedly `n` times to get a vector of `n` results. -/
-def replicate (oa : OracleComp spec α) : (n : ℕ) → OracleComp spec (Vector α n)
-  | 0 => pure Vector.nil
+def replicate (oa : OracleComp spec α) : (n : ℕ) → OracleComp spec (Mathlib.Vector α n)
+  | 0 => pure Mathlib.Vector.nil
   | n + 1 => (· ::ᵥ ·) <$> oa <*> replicate oa n
 
 variable (oa : OracleComp spec α)
@@ -80,8 +80,8 @@ lemma evalDist_replicate_zero_add (n : ℕ) :
   eq_of_heq <| (evalDist_replicate_zero_add_heq oa n).trans <| heq_eqRec_iff_heq.2 HEq.rfl
 
 @[simp]
-lemma probOutput_replicate_zero_add (n : ℕ) (xs : Vector α (0 + n)) :
-    let hxs : xs.1.length = n := (Vector.length_val xs).trans (zero_add n)
+lemma probOutput_replicate_zero_add (n : ℕ) (xs : Mathlib.Vector α (0 + n)) :
+    let hxs : xs.1.length = n := (Mathlib.Vector.length_val xs).trans (zero_add n)
     [= xs | oa.replicate (0 + n)] = [= ⟨xs.1, hxs⟩ | oa.replicate n] := by
   have h : [= xs | oa.replicate (0 + n)] = [= (zero_add n).symm ▸ xs | oa.replicate n] :=
   by congr <;> simp
@@ -92,7 +92,7 @@ lemma probOutput_replicate_zero_add (n : ℕ) (xs : Vector α (0 + n)) :
   congr <;> try simp
 
 -- @[simp] TODO: should we simp this with the `subst` there?
-lemma probEvent_replicate_zero_add (n : ℕ) (xss : Set (Vector α (0 + n))) :
+lemma probEvent_replicate_zero_add (n : ℕ) (xss : Set (Mathlib.Vector α (0 + n))) :
     [xss | oa.replicate (0 + n)] = [(zero_add n).symm ▸ xss | oa.replicate n] := by
   congr <;> simp
 
@@ -124,7 +124,7 @@ end comm
 /-- The probability of getting a vector from `replicate` is the product of the chances of
 getting each of the individual elements. -/
 @[simp]
-lemma probOutput_replicate (oa : OracleComp spec α) (n : ℕ) (xs : Vector α n) :
+lemma probOutput_replicate (oa : OracleComp spec α) (n : ℕ) (xs : Mathlib.Vector α n) :
     [= xs | replicate oa n] = (xs.toList.map ([= · | oa])).prod := by
   induction n with
     | zero => simp
@@ -152,7 +152,7 @@ section SelectableTypeVector
 /-- Vectors can be selected uniformly if the underlying type can be.
 Note: this isn't very efficient as an actual implementation in practice. -/
 instance (α : Type) [Fintype α] [Inhabited α] [SelectableType α] (n : ℕ) :
-    SelectableType (Vector α n) where
+    SelectableType (Mathlib.Vector α n) where
   selectElem := replicate ($ᵗ α) n
   probOutput_selectElem_eq xs ys := by simp
 

--- a/VCVio/OracleComp/Constructions/UniformSelect.lean
+++ b/VCVio/OracleComp/Constructions/UniformSelect.lean
@@ -126,52 +126,52 @@ section uniformSelectVector
 
 /-- Select a random element from a vector by indexing into it with a uniform value. -/
 instance hasUniformSelectVector (α : Type) [DecidableEq α] (n : ℕ) :
-    HasUniformSelect (Vector α (n + 1)) α where
+    HasUniformSelect (Mathlib.Vector α (n + 1)) α where
   uniformSelect := λ xs ↦ (xs[·]) <$> $[0..n]
 
-lemma uniformSelectVector_def {α : Type} [DecidableEq α] {n : ℕ} (xs : Vector α (n + 1)) :
+lemma uniformSelectVector_def {α : Type} [DecidableEq α] {n : ℕ} (xs : Mathlib.Vector α (n + 1)) :
     ($ xs) = (xs[·]) <$> $[0..n] := rfl
 
 variable {α : Type} [DecidableEq α] {n : ℕ}
 
 /-- Uniform selection from a vector is exactly equal to uniform selection from the underlying list,
 given some `Inhabited` instance on the output type. -/
-lemma uniformSelectVector_eq_uniformSelectList (xs : Vector α (n + 1)) :
+lemma uniformSelectVector_eq_uniformSelectList (xs : Mathlib.Vector α (n + 1)) :
     let _ :  Inhabited α := ⟨xs.head⟩; ($ xs) = ($ xs.toList : ProbComp α) :=
   match xs with
   | ⟨x :: xs, h⟩ => by
     have hxs : n = List.length xs := by simpa using symm h
     cases hxs
-    simp only [uniformSelectVector_def, Fin.getElem_fin, Vector.getElem_eq_get, Vector.get,
+    simp only [uniformSelectVector_def, Fin.getElem_fin, Mathlib.Vector.getElem_eq_get, Mathlib.Vector.get,
       List.length_cons, Fin.eta, Fin.cast_eq_self, List.get_eq_getElem, map_eq_bind_pure_comp,
       Function.comp, Vector.toList_mk, uniformSelectList_cons]
 
 @[simp]
-lemma evalDist_uniformSelectVector (xs : Vector α (n + 1)) :
+lemma evalDist_uniformSelectVector (xs : Mathlib.Vector α (n + 1)) :
     evalDist ($ xs) = (PMF.uniformOfFintype (Fin (n + 1))).map (xs[·]) := by
   simp only [uniformSelectVector_def, Fin.getElem_fin, evalDist_map, evalDist_uniformFin]
 
 @[simp]
-lemma support_uniformSelectVector (xs : Vector α (n + 1)) :
+lemma support_uniformSelectVector (xs : Mathlib.Vector α (n + 1)) :
     ($ xs).support = {x | x ∈ xs.toList} := by
   simp only [uniformSelectVector_eq_uniformSelectList, support_uniformSelectList,
     Vector.empty_toList_eq_ff, Bool.false_eq_true, ↓reduceIte]
 
 @[simp]
-lemma finSupport_uniformSelectVector (xs : Vector α (n + 1)) :
+lemma finSupport_uniformSelectVector (xs : Mathlib.Vector α (n + 1)) :
     ($ xs).finSupport = xs.toList.toFinset := by
   simp only [uniformSelectVector_eq_uniformSelectList, finSupport_uniformSelectList,
     Vector.empty_toList_eq_ff, Bool.false_eq_true, ↓reduceIte]
 
 @[simp]
-lemma probOutput_uniformSelectVector (xs : Vector α (n + 1)) (x : α) :
+lemma probOutput_uniformSelectVector (xs : Mathlib.Vector α (n + 1)) (x : α) :
     [= x | $ xs] = xs.toList.count x / (n + 1) := by
   simp only [uniformSelectVector_eq_uniformSelectList, probOutput_uniformSelectList,
     Vector.empty_toList_eq_ff, Bool.false_eq_true, ↓reduceIte, Vector.toList_length, Nat.cast_add,
     Nat.cast_one]
 
 @[simp]
-lemma probEvent_uniformSelectVector (xs : Vector α (n + 1)) (p : α → Prop) [DecidablePred p] :
+lemma probEvent_uniformSelectVector (xs : Mathlib.Vector α (n + 1)) (p : α → Prop) [DecidablePred p] :
     [p | $ xs] = xs.toList.countP p / (n + 1) := by
   simp only [uniformSelectVector_eq_uniformSelectList, probEvent_uniformSelectList,
     Vector.empty_toList_eq_ff, Bool.false_eq_true, ↓reduceIte, Vector.toList_length, Nat.cast_add,

--- a/VCVio/OracleComp/DistSemantics/List.lean
+++ b/VCVio/OracleComp/DistSemantics/List.lean
@@ -75,7 +75,7 @@ end List
 
 section Vector
 
-variable {n : ℕ} (oa : OracleComp spec α) (ob : OracleComp spec (Vector α n))
+variable {n : ℕ} (oa : OracleComp spec α) (ob : OracleComp spec (Mathlib.Vector α n))
 
 @[simp]
 lemma support_seq_map_vector_cons : ((· ::ᵥ ·) <$> oa <*> ob).support =
@@ -84,13 +84,13 @@ lemma support_seq_map_vector_cons : ((· ::ᵥ ·) <$> oa <*> ob).support =
   simp [Set.ext_iff, @eq_comm _ _ xs, Vector.eq_cons_iff]
 
 @[simp]
-lemma probOutput_seq_map_vector_cons_eq_mul (xs : Vector α (n + 1)) :
+lemma probOutput_seq_map_vector_cons_eq_mul (xs : Mathlib.Vector α (n + 1)) :
     [= xs | (· ::ᵥ ·) <$> oa <*> ob] = [= xs.head | oa] * [= xs.tail | ob] := by
   rw [← probOutput_seq_map_eq_mul_of_injective2 oa ob _ Vector.injective2_cons,
     Vector.cons_head_tail]
 
 @[simp]
-lemma probOutput_seq_map_vector_cons_eq_mul' (xs : Vector α (n + 1)) :
+lemma probOutput_seq_map_vector_cons_eq_mul' (xs : Mathlib.Vector α (n + 1)) :
     [= xs | (λ xs x ↦ x ::ᵥ xs) <$> ob <*> oa] = [= xs.head | oa] * [= xs.tail | ob] :=
   (probOutput_seq_map_swap oa ob (· ::ᵥ ·) (xs)).trans
     (probOutput_seq_map_vector_cons_eq_mul oa ob xs)
@@ -99,7 +99,7 @@ end Vector
 
 section Vector_toList
 
-variable {n : ℕ} (oa : OracleComp spec (Vector α n))
+variable {n : ℕ} (oa : OracleComp spec (Mathlib.Vector α n))
 
 @[simp]
 lemma probOutput_vector_toList (xs : List α) : [= xs | Vector.toList <$> oa] =


### PR DESCRIPTION
First update mathlib (should be 4.15.0 or above), then merge this.