### PR TITLE
feat: various probability lemmas

### DIFF
--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -16,6 +16,21 @@ in general mathlib than in the project itself.
 
 universe u v w
 
+namespace ENNReal
+
+lemma one_sub_one_sub_mul_one_sub {x y : ℝ≥0∞} (hx : x ≤ 1) (hy : y ≤ 1) :
+    1 - (1 - x) * (1 - y) = x + y - x * y := by
+  have hxy : x * y ≤ x + y := by sorry
+  have hxy' : (1 - x) * (1 - y) ≤ 1 := by sorry
+  rw [← ENNReal.toReal_eq_toReal_iff']
+  rw [ENNReal.toReal_sub_of_le, ENNReal.toReal_mul, ENNReal.toReal_sub_of_le,
+    ENNReal.toReal_sub_of_le, ENNReal.toReal_sub_of_le, ENNReal.toReal_add, ENNReal.toReal_mul]
+  simp
+  linarith
+  all_goals try aesop
+
+end ENNReal
+
 section sum_thing
 
 open Filter Finset Function Topology SummationFilter

--- a/VCVio/EvalDist/Defs/NeverFails.lean
+++ b/VCVio/EvalDist/Defs/NeverFails.lean
@@ -77,7 +77,7 @@ instance neverFail_pure (x : α) : NeverFail (pure x : m α) := by grind
 @[simp, grind =]
 lemma neverFail_bind_iff (mx : m α) (my : α → m β) :
     NeverFail (mx >>= my) ↔ NeverFail mx ∧ ∀ x ∈ support mx, NeverFail (my x) := by
-  simp [neverFail_iff, probFailure_bind_eq_tsum, add_eq_zero]
+  simp [neverFail_iff, probFailure_bind_eq_add_tsum, add_eq_zero]
   grind
 
 @[simp, grind =]
@@ -128,7 +128,7 @@ lemma bind_of_mem_support {mx : m α} {my : α → m β}
     [hx : NeverFail mx] (hy : ∀ x ∈ support mx, NeverFail (my x)) :
     NeverFail (mx >>= my) where
   probFailure_eq_zero := by
-    simp [probFailure_bind_eq_tsum]
+    simp [probFailure_bind_eq_add_tsum]
     simp [HasEvalSPMF.neverFail_iff] at hy
     tauto
 

--- a/VCVio/EvalDist/Defs/Support.lean
+++ b/VCVio/EvalDist/Defs/Support.lean
@@ -56,7 +56,7 @@ export HasEvalFinset (finSupport coe_finSupport)
 
 attribute [simp, grind =] coe_finSupport
 
-@[grind =]
+@[grind =, aesop unsafe norm]
 lemma mem_finSupport_iff_mem_support [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
     (mx : m α) (x : α) : x ∈ finSupport mx ↔ x ∈ support mx := by
   rw [← Finset.mem_coe, coe_finSupport]

--- a/VCVio/EvalDist/Fintype.lean
+++ b/VCVio/EvalDist/Fintype.lean
@@ -29,7 +29,7 @@ lemma probOutput_bind_eq_sum_fintype [HasEvalSPMF m]
 lemma probFailure_bind_eq_sum_fintype [HasEvalSPMF m]
     (mx : m α) (my : α → m β) [Fintype α] :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑ x : α, Pr[= x | mx] * Pr[⊥ | my x] :=
-  (probFailure_bind_eq_tsum mx my).trans (congr_arg (Pr[⊥ | mx] + ·) <| tsum_fintype _)
+  (probFailure_bind_eq_add_tsum mx my).trans (congr_arg (Pr[⊥ | mx] + ·) <| tsum_fintype _)
 
 lemma probEvent_bind_eq_sum_fintype [HasEvalSPMF m]
     (mx : m α) (my : α → m β) [Fintype α] (q : β → Prop) :

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -127,6 +127,10 @@ lemma evalDist_bind [HasEvalSPMF m] (mx : m α) (my : α → m β) :
     evalDist (mx >>= my) = evalDist mx >>= fun x => evalDist (my x) :=
   MonadHom.toFun_bind' _ mx my
 
+lemma evalDist_bind_of_support_eq_empty [HasEvalSPMF m] (mx : m α) (my : α → m β)
+    (h : support mx = ∅) : evalDist (mx >>= my) = failure := by
+  simp [SPMF.ext_iff, ← probOutput_def, h]
+
 @[grind =]
 lemma probOutput_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (y : β) :
     Pr[= y | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[= y | my x] := by
@@ -140,24 +144,26 @@ lemma probEvent_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (q :
   rw [ENNReal.tsum_comm]
   refine tsum_congr fun x => by split_ifs <;> simp
 
-lemma probFailure_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) :
+@[grind =]
+lemma probFailure_bind_eq_add_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑' x : α, Pr[= x | mx] * Pr[⊥ | my x] := by
-  rw [probFailure_eq_sub_tsum]
-  conv =>
-    left
-    right
-    congr
-    ext
-    rw [probOutput_bind_eq_tsum]
+  simp [probFailure_def, Option.elimM, tsum_option, probOutput_def,
+    SPMF.apply_eq_toPMF_some]
 
-  simp only [probFailure_eq_sub_tsum]
-
-  sorry
+@[grind =]
+lemma probFailure_bind_eq_add_tsum_support [HasEvalSPMF m] (mx : m α) (my : α → m β) :
+    Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑' x : support mx, Pr[= x | mx] * Pr[⊥ | my x] := by
+  rw [probFailure_bind_eq_add_tsum]
+  congr 1
+  rw [tsum_subtype (support mx) (fun x => Pr[= x | mx] * Pr[⊥ | my x])]
+  refine tsum_congr fun x => ?_
+  unfold Set.indicator
+  aesop
 
 @[simp, grind =]
 lemma probFailure_bind_eq_zero_iff [HasEvalSPMF m] (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = 0 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, Pr[⊥ | my x] = 0 := by
-  simp [probFailure_bind_eq_tsum]
+  simp [probFailure_bind_eq_add_tsum]
   grind
 
 /-- Version of `probOutput_bind_eq_tsum` that sums only over the subtype given by the support
@@ -166,8 +172,8 @@ happen in practice after the first computation. A common example is if the first
 does some error handling to avoids returning malformed outputs. -/
 lemma probOutput_bind_eq_tsum_subtype [HasEvalSPMF m] (mx : m α) (my : α → m β) (y : β) :
     Pr[= y | mx >>= my] = ∑' x : support mx, Pr[= x | mx] * Pr[= y | my x] := by
-  rw [tsum_subtype _ (fun x ↦ Pr[= x | mx] * Pr[= y | my x]), probOutput_bind_eq_tsum]
-  refine tsum_congr (fun x ↦ ?_)
+  rw [tsum_subtype _ (fun x => Pr[= x | mx] * Pr[= y | my x]), probOutput_bind_eq_tsum]
+  refine tsum_congr (fun x => ?_)
   by_cases hx : x ∈ support mx <;> aesop
 
 lemma probEvent_bind_eq_tsum_subtype [HasEvalSPMF m] (mx : m α) (my : α → m β) (q : β → Prop) :
@@ -197,7 +203,10 @@ lemma support_bind_const [HasEvalSet m] (mx : m α) (my : m β) :
 lemma finSupport_bind_const [HasEvalSet m] [HasEvalFinset m]
     [DecidableEq β] [DecidableEq α] (mx : m α) (my : m β) :
     finSupport (mx >>= fun _ => my) = if (finSupport mx).Nonempty then finSupport my else ∅ := by
-  aesop
+  split_ifs with h
+  · obtain ⟨x, hx⟩ := h
+    aesop
+  · aesop
 
 lemma probOutput_bind_of_const [HasEvalSPMF m] (mx : m α)
     {my : α → m β} {y : β} {r : ℝ≥0∞} (h : ∀ x ∈ support mx, Pr[= y | my x] = r) :
@@ -228,57 +237,47 @@ lemma probEvent_bind_const [HasEvalSPMF m] (mx : m α) (my : m β) (p : β → P
     Pr[p | mx >>= fun _ => my] = (1 - Pr[⊥ | mx]) * Pr[p | my] := by
   rw [probEvent_bind_of_const mx fun _ _ => rfl]
 
--- TODO: `h` should only require `∀ x ∈ support mx`.
-lemma probFailure_bind_of_const [Nonempty α] [HasEvalSPMF m]
-    (mx : m α) {my : α → m β} {r : ℝ≥0∞} (h : ∀ x, Pr[⊥ | my x] = r) :
+/-- Write the probability of `mx >>= my` failing given that `my` has constant failure chance over
+the possible outputs in `support mx` as a fixed expression without any sums. -/
+lemma probFailure_bind_of_const [HasEvalSPMF m]
+    {mx : m α} {my : α → m β} {r : ℝ≥0∞} (h : ∀ x ∈ support mx, Pr[⊥ | my x] = r) :
+    Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + r * (1 - Pr[⊥ | mx]) := by
+  calc Pr[⊥ | mx >>= my]
+    _ = Pr[⊥ | mx] + ∑' x : support mx, Pr[= x | mx] * Pr[⊥ | my x] := by grind
+    _ = Pr[⊥ | mx] + ∑' x : support mx, Pr[= x | mx] * r := by grind
+    _ = Pr[⊥ | mx] + r * (1 - Pr[⊥ | mx]) := by
+      rw [ENNReal.tsum_mul_right, mul_comm, tsum_support_probOutput_eq_sub]
+
+lemma probFailure_bind_of_const' [HasEvalSPMF m]
+    {mx : m α} {my : α → m β} {r : ℝ≥0∞} (hr : r ≠ ⊤) (h : ∀ x ∈ support mx, Pr[⊥ | my x] = r) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + r - Pr[⊥ | mx] * r := by
-  have : r ≠ ⊤ := λ hr ↦ probFailure_ne_top ((h (Classical.arbitrary α)).trans hr)
-  simp [probFailure_bind_eq_tsum, h, ENNReal.tsum_mul_right, tsum_probOutput_eq_sub]
-  rw [ENNReal.sub_mul λ _ _ ↦ this, one_mul]
-  refine symm (AddLECancellable.add_tsub_assoc_of_le ?_ ?_ _)
-  · refine ENNReal.addLECancellable_iff_ne.2 (ENNReal.mul_ne_top probFailure_ne_top this)
-  · by_cases hr : r = 0
-    · simp only [hr, mul_zero, le_refl]
-    refine mul_le_of_le_div (le_of_le_of_eq probFailure_le_one ?_)
-    refine symm (ENNReal.div_self hr this)
+  rw [probFailure_bind_of_const h, ENNReal.mul_sub, AddLECancellable.add_tsub_assoc_of_le,
+    mul_comm Pr[⊥ | mx] r, mul_one] <;> simp [hr, ENNReal.mul_eq_top]
 
 @[simp, grind =_]
-lemma probFailure_bind_const [Nonempty α] [HasEvalSPMF m] (mx : m α) (my : m β) :
+lemma probFailure_bind_const [HasEvalSPMF m] (mx : m α) (my : m β) :
     Pr[⊥ | mx >>= fun _ => my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by
-  rw [probFailure_bind_of_const mx fun _ => rfl]
+  rw [probFailure_bind_of_const' (by simp) fun _ _ => rfl]
 
 lemma probFailure_bind_eq_sub_mul [HasEvalSPMF m]
-    (mx : m α) (my : α → m β) (r : ℝ≥0∞) (h : ∀ x, Pr[⊥ | my x] = r) :
+    (mx : m α) (my : α → m β) (r : ℝ≥0∞) (hr : r ≠ ⊤) (h : ∀ x ∈ support mx, Pr[⊥ | my x] = r) :
     Pr[⊥ | mx >>= my] = 1 - (1 - Pr[⊥ | mx]) * (1 - r) := by
-  rw [probFailure_bind_eq_tsum]
-  rw [← tsum_probOutput_eq_sub]
-  rw [← ENNReal.tsum_mul_right]
-
-  sorry
-  -- have hl : ∀ x, [=x|mx] * [⊥|my x] ≤ [=x|mx] :=
-  --   λ x ↦ le_of_le_of_eq (mul_le_mul' le_rfl probFailure_le_one) (mul_one _)
-  -- calc [⊥ | mx] + ∑' x, [= x | mx] * [⊥ | my x]
-  --   _ = 1 - (∑' x, [= x | mx]) + (∑' x, [= x | mx] * [⊥ | my x]) := by
-  --     rw [probFailure_eq_sub_tsum]
-  --   _ = 1 - (∑' x, [= x | mx] - ∑' x, [= x | mx] * [⊥ | my x]) := by
-  --     exact Eq.symm (AddLECancellable.tsub_tsub_assoc
-  --       (by simp) tsum_probOutput_le_one (ENNReal.tsum_le_tsum hl))
-  --   _ = 1 - ∑' x, ([= x | mx] - [= x | mx] * [⊥ | my x]) := by
-  --     refine congr_arg (1 - ·) (ENNReal.eq_sub_of_add_eq ?_ ?_).symm
-  --     · refine ne_top_of_le_ne_top one_ne_top ?_
-  --       refine le_trans ?_ (@tsum_probOutput_le_one _ _ _ _ mx)
-  --       refine ENNReal.tsum_le_tsum λ x ↦ ?_
-  --       exact hl x
-  --     rw [← ENNReal.tsum_add]
-  --     refine tsum_congr λ x ↦ tsub_add_cancel_of_le (hl x)
-  --   _ = 1 - ∑' x : α, [= x | mx] * (1 - r) := by
-  --     refine congr_arg (1 - ·) (tsum_congr λ x ↦ ?_)
-  --     rw [ENNReal.mul_sub (λ _ _ ↦ probOutput_ne_top), mul_one, ← h x]
+  by_cases h' : (support mx).Nonempty
+  · obtain ⟨x, hx⟩ := h'
+    have : Pr[⊥ | my x] = r := h x hx
+    have hr : r ≠ ⊤ := by aesop
+    rw [probFailure_bind_of_const' hr h, ENNReal.one_sub_one_sub_mul_one_sub (by simp)]
+    aesop
+  · rw [Set.nonempty_iff_ne_empty, not_not] at h'
+    have := evalDist_bind_of_support_eq_empty mx my h'
+    have hmx : Pr[⊥ | mx] = 1 := by aesop
+    rw [probFailure_def, this]
+    simp [hmx]
 
 end const
 
 lemma probFailure_bind_le_of_forall [HasEvalSPMF m] {mx : m α}
-    {s : ℝ≥0∞} (h' : Pr[⊥ | mx] = s) (my : α → m β) {r : ℝ≥0∞}
+    {s : ℝ≥0∞} (h' : Pr[⊥ | mx] ≤ s) (my : α → m β) {r : ℝ≥0∞}
     (hr : ∀ x ∈ support mx, Pr[⊥ | my x] ≤ r) :
     Pr[⊥ | mx >>= my] ≤ s + (1 - s) * r := by
   sorry

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -98,7 +98,7 @@ lemma probOutput_map_eq_sum_filter_finSupport [HasEvalFinset m] [DecidableEq α]
 
 @[simp, grind =]
 lemma probFailure_map : Pr[⊥ | f <$> mx] = Pr[⊥ | mx] := by
-  simp [map_eq_bind_pure_comp, probFailure_bind_eq_tsum]
+  simp [map_eq_bind_pure_comp, probFailure_bind_eq_add_tsum]
 
 @[simp, grind =]
 lemma probEvent_map (q : β → Prop) : Pr[q | f <$> mx] = Pr[q ∘ f | mx] := by

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -94,7 +94,7 @@ end seqRight
 
 -- lemma probFailure_seq [spec.FiniteRange] :
 --     [⊥ | og <*> oa] = [⊥ | og] + [⊥ | oa] - [⊥ | og] * [⊥ | oa] := by
---   rw [seq_eq_bind_map, probFailure_bind_eq_tsum]
+--   rw [seq_eq_bind_map, probFailure_bind_eq_add_tsum]
 --   rw [AddLECancellable.add_tsub_assoc_of_le]
 --   · refine congr_arg ([⊥ | og] + ·) ?_
 --     simp [ENNReal.tsum_mul_right]

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -48,7 +48,7 @@ lemma probOutput_uniformSample [Fintype α] (x : α) :
     by simp only [Finset.sum_const, Finset.card_univ, nsmul_eq_mul, mul_one]
   refine ENNReal.eq_inv_of_mul_eq_one_left ?_
   simp_rw [this, Finset.mul_sum, mul_one]
-  rw [← sum_probOutput_eq_one ($ᵗ α) SampleableType.probFailure_selectElem]
+  rw [← sum_probOutput_eq_one (mx := $ᵗ α) SampleableType.probFailure_selectElem]
   exact Finset.sum_congr rfl λ y _ ↦ SampleableType.probOutput_selectElem_eq x y
 
 lemma probFailure_uniformSample : Pr[⊥ | $ᵗ α] = 0 :=

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -25,10 +25,11 @@ section support
 
 /-- The possible outputs of `mx` when queries can output values in the specified sets.
 NOTE: currently proofs using this should reduce to `simulateQ`. A full API would be better -/
-def supportWhen (o : QueryImpl spec Set) (mx : OracleComp spec α) : Set α :=
+def supportWhen (o : QueryImpl spec Set)
+    (mx : OracleComp spec α) : Set α :=
   simulateQ (r := SetM) o mx
 
-/-- The support of a computation assuming any possible return value of queries. -/
+/-- The `support` instance for `OracleComp`, defined as  -/
 instance hasEvalSet : HasEvalSet (OracleComp spec) where
   toSet := simulateQ' (r := SetM) fun _ : spec.Domain => Set.univ
 
@@ -84,7 +85,8 @@ section evalDist
 
 /-- The output distribution of `mx` when queries follow the specified distribution.
 NOTE: currently proofs using this should reduce to `simulateQ`. A full API would be better -/
-noncomputable def evalDistWhen (d : QueryImpl spec SPMF) (mx : OracleComp spec α) : SPMF α :=
+noncomputable def evalDistWhen (d : QueryImpl spec SPMF)
+    (mx : OracleComp spec α) : SPMF α :=
   simulateQ (r := SPMF) d mx
 
 variable [spec.Fintype] [spec.Inhabited]
@@ -144,6 +146,13 @@ lemma probEvent_query (t : spec.Domain) (p : spec.Range t → Prop) [DecidablePr
 end evalDist
 
 end OracleComp
+
+
+
+
+
+
+
 
 
 -- @[simp]
@@ -254,190 +263,7 @@ section support
 -- --   rw [mem_support_evalDist_iff, mem_finSupport_iff_mem_support]
 -- -- alias ⟨mem_finSupport_of_mem_support_evalDist, mem_support_evalDist'⟩ := mem_support_evalDist_iff'
 
--- @[simp]
--- lemma evalDist_apply_eq_zero_iff (x : Option α) :
---     (evalDist oa).run x = 0 ↔ x.rec (Pr[⊥ | oa] = 0) (· ∉ support oa) :=
---   match x with
---   | none => by simp [probFailure_def]
---   | some x => by simp [OptionT.run, ← mem_support_evalDist_iff]; sorry
-
--- @[simp]
--- lemma evalDist_apply_eq_zero_iff' [spec.DecidableEq] [DecidableEq α] (x : Option α) :
---     (evalDist oa).run x = 0 ↔ x.rec ([⊥ | oa] = 0) (· ∉ oa.finSupport) := by
---   cases x <;> simp [mem_finSupport_iff_mem_support]
-
--- /-- The support of `evalDist oa` is exactly `support oa`. -/
--- lemma support_evalDist : (evalDist oa).run.support = if [⊥ | oa] = 0 then
---     some '' oa.support else insert none (some '' oa.support) := by
---   rw [probFailure_def]
---   refine Set.ext (λ x ↦ x.rec ?_ ?_)
---   · split_ifs with h <;> simp [h]
---   · split_ifs <;> simp
-
--- lemma support_evalDist' [spec.DecidableEq] [DecidableEq α] :
---     (evalDist oa).run.support = if [⊥ | oa] = 0 then
---       oa.finSupport.image some else insert none (oa.finSupport.image some) := by
---   rw [support_evalDist]
---   split_ifs with h <;> simp only [Finset.coe_insert, Finset.coe_image, coe_finSupport]
-
--- @[simp low]
--- lemma probEvent_eq_zero_iff : [p | oa] = 0 ↔ ∀ x ∈ oa.support, ¬ p x := by
---   rw [probEvent_def, PMF.toOuterMeasure_apply_eq_zero_iff]
---   simp [Set.disjoint_iff_forall_ne, Option.forall]
---   refine forall_congr' λ x ↦ forall_congr' λ hx ↦ ?_
---   refine ⟨λ h hx ↦ h x hx rfl, λ h y hy hxy ↦ h (hxy ▸ hy)⟩
--- alias ⟨not_of_mem_support_of_probEvent_eq_zero, probEvent_eq_zero⟩ := probEvent_eq_zero_iff
--- @[simp low]
--- lemma zero_eq_probEvent_iff : 0 = [p | oa] ↔ ∀ x ∈ oa.support, ¬ p x := by
---   rw [eq_comm, probEvent_eq_zero_iff]
--- alias ⟨_, zero_eq_probEvent⟩ := zero_eq_probEvent_iff
-
--- @[simp]
--- lemma probEvent_eq_zero_iff' [spec.DecidableEq] [DecidableEq α] :
---     [p | oa] = 0 ↔ ∀ x ∈ oa.finSupport, ¬ p x := by
---   simp only [probEvent_eq_zero_iff, mem_finSupport_iff_mem_support]
--- alias ⟨not_of_mem_finSupport_of_probEvent_eq_zero, probEvent_eq_zero'⟩ := probEvent_eq_zero_iff'
--- @[simp]
--- lemma zero_eq_probEvent_iff' [spec.DecidableEq] [DecidableEq α] :
---     0 = [p | oa] ↔ ∀ x ∈ oa.finSupport, ¬ p x := by
---   rw [eq_comm, probEvent_eq_zero_iff']
--- alias ⟨_, zero_eq_probEvent'⟩ := zero_eq_probEvent_iff'
-
--- @[simp low]
--- lemma probOutput_pos_iff : 0 < [= x | oa] ↔ x ∈ oa.support := by
---   rw [pos_iff_ne_zero, ne_eq, probOutput_eq_zero_iff, not_not]
--- alias ⟨mem_support_of_probOutput_pos, probOutput_pos⟩ := probOutput_pos_iff
-
--- @[simp]
--- lemma probOutput_pos_iff' [spec.DecidableEq] [DecidableEq α] :
---     0 < [= x | oa] ↔ x ∈ oa.finSupport := by
---   rw [probOutput_pos_iff, mem_finSupport_iff_mem_support]
--- alias ⟨mem_finSupport_of_probOutput_pos, probOutput_pos'⟩ := probOutput_pos_iff'
-
--- @[simp low]
--- lemma probEvent_pos_iff : 0 < [p | oa] ↔ ∃ x ∈ oa.support, p x := by
---   simp_rw [pos_iff_ne_zero, ne_eq, probEvent_eq_zero_iff, not_forall, not_not, exists_prop]
--- alias ⟨exists_mem_support_of_probEvent_pos, probEvent_pos⟩ := probEvent_pos_iff
-
--- @[simp]
--- lemma probEvent_pos_iff' [spec.DecidableEq] [DecidableEq α] :
---     0 < [p | oa] ↔ ∃ x ∈ oa.finSupport, p x := by
---   simp_rw [pos_iff_ne_zero, ne_eq, probEvent_eq_zero_iff', not_forall, not_not, exists_prop]
--- alias ⟨exists_mem_finSupport_of_probEvent_pos, probEvent_pos'⟩ := probEvent_pos_iff'
-
--- @[simp low]
--- lemma probOutput_eq_one_iff :
---     [= x | oa] = 1 ↔ [⊥ | oa] = 0 ∧ oa.support = {x} := by
---   simp [probOutput_def, PMF.apply_eq_one_iff, Set.ext_iff, Option.forall]
--- alias ⟨_, probOutput_eq_one⟩ := probOutput_eq_one_iff
--- @[simp low]
--- lemma one_eq_probOutput_iff :
---     1 = [= x | oa] ↔ [⊥ | oa] = 0 ∧ oa.support = {x} := by
---   rw [eq_comm, probOutput_eq_one_iff]
--- alias ⟨_, one_eq_probOutput⟩ := one_eq_probOutput_iff
-
--- @[simp]
--- lemma probOutput_eq_one_iff' [spec.DecidableEq] [DecidableEq α] :
---     [= x | oa] = 1 ↔ [⊥ | oa] = 0 ∧ oa.finSupport = {x} := by
---   rw [probOutput_eq_one_iff, finSupport_eq_iff_support_eq_coe, Finset.coe_singleton]
--- alias ⟨_, probOutput_eq_one'⟩ := probOutput_eq_one_iff'
--- @[simp]
--- lemma one_eq_probOutput_iff' [spec.DecidableEq] [DecidableEq α] :
---     1 = [= x | oa] ↔ [⊥ | oa] = 0 ∧ oa.finSupport = {x} := by
---   rw [eq_comm, probOutput_eq_one_iff']
--- alias ⟨_, one_eq_probOutput'⟩ := one_eq_probOutput_iff'
-
--- @[simp low]
--- lemma probEvent_eq_one_iff : [p | oa] = 1 ↔ [⊥ | oa] = 0 ∧ ∀ x ∈ oa.support, p x := by
---   rw [probEvent, PMF.toOuterMeasure_apply_eq_one_iff]
---   simp [support_evalDist]
---   split_ifs with hoa
---   · simp [hoa, Set.preimage_image_eq _ (some_injective α), Set.subset_def]
---   · simp [hoa]
---     intro h
---     specialize h (Set.mem_insert none _)
---     simp at h
--- alias ⟨_, probEvent_eq_one⟩ := probEvent_eq_one_iff
--- @[simp low]
--- lemma one_eq_probEvent_iff : 1 = [p | oa] ↔ [⊥ | oa] = 0 ∧ ∀ x ∈ oa.support, p x := by
---   rw [eq_comm, probEvent_eq_one_iff]
--- alias ⟨_, one_eq_probEvent⟩ := probEvent_eq_one_iff
-
--- @[simp]
--- lemma probEvent_eq_one_iff' [spec.DecidableEq] [DecidableEq α] :
---     [p | oa] = 1 ↔ [⊥ | oa] = 0 ∧ ∀ x ∈ oa.finSupport, p x := by
---   simp_rw [probEvent_eq_one_iff, mem_finSupport_iff_mem_support]
--- alias ⟨_, probEvent_eq_one'⟩ := probEvent_eq_one_iff'
--- @[simp]
--- lemma one_eq_probEvent_iff' [spec.DecidableEq] [DecidableEq α] :
---     1 = [p | oa] ↔ [⊥ | oa] = 0 ∧ ∀ x ∈ oa.finSupport, p x := by
---   rw [eq_comm, probEvent_eq_one_iff']
--- alias ⟨_, one_eq_probEvent'⟩ := one_eq_probEvent_iff'
-
--- lemma mem_support_iff_probOutput_ne_zero : x ∈ oa.support ↔ [= x | oa] ≠ 0 := by
---   simp only [ne_eq, probOutput_eq_zero_iff, not_not]
--- lemma mem_finSupport_iff_probOutput_ne_zero [spec.DecidableEq] [DecidableEq α] :
---     x ∈ oa.finSupport ↔ [= x | oa] ≠ 0 := by
---   rw [mem_finSupport_iff_mem_support, mem_support_iff_probOutput_ne_zero]
-
--- lemma mem_support_iff_probOutput_pos : x ∈ oa.support ↔ 0 < [= x | oa] := by
---   simp only [probOutput_pos_iff]
-
--- lemma not_mem_support_iff_probOutput_eq_zero : x ∉ oa.support ↔ [= x | oa] = 0 := by
---   simp only [probOutput_eq_zero_iff]
-
--- variable {oa x p q}
-
--- /-- If `p` implies `q` on the `support` of a computation then it is more likely to happen. -/
--- lemma probEvent_mono (h : ∀ x ∈ oa.support, p x → q x) : [p | oa] ≤ [q | oa] := by
---   refine PMF.toOuterMeasure_mono _ λ x hx ↦ match x with
---   | none => by simp at hx
---   | some x => by
---       simp only [Set.mem_inter_iff, Set.mem_image, Set.mem_setOf_eq, some.injEq, exists_eq_right,
---         PMF.mem_support_iff, ne_eq, evalDist_apply_eq_zero_iff, not_not] at hx
---       exact ⟨x, h x hx.2 hx.1, rfl⟩
-
--- /-- If `p` implies `q` on the `finSupport` of a computation then it is more likely to happen. -/
--- lemma probEvent_mono' [spec.DecidableEq] [DecidableEq α]
---     (h : ∀ x ∈ oa.finSupport, p x → q x) : [p | oa] ≤ [q | oa] :=
---   probEvent_mono (λ x hx hpx ↦ h x (mem_finSupport_of_mem_support oa hx) hpx)
-
--- -- NOTE: should allow `p` and `q` to differ outside the shared support.
--- lemma probEvent_congr {oa : OracleComp spec α} {oa' : OracleComp spec' α}
---     (h1 : ∀ x, p x ↔ q x) (h2 : evalDist oa = evalDist oa') : [p | oa] = [q | oa'] := by
---   simp only [probEvent, probOutput, h1, h2]
-
--- lemma probEvent_ext (h : ∀ x ∈ oa.support, p x ↔ q x) : [p | oa] = [q | oa] :=
---   le_antisymm (probEvent_mono <| λ x hx hp ↦ (h x hx).1 hp)
---     (probEvent_mono <| λ x hx hp ↦ (h x hx).2 hp)
-
--- lemma probEvent_ext' [spec.DecidableEq] [DecidableEq α]
---     (h : ∀ x ∈ oa.finSupport, p x ↔ q x) : [p | oa] = [q | oa] :=
---   le_antisymm (probEvent_mono' <| λ x hx hp ↦ (h x hx).1 hp)
---     (probEvent_mono' <| λ x hx hp ↦ (h x hx).2 hp)
-
--- @[simp]
--- lemma function_support_probOutput : Function.support ([= · | oa]) = oa.support := by
---   simp only [Function.support, ne_eq, probOutput_eq_zero_iff, not_not, Set.setOf_mem_eq]
-
--- lemma mem_support_iff_of_evalDist_eq {oa : OracleComp spec α} {oa' : OracleComp spec' α}
---     (h : evalDist oa = evalDist oa') (x : α) : x ∈ oa.support ↔ x ∈ oa'.support := by
---   simp only [mem_support_iff_probOutput_ne_zero, probOutput_def, h]
-
--- lemma mem_finSupport_iff_of_evalDist_eq [spec.DecidableEq] [spec'.DecidableEq]
---     [DecidableEq α] {oa : OracleComp spec α} {oa' : OracleComp spec' α}
---     (h : evalDist oa = evalDist oa') (x : α) : x ∈ oa.finSupport ↔ x ∈ oa'.finSupport := by
---   simp only [mem_finSupport_iff_mem_support, mem_support_iff_of_evalDist_eq h]
-
 end support
-
--- @[simp] lemma probEvent_eq_eq_probOutput (oa : OracleComp spec α) (x : α) :
---     [(· = x) | oa] = [= x | oa] := by
---   simp [probEvent_def, PMF.toOuterMeasure_apply_singleton, evalDist_apply_some]
-
--- @[simp] lemma probEvent_eq_eq_probOutput' (oa : OracleComp spec α) (x : α) :
---     [(x = ·) | oa] = [= x | oa] :=
---   (probEvent_congr (λ _ ↦ eq_comm) rfl).trans (probEvent_eq_eq_probOutput oa x)
 
 -- section sums
 
@@ -520,7 +346,7 @@ end support
 --   -- induction oa using OracleComp.inductionOn with
 --   -- | pure x => simp
 --   -- | failure => simp
---   -- | query_bind i t oa h => simp [probFailure_bind_eq_tsum, h]
+--   -- | query_bind i t oa h => simp [probFailure_bind_eq_add_tsum, h]
 
 -- @[simp]
 -- lemma probFailure_pos_iff (oa : OracleComp spec α) : 0 < [⊥ | oa] ↔ ¬ oa.NeverFail := by
@@ -686,7 +512,7 @@ end support
 --   | pure x => simp
 --   | failure => simp
 --   | query_bind i t oa hq => {
---     simp [probFailure_bind_eq_tsum, h, hq]
+--     simp [probFailure_bind_eq_add_tsum, h, hq]
 --     intro s
 --     rw [ENNReal.tsum_prod']
 --     refine tsum_congr fun x => ?_

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -389,7 +389,9 @@ end uniformSelectFinset
 section uniformSelectArray
 
 instance {α : Type _} : HasUniformSelect (Array α) α where
-  uniformSelect xs := do (xs[← $[0..xs.size]]?).getM
+  uniformSelect xs := if h : xs.size = 0 then failure else do
+    let u ← $[0..xs.size-1]
+    return xs[u] -- Note the in-index bound here relies on `h`.
 
 end uniformSelectArray
 

--- a/VCVio/OracleComp/SimSemantics/WriterT.lean
+++ b/VCVio/OracleComp/SimSemantics/WriterT.lean
@@ -42,7 +42,7 @@ variable {ι : Type u} {spec : OracleSpec ι} {α : Type u} {ω : Type u} [Monoi
 --   induction oa using OracleComp.inductionOn with
 --   | pure x => simp
 --   | query_bind i t oa h =>
---       simp [probFailure_bind_eq_tsum, h, hso']
+--       simp [probFailure_bind_eq_add_tsum, h, hso']
 --       rw [ENNReal.tsum_prod']
 --       refine tsum_congr fun x => ?_
 --       simp [ENNReal.tsum_mul_right]


### PR DESCRIPTION
This PR contains a number of probability lemmas that were missing after 4.26, adjusts some `simp` and `grind` tags, and fills in a few `sorry`. instances.