### PR TITLE
chore: fix simp direction of `monadLift`

### DIFF
--- a/ToMathlib/Control/Lawful/MonadLift.lean
+++ b/ToMathlib/Control/Lawful/MonadLift.lean
@@ -16,7 +16,7 @@ universe u v w
   asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
-monadLift ma >>= monadLift ∘ f = monadLift (ma >>= f)
+monadLift (ma >>= f) = monadLift ma >>= monadLift ∘ f
 ```
 -/
 class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Type w)
@@ -25,13 +25,13 @@ class LawfulMonadLift (m : semiOutParam (Type u → Type v)) (n : Type u → Typ
   monadLift_pure {α : Type u} (a : α) : inst.monadLift (pure a) = pure a
   /-- Lifting preserves `bind` -/
   monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
-    inst.monadLift ma >>= (fun x => inst.monadLift (f x)) = inst.monadLift (ma >>= f)
+    inst.monadLift (ma >>= f) = inst.monadLift ma >>= (fun x => inst.monadLift (f x))
 
 /-- The `MonadLiftT` typeclass only contains the transitive lifting operation.
   `LawfulMonadLiftT` further asserts that lifting commutes with `pure` and `bind`:
 ```
 monadLift (pure a) = pure a
-monadLift ma >>= monadLift ∘ f = monadLift (ma >>= f)
+monadLift (ma >>= f) = monadLift ma >>= monadLift ∘ f
 ```
 -/
 class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m] [Monad n]
@@ -40,7 +40,7 @@ class LawfulMonadLiftT (m : Type u → Type v) (n : Type u → Type w) [Monad m]
   monadLift_pure {α : Type u} (a : α) : inst.monadLift (pure a) = pure a
   /-- Lifting preserves `bind` -/
   monadLift_bind {α β : Type u} (ma : m α) (f : α → m β) :
-    monadLift ma >>= (fun x => monadLift (f x)) = inst.monadLift (ma >>= f)
+    inst.monadLift (ma >>= f) = monadLift ma >>= (fun x => monadLift (f x))
 
 export LawfulMonadLiftT (monadLift_pure monadLift_bind)
 
@@ -50,35 +50,53 @@ section Lemmas
 
 variable [Monad m] [Monad n] [MonadLiftT m n] [LawfulMonadLiftT m n]
 
+theorem monadLift_map [LawfulMonad m] [LawfulMonad n] (f : α → β) (ma : m α) :
+    monadLift (f <$> ma) = f <$> (monadLift ma : n α) := by
+  rw [← bind_pure_comp, ← bind_pure_comp, monadLift_bind]
+  simp only [bind_pure_comp, monadLift_pure]
+
+theorem monadLift_seq [LawfulMonad m] [LawfulMonad n] (mf : m (α → β)) (ma : m α) :
+    monadLift (mf <*> ma) = monadLift mf <*> (monadLift ma : n α) := by
+  simp only [seq_eq_bind, monadLift_map, monadLift_bind]
+
+theorem monadLift_seqLeft [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
+    monadLift (x <* y) = (monadLift x : n α) <* (monadLift y : n β) := by
+  simp only [seqLeft_eq, monadLift_map, monadLift_seq]
+
+theorem monadLift_seqRight [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
+    monadLift (x *> y) = (monadLift x : n α) *> (monadLift y : n β) := by
+  simp only [seqRight_eq, monadLift_map, monadLift_seq]
+
+/-! We duplicate the theorems for `monadLift` to `liftM` since `rw` matches on syntax only. -/
+
 @[simp]
 theorem liftM_pure (a : α) : liftM (pure a : m α) = pure (f := n) a :=
   monadLift_pure _
 
 @[simp]
 theorem liftM_bind (ma : m α) (f : α → m β) :
-    liftM ma >>= (fun a => liftM (f a)) = liftM (n := n) (ma >>= f) :=
+    liftM (n := n) (ma >>= f) = liftM ma >>= (fun a => liftM (f a)) :=
   monadLift_bind _ _
 
 @[simp]
 theorem liftM_map [LawfulMonad m] [LawfulMonad n] (f : α → β) (ma : m α) :
-    f <$> (liftM ma : n α) = liftM (f <$> ma) := by
-  rw [← bind_pure_comp, ← bind_pure_comp, ← liftM_bind]
-  simp only [bind_pure_comp, liftM_pure]
+    liftM (f <$> ma) = f <$> (liftM ma : n α) :=
+  monadLift_map _ _
 
 @[simp]
 theorem liftM_seq [LawfulMonad m] [LawfulMonad n] (mf : m (α → β)) (ma : m α) :
-    liftM mf <*> (liftM ma : n α) = liftM (mf <*> ma) := by
-  simp only [seq_eq_bind, liftM_map, liftM_bind]
+    liftM (mf <*> ma) = liftM mf <*> (liftM ma : n α) :=
+  monadLift_seq _ _
 
 @[simp]
 theorem liftM_seqLeft [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
-    (liftM x : n α) <* (liftM y : n β) = liftM (x <* y) := by
-  simp only [seqLeft_eq, liftM_map, liftM_seq]
+    liftM (x <* y) = (liftM x : n α) <* (liftM y : n β) :=
+  monadLift_seqLeft _ _
 
 @[simp]
 theorem liftM_seqRight [LawfulMonad m] [LawfulMonad n] (x : m α) (y : m β) :
-    (liftM x : n α) *> (liftM y : n β) = liftM (x *> y) := by
-  simp only [seqRight_eq, liftM_map, liftM_seq]
+    liftM (x *> y) = (liftM x : n α) *> (liftM y : n β) :=
+  monadLift_seqRight _ _
 
 instance (m n o) [Monad m] [Monad n] [Monad o] [MonadLift n o] [MonadLiftT m n]
     [LawfulMonadLift n o] [LawfulMonadLiftT m n] : LawfulMonadLiftT m o where
@@ -133,7 +151,7 @@ theorem lift_pure (a : α) : OptionT.lift (pure a : m α) = pure a := by
 
 @[simp]
 theorem lift_bind (ma : m α) (f : α → m β) :
-    OptionT.lift ma >>= (fun a => OptionT.lift (f a)) = OptionT.lift (ma >>= f) := by
+    OptionT.lift (ma >>= f) = OptionT.lift ma >>= (fun a => OptionT.lift (f a)) := by
   simp only [instMonad, OptionT.bind, OptionT.mk, OptionT.lift, bind_pure_comp, bind_map_left,
     map_bind]
 
@@ -149,7 +167,7 @@ variable [Monad m] [LawfulMonad m]
 
 @[simp]
 theorem lift_bind (ma : m α) (f : α → m β) :
-    ExceptT.lift ma >>= (fun a => ExceptT.lift (f a)) = ExceptT.lift (ε := ε) (ma >>= f) := by
+    ExceptT.lift (ε := ε) (ma >>= f) =ExceptT.lift ma >>= (fun a => ExceptT.lift (f a)) := by
   simp only [instMonad, ExceptT.bind, mk, ExceptT.lift, bind_map_left, ExceptT.bindCont, map_bind]
 
 instance : LawfulMonadLift m (ExceptT ε m) where
@@ -198,7 +216,7 @@ namespace ExceptCpsT
 
 instance [Monad m] [LawfulMonad m] : LawfulMonadLift m (ExceptCpsT ε m) where
   monadLift_pure _ := by
-    simp [MonadLift.monadLift, pure]
+    simp only [MonadLift.monadLift, pure]
     unfold ExceptCpsT.lift
     simp only [pure_bind]
   monadLift_bind _ _ := by

--- a/ToMathlib/Control/MonadRelation.lean
+++ b/ToMathlib/Control/MonadRelation.lean
@@ -47,7 +47,7 @@ instance instOfMonadLiftT {m n} [MonadLiftT m n] : MonadRelation m n where
 instance instOfLawfulMonadLiftT {m n} [Monad m] [Monad n] [MonadLiftT m n] [LawfulMonadLiftT m n] :
     LawfulMonadRelation m n where
   monadRel_pure _ := by simp only [monadRel, liftM_pure]
-  monadRel_bind _ _ := by simp_all only [monadRel, ← liftM_bind]
+  monadRel_bind _ _ := by simp_all only [monadRel, liftM_bind]
 
 end MonadRelation
 

--- a/ToMathlib/Control/OrderedMonad.lean
+++ b/ToMathlib/Control/OrderedMonad.lean
@@ -182,14 +182,10 @@ instance {m n} [Monad m] [OrderedMonad n] [MonadLiftT m n] : MonadRelation m n w
 
 instance {m n} [Monad m] [OrderedMonad n] [MonadLiftT m n] [LawfulMonad m] [LawfulMonad n]
     [LawfulMonadLiftT m n] : LawfulMonadRelation m n where
-  monadRel_pure := by simp [monadRel]
+  monadRel_pure := by
+    simp only [monadRel, liftM_pure, ge_iff_le, le_refl, implies_true]
   monadRel_bind ha hb := by
-    simp_all only [monadRel, ge_iff_le]
-    rename_i ma mb na nb
-    rw [← monadLift_bind]
-    calc
-      _ ≤ na >>= (fun x => monadLift (mb x)) := bind_mono ha (by simp)
-      _ ≤ na >>= nb := bind_mono (le_of_eq rfl) hb
+    simp_all only [monadRel, ge_iff_le, liftM_bind, implies_true, bind_mono]
 
 -- TODO: monad morphism also defines a monad ideal
 


### PR DESCRIPTION
This PR reverses the simp direction of lawful monadLift operations, so that they got pulled inward rather than outward. This is similar to the direction in classes like MulHomClass and also consistent with the [Haskell documentation](https://hackage.haskell.org/package/transformers-0.5.6.2/docs/Control-Monad-Trans-Class.html#t:MonadTrans).

We also duplicate the lemmas for monadLift and liftM to help in rewriting, which matches on syntax only. We set the simp attribute for lemmas about liftM only, since simp can look into definitions.