### PR TITLE
feat(examples): finish simple PIR proof and loop bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /.lake/
 .DS_Store
 /.ignore/
+/.gauss/
 
 # LaTeX compilation files
 *.aux

--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -60,49 +60,11 @@ namespace br93AsymmEnc
 
 variable {tdp : TrapdoorPermutation PK SK Rand} {hash : Rand → M}
 
-set_option maxHeartbeats 400000 in
 /-- Correctness of BR93 follows from correctness of the underlying trapdoor permutation. -/
 theorem correct (hcorrect : tdp.Correct) :
     (br93AsymmEnc (M := M) tdp hash).PerfectlyCorrect := by
   intro msg
-  simp only [AsymmEncAlg.CorrectExp, br93AsymmEnc_keygen, br93AsymmEnc_encrypt,
-    br93AsymmEnc_decrypt]
-  have huniq : ∀ y ∈ support ((br93AsymmEnc tdp hash).exec (do
-    let x ← tdp.keygen
-    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x.1 r, hash r + msg))
-    let msg' ← pure (some (c.2 - hash (tdp.inverse x.2 c.1)))
-    pure (decide (msg' = some msg)))), y = true := by
-    intro y hy
-    rw [show (br93AsymmEnc tdp hash).exec = id from rfl] at hy
-    simp only [id] at hy
-    rw [mem_support_bind_iff] at hy
-    obtain ⟨⟨pk, sk⟩, hpksk, hy⟩ := hy
-    rw [mem_support_bind_iff] at hy
-    obtain ⟨c, hc, hy⟩ := hy
-    rw [mem_support_bind_iff] at hc
-    obtain ⟨r, _, hc⟩ := hc
-    simp only [support_pure, Set.mem_singleton_iff] at hc hy
-    subst hc; subst hy
-    simp [hcorrect pk sk hpksk r]
-  have hnot : ∀ y ≠ true, Pr[= y | (br93AsymmEnc tdp hash).exec (do
-    let x ← tdp.keygen
-    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x.1 r, hash r + msg))
-    let msg' ← pure (some (c.2 - hash (tdp.inverse x.2 c.1)))
-    pure (decide (msg' = some msg)))] = 0 :=
-    fun y hy => (probOutput_eq_zero_iff _ _).mpr (fun hmem => hy (huniq y hmem))
-  have hsum : ∑' x, Pr[= x | (br93AsymmEnc tdp hash).exec (do
-    let x_1 ← tdp.keygen
-    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x_1.1 r, hash r + msg))
-    let msg' ← pure (some (c.2 - hash (tdp.inverse x_1.2 c.1)))
-    pure (decide (msg' = some msg)))] = Pr[= true | _] :=
-    tsum_eq_single true hnot
-  have htot := probFailure_add_tsum_probOutput ((br93AsymmEnc tdp hash).exec (do
-    let x ← tdp.keygen
-    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x.1 r, hash r + msg))
-    let msg' ← pure (some (c.2 - hash (tdp.inverse x.2 c.1)))
-    pure (decide (msg' = some msg))))
-  rw [NeverFail.probFailure_eq_zero, hsum, zero_add] at htot
-  exact htot
+  sorry
 
 /-! ## One-time IND-CPA in the random-oracle model -/
 
@@ -271,15 +233,7 @@ reduction. -/
 theorem indcpa_bound (adv : CPA_Adv (PK := PK) (Rand := Rand) (M := M)) :
     |(Pr[= true | cpaGame tdp adv]).toReal - 1 / 2| ≤
       (tdpAdvantage tdp (inverter tdp adv)).toReal := by
-  have hg12 : Pr[= true | game1 tdp adv] = Pr[= true | game2 tdp adv] :=
-    congr_fun (congr_arg _ (game1_eq_game2 adv)) true
-  calc |(Pr[= true | cpaGame tdp adv]).toReal - 1 / 2|
-      = |(Pr[= true | cpaGame tdp adv]).toReal -
-          (Pr[= true | game1 tdp adv]).toReal| := by
-        congr 1; rw [hg12, game2_eq_half adv]; norm_num
-    _ ≤ badEventProb tdp adv := cpaGame_gap_le_badEvent adv
-    _ ≤ (tdpAdvantage tdp (inverter tdp adv)).toReal :=
-        badEventProb_le_tdpAdvantage adv
+  sorry
 
 end br93AsymmEnc
 

--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -60,11 +60,49 @@ namespace br93AsymmEnc
 
 variable {tdp : TrapdoorPermutation PK SK Rand} {hash : Rand → M}
 
+set_option maxHeartbeats 400000 in
 /-- Correctness of BR93 follows from correctness of the underlying trapdoor permutation. -/
 theorem correct (hcorrect : tdp.Correct) :
     (br93AsymmEnc (M := M) tdp hash).PerfectlyCorrect := by
   intro msg
-  sorry
+  simp only [AsymmEncAlg.CorrectExp, br93AsymmEnc_keygen, br93AsymmEnc_encrypt,
+    br93AsymmEnc_decrypt]
+  have huniq : ∀ y ∈ support ((br93AsymmEnc tdp hash).exec (do
+    let x ← tdp.keygen
+    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x.1 r, hash r + msg))
+    let msg' ← pure (some (c.2 - hash (tdp.inverse x.2 c.1)))
+    pure (decide (msg' = some msg)))), y = true := by
+    intro y hy
+    rw [show (br93AsymmEnc tdp hash).exec = id from rfl] at hy
+    simp only [id] at hy
+    rw [mem_support_bind_iff] at hy
+    obtain ⟨⟨pk, sk⟩, hpksk, hy⟩ := hy
+    rw [mem_support_bind_iff] at hy
+    obtain ⟨c, hc, hy⟩ := hy
+    rw [mem_support_bind_iff] at hc
+    obtain ⟨r, _, hc⟩ := hc
+    simp only [support_pure, Set.mem_singleton_iff] at hc hy
+    subst hc; subst hy
+    simp [hcorrect pk sk hpksk r]
+  have hnot : ∀ y ≠ true, Pr[= y | (br93AsymmEnc tdp hash).exec (do
+    let x ← tdp.keygen
+    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x.1 r, hash r + msg))
+    let msg' ← pure (some (c.2 - hash (tdp.inverse x.2 c.1)))
+    pure (decide (msg' = some msg)))] = 0 :=
+    fun y hy => (probOutput_eq_zero_iff _ _).mpr (fun hmem => hy (huniq y hmem))
+  have hsum : ∑' x, Pr[= x | (br93AsymmEnc tdp hash).exec (do
+    let x_1 ← tdp.keygen
+    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x_1.1 r, hash r + msg))
+    let msg' ← pure (some (c.2 - hash (tdp.inverse x_1.2 c.1)))
+    pure (decide (msg' = some msg)))] = Pr[= true | _] :=
+    tsum_eq_single true hnot
+  have htot := probFailure_add_tsum_probOutput ((br93AsymmEnc tdp hash).exec (do
+    let x ← tdp.keygen
+    let c ← (do let r ← $ᵗ Rand; pure (tdp.forward x.1 r, hash r + msg))
+    let msg' ← pure (some (c.2 - hash (tdp.inverse x.2 c.1)))
+    pure (decide (msg' = some msg))))
+  rw [NeverFail.probFailure_eq_zero, hsum, zero_add] at htot
+  exact htot
 
 /-! ## One-time IND-CPA in the random-oracle model -/
 
@@ -233,7 +271,15 @@ reduction. -/
 theorem indcpa_bound (adv : CPA_Adv (PK := PK) (Rand := Rand) (M := M)) :
     |(Pr[= true | cpaGame tdp adv]).toReal - 1 / 2| ≤
       (tdpAdvantage tdp (inverter tdp adv)).toReal := by
-  sorry
+  have hg12 : Pr[= true | game1 tdp adv] = Pr[= true | game2 tdp adv] :=
+    congr_fun (congr_arg _ (game1_eq_game2 adv)) true
+  calc |(Pr[= true | cpaGame tdp adv]).toReal - 1 / 2|
+      = |(Pr[= true | cpaGame tdp adv]).toReal -
+          (Pr[= true | game1 tdp adv]).toReal| := by
+        congr 1; rw [hg12, game2_eq_half adv]; norm_num
+    _ ≤ badEventProb tdp adv := cpaGame_gap_le_badEvent adv
+    _ ≤ (tdpAdvantage tdp (inverter tdp adv)).toReal :=
+        badEventProb_le_tdpAdvantage adv
 
 end br93AsymmEnc
 

--- a/Examples/SimpleTwoServerPIR.lean
+++ b/Examples/SimpleTwoServerPIR.lean
@@ -45,6 +45,20 @@ open OracleComp OracleSpec ENNReal
 
 variable {N : ℕ}
 
+/-- Imperative-style PIR query generation using `for` / `let mut` syntax. -/
+def pirQuery' {N : ℕ} (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) := do
+  let mut s  : List (Fin N) := []
+  let mut s' : List (Fin N) := []
+  for j in List.finRange N do
+    let b ← $ᵗ Bool
+    if j = i₀ then
+      if b then s := j :: s else s' := j :: s'
+    else
+      if b then
+        s := j :: s
+        s' := j :: s'
+  return (s, s')
+
 /-- PIR query generation: build two index sets `s, s'` whose "symmetric difference"
 is `{i₀}`. Uses `foldlM` over `List.finRange N` with a random coin per index. -/
 def pirQuery {N : ℕ} (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) :=
@@ -55,6 +69,20 @@ def pirQuery {N : ℕ} (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) 
     else
       return if b then (j :: acc.1, j :: acc.2) else acc
   ) ([], [])
+
+/-- The imperative-style `pirQuery'` (using `for`/`let mut`) and the functional-style
+`pirQuery` (using `List.foldlM`) compute exactly the same oracle computation.
+
+Uses the general `List.forIn_mprod_yield_eq_foldlM` bridge from `ToMathlib.General`
+to convert the `for`/`let mut` desugaring (which uses `forIn` + `MProd` state +
+`ForInStep.yield`) into the direct `foldlM` formulation. The only proof obligation
+is showing that each branch of the loop body wraps its result in `ForInStep.yield`. -/
+theorem pirQuery'_eq_pirQuery {N : ℕ} (i₀ : Fin N) : pirQuery' i₀ = pirQuery i₀ := by
+  simp only [pirQuery', pirQuery, pure_bind]
+  exact List.forIn_mprod_yield_eq_foldlM _ _ _ _ _ (fun j b c => by
+    simp only [bind_assoc]
+    congr 1; ext b₁
+    split <;> split <;> simp)
 
 /-! ## Response computation and main protocol -/
 
@@ -72,6 +100,62 @@ def pirMain (a : Fin N → W) (i₀ : Fin N) : ProbComp W := do
 
 /-! ## Correctness -/
 
+private lemma foldl_add_shift {β : Type*} (g : β → W) (c : W) (l : List β) :
+    l.foldl (fun acc x => acc + g x) c = c + l.foldl (fun acc x => acc + g x) 0 := by
+  induction l generalizing c with
+  | nil => simp
+  | cons x t ih => simp only [List.foldl_cons]; rw [ih, ih (0 + g x), zero_add, add_assoc]
+
+private lemma pirResponse_cons (a : Fin N → W) (j : Fin N) (s : List (Fin N)) :
+    pirResponse a (j :: s) = a j + pirResponse a s := by
+  simp only [pirResponse, List.foldl_cons, zero_add]; exact foldl_add_shift _ (a j) s
+
+/-- For any output in the support of the foldlM, the sum of responses accumulates `a i₀`
+exactly when `i₀` appears in the fold list. -/
+private lemma pirQuery_foldl_support [DecidableEq W]
+    (hchar : ∀ x : W, x + x = 0) (a : Fin N → W) (i₀ : Fin N)
+    (l : List (Fin N)) (hl : l.Nodup)
+    (init ss : List (Fin N) × List (Fin N))
+    (hss : ss ∈ support (l.foldlM (fun acc j => do
+      let b ← $ᵗ Bool
+      if j = i₀ then
+        return if b then (j :: acc.1, acc.2) else (acc.1, j :: acc.2)
+      else
+        return if b then (j :: acc.1, j :: acc.2) else acc) init)) :
+    pirResponse a ss.1 + pirResponse a ss.2 =
+      pirResponse a init.1 + pirResponse a init.2 + if i₀ ∈ l then a i₀ else 0 := by
+  induction l generalizing init with
+  | nil => simp [List.foldlM] at hss; subst hss; simp
+  | cons j rest ih =>
+    rw [List.foldlM_cons] at hss
+    rw [mem_support_bind_iff] at hss
+    obtain ⟨mid, hmid, hss⟩ := hss
+    have hnodup := hl
+    rw [List.nodup_cons] at hnodup
+    have := ih hnodup.2 mid hss
+    rw [this]; clear this
+    -- Now show: mid response sum = init response sum + (if j = i₀ then a i₀ else 0)
+    -- and combine with the rest-of-list contribution
+    simp only [support_bind, Set.mem_iUnion] at hmid
+    obtain ⟨b, _, hmid⟩ := hmid
+    by_cases hj : j = i₀
+    · subst hj
+      simp [hnodup.1] at hmid ⊢
+      -- mid is either (j :: init.1, init.2) or (init.1, j :: init.2)
+      rcases b with _ | _  <;> simp at hmid <;> subst hmid <;>
+        simp [pirResponse_cons] <;> abel
+    · have hij : i₀ ≠ j := Ne.symm hj
+      simp only [hj, hij, ↓reduceIte, false_or, List.mem_cons] at hmid ⊢
+      rcases b with _ | _
+      · -- b = false: mid = init, unchanged
+        simp at hmid; subst hmid; rfl
+      · -- b = true: mid = (j :: init.1, j :: init.2)
+        simp at hmid; subst hmid; simp only [pirResponse_cons]; congr 1
+        have h := hchar (a j)
+        calc _ = (a j + a j) + (pirResponse a init.1 + pirResponse a init.2) := by abel
+          _ = 0 + _ := by rw [h]
+          _ = _ := by rw [zero_add]
+
 /-- Correctness: the PIR protocol always returns `a[i₀]`, assuming `W` has
 characteristic 2 (i.e. `x + x = 0` for all `x`). This ensures that database
 entries appearing in both query sets cancel out.
@@ -83,7 +167,27 @@ theorem pir_correct [DecidableEq W]
     (hchar : ∀ x : W, x + x = 0)
     (a : Fin N → W) (i₀ : Fin N) :
     Pr[= a i₀ | pirMain a i₀] = 1 := by
-  sorry
+  -- Every output of pirMain a i₀ equals a i₀
+  have huniq : ∀ y ∈ support (pirMain a i₀), y = a i₀ := by
+    intro y hy
+    rw [pirMain, pirQuery] at hy
+    rw [mem_support_bind_iff] at hy
+    obtain ⟨ss, hss, hy⟩ := hy
+    rw [support_pure, Set.mem_singleton_iff] at hy
+    have h := pirQuery_foldl_support hchar a i₀ (List.finRange N)
+      (List.nodup_finRange N) ([], []) ss hss
+    simp [pirResponse] at h
+    exact hy.trans h
+  -- All outputs other than a i₀ have probability 0
+  have hnot : ∀ y ≠ a i₀, Pr[= y | pirMain a i₀] = 0 :=
+    fun y hy => (probOutput_eq_zero_iff _ _).mpr (fun hmem => hy (huniq y hmem))
+  -- The total probability collapses to Pr[= a i₀ | ...]
+  have hsum : ∑' x, Pr[= x | pirMain a i₀] = Pr[= a i₀ | pirMain a i₀] :=
+    tsum_eq_single (a i₀) hnot
+  -- ProbComp never fails; combine with total probability = 1
+  have htot := probFailure_add_tsum_probOutput (pirMain a i₀)
+  rw [NeverFail.probFailure_eq_zero, hsum, zero_add] at htot
+  exact htot
 
 /-- Privacy of the first server view: the distribution of the first query set `s`
 is independent of which index is being queried. Intuitively, each index `j` appears in `s` with
@@ -96,11 +200,67 @@ server view is handled by `pir_private_snd`. -/
 theorem pir_private (i₁ i₂ : Fin N) :
     evalDist (Prod.fst <$> pirQuery i₁) =
     evalDist (Prod.fst <$> pirQuery i₂) := by
-  sorry
+  simp only [pirQuery]
+  by_equiv
+  rvcgen_step -- handle map
+  rvcgen_step -- handle foldlM
+  · rfl -- initial states: ([], []).1 = ([], []).1
+  · intro j acc₁ acc₂ hS
+    simp only [ProgramLogic.Relational.EqRel] at hS
+    rvcgen_step using (fun b₁ b₂ => b₁ = b₂)
+    · intro b₁ b₂ hb; subst hb
+      cases b₁ <;> simp <;>
+        (split <;> split <;>
+          apply ProgramLogic.Relational.relTriple_pure_pure <;>
+          simp_all [ProgramLogic.Relational.EqRel])
+    · exact ProgramLogic.Relational.relTriple_uniformSample_bij
+        Function.bijective_id _ (fun _ => rfl)
 
 /-- Privacy of the second server view: the distribution of the second query set `s'`
-is independent of which index is being queried. -/
+is independent of which index is being queried. Intuitively, each index `j` appears in `s'` with
+probability 1/2 regardless of whether `j = i₀` or not:
+- If `j = i₀`: `j ∈ s'` iff coin is tails (prob 1/2)
+- If `j ≠ i₀`: `j ∈ s'` iff coin is heads (prob 1/2)
+
+This is the other half of the information-theoretic privacy guarantee (see `pir_private`).
+The proof uses a coupling argument with four cases depending on whether `j` equals `i₁`, `i₂`,
+both, or neither. When `j` equals exactly one of them, the coupling negates the coin (`b ↦ !b`),
+exploiting the symmetry of the uniform distribution on `Bool`. -/
 theorem pir_private_snd (i₁ i₂ : Fin N) :
     evalDist (Prod.snd <$> pirQuery i₁) =
     evalDist (Prod.snd <$> pirQuery i₂) := by
-  sorry
+  simp only [pirQuery]
+  by_equiv
+  rvcgen_step -- handle map
+  rvcgen_step -- handle foldlM
+  · rfl
+  · intro j acc₁ acc₂ hS
+    simp only [ProgramLogic.Relational.EqRel] at hS
+    by_cases h₁ : j = i₁ <;> by_cases h₂ : j = i₂
+    -- Case 1: j = i₁ ∧ j = i₂ — identical, identity coupling
+    · subst h₁; subst h₂
+      rvcgen_step using (fun b₁ b₂ => b₁ = b₂)
+      · intro b₁ b₂ hb; subst hb; cases b₁ <;>
+          simp_all [ProgramLogic.Relational.EqRel]
+      · exact ProgramLogic.Relational.relTriple_uniformSample_bij
+          Function.bijective_id _ (fun _ => rfl)
+    -- Case 2: j = i₁ ∧ j ≠ i₂ — negation coupling
+    · subst h₁
+      rvcgen_step using (fun b₁ b₂ => b₂ = !b₁)
+      · intro b₁ b₂ hb; subst hb; simp [h₂]; cases b₁ <;>
+          simp_all [ProgramLogic.Relational.EqRel]
+      · exact ProgramLogic.Relational.relTriple_uniformSample_bij
+          Bool.involutive_not.bijective _ (fun _ => rfl)
+    -- Case 3: j ≠ i₁ ∧ j = i₂ — negation coupling
+    · subst h₂
+      rvcgen_step using (fun b₁ b₂ => b₂ = !b₁)
+      · intro b₁ b₂ hb; subst hb; simp [h₁]; cases b₁ <;>
+          simp_all [ProgramLogic.Relational.EqRel]
+      · exact ProgramLogic.Relational.relTriple_uniformSample_bij
+          Bool.involutive_not.bijective _ (fun _ => rfl)
+    -- Case 4: j ≠ i₁ ∧ j ≠ i₂ — identity coupling
+    · rvcgen_step using (fun b₁ b₂ => b₁ = b₂)
+      · intro b₁ b₂ hb; subst hb; simp [h₁, h₂]; cases b₁ <;>
+          simp_all [ProgramLogic.Relational.EqRel]
+      · exact ProgramLogic.Relational.relTriple_uniformSample_bij
+          Function.bijective_id _ (fun _ => rfl)

--- a/Examples/SimpleTwoServerPIR.lean
+++ b/Examples/SimpleTwoServerPIR.lean
@@ -46,7 +46,7 @@ open OracleComp OracleSpec ENNReal
 variable {N : ℕ}
 
 /-- Imperative-style PIR query generation using `for` / `let mut` syntax. -/
-def pirQuery' {N : ℕ} (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) := do
+def pirQuery' (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) := do
   let mut s  : List (Fin N) := []
   let mut s' : List (Fin N) := []
   for j in List.finRange N do
@@ -61,7 +61,7 @@ def pirQuery' {N : ℕ} (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N))
 
 /-- PIR query generation: build two index sets `s, s'` whose "symmetric difference"
 is `{i₀}`. Uses `foldlM` over `List.finRange N` with a random coin per index. -/
-def pirQuery {N : ℕ} (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) :=
+def pirQuery (i₀ : Fin N) : ProbComp (List (Fin N) × List (Fin N)) :=
   (List.finRange N).foldlM (fun (acc : List (Fin N) × List (Fin N)) (j : Fin N) => do
     let b ← $ᵗ Bool
     if j = i₀ then
@@ -77,7 +77,7 @@ Uses the general `List.forIn_mprod_yield_eq_foldlM` bridge from `ToMathlib.Gener
 to convert the `for`/`let mut` desugaring (which uses `forIn` + `MProd` state +
 `ForInStep.yield`) into the direct `foldlM` formulation. The only proof obligation
 is showing that each branch of the loop body wraps its result in `ForInStep.yield`. -/
-theorem pirQuery'_eq_pirQuery {N : ℕ} (i₀ : Fin N) : pirQuery' i₀ = pirQuery i₀ := by
+theorem pirQuery'_eq_pirQuery (i₀ : Fin N) : pirQuery' i₀ = pirQuery i₀ := by
   simp only [pirQuery', pirQuery, pure_bind]
   exact List.forIn_mprod_yield_eq_foldlM _ _ _ _ _ (fun j b c => by
     simp only [bind_assoc]
@@ -112,7 +112,7 @@ private lemma pirResponse_cons (a : Fin N → W) (j : Fin N) (s : List (Fin N)) 
 
 /-- For any output in the support of the foldlM, the sum of responses accumulates `a i₀`
 exactly when `i₀` appears in the fold list. -/
-private lemma pirQuery_foldl_support [DecidableEq W]
+private lemma pirQuery_foldl_support
     (hchar : ∀ x : W, x + x = 0) (a : Fin N → W) (i₀ : Fin N)
     (l : List (Fin N)) (hl : l.Nodup)
     (init ss : List (Fin N) × List (Fin N))

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -557,3 +557,39 @@ lemma list_mapM_loop_eq {m : Type u → Type v} [Monad m] [LawfulMonad m]
       simp only [List.mapM.loop, map_bind]
       refine congr_arg (f x >>= ·) (funext λ x ↦ ?_)
       simp [h (x :: ys), h [x]]
+
+/-! ### `forIn` / `foldlM` bridge for imperative-style loops
+
+Lean's `for`/`let mut` syntax desugars to `List.forIn` with `MProd` state and
+`ForInStep.yield` continuations, while functional-style code uses `List.foldlM`
+with `Prod` state. The lemmas below bridge these two representations.
+
+For a single mutable variable (no `MProd` wrapper), use Mathlib's
+`List.forIn_yield_eq_foldlM` directly. -/
+
+/-- A `for`/`let mut` loop with two mutable variables (desugared to `forIn` over
+`MProd` state with `ForInStep.yield` in every branch) is equivalent to `foldlM`
+with `Prod` state. This bridges two impedance mismatches at once:
+
+1. `forIn` with yield-only body ↔ `foldlM`
+2. `MProd` state from `let mut` desugaring ↔ `Prod` state -/
+theorem List.forIn_mprod_yield_eq_foldlM
+    {m : Type u → Type v} [Monad m] [LawfulMonad m]
+    {α : Type w} {β γ : Type u} (l : List α) (b₀ : β) (c₀ : γ)
+    (f : α → MProd β γ → m (ForInStep (MProd β γ)))
+    (g : β × γ → α → m (β × γ))
+    (hfg : ∀ a b c, f a ⟨b, c⟩ = do
+      let r ← g (b, c) a; pure (.yield ⟨r.1, r.2⟩)) :
+    (do let r ← forIn l ⟨b₀, c₀⟩ f; pure (r.fst, r.snd)) =
+    l.foldlM g (b₀, c₀) := by
+  suffices ∀ (b : β) (c : γ),
+    (do let r ← forIn l ⟨b, c⟩ f; pure (r.fst, r.snd)) = l.foldlM g (b, c) from
+    this b₀ c₀
+  intro b c
+  induction l generalizing b c with
+  | nil => simp [List.forIn_nil, List.foldlM_nil]
+  | cons x xs ih =>
+    rw [List.forIn_cons, List.foldlM_cons, hfg]
+    simp only [bind_assoc, pure_bind]
+    congr 1; funext ⟨b', c'⟩
+    exact ih b' c'


### PR DESCRIPTION
## Summary
- add a general `forIn`/`foldlM` bridge in `ToMathlib.General` for imperative-style loops with two mutable variables
- use that bridge to prove the imperative and functional PIR query generators are equal in `Examples/SimpleTwoServerPIR`
- complete the simple two-server PIR correctness/privacy proofs and ignore local `.gauss/` artifacts

## Linked issues
Closes #136
Closes #137

## Test plan
- [x] `lake build ToMathlib.General Examples.SimpleTwoServerPIR`

Posted by Cursor assistant (model: GPT-5.4) on behalf of the user (Quang Dao) with approval.