### PR TITLE
Add normalized vcspec IR and compiled unary rules

### DIFF
--- a/VCVio/ProgramLogic/Tactics/Common.lean
+++ b/VCVio/ProgramLogic/Tactics/Common.lean
@@ -6,5 +6,7 @@ Authors: Quang Dao
 
 import VCVio.ProgramLogic.Tactics.Common.Core
 import VCVio.ProgramLogic.Tactics.Common.Naming
+import VCVio.ProgramLogic.Tactics.Common.SpecIR
 import VCVio.ProgramLogic.Tactics.Common.Registry
+import VCVio.ProgramLogic.Tactics.Common.CompiledRules
 import VCVio.ProgramLogic.Tactics.Common.Suggestions

--- a/VCVio/ProgramLogic/Tactics/Common/CompiledRules.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/CompiledRules.lean
@@ -1,0 +1,57 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import VCVio.ProgramLogic.Tactics.Common.Registry
+
+open Lean Elab Meta
+
+namespace OracleComp.ProgramLogic
+
+inductive UnaryRuleApplicationMode where
+  | direct
+  | tripleConseq
+  deriving Inhabited, BEq, Repr
+
+structure CompiledUnaryVCSpecRule where
+  entry : VCSpecEntry
+  modes : Array UnaryRuleApplicationMode
+  deriving Inhabited, Repr
+
+def CompiledUnaryVCSpecRule.theoremName (rule : CompiledUnaryVCSpecRule) : Name :=
+  rule.entry.decl
+
+def CompiledUnaryVCSpecRule.kind (rule : CompiledUnaryVCSpecRule) : VCSpecKind :=
+  rule.entry.kind
+
+def CompiledUnaryVCSpecRule.replayText (rule : CompiledUnaryVCSpecRule) : String :=
+  s!"vcstep with {rule.theoremName}"
+
+def CompiledUnaryVCSpecRule.canUseConsequence (rule : CompiledUnaryVCSpecRule) : Bool :=
+  rule.modes.contains .tripleConseq
+
+def compileUnaryVCSpecRule? (entry : VCSpecEntry) : Option CompiledUnaryVCSpecRule :=
+  match entry.kind with
+  | .unaryTriple =>
+      let modes :=
+        if entry.spec.postShape == .concrete then
+          #[.direct, .tripleConseq]
+        else
+          #[.direct]
+      some { entry, modes }
+  | .unaryWP =>
+      some { entry, modes := #[.direct] }
+  | _ => none
+
+def compileUnaryVCSpecRules (entries : Array VCSpecEntry) : Array CompiledUnaryVCSpecRule :=
+  entries.filterMap compileUnaryVCSpecRule?
+
+def getCompiledUnaryVCSpecRules (comp : Expr) : MetaM (Array CompiledUnaryVCSpecRule) := do
+  return compileUnaryVCSpecRules (← getRegisteredUnaryVCSpecEntries comp)
+
+def getCompiledUnaryVCSpecRulesOfKind (kind : VCSpecKind) : CoreM (Array CompiledUnaryVCSpecRule) := do
+  return compileUnaryVCSpecRules (← getVCSpecEntriesOfKind kind)
+
+end OracleComp.ProgramLogic

--- a/VCVio/ProgramLogic/Tactics/Common/Core.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/Core.lean
@@ -119,11 +119,33 @@ def wpGoalComp? (target : Expr) : Option Expr := do
   let #[oa, _post] := args | none
   some oa
 
+def wpGoalParts? (target : Expr) : Option (Expr × Expr) := do
+  let app ← findAppWithHead? ``OracleComp.ProgramLogic.wp target
+  let args ← trailingArgs? app 2
+  let #[oa, post] := args | none
+  some (oa, post)
+
+def rawWPGoalParts? (target : Expr) : Option (Expr × Expr × Expr) := do
+  let target := target.consumeMData
+  if target.isAppOfArity ``LE.le 4 then
+    let pre := target.getArg! 2
+    let rhs := target.getArg! 3
+    let (oa, post) ← wpGoalParts? rhs
+    some (pre, oa, post)
+  else
+    none
+
 def tripleGoalComp? (target : Expr) : Option Expr := do
   let app ← findAppWithHead? ``OracleComp.ProgramLogic.Triple target
   let args ← trailingArgs? app 3
   let #[_pre, oa, _post] := args | none
   some oa
+
+def tripleGoalParts? (target : Expr) : Option (Expr × Expr × Expr) := do
+  let app ← findAppWithHead? ``OracleComp.ProgramLogic.Triple target
+  let args ← trailingArgs? app 3
+  let #[pre, oa, post] := args | none
+  some (pre, oa, post)
 
 def isSimulateQAction (e : Expr) : Bool :=
   (findAppWithHead? ``simulateQ e).isSome

--- a/VCVio/ProgramLogic/Tactics/Common/Registry.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/Registry.lean
@@ -5,24 +5,22 @@ Authors: Quang Dao
 -/
 
 import Lean
-import VCVio.ProgramLogic.Tactics.Common.Core
+import VCVio.ProgramLogic.Tactics.Common.SpecIR
 
 open Lean Elab Meta
 
 namespace OracleComp.ProgramLogic
 
-inductive VCSpecKind where
-  | unaryTriple
-  | unaryWP
-  | relTriple
-  | relWP
-  | eRelTriple
-  deriving Inhabited, BEq, Repr
-
 structure VCSpecEntry where
   decl : Name
-  kind : VCSpecKind
+  spec : NormalizedVCSpec
   deriving Inhabited, BEq, Repr
+
+def VCSpecEntry.kind (entry : VCSpecEntry) : VCSpecKind :=
+  entry.spec.kind
+
+def VCSpecEntry.lookupKey (entry : VCSpecEntry) : VCSpecLookupKey :=
+  entry.spec.lookupKey
 
 structure VCSpecRegistry where
   all : Array VCSpecEntry := #[]
@@ -49,50 +47,16 @@ private def VCSpecRegistry.addRelational
   { registry with
       relational := registry.relational.insert leftHead (inner.insert rightHead (prev.push entry)) }
 
-private def headConstNameOrError (attrName : Name) (kindMsg : String) (comp : Expr) :
-    MetaM Name := do
-  let comp ← whnfReducible (← instantiateMVars comp)
-  let some head := headConstName? comp
-    | throwError
-        m!"@[{attrName}] only supports {kindMsg} with a constant head symbol, got:{indentExpr comp}"
-  return head
-
-private def relationalHeadsOrError (oa ob : Expr) : MetaM (Name × Name) := do
-  let leftHead ← headConstNameOrError `vcspec "relational left computations" oa
-  let rightHead ← headConstNameOrError `vcspec "relational right computations" ob
-  return (leftHead, rightHead)
-
-private def detectVCSpecShape (declTy : Expr) : MetaM (VCSpecKind × Sum Name (Name × Name)) := do
-  let (_, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
-  if let some comp := tripleGoalComp? targetTy then
-    return (.unaryTriple, .inl (← headConstNameOrError `vcspec "unary computations" comp))
-  if let some comp := wpGoalComp? targetTy then
-    return (.unaryWP, .inl (← headConstNameOrError `vcspec "unary computations" comp))
-  if let some (oa, ob, _) := relTripleGoalParts? targetTy then
-    return (.relTriple, .inr (← relationalHeadsOrError oa ob))
-  if let some (oa, ob, _) := relWPGoalParts? targetTy then
-    return (.relWP, .inr (← relationalHeadsOrError oa ob))
-  if let some (_, oa, ob, _) := eRelTripleGoalParts? targetTy then
-    return (.eRelTriple, .inr (← relationalHeadsOrError oa ob))
-  throwError
-    m!"@[vcspec] expects a theorem whose target is one of:\n\
-    - a unary `Triple`\n\
-    - a unary raw `wp` goal\n\
-    - a relational `RelTriple`\n\
-    - a relational raw `RelWP`\n\
-    - an `eRelTriple`\n\
-    got:{indentExpr declTy}"
-
 initialize vcSpecRegistry :
     SimpleScopedEnvExtension
-      (VCSpecEntry × Sum Name (Name × Name))
+      VCSpecEntry
       VCSpecRegistry ←
   registerSimpleScopedEnvExtension {
-    addEntry := fun registry (entry, key) =>
+    addEntry := fun registry entry =>
       let registry := { registry with all := registry.all.push entry }
-      match key with
-      | .inl head => registry.addUnary head entry
-      | .inr (leftHead, rightHead) => registry.addRelational leftHead rightHead entry
+      match entry.lookupKey with
+      | .unary head => registry.addUnary head entry
+      | .relational leftHead rightHead => registry.addRelational leftHead rightHead entry
     initial := {}
   }
 
@@ -101,8 +65,8 @@ initialize registerBuiltinAttribute {
   descr := "Register a unary or relational program-logic theorem for vcgen/rvcgen lookup."
   add := fun decl _ kind => MetaM.run' do
     let declTy := (← getConstInfo decl).type
-    let (specKind, key) ← detectVCSpecShape declTy
-    vcSpecRegistry.add ({ decl, kind := specKind }, key) kind
+    let spec ← normalizeVCSpecTarget `vcspec declTy
+    vcSpecRegistry.add { decl, spec } kind
 }
 
 private def getUnaryEntriesForHead (head : Name) : CoreM (Array VCSpecEntry) := do
@@ -146,5 +110,11 @@ def getVCSpecEntriesOfKind (kind : VCSpecKind) : CoreM (Array VCSpecEntry) := do
 
 def getVCSpecTheoremsOfKind (kind : VCSpecKind) : CoreM (Array Name) := do
   return (← getVCSpecEntriesOfKind kind).map (·.decl)
+
+def getNormalizedUnaryVCSpecs (comp : Expr) : MetaM (Array NormalizedVCSpec) := do
+  return (← getRegisteredUnaryVCSpecEntries comp).map (·.spec)
+
+def getNormalizedRelationalVCSpecs (oa ob : Expr) : MetaM (Array NormalizedVCSpec) := do
+  return (← getRegisteredRelationalVCSpecEntries oa ob).map (·.spec)
 
 end OracleComp.ProgramLogic

--- a/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
@@ -1,0 +1,115 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import Lean
+import VCVio.ProgramLogic.Tactics.Common.Core
+
+open Lean Elab Meta
+
+namespace OracleComp.ProgramLogic
+
+inductive VCSpecKind where
+  | unaryTriple
+  | unaryWP
+  | relTriple
+  | relWP
+  | eRelTriple
+  deriving Inhabited, BEq, Repr
+
+inductive VCSpecLookupKey where
+  | unary (head : Name)
+  | relational (leftHead rightHead : Name)
+  deriving Inhabited, BEq, Repr
+
+inductive VCSpecArgShape where
+  | schematic
+  | concrete
+  deriving Inhabited, BEq, Repr
+
+structure NormalizedVCSpec where
+  kind : VCSpecKind
+  lookupKey : VCSpecLookupKey
+  theoremBinderCount : Nat
+  preShape : Option VCSpecArgShape
+  postShape : VCSpecArgShape
+  deriving Inhabited, BEq, Repr
+
+def VCSpecLookupKey.toLegacyKey : VCSpecLookupKey → Sum Name (Name × Name)
+  | .unary head => .inl head
+  | .relational leftHead rightHead => .inr (leftHead, rightHead)
+
+private def classifyArgShape (e : Expr) : VCSpecArgShape :=
+  if e.consumeMData.isFVar then
+    .schematic
+  else
+    .concrete
+
+private def headConstNameOrError (attrName : Name) (kindMsg : String) (comp : Expr) :
+    MetaM Name := do
+  let comp ← whnfReducible (← instantiateMVars comp)
+  let some head := headConstName? comp
+    | throwError
+        m!"@[{attrName}] only supports {kindMsg} with a constant head symbol, got:{indentExpr comp}"
+  return head
+
+private def relationalLookupKeyOrError (oa ob : Expr) : MetaM VCSpecLookupKey := do
+  let leftHead ← headConstNameOrError `vcspec "relational left computations" oa
+  let rightHead ← headConstNameOrError `vcspec "relational right computations" ob
+  return .relational leftHead rightHead
+
+def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVCSpec := do
+  let (xs, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
+  let binderCount := xs.size
+  if let some (pre, comp, post) := tripleGoalParts? targetTy then
+    return {
+      kind := .unaryTriple
+      lookupKey := .unary (← headConstNameOrError attrName "unary computations" comp)
+      theoremBinderCount := binderCount
+      preShape := some (classifyArgShape pre)
+      postShape := classifyArgShape post
+    }
+  if let some (pre, comp, post) := rawWPGoalParts? targetTy then
+    return {
+      kind := .unaryWP
+      lookupKey := .unary (← headConstNameOrError attrName "unary computations" comp)
+      theoremBinderCount := binderCount
+      preShape := some (classifyArgShape pre)
+      postShape := classifyArgShape post
+    }
+  if let some (oa, ob, post) := relTripleGoalParts? targetTy then
+    return {
+      kind := .relTriple
+      lookupKey := ← relationalLookupKeyOrError oa ob
+      theoremBinderCount := binderCount
+      preShape := none
+      postShape := classifyArgShape post
+    }
+  if let some (oa, ob, post) := relWPGoalParts? targetTy then
+    return {
+      kind := .relWP
+      lookupKey := ← relationalLookupKeyOrError oa ob
+      theoremBinderCount := binderCount
+      preShape := none
+      postShape := classifyArgShape post
+    }
+  if let some (pre, oa, ob, post) := eRelTripleGoalParts? targetTy then
+    return {
+      kind := .eRelTriple
+      lookupKey := ← relationalLookupKeyOrError oa ob
+      theoremBinderCount := binderCount
+      preShape := some (classifyArgShape pre)
+      postShape := classifyArgShape post
+    }
+  throwError
+    m!"@[{attrName}] expects a theorem whose target is one of:\n\
+    - a unary `Triple`\n\
+    - a unary raw `wp` goal\n\
+    - a relational `RelTriple`\n\
+    - a relational raw `RelWP`\n\
+    - an `eRelTriple`\n\
+    got:{indentExpr declTy}"
+
+end OracleComp.ProgramLogic

--- a/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
@@ -79,6 +79,14 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
       preShape := some (classifyArgShape pre)
       postShape := classifyArgShape post
     }
+  if let some (comp, post) := wpGoalParts? targetTy then
+    return {
+      kind := .unaryWP
+      lookupKey := .unary (← headConstNameOrError attrName "unary computations" comp)
+      theoremBinderCount := binderCount
+      preShape := none
+      postShape := classifyArgShape post
+    }
   if let some (oa, ob, post) := relTripleGoalParts? targetTy then
     return {
       kind := .relTriple

--- a/VCVio/ProgramLogic/Tactics/Examples.lean
+++ b/VCVio/ProgramLogic/Tactics/Examples.lean
@@ -39,6 +39,10 @@ example (oa : OracleComp spec α) :
 
 section Unary
 
+@[local vcspec] theorem wp_pure_eq_spec (x : α) (post : α → ℝ≥0∞) :
+    wp⟦(pure x : OracleComp spec α)⟧ post = post x := by
+  simp [OracleComp.ProgramLogic.wp]
+
 example (x : α) (post : α → ℝ≥0∞) :
     wp⟦(pure x : OracleComp spec α)⟧ post = post x := by
   vcstep

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -126,13 +126,21 @@ private def runVCGenStepWithTheoremConseq
   saved.restore
   return false
 
-private def theoremHasConcreteUnaryPost (thm : Name) : MetaM Bool := do
-  let declTy := (← getConstInfo thm).type
-  let (_, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
-  if let some app := findAppWithHead? ``OracleComp.ProgramLogic.Triple targetTy then
-    if let some args := trailingArgs? app 3 then
-      let post := (args[2]!).consumeMData
-      return !(post.isMVar || post.isFVar || post.isBVar)
+private def runCompiledUnaryRuleMode
+    (rule : CompiledUnaryVCSpecRule)
+    (mode : UnaryRuleApplicationMode)
+    (requireClosed : Bool := false) : TacticM Bool := do
+  match mode with
+  | .direct =>
+      runVCGenStepWithTheoremDirect (mkIdent rule.theoremName) requireClosed
+  | .tripleConseq =>
+      runVCGenStepWithTheoremConseq (mkIdent rule.theoremName) requireClosed
+
+private def runCompiledUnaryRule
+    (rule : CompiledUnaryVCSpecRule) (requireClosed : Bool := false) : TacticM Bool := do
+  for mode in rule.modes do
+    if ← runCompiledUnaryRuleMode rule mode requireClosed then
+      return true
   return false
 
 /-- Apply an explicit unary theorem/assumption step and try to close any easy side goals.
@@ -338,45 +346,34 @@ private def unaryGoalKindAndComp? (target : Expr) : Option (VCSpecKind × Expr) 
       | none => none
 
 /-- Find the registered theorems whose bounded application makes progress. -/
-def findRegisteredVCGenTheoremCandidates : TacticM (Array Name) := do
+def findRegisteredVCGenRuleCandidates : TacticM (Array CompiledUnaryVCSpecRule) := do
   let target ← instantiateMVars (← getMainTarget)
   let some (kind, comp) := unaryGoalKindAndComp? target | return #[]
   let direct :=
-    ((← getRegisteredUnaryVCSpecEntries comp).filter (·.kind == kind)).map (·.decl)
+    (← getCompiledUnaryVCSpecRules comp).filter (·.kind == kind)
   let fallback :=
-    (← getVCSpecTheoremsOfKind kind).filter (fun name => !(direct.contains name))
-  let mut found : Array Name := #[]
-  for thm in direct.toList.take 8 do
+    (← getCompiledUnaryVCSpecRulesOfKind kind).filter fun rule =>
+      !(direct.any fun directRule => directRule.theoremName == rule.theoremName)
+  let mut found : Array CompiledUnaryVCSpecRule := #[]
+  for rule in direct.toList.take 8 do
     let saved ← saveState
-    let ok ←
-      if ← runVCGenStepWithTheoremDirect (mkIdent thm) then
-        pure true
-      else if ← theoremHasConcreteUnaryPost thm then
-        runVCGenStepWithTheoremConseq (mkIdent thm)
-      else
-        pure false
+    let ok ← runCompiledUnaryRule rule
     saved.restore
     if ok then
-      found := found.push thm
+      found := found.push rule
   unless found.isEmpty do
     return found
-  for thm in fallback.toList.take 8 do
+  for rule in fallback.toList.take 8 do
     let saved ← saveState
-    let ok ←
-      if ← runVCGenStepWithTheoremDirect (mkIdent thm) then
-        pure true
-      else if ← theoremHasConcreteUnaryPost thm then
-        runVCGenStepWithTheoremConseq (mkIdent thm)
-      else
-        pure false
+    let ok ← runCompiledUnaryRule rule
     saved.restore
     if ok then
-      found := found.push thm
+      found := found.push rule
   return found
 
 /-- Find the first registered theorem whose bounded application makes progress. -/
-def findRegisteredVCGenTheorem? : TacticM (Option Name) := do
-  return (← findRegisteredVCGenTheoremCandidates).toList.head?
+def findRegisteredVCGenRule? : TacticM (Option CompiledUnaryVCSpecRule) := do
+  return (← findRegisteredVCGenRuleCandidates).toList.head?
 
 def throwVCGenStepError : TacticM Unit := withMainContext do
   let target ← instantiateMVars (← getMainTarget)
@@ -400,7 +397,7 @@ def throwVCGenStepError : TacticM Unit := withMainContext do
       else if let some comp := wpGoalComp? target then
         let comp ← whnfReducible (← instantiateMVars comp)
         let theoremMsg ← do
-          let thms ← findRegisteredVCGenTheoremCandidates
+          let thms := (← findRegisteredVCGenRuleCandidates).map (·.theoremName)
           pure <| if thms.isEmpty then "" else
             s!"\nRegistered `@[vcspec]` candidates: {formatCandidateNames thms}"
         throwError
@@ -425,7 +422,7 @@ def throwVCGenStepError : TacticM Unit := withMainContext do
         else
           pure ""
       let theoremMsg ← do
-        let thms ← findRegisteredVCGenTheoremCandidates
+        let thms := (← findRegisteredVCGenRuleCandidates).map (·.theoremName)
         pure <| if thms.isEmpty then "" else
           s!"\nRegistered `@[vcspec]` candidates: {formatCandidateNames thms}"
       throwError
@@ -900,11 +897,11 @@ private def chooseBestInvariantStep? : TacticM (Option (PlannedStep × PreviewRe
   chooseBestPlannedStepCandidate? steps
 
 private def chooseBestTheoremStep? : TacticM (Option (PlannedStep × PreviewResult)) := do
-  let steps := (← findRegisteredVCGenTheoremCandidates).map fun theoremName =>
+  let steps := (← findRegisteredVCGenRuleCandidates).map fun rule =>
     mkVCGenPlannedStep
-      "vcgen registered theorem"
-      s!"vcstep with {theoremName}"
-      (runVCGenStepWithTheorem (mkIdent theoremName))
+      "vcgen compiled theorem rule"
+      rule.replayText
+      (runCompiledUnaryRule rule)
   chooseBestPlannedStepCandidate? steps
 
 private def planExplicitProbEqStep? (plainPreview : PreviewResult) :
@@ -1010,8 +1007,8 @@ def runVCGenStep : TacticM Bool := do
       return true
   if ← runVCGenStructuralCore then
     return true
-  if let some theoremName ← findRegisteredVCGenTheorem? then
-    if ← runVCGenStepWithTheorem (mkIdent theoremName) then
+  if let some rule ← findRegisteredVCGenRule? then
+    if ← runCompiledUnaryRule rule then
       return true
   tryCloseSpecGoal
 


### PR DESCRIPTION
## Summary
- add a normalized `@[vcspec]` spec IR with coarse pre/post shape metadata and explicit unary/relational lookup keys
- add compiled unary vcspec rules and migrate unary theorem-backed candidate selection and planner replay onto those compiled rules
- keep the public tactic surface stable while preserving the current tactic examples and downstream proof builds

## Validation
- `lake build VCVio.ProgramLogic.Tactics.Common.CompiledRules VCVio.ProgramLogic.Tactics.Unary.Internals VCVio.ProgramLogic.Tactics.Unary`
- `lake build VCVio.ProgramLogic.Tactics.Examples Examples.OneTimePad Examples.Schnorr Examples.ElGamal VCVio.CryptoFoundations.FiatShamir`

Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.