### PR TITLE
Prefer same-form vcspec fallback rules

### DIFF
--- a/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
@@ -95,10 +95,10 @@ def classifyVCSpecCompForm (comp : Expr) : VCSpecCompForm :=
     .listMapM
   else if isListFoldlMExpr comp then
     .listFoldlM
-  else if (findAppWithHead? ``query comp).isSome then
-    .query
   else if isSimulateQAction comp then
     .simulateQ
+  else if (findAppWithHead? ``query comp).isSome then
+    .query
   else
     .other
 
@@ -133,6 +133,7 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
     return {
       kind := .unaryWP
       lookupKey := .unary (← headConstNameOrError attrName "unary computations" comp)
+      compPattern := classifyUnaryCompPattern comp
       theoremBinderCount := binderCount
       preShape := none
       postShape := classifyArgShape post

--- a/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/SpecIR.lean
@@ -29,9 +29,28 @@ inductive VCSpecArgShape where
   | concrete
   deriving Inhabited, BEq, Repr
 
+inductive VCSpecCompForm where
+  | bind
+  | pure
+  | ite
+  | map
+  | replicate
+  | listMapM
+  | listFoldlM
+  | query
+  | simulateQ
+  | other
+  deriving Inhabited, BEq, Repr
+
+inductive VCSpecCompPattern where
+  | unary (form : VCSpecCompForm)
+  | relational (leftForm rightForm : VCSpecCompForm)
+  deriving Inhabited, BEq, Repr
+
 structure NormalizedVCSpec where
   kind : VCSpecKind
   lookupKey : VCSpecLookupKey
+  compPattern : VCSpecCompPattern
   theoremBinderCount : Nat
   preShape : Option VCSpecArgShape
   postShape : VCSpecArgShape
@@ -60,6 +79,35 @@ private def relationalLookupKeyOrError (oa ob : Expr) : MetaM VCSpecLookupKey :=
   let rightHead ← headConstNameOrError `vcspec "relational right computations" ob
   return .relational leftHead rightHead
 
+def classifyVCSpecCompForm (comp : Expr) : VCSpecCompForm :=
+  let comp := comp.consumeMData
+  if isBindExpr comp then
+    .bind
+  else if isPureExpr comp then
+    .pure
+  else if isIfExpr comp then
+    .ite
+  else if isMapExpr comp then
+    .map
+  else if isReplicateExpr comp then
+    .replicate
+  else if isListMapMExpr comp then
+    .listMapM
+  else if isListFoldlMExpr comp then
+    .listFoldlM
+  else if (findAppWithHead? ``query comp).isSome then
+    .query
+  else if isSimulateQAction comp then
+    .simulateQ
+  else
+    .other
+
+def classifyUnaryCompPattern (comp : Expr) : VCSpecCompPattern :=
+  .unary (classifyVCSpecCompForm comp)
+
+def classifyRelationalCompPattern (oa ob : Expr) : VCSpecCompPattern :=
+  .relational (classifyVCSpecCompForm oa) (classifyVCSpecCompForm ob)
+
 def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVCSpec := do
   let (xs, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
   let binderCount := xs.size
@@ -67,6 +115,7 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
     return {
       kind := .unaryTriple
       lookupKey := .unary (← headConstNameOrError attrName "unary computations" comp)
+      compPattern := classifyUnaryCompPattern comp
       theoremBinderCount := binderCount
       preShape := some (classifyArgShape pre)
       postShape := classifyArgShape post
@@ -75,6 +124,7 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
     return {
       kind := .unaryWP
       lookupKey := .unary (← headConstNameOrError attrName "unary computations" comp)
+      compPattern := classifyUnaryCompPattern comp
       theoremBinderCount := binderCount
       preShape := some (classifyArgShape pre)
       postShape := classifyArgShape post
@@ -91,6 +141,7 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
     return {
       kind := .relTriple
       lookupKey := ← relationalLookupKeyOrError oa ob
+      compPattern := classifyRelationalCompPattern oa ob
       theoremBinderCount := binderCount
       preShape := none
       postShape := classifyArgShape post
@@ -99,6 +150,7 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
     return {
       kind := .relWP
       lookupKey := ← relationalLookupKeyOrError oa ob
+      compPattern := classifyRelationalCompPattern oa ob
       theoremBinderCount := binderCount
       preShape := none
       postShape := classifyArgShape post
@@ -107,6 +159,7 @@ def normalizeVCSpecTarget (attrName : Name) (declTy : Expr) : MetaM NormalizedVC
     return {
       kind := .eRelTriple
       lookupKey := ← relationalLookupKeyOrError oa ob
+      compPattern := classifyRelationalCompPattern oa ob
       theoremBinderCount := binderCount
       preShape := some (classifyArgShape pre)
       postShape := classifyArgShape post

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -462,11 +462,14 @@ def findRegisteredRVCGenRuleCandidates : TacticM (Array CompiledRelationalVCSpec
   let target ← instantiateMVars (← getMainTarget)
   let some kind := relationalGoalKind? target | return #[]
   let some (oa, ob, _) := relationalGoalParts? target | return #[]
+  let goalPattern := classifyRelationalCompPattern oa ob
   let direct :=
     (← getCompiledRelationalVCSpecRules oa ob).filter (·.kind == kind)
-  let fallback :=
+  let fallbackAll :=
     (← getCompiledRelationalVCSpecRulesOfKind kind).filter fun rule =>
       !(direct.any fun directRule => directRule.theoremName == rule.theoremName)
+  let fallbackPreferred := fallbackAll.filter (·.entry.spec.compPattern == goalPattern)
+  let fallbackFallback := fallbackAll.filter (·.entry.spec.compPattern != goalPattern)
   let mut found : Array CompiledRelationalVCSpecRule := #[]
   for rule in direct.toList.take 8 do
     let saved ← saveState
@@ -476,12 +479,15 @@ def findRegisteredRVCGenRuleCandidates : TacticM (Array CompiledRelationalVCSpec
       found := found.push rule
   unless found.isEmpty do
     return found
-  for rule in fallback.toList.take 8 do
-    let saved ← saveState
-    let ok ← runCompiledRelationalRule rule
-    saved.restore
-    if ok then
-      found := found.push rule
+  for fallback in [fallbackPreferred, fallbackFallback] do
+    for rule in fallback.toList.take 8 do
+      let saved ← saveState
+      let ok ← runCompiledRelationalRule rule
+      saved.restore
+      if ok then
+        found := found.push rule
+    unless found.isEmpty do
+      return found
   return found
 
 private def buildRelHintStep (hintName : Name) : TacticM PlannedStep := do

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -337,11 +337,14 @@ private def unaryGoalKindAndComp? (target : Expr) : Option (VCSpecKind × Expr) 
 def findRegisteredVCGenRuleCandidates : TacticM (Array CompiledUnaryVCSpecRule) := do
   let target ← instantiateMVars (← getMainTarget)
   let some (kind, comp) := unaryGoalKindAndComp? target | return #[]
+  let goalPattern := classifyUnaryCompPattern comp
   let direct :=
     (← getCompiledUnaryVCSpecRules comp).filter (·.kind == kind)
-  let fallback :=
+  let fallbackAll :=
     (← getCompiledUnaryVCSpecRulesOfKind kind).filter fun rule =>
       !(direct.any fun directRule => directRule.theoremName == rule.theoremName)
+  let fallbackPreferred := fallbackAll.filter (·.entry.spec.compPattern == goalPattern)
+  let fallbackFallback := fallbackAll.filter (·.entry.spec.compPattern != goalPattern)
   let mut found : Array CompiledUnaryVCSpecRule := #[]
   for rule in direct.toList.take 8 do
     let saved ← saveState
@@ -351,12 +354,15 @@ def findRegisteredVCGenRuleCandidates : TacticM (Array CompiledUnaryVCSpecRule) 
       found := found.push rule
   unless found.isEmpty do
     return found
-  for rule in fallback.toList.take 8 do
-    let saved ← saveState
-    let ok ← runCompiledUnaryRule rule
-    saved.restore
-    if ok then
-      found := found.push rule
+  for fallback in [fallbackPreferred, fallbackFallback] do
+    for rule in fallback.toList.take 8 do
+      let saved ← saveState
+      let ok ← runCompiledUnaryRule rule
+      saved.restore
+      if ok then
+        found := found.push rule
+    unless found.isEmpty do
+      return found
   return found
 
 /-- Find the first registered theorem whose bounded application makes progress. -/


### PR DESCRIPTION
## Summary
- extend the normalized vcspec IR with coarse computation-form tags for unary and relational computations
- prefer same-form compiled vcspec fallback rules before probing the broader same-kind candidate pool
- improve structural matching behavior conservatively without changing the public tactic surface

## Validation
- `lake build VCVio.ProgramLogic.Tactics.Common.SpecIR VCVio.ProgramLogic.Tactics.Unary VCVio.ProgramLogic.Tactics.Relational VCVio.ProgramLogic.Tactics.Examples`

Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.