### PR TITLE
Share planner step ranking across unary and relational tactics

### DIFF
--- a/VCVio/ProgramLogic/Tactics/Common/Core.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/Core.lean
@@ -58,6 +58,37 @@ def previewPlannedStep (step : PlannedStep) : TacticM Bool :=
 def previewPlannedStepWithGoals (step : PlannedStep) : TacticM PreviewResult :=
   previewActionWithGoals step.run
 
+def renderPlannedStepPreview (step : PlannedStep) (preview : PreviewResult) : String :=
+  s!"{step.replayText} -> {preview.goalCount} goal(s)"
+
+def attachPlannerChoiceNotes
+    (step : PlannedStep) (preview : PreviewResult) (alternatives : Array String) : PlannedStep :=
+  withStepNotes step <|
+    [s!"planner preview leaves {preview.goalCount} goal(s)"] ++
+      if alternatives.isEmpty then
+        []
+      else
+        [s!"alternatives: {String.intercalate "; " alternatives.toList}"]
+
+def chooseBestPlannedStepCandidate? (steps : Array PlannedStep) :
+    TacticM (Option (PlannedStep × PreviewResult)) := do
+  let mut best? : Option (PlannedStep × PreviewResult) := none
+  let mut accepted : Array String := #[]
+  for step in steps do
+    let preview ← previewPlannedStepWithGoals step
+    if preview.ok then
+      accepted := accepted.push (renderPlannedStepPreview step preview)
+      match best? with
+      | none => best? := some (step, preview)
+      | some (_, bestPreview) =>
+          if preview.goalCount < bestPreview.goalCount then
+            best? := some (step, preview)
+  match best? with
+  | none => return none
+  | some (step, preview) =>
+      let alternatives := accepted.filter (· != renderPlannedStepPreview step preview)
+      return some (attachPlannerChoiceNotes step preview alternatives, preview)
+
 def logPlannedStep (step : PlannedStep) (beforeGoals afterGoals : Nat) : TacticM Unit := do
   if vcvio.vcgen.traceSteps.get (← getOptions) then
     logInfo m!"[{step.label}] {step.replayText} (goals {beforeGoals} -> {afterGoals})"

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -20,18 +20,6 @@ attribute [vcspec]
 private def mkRVCGenPlannedStep (label replayText : String) (run : TacticM Bool) : PlannedStep :=
   { label, replayText, run }
 
-private def renderPlannedStepPreview (step : PlannedStep) (preview : PreviewResult) : String :=
-  s!"{step.replayText} -> {preview.goalCount} goal(s)"
-
-private def attachPlannerChoiceNotes
-    (step : PlannedStep) (preview : PreviewResult) (alternatives : Array String) : PlannedStep :=
-  withStepNotes step <|
-    [s!"planner preview leaves {preview.goalCount} goal(s)"] ++
-      if alternatives.isEmpty then
-        []
-      else
-        [s!"alternatives: {String.intercalate "; " alternatives.toList}"]
-
 def tryCloseRelGoalImmediate : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic| assumption)) <||>
   tryEvalTacticSyntax (← `(tactic|
@@ -517,48 +505,21 @@ private def buildRelHintStep (hintName : Name) : TacticM PlannedStep := do
 
 private def chooseBestRelHintStep? : TacticM (Option (PlannedStep × PreviewResult)) := do
   let hintNames ← findRelHintCandidates
-  let mut best? : Option (PlannedStep × PreviewResult) := none
-  let mut accepted : Array String := #[]
+  let mut steps : Array PlannedStep := #[]
   for hintName in hintNames do
     let step ← buildRelHintStep hintName
-    let preview ← previewPlannedStepWithGoals step
-    if preview.ok then
-      accepted := accepted.push (renderPlannedStepPreview step preview)
-      match best? with
-      | none => best? := some (step, preview)
-      | some (_, bestPreview) =>
-          if preview.goalCount < bestPreview.goalCount then
-            best? := some (step, preview)
-  match best? with
-  | none => return none
-  | some (step, preview) =>
-      let alternatives := accepted.filter (· != renderPlannedStepPreview step preview)
-      return some (attachPlannerChoiceNotes step preview alternatives, preview)
+    steps := steps.push step
+  chooseBestPlannedStepCandidate? steps
 
 private def chooseBestRegisteredRVCGenTheoremStep? :
     TacticM (Option (PlannedStep × PreviewResult)) := do
   let theoremRules ← findRegisteredRVCGenRuleCandidates
-  let mut best? : Option (PlannedStep × PreviewResult) := none
-  let mut accepted : Array String := #[]
-  for rule in theoremRules do
-    let step :=
-      mkRVCGenPlannedStep
-        "rvcgen compiled theorem rule"
-        rule.replayText
-        (runCompiledRelationalRule rule)
-    let preview ← previewPlannedStepWithGoals step
-    if preview.ok then
-      accepted := accepted.push (renderPlannedStepPreview step preview)
-      match best? with
-      | none => best? := some (step, preview)
-      | some (_, bestPreview) =>
-          if preview.goalCount < bestPreview.goalCount then
-            best? := some (step, preview)
-  match best? with
-  | none => return none
-  | some (step, preview) =>
-      let alternatives := accepted.filter (· != renderPlannedStepPreview step preview)
-      return some (attachPlannerChoiceNotes step preview alternatives, preview)
+  let steps := theoremRules.map fun rule =>
+    mkRVCGenPlannedStep
+      "rvcgen compiled theorem rule"
+      rule.replayText
+      (runCompiledRelationalRule rule)
+  chooseBestPlannedStepCandidate? steps
 
 /-- Structural/default relational VCGen step, excluding explicit `using`-hint fallbacks. -/
 def runRVCGenStructuralCore : TacticM Bool := do

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -505,10 +505,7 @@ private def buildRelHintStep (hintName : Name) : TacticM PlannedStep := do
 
 private def chooseBestRelHintStep? : TacticM (Option (PlannedStep × PreviewResult)) := do
   let hintNames ← findRelHintCandidates
-  let mut steps : Array PlannedStep := #[]
-  for hintName in hintNames do
-    let step ← buildRelHintStep hintName
-    steps := steps.push step
+  let steps ← hintNames.mapM buildRelHintStep
   chooseBestPlannedStepCandidate? steps
 
 private def chooseBestRegisteredRVCGenTheoremStep? :

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -16,18 +16,6 @@ namespace Unary
 private def mkVCGenPlannedStep (label replayText : String) (run : TacticM Bool) : PlannedStep :=
   { label, replayText, run }
 
-private def renderPlannedStepPreview (step : PlannedStep) (preview : PreviewResult) : String :=
-  s!"{step.replayText} -> {preview.goalCount} goal(s)"
-
-private def attachPlannerChoiceNotes
-    (step : PlannedStep) (preview : PreviewResult) (alternatives : Array String) : PlannedStep :=
-  withStepNotes step <|
-    [s!"planner preview leaves {preview.goalCount} goal(s)"] ++
-      if alternatives.isEmpty then
-        []
-      else
-        [s!"alternatives: {String.intercalate "; " alternatives.toList}"]
-
 private def hasProbGoal (target : Expr) : Bool :=
   (findAppWithHead? ``probEvent target).isSome || (findAppWithHead? ``probOutput target).isSome
 
@@ -860,25 +848,6 @@ private def runVCGenStructuralCoreWithNames (names : Array Name) : TacticM Bool 
     renameInaccessibleNames names
     return true
   return false
-
-private def chooseBestPlannedStepCandidate? (steps : Array PlannedStep) :
-    TacticM (Option (PlannedStep × PreviewResult)) := do
-  let mut best? : Option (PlannedStep × PreviewResult) := none
-  let mut accepted : Array String := #[]
-  for step in steps do
-    let preview ← previewPlannedStepWithGoals step
-    if preview.ok then
-      accepted := accepted.push (renderPlannedStepPreview step preview)
-      match best? with
-      | none => best? := some (step, preview)
-      | some (_, bestPreview) =>
-          if preview.goalCount < bestPreview.goalCount then
-            best? := some (step, preview)
-  match best? with
-  | none => return none
-  | some (step, preview) =>
-      let alternatives := accepted.filter (· != renderPlannedStepPreview step preview)
-      return some (attachPlannerChoiceNotes step preview alternatives, preview)
 
 private def chooseBestCutStep? : TacticM (Option (PlannedStep × PreviewResult)) := do
   let steps := (← findHoareCutHintCandidates).map fun cutName =>


### PR DESCRIPTION
## Summary
- move generic planned-step preview rendering and best-candidate ranking into the shared common tactic layer
- switch both unary and relational tactic internals to the shared ranking helper for theorem, hint, and cut/invariant step selection
- reduce duplicated planner logic while preserving current replay suggestions and build behavior

## Validation
- `lake build VCVio.ProgramLogic.Tactics.Unary VCVio.ProgramLogic.Tactics.Relational VCVio.ProgramLogic.Tactics.Examples`

Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.