### PR TITLE
feat: update `noFailure` & fix errors

### DIFF
--- a/VCVio/OracleComp/NoFailure.lean
+++ b/VCVio/OracleComp/NoFailure.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2025 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Devon Tuma
+Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.OracleComp.DistSemantics.Support
 
@@ -18,48 +18,65 @@ open OracleSpec
 
 namespace OracleComp
 
-variable {ι : Type*} {spec : OracleSpec ι} {α β γ : Type u}
+variable {ι : Type*} {spec : OracleSpec ι}
 
--- TODO: should this actually be a class? feels like slightly abusing type-class search
-class noFailure {α : Type u} (oa : OracleComp spec α) : Prop where
-  no_failure : by induction oa using OracleComp.construct with
-    | pure _ => exact True
-    | failure => exact False
-    | query_bind _ _ r => exact ∀ x, r x
+def noFailure {α : Type u} (oa : OracleComp spec α) : Prop := by
+  induction oa using OracleComp.construct with
+  | pure _ => exact True
+  | failure => exact False
+  | query_bind _ _ r => exact ∀ x, r x
+
+variable {α β γ : Type u}
+
+lemma noFailure_eq_oracleComp_construct (oa : OracleComp spec α) :
+    oa.noFailure = OracleComp.construct
+      (fun _ ↦ True) (fun {β} _ _ r ↦ ∀ (x : β), r x) False oa := rfl
+
+lemma noFailure_eq_freeMonad_construct (oa : OracleComp spec α) :
+    oa.noFailure = FreeMonad.construct
+      (fun t ↦ Option.rec False (fun _ ↦ True) t) (fun _ _ r ↦ ∀ x, r x) oa := rfl
 
 @[simp]
-instance noFailure_pure (x : α) : noFailure (pure x : OracleComp spec α) where
-  no_failure := trivial
+lemma noFailure_pure (x : α) : noFailure (pure x : OracleComp spec α) := trivial
 
 @[simp]
-instance noFailure_query (q : OracleQuery spec α) : noFailure (q : OracleComp spec α) where
-  no_failure := fun _ => trivial
+lemma noFailure_query (q : OracleQuery spec α) : noFailure (q : OracleComp spec α) :=
+  fun _ => trivial
 
 @[simp]
-lemma not_noFailure_failure : ¬ noFailure (failure : OracleComp spec α) := fun ⟨h⟩ => h
+lemma noFailure_query_bind_iff {q : OracleQuery spec α} {oa : α → OracleComp spec β} :
+    (liftM q >>= oa).noFailure ↔ ∀ x, noFailure (oa x) := by
+  simp [liftM, monadLift, MonadLift.monadLift, lift, OptionT.lift, OptionT.mk, bind, OptionT.bind]
+  rw [noFailure_eq_freeMonad_construct]
+  unfold FreeMonad.construct
+  exact Eq.to_iff (by simp_rw [noFailure_eq_freeMonad_construct])
+
+alias ⟨noFailure_query_bind, _⟩ := noFailure_query_bind_iff
+
+@[simp]
+lemma not_noFailure_failure : ¬ noFailure (failure : OracleComp spec α) := fun h => h
 
 @[simp]
 lemma noFailure_bind_iff (oa : OracleComp spec α) (ob : α → OracleComp spec β) :
     (oa >>= ob).noFailure ↔ oa.noFailure ∧ ∀ x ∈ oa.support, (ob x).noFailure := by
-  sorry
+  induction oa using OracleComp.inductionOn with
+  | pure x => simp
+  | failure => simp
+  | query_bind _ _ r ih =>
+    simp [ih]
+    constructor <;> intro h
+    · exact ⟨fun x => (h x).1, fun a x h' => (h x).2 a h'⟩
+    · exact fun x => ⟨h.1 x, fun a h' => h.2 a x h'⟩
 
-instance {oa : OracleComp spec α} {ob : α → OracleComp spec β}
-    [h : noFailure oa] [h' : ∀ x, noFailure (ob x)] : noFailure (oa >>= ob) where
-  no_failure := by
-    induction oa using OracleComp.inductionOn generalizing h with
-    | pure x => exact (h' x).no_failure
-    | failure => exact h.no_failure.elim
-    | query_bind _ _ r => sorry
+alias ⟨noFailure_bind, _⟩ := noFailure_bind_iff
 
 @[simp]
 lemma noFailure_map_iff (oa : OracleComp spec α) (f : α → β) :
-    noFailure (f <$> oa) ↔ noFailure oa := by sorry
-
-instance {oa : OracleComp spec α} {f : α → β} [noFailure oa] : noFailure (f <$> oa) := by
-  sorry
+    noFailure (f <$> oa) ↔ noFailure oa := by
+  rw [map_eq_bind_pure_comp]
+  simp only [noFailure_bind_iff, Function.comp_apply, noFailure_pure, implies_true, and_true]
 
 @[simp]
-
 instance {α : Type u} [spec.FiniteRange] : DecidablePred (@OracleComp.noFailure _ spec α) :=
   fun oa => by induction oa using OracleComp.construct with
   | pure x =>
@@ -71,5 +88,109 @@ instance {α : Type u} [spec.FiniteRange] : DecidablePred (@OracleComp.noFailure
       simp only [noFailure_bind_iff, noFailure_query, support_liftM, Set.mem_univ, forall_const, true_and]
       exact Fintype.decidableForallFintype
 
+section List
+
+open List
+
+/-- If each element of a list is mapped to a computation that never fails, then the computation
+  obtained by monadic mapping over the list also never fails. -/
+@[simp] lemma noFailure_list_mapM {f : α → OracleComp spec β} {as : List α}
+    (h : ∀ x ∈ as, noFailure (f x)) : noFailure (mapM f as) := by
+  induction as with
+  | nil => simp only [mapM, mapM.loop, reverse_nil, noFailure_pure]
+  | cons a as ih =>
+    simp [mapM_cons, h]
+    exact fun _ _ => ih (by simp at h; exact h.2)
+
+@[simp] lemma noFailure_list_mapM' {f : α → OracleComp spec β} {as : List α}
+    (h : ∀ x ∈ as, noFailure (f x)) : noFailure (mapM' f as) := by
+  rw [mapM'_eq_mapM]
+  exact noFailure_list_mapM h
+
+@[simp] lemma noFailure_list_flatMapM {f : α → OracleComp spec (List β)} {as : List α}
+    (h : ∀ x ∈ as, noFailure (f x)) : noFailure (flatMapM f as) := by
+  induction as with
+  | nil => simp only [flatMapM_nil, noFailure_pure]
+  | cons a as ih =>
+    simp only [flatMapM_cons, bind_pure_comp, noFailure_bind_iff, noFailure_map_iff]
+    exact ⟨h a (by simp), fun y hy => ih (fun x hx => h x (by simp [hx]))⟩
+
+@[simp] lemma noFailure_list_filterMapM {f : α → OracleComp spec (Option β)} {as : List α}
+    (h : ∀ x ∈ as, noFailure (f x)) : noFailure (filterMapM f as) := by
+  induction as with
+  | nil => simp only [filterMapM_nil, noFailure_pure]
+  | cons a as ih =>
+    simp only [filterMapM_cons, bind_pure_comp, noFailure_bind_iff, noFailure_map_iff]
+    refine ⟨h a (by simp), fun y hy => ?_⟩
+    rcases y with _ | y <;> simp <;> exact ih (fun x hx => h x (by simp [hx]))
+
+variable {s : Type v}
+
+@[simp] lemma noFailure_list_foldlM {f : s → α → OracleComp spec s} {init : s} {as : List α}
+    (h : ∀ i, ∀ x ∈ as, noFailure (f i x)) : noFailure (foldlM f init as) := by
+  induction as generalizing init with
+  | nil => simp only [foldlM, reverse_nil, noFailure_pure]
+  | cons b bs ih =>
+      simp only [foldlM_cons, noFailure_bind_iff, mem_cons, true_or, h, true_and]
+      exact fun _ _ => ih (fun i x hx' => h i x (by simp [hx']))
+
+@[simp] lemma noFailure_list_foldrM {f : α → s → OracleComp spec s} {init : s} {as : List α}
+    (h : ∀ i, ∀ x ∈ as, noFailure (f x i)) : noFailure (foldrM f init as) := by
+  induction as generalizing init with
+  | nil => simp only [foldrM, reverse_nil, foldlM_nil, noFailure_pure]
+  | cons b bs ih =>
+      simp only [foldrM_cons, noFailure_bind_iff]
+      exact ⟨ih (fun i x hx => h i x (by simp [hx])), fun y _ => h y b (by simp)⟩
+
+-- TODO: add lemmas for more monadic list operations
+
+end List
+
+section List.Vector
+
+variable {n : ℕ}
+
+@[simp] lemma noFailure_list_vector_mmap {f : α → OracleComp spec β} {as : List.Vector α n}
+    (h : ∀ x ∈ as.toList, noFailure (f x)) : noFailure (List.Vector.mmap f as) := by
+  induction as with
+  | nil => simp only [List.Vector.mmap, noFailure_pure]
+  | @cons n x xs ih =>
+    simp only [List.Vector.mmap_cons, bind_pure_comp, noFailure_bind_iff, noFailure_map_iff]
+    exact ⟨h x (by simp), fun y hy => ih (fun x' hx' => h x' (by simp [hx']))⟩
+
+end List.Vector
+
+section Array
+
+open Array
+
+@[simp] lemma noFailure_array_mapM {f : α → OracleComp spec β} {as : Array α}
+    (h : ∀ x ∈ as, noFailure (f x)) : noFailure (mapM f as) := by
+  induction ha : as.toList generalizing as with
+  | nil => simp_all [h, Array.mapM, mapM.map, noFailure_pure]
+  | cons x xs ih =>
+    simp_rw [mapM_eq_mapM_toList, ha] at ih ⊢
+    simp at ih ⊢
+    -- boring case analysis
+    sorry
+
+end Array
+
+section Vector
+
+open Vector
+
+variable {n : ℕ}
+
+-- Need induction principle for vectors
+@[simp] lemma noFailure_vector_mapM {f : α → OracleComp spec β} {xs : Vector α n}
+    (h : ∀ x ∈ xs.toList, noFailure (f x)) : noFailure (mapM f xs) := by sorry
+  -- match h : xs with
+  -- | ⟨⟨[]⟩, _⟩ => simp [Vector.mapM, Vector.mapM.go, noFailure_pure]
+  -- | ⟨⟨x :: xs⟩, _⟩ =>
+  --   simp only [mapM_cons, bind_pure_comp, noFailure_bind_iff, noFailure_map_iff]
+  --   exact ⟨h x (by simp), fun y hy => ih (fun x' hx' => h x' (by simp [hx']))⟩
+
+end Vector
 
 end OracleComp

--- a/VCVio/OracleComp/SimSemantics/QueryTracking/CountingOracle.lean
+++ b/VCVio/OracleComp/SimSemantics/QueryTracking/CountingOracle.lean
@@ -56,8 +56,15 @@ def single (i : ι) : QueryCount spec := Function.update 0 i 1
 
 @[simp]
 lemma single_le_iff_pos (i : ι) (qc : QueryCount spec) :
-    single i ≤ qc ↔ 0 < qc i :=
-  sorry
+    single i ≤ qc ↔ 0 < qc i := by
+  simp [single, update, Pi.hasLe]
+  constructor <;> intro h
+  · have : 1 ≤ qc i := by simpa using h i
+    exact this
+  · intro j
+    by_cases hj : j = i
+    · simp [hj]; omega
+    · simp [hj]
 
 end single
 
@@ -99,9 +106,7 @@ lemma noFailure_run_simulateQ_iff (oa : OracleComp spec α) :
     noFailure (simulateQ countingOracle oa).run ↔ noFailure oa :=
   noFailure_writerT_run_simulateQ_iff (by simp) (by simp) oa
 
-instance noFailure_simulateQ (oa : OracleComp spec α) [noFailure oa] :
-    noFailure (simulateQ countingOracle oa).run := by
-  rwa [noFailure_run_simulateQ_iff]
+alias ⟨_, noFailure_simulateQ⟩ := noFailure_run_simulateQ_iff
 
 -- lemma run_simulateT_eq_run_simulateT_zero (oa : OracleComp spec α) (qc : ι → ℕ) :
 --     (simulateT countingOracle oa).run qc =

--- a/VCVio/OracleComp/SimSemantics/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/SimSemantics/QueryTracking/LoggingOracle.lean
@@ -212,8 +212,6 @@ lemma noFailure_run_simulateQ_iff (oa : OracleComp spec α) :
     noFailure (simulateQ loggingOracle oa).run ↔ noFailure oa :=
   noFailure_writerT_run_simulateQ_iff (by simp) (by simp) oa
 
-instance noFailure_simulateQ (oa : OracleComp spec α) [noFailure oa] :
-    noFailure (simulateQ loggingOracle oa).run := by
-  rwa [noFailure_run_simulateQ_iff]
+alias ⟨_, noFailure_simulateQ⟩ := noFailure_run_simulateQ_iff
 
 end loggingOracle


### PR DESCRIPTION
This PR fills in more lemmas for `noFailure`, plus making it a definition rather than a type class (don't think type class search really helps).