### PR TITLE
feat: syntax for binding variables in probability calculations

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -5,3 +5,4 @@ import Examples.HHS_Signature
 import Examples.OneTimePad
 import Examples.RF_RP_Switching_alt
 import Examples.Regev
+import Examples.SyntaxTesting

--- a/Examples/SyntaxTesting.lean
+++ b/Examples/SyntaxTesting.lean
@@ -1,9 +1,9 @@
 import VCVio
 
-open Lean OracleComp
+open Lean OracleComp ENNReal
 
 syntax (name := probThing)
-  "[" term " | " sepBy((sepBy(ident, ",") " ← " term),";") "]" : term
+  "Pr[" term " | " sepBy((sepBy(ident, ",") " ← " term),";") "]" : term
 
 def BuildProdGen : List (TSyntax `term) → MacroM (TSyntax `term)
   | [] => Macro.throwUnsupported
@@ -21,8 +21,9 @@ def BuildCond (cond : TSyntax `term)
     let rcall ← BuildCond cond vs
     `(Function.uncurry fun $v => $rcall)
 
+
 macro_rules
-  | `([$cond | $vars1:ident,* ← $src1]) => do
+  | `(Pr[$cond | $vars1:ident,* ← $src1]) => do
     let vars_list : List (List (TSyntax `ident)) :=
       [(↑vars1 : Array (TSyntax `ident)).toList]
     let sources :=
@@ -31,8 +32,8 @@ macro_rules
     let check ← BuildCond cond vars_list.flatten
     `(probEvent $call $check)
 
-  | `([$cond | $vars1:ident,* ← $src1;
-               $vars2:ident,* ← $src2]) => do
+  | `(Pr[$cond | $vars1:ident,* ← $src1;
+                 $vars2:ident,* ← $src2]) => do
     let vars_list : List (List (TSyntax `ident)) :=
       [(↑vars1 : Array (TSyntax `ident)).toList,
        (↑vars2 : Array (TSyntax `ident)).toList]
@@ -43,9 +44,9 @@ macro_rules
     let check ← BuildCond cond vars_list.flatten
     `(probEvent $call $check)
 
-  | `([$cond | $vars1:ident,* ← $src1;
-               $vars2:ident,* ← $src2;
-               $vars3:ident,* ← $src3]) => do
+  | `(Pr[$cond | $vars1:ident,* ← $src1;
+                 $vars2:ident,* ← $src2;
+                 $vars3:ident,* ← $src3]) => do
     let vars_list : List (List (TSyntax `ident)) :=
       [(↑vars1 : Array (TSyntax `ident)).toList,
        (↑vars2 : Array (TSyntax `ident)).toList,
@@ -58,11 +59,13 @@ macro_rules
     let check ← BuildCond cond vars_list.flatten
     `(probEvent $call $check)
 
+#check Lean.Parser.doElemParser
+
 noncomputable example (F : Type _) [Field F] [SelectableType F] : Unit := by
-  let t := [∀ i : Fin 3, y[i] ≠ 0| y ←$ᵗ Vector F 3]
-  let u := [y[0] = y[1] ∧ x[0] ≠ 0 | x, y ←$ᵗ Vector F 3]
-  let v := [(x ∧ y) ∨ (x ∧ !z) | x, y, z ←$ᵗ Bool]
-  let w := [b ∧ x[0] ≠ 0 | b ←$ᵗ Bool; x ←$ᵗ Vector F 3]
-  let μ := [b ∧ b' ∧ x * y = 1 | b, b' ←$ᵗ Bool; x, y ←$ᵗ F]
-  let ν := [xs[0] = x ∨ b = true | b ←$ᵗ Bool; x ←$ᵗ F; xs ←$ᵗ Vector F 5]
+  let t := Pr[∀ i : Fin 3, y[i] ≠ 0| y ←$ᵗ Vector F 3]
+  let u := Pr[y[0] = x[0] ∧ x[1] ≠ y[2] | x, y ←$ᵗ Vector F 3]
+  let v := Pr[(x ∧ y) ∨ (x ∧ !z) | x, y, z ←$ᵗ Bool]
+  let w := Pr[b ∧ x[0] ≠ 0 | b ←$ᵗ Bool; x ←$ᵗ Vector F 3]
+  let μ := Pr[b ∧ b' ∧ x * y = 1 | b, b' ←$ᵗ Bool; x, y ←$ᵗ F]
+  let ν := Pr[xs[0] = x ∨ b = true | b ←$ᵗ Bool; x ←$ᵗ F; xs ←$ᵗ Vector F 5]
   exact ()

--- a/Examples/SyntaxTesting.lean
+++ b/Examples/SyntaxTesting.lean
@@ -1,0 +1,68 @@
+import VCVio
+
+open Lean OracleComp
+
+syntax (name := probThing)
+  "[" term " | " sepBy((sepBy(ident, ",") " ← " term),";") "]" : term
+
+def BuildProdGen : List (TSyntax `term) → MacroM (TSyntax `term)
+  | [] => Macro.throwUnsupported
+  | src :: [] => `($src)
+  | src :: sources => do
+    let rcall ← BuildProdGen sources
+    `(Prod.mk <$> $src <*> $rcall)
+
+def BuildCond (cond : TSyntax `term)
+    (vars : List (TSyntax `ident)) : MacroM (TSyntax `term) :=
+  match vars with
+  | [] => `($cond)
+  | v :: [] => `(fun $v => $cond)
+  | v :: vs => do
+    let rcall ← BuildCond cond vs
+    `(Function.uncurry fun $v => $rcall)
+
+macro_rules
+  | `([$cond | $vars1:ident,* ← $src1]) => do
+    let vars_list : List (List (TSyntax `ident)) :=
+      [(↑vars1 : Array (TSyntax `ident)).toList]
+    let sources :=
+      (↑vars1 : Array (TSyntax `ident)).toList.map (fun _ => src1)
+    let call ← BuildProdGen sources
+    let check ← BuildCond cond vars_list.flatten
+    `(probEvent $call $check)
+
+  | `([$cond | $vars1:ident,* ← $src1;
+               $vars2:ident,* ← $src2]) => do
+    let vars_list : List (List (TSyntax `ident)) :=
+      [(↑vars1 : Array (TSyntax `ident)).toList,
+       (↑vars2 : Array (TSyntax `ident)).toList]
+    let sources :=
+      (↑vars1 : Array (TSyntax `ident)).toList.map (fun _ => src1) ++
+      (↑vars2 : Array (TSyntax `ident)).toList.map (fun _ => src2)
+    let call ← BuildProdGen sources
+    let check ← BuildCond cond vars_list.flatten
+    `(probEvent $call $check)
+
+  | `([$cond | $vars1:ident,* ← $src1;
+               $vars2:ident,* ← $src2;
+               $vars3:ident,* ← $src3]) => do
+    let vars_list : List (List (TSyntax `ident)) :=
+      [(↑vars1 : Array (TSyntax `ident)).toList,
+       (↑vars2 : Array (TSyntax `ident)).toList,
+       (↑vars3 : Array (TSyntax `ident)).toList]
+    let sources :=
+      (↑vars1 : Array (TSyntax `ident)).toList.map (fun _ => src1) ++
+      (↑vars2 : Array (TSyntax `ident)).toList.map (fun _ => src2) ++
+      (↑vars3 : Array (TSyntax `ident)).toList.map (fun _ => src3)
+    let call ← BuildProdGen sources
+    let check ← BuildCond cond vars_list.flatten
+    `(probEvent $call $check)
+
+noncomputable example (F : Type _) [Field F] [SelectableType F] : Unit := by
+  let t := [∀ i : Fin 3, y[i] ≠ 0| y ←$ᵗ Vector F 3]
+  let u := [y[0] = y[1] ∧ x[0] ≠ 0 | x, y ←$ᵗ Vector F 3]
+  let v := [(x ∧ y) ∨ (x ∧ !z) | x, y, z ←$ᵗ Bool]
+  let w := [b ∧ x[0] ≠ 0 | b ←$ᵗ Bool; x ←$ᵗ Vector F 3]
+  let μ := [b ∧ b' ∧ x * y = 1 | b, b' ←$ᵗ Bool; x, y ←$ᵗ F]
+  let ν := [xs[0] = x ∨ b = true | b ←$ᵗ Bool; x ←$ᵗ F; xs ←$ᵗ Vector F 5]
+  exact ()


### PR DESCRIPTION
This PR is a WIP to add support for syntax like `[∀ i : Fin 3, y[i] ≠ 0| y ←$ᵗ Vector F 3]`, where the variable in the predicate is bound at the site of the computation. So far can support things like:

* Multiple variables: `Pr[(x ∧ y) ∨ (x ∧ !z) | x, y, z ←$ᵗ Bool]`
* Multiple computations: `Pr[b ∧ b' ∧ x * y = 1 | b, b' ←$ᵗ Bool; x, y ←$ᵗ F]`
* Arbitrary computations `Pr[!x ∨ !y | x, y ← my_computation]`

The first allows for arbitrary numbers of variables. The last only works for up to three clauses now. Ideally this could be generalized but the syntax manipulation is trickier.

Long-term it would be nice if computations in later clauses can depend on variables in the earlier ones. This seems like it requires manually building up do terms.