### PR TITLE
feat: merge the definitions of `SubPMF` and `SPMF` and standardize notation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Lean environment
+        uses: leanprover/lean-action@v1
+        with:
+          auto-config: false
+          build: false
+          test: false
+          lint: false
+          use-github-cache: false
+          use-mathlib-cache: false
+
       - name: update root import files
         run: lake exe mk_all
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: update root import files
-        run: bash ./scripts/update-lib.sh
+        run: lake exe mk_all
 
       - name: check that all files are imported
         run: git diff --exit-code

--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -1,42 +1,41 @@
-module
-
-public import ToMathlib.Control.AlternativeMonad
-public import ToMathlib.Control.Comonad.Basic
-public import ToMathlib.Control.Comonad.Cofree
-public import ToMathlib.Control.Comonad.Instances
-public import ToMathlib.Control.Lawful.MonadControl
-public import ToMathlib.Control.Lawful.MonadFunctor
-public import ToMathlib.Control.Lawful.MonadReader
-public import ToMathlib.Control.Lawful.MonadState
-public import ToMathlib.Control.Monad.Algebra
-public import ToMathlib.Control.Monad.Commutative
-public import ToMathlib.Control.Monad.Dijkstra
-public import ToMathlib.Control.Monad.Equiv
-public import ToMathlib.Control.Monad.Free
-public import ToMathlib.Control.Monad.FreeCont
-public import ToMathlib.Control.Monad.Graded
-public import ToMathlib.Control.Monad.Hom
-public import ToMathlib.Control.Monad.Indexed
-public import ToMathlib.Control.Monad.Ordered
-public import ToMathlib.Control.Monad.Relation
-public import ToMathlib.Control.Monad.RelationalAlgebra
-public import ToMathlib.Control.Monad.Relative
-public import ToMathlib.Control.Monad.Transformer
-public import ToMathlib.Control.OptionT
-public import ToMathlib.Control.StateT
-public import ToMathlib.Control.WriterT
-public import ToMathlib.Data.ENNReal.AbsDiff
-public import ToMathlib.Data.ENNReal.SumSquares
-public import ToMathlib.General
-public import ToMathlib.OrderEnrichedCategory
-public import ToMathlib.PFunctor.Basic
-public import ToMathlib.PFunctor.Category
-public import ToMathlib.PFunctor.Chart.Basic
-public import ToMathlib.PFunctor.Cofree
-public import ToMathlib.PFunctor.Equiv.Basic
-public import ToMathlib.PFunctor.Free
-public import ToMathlib.PFunctor.Lens.Basic
-public import ToMathlib.Probability.ProbabilityMassFunction.TotalVariation
-public import ToMathlib.ProbabilityTheory.Coupling
-public import ToMathlib.ProbabilityTheory.FinRatPMF
-public import ToMathlib.ProbabilityTheory.OptimalCoupling
+import ToMathlib.Control.AlternativeMonad
+import ToMathlib.Control.Comonad.Basic
+import ToMathlib.Control.Comonad.Cofree
+import ToMathlib.Control.Comonad.Instances
+import ToMathlib.Control.Lawful.MonadControl
+import ToMathlib.Control.Lawful.MonadFunctor
+import ToMathlib.Control.Lawful.MonadReader
+import ToMathlib.Control.Lawful.MonadState
+import ToMathlib.Control.Monad.Algebra
+import ToMathlib.Control.Monad.Commutative
+import ToMathlib.Control.Monad.Dijkstra
+import ToMathlib.Control.Monad.Equiv
+import ToMathlib.Control.Monad.Free
+import ToMathlib.Control.Monad.FreeCont
+import ToMathlib.Control.Monad.Graded
+import ToMathlib.Control.Monad.Hom
+import ToMathlib.Control.Monad.Indexed
+import ToMathlib.Control.Monad.Ordered
+import ToMathlib.Control.Monad.Relation
+import ToMathlib.Control.Monad.RelationalAlgebra
+import ToMathlib.Control.Monad.Relative
+import ToMathlib.Control.Monad.Transformer
+import ToMathlib.Control.OptionT
+import ToMathlib.Control.StateT
+import ToMathlib.Control.WriterT
+import ToMathlib.Data.ENNReal.AbsDiff
+import ToMathlib.Data.ENNReal.SumSquares
+import ToMathlib.General
+import ToMathlib.OrderEnrichedCategory
+import ToMathlib.PFunctor.Basic
+import ToMathlib.PFunctor.Category
+import ToMathlib.PFunctor.Chart.Basic
+import ToMathlib.PFunctor.Cofree
+import ToMathlib.PFunctor.Equiv.Basic
+import ToMathlib.PFunctor.Free
+import ToMathlib.PFunctor.Lens.Basic
+import ToMathlib.Probability.ProbabilityMassFunction.TotalVariation
+import ToMathlib.ProbabilityTheory.Coupling
+import ToMathlib.ProbabilityTheory.FinRatPMF
+import ToMathlib.ProbabilityTheory.OptimalCoupling
+import ToMathlib.ProbabilityTheory.SPMF

--- a/ToMathlib/Probability/ProbabilityMassFunction/TotalVariation.lean
+++ b/ToMathlib/Probability/ProbabilityMassFunction/TotalVariation.lean
@@ -189,7 +189,7 @@ section OptionPUnit
 
 variable (p q : PMF (Option PUnit))
 
-private lemma pmf_none_eq (p : PMF (Option PUnit)) :
+lemma pmf_none_eq (p : PMF (Option PUnit)) :
     p none = 1 - p (some ()) := by
   have h := p.tsum_coe
   rw [tsum_fintype, Fintype.sum_option, Fintype.sum_unique] at h

--- a/ToMathlib/ProbabilityTheory/Coupling.lean
+++ b/ToMathlib/ProbabilityTheory/Coupling.lean
@@ -1,13 +1,14 @@
 /-
 Copyright (c) 2025 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Quang Dao, Devon Tuma
 -/
 module
 
 public import Mathlib.Probability.ProbabilityMassFunction.Constructions
 public import ToMathlib.Control.Monad.Transformer
 public import Batteries.Control.AlternativeMonad
+public import ToMathlib.ProbabilityTheory.SPMF
 
 /-!
 # Coupling for probability distributions
@@ -33,193 +34,113 @@ def Coupling (p : PMF α) (q : PMF β) :=
 
 end PMF
 
-/-- Subprobability distribution. -/
--- @[reducible]
-abbrev SubPMF : Type u → Type u := OptionT PMF
-
-namespace SubPMF
+namespace SPMF
 
 variable {α β : Type u}
 
--- @[reducible] protected def mk (m : PMF (Option α)) : SubPMF α := OptionT.mk m
-
--- @[reducible] protected def run (m : SubPMF α) : PMF (Option α) := OptionT.run m
-
--- instance : AlternativeMonad SubPMF := inferInstance
-
--- instance : LawfulAlternative SubPMF := inferInstance
-
-instance : FunLike (SubPMF α) (Option α) ENNReal :=
-  inferInstanceAs (FunLike (PMF (Option α)) (Option α) ENNReal)
-
--- instance : MonadLift PMF SubPMF := inferInstance
-
--- instance : LawfulMonadLift PMF SubPMF := inferInstance
-
-theorem pure_eq_pmf_pure {a : α} : (pure a : SubPMF α) = PMF.pure a := by
-  simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
-
-theorem bind_eq_pmf_bind {p : SubPMF α} {f : α → SubPMF β} :
-    (p >>= f) = PMF.bind p (fun a => match a with | some a' => f a' | none => PMF.pure none) := by
-  simp [bind, OptionT.bind, PMF.instMonad, OptionT.mk]
-  rfl
-
-@[simp] lemma map_some_apply_some (p : PMF α) (x : α) : p.map some (some x) = p x := by
-  simp [PMF.map_apply]
-  rw [tsum_eq_single x (by intro b hb; simp [Ne.symm hb])]
-  simp
-
-@[simp] lemma PMF.map_some_apply_some (p : PMF α) (x : α) : (some <$> p) (some x) = p x := by
-  change p.map some (some x) = p x
-  simp [PMF.map_apply]
-  rw [tsum_eq_single x (by intro b hb; simp [Ne.symm hb])]
-  simp
-
-/-- `pure a` in SubPMF equals `PMF.pure (some a)` as a PMF on `Option α`. -/
-private lemma spmf_pure_eq (a : α) : (pure a : SubPMF α) = PMF.pure (some a) := by
-  have : (pure a : SubPMF α) = liftM (PMF.pure a) := by
-    simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
-  rw [this]; change (PMF.pure a).bind (fun x => PMF.pure (some x)) = _; rw [PMF.pure_bind]
-
-/-- The functor map for SubPMF equals `PMF.map (Option.map f)`. -/
-private lemma spmf_fmap_eq_map (f : α → β) (c : SubPMF α) :
-    (f <$> c : SubPMF β) = PMF.map (Option.map f) c := by
-  have : (f <$> c : SubPMF β) =
-    PMF.bind c (fun a => match a with
-      | some a' => (pure (f a') : SubPMF β) | none => PMF.pure none) := by
-    show (c >>= (pure ∘ f)) = _; exact bind_eq_pmf_bind
-  rw [this]; apply PMF.ext; intro x
-  simp only [PMF.bind_apply, PMF.map_apply]
-  congr 1; ext y; cases y with
-  | none => cases x <;> simp [PMF.pure_apply]
-  | some a => simp only [spmf_pure_eq, PMF.pure_apply]; cases x <;> simp
-
-/-- If `PMF.map f c = PMF.pure b` and `f a ≠ b`, then `c a = 0`. -/
-private lemma pmf_map_eq_pure_zero {γ δ : Type*} (f : γ → δ) (c : PMF γ) (b : δ)
-    (h : PMF.map f c = PMF.pure b) (a : γ) (ha : f a ≠ b) : c a = 0 := by
-  have key := congr_fun (congrArg DFunLike.coe h) (f a)
-  simp [PMF.map_apply, PMF.pure_apply, ha] at key
-  exact key a rfl
-
-/-- A PMF that is zero at all points except `a` equals `PMF.pure a`. -/
-private lemma pmf_eq_pure_of_forall_ne_eq_zero {γ : Type*} (p : PMF γ) (a : γ)
-    (h : ∀ x, x ≠ a → p x = 0) : p = PMF.pure a := by
-  ext x; by_cases hx : x = a
-  · subst hx; simp only [PMF.pure_apply, if_true]
-    rw [← p.tsum_coe]; exact (tsum_eq_single x (fun b hb => h b hb)).symm
-  · simp [PMF.pure_apply, hx, h x hx]
-
 @[ext]
-class IsCoupling (c : SubPMF (α × β)) (p : SubPMF α) (q : SubPMF β) : Prop where
+class IsCoupling (c : SPMF (α × β)) (p : SPMF α) (q : SPMF β) : Prop where
   map_fst : Prod.fst <$> c = p
   map_snd : Prod.snd <$> c = q
 
-def Coupling (p : SubPMF α) (q : SubPMF β) :=
-  { c : SubPMF (α × β) // IsCoupling c p q }
+def Coupling (p : SPMF α) (q : SPMF β) :=
+  { c : SPMF (α × β) // IsCoupling c p q }
 
 -- Interaction between `Coupling` and `pure` / `bind`
 
 example (f g : α → β) (h : f = g) : ∀ x, f x = g x := by exact fun x ↦ congrFun h x
 
 /-- The coupling of two pure values must be the pure pair of those values -/
-theorem IsCoupling.pure_iff {α β : Type u} {a : α} {b : β} {c : SubPMF (α × β)} :
+theorem IsCoupling.pure_iff {α β : Type u} {a : α} {b : β} {c : SPMF (α × β)} :
     IsCoupling c (pure a) (pure b) ↔ c = pure (a, b) := by
   constructor
   · intro ⟨h1, h2⟩
-    simp [pure_eq_pmf_pure, liftM, monadLift, OptionT.instMonadLift, OptionT.lift,
-      OptionT.mk] at h1 h2
-    rw [spmf_fmap_eq_map] at h1 h2
-    change PMF.map (Option.map Prod.fst) c = PMF.map some (PMF.pure a) at h1
-    change PMF.map (Option.map Prod.snd) c = PMF.map some (PMF.pure b) at h2
-    rw [PMF.pure_map] at h1 h2
-    rw [show (pure (a, b) : SubPMF (α × β)) = PMF.pure (some (a, b)) from spmf_pure_eq (a, b)]
-    exact pmf_eq_pure_of_forall_ne_eq_zero c (some (a, b)) fun x hx => by
+    rw [SPMF.fmap_eq_map] at h1 h2
+    change PMF.map (Option.map Prod.fst) c = PMF.pure (some a) at h1
+    change PMF.map (Option.map Prod.snd) c = PMF.pure (some b) at h2
+    rw [show (pure (a, b) : SPMF (α × β)) = PMF.pure (some (a, b)) from SPMF.pure_eq_pure_some (a, b)]
+    exact PMF.eq_pure_of_forall_ne_eq_zero c (some (a, b)) fun x hx => by
       cases x with
-      | none => exact pmf_map_eq_pure_zero _ c _ h1 none (by simp)
+      | none => exact PMF.map_eq_pure_zero _ c _ h1 none (by simp)
       | some p =>
         obtain ⟨x, y⟩ := p
         have hne : x ≠ a ∨ y ≠ b := by
           by_contra h; push_neg at h; exact hx (by rw [h.1, h.2])
         cases hne with
-        | inl hx => exact pmf_map_eq_pure_zero _ c _ h1 (some (x, y)) (by simp [hx])
-        | inr hy => exact pmf_map_eq_pure_zero _ c _ h2 (some (x, y)) (by simp [hy])
+        | inl hx => exact PMF.map_eq_pure_zero _ c _ h1 (some (x, y)) (by simp [hx])
+        | inr hy => exact PMF.map_eq_pure_zero _ c _ h2 (some (x, y)) (by simp [hy])
   · intro h; constructor <;> simp [h, - liftM_map]
 
-theorem IsCoupling.none_iff {α β : Type u} {c : SubPMF (α × β)} :
-    IsCoupling c (failure : SubPMF α) (failure : SubPMF β) ↔ c = failure := by
+theorem IsCoupling.none_iff {α β : Type u} {c : SPMF (α × β)} :
+    IsCoupling c (failure : SPMF α) (failure : SPMF β) ↔ c = failure := by
   simp [failure]
   constructor
   · intro ⟨h1, h2⟩
-    rw [spmf_fmap_eq_map] at h1
+    rw [SPMF.fmap_eq_map] at h1
     change PMF.map (Option.map Prod.fst) c = PMF.pure none at h1
-    exact pmf_eq_pure_of_forall_ne_eq_zero c none fun x hx => by
+    exact PMF.eq_pure_of_forall_ne_eq_zero c none fun x hx => by
       cases x with
       | none => exact absurd rfl hx
       | some p =>
-        exact pmf_map_eq_pure_zero _ c _ h1 (some p) (by simp)
+        exact PMF.map_eq_pure_zero _ c _ h1 (some p) (by simp)
   · intro h
     constructor
-    · subst h; rw [spmf_fmap_eq_map]
+    · subst h; rw [SPMF.fmap_eq_map]
       change PMF.map _ (PMF.pure none) = PMF.pure none; simp [PMF.pure_map]
-    · subst h; rw [spmf_fmap_eq_map]
+    · subst h; rw [SPMF.fmap_eq_map]
       change PMF.map _ (PMF.pure none) = PMF.pure none; simp [PMF.pure_map]
 
-/-- `PMF.bind` respects equality on the support. -/
-private lemma pmf_bind_congr {γ δ : Type*} (p : PMF γ) (f g : γ → PMF δ)
-    (h : ∀ x, p x ≠ 0 → f x = g x) : p.bind f = p.bind g := by
-  ext y; simp only [PMF.bind_apply]; congr 1; ext x
-  by_cases hx : p x = 0 <;> simp [hx, h x]
 
 /-- Main theorem about coupling and bind operations -/
 theorem IsCoupling.bind {α₁ α₂ β₁ β₂ : Type u}
-    {p : SubPMF α₁} {q : SubPMF α₂} {f : α₁ → SubPMF β₁} {g : α₂ → SubPMF β₂}
-    (c : Coupling p q) (d : (a₁ : α₁) → (a₂ : α₂) → SubPMF (β₁ × β₂))
+    {p : SPMF α₁} {q : SPMF α₂} {f : α₁ → SPMF β₁} {g : α₂ → SPMF β₂}
+    (c : Coupling p q) (d : (a₁ : α₁) → (a₂ : α₂) → SPMF (β₁ × β₂))
     (h : ∀ (a₁ : α₁) (a₂ : α₂), c.1.1 (some (a₁, a₂)) ≠ 0 → IsCoupling (d a₁ a₂) (f a₁) (g a₂)) :
     IsCoupling (c.1 >>= λ (p : α₁ × α₂) => d p.1 p.2) (p >>= f) (q >>= g) := by
   obtain ⟨hc₁, hc₂⟩ := c.2
   constructor
-  · rw [spmf_fmap_eq_map, bind_eq_pmf_bind, PMF.map_bind]
-    conv_rhs => rw [← hc₁, spmf_fmap_eq_map, bind_eq_pmf_bind, PMF.bind_map]
-    apply pmf_bind_congr; intro o ho
+  · rw [SPMF.fmap_eq_map, bind_eq_pmf_bind, PMF.map_bind]
+    conv_rhs => rw [← hc₁, SPMF.fmap_eq_map, bind_eq_pmf_bind, PMF.bind_map]
+    apply PMF.bind_congr; intro o ho
     cases o with
     | none => simp [PMF.pure_map]
     | some ab =>
       obtain ⟨a₁, a₂⟩ := ab
       simp only [Function.comp, Option.map]
-      rw [← spmf_fmap_eq_map]
+      rw [← SPMF.fmap_eq_map]
       exact (h a₁ a₂ ho).map_fst
-  · rw [spmf_fmap_eq_map, bind_eq_pmf_bind, PMF.map_bind]
-    conv_rhs => rw [← hc₂, spmf_fmap_eq_map, bind_eq_pmf_bind, PMF.bind_map]
-    apply pmf_bind_congr; intro o ho
+  · rw [SPMF.fmap_eq_map, bind_eq_pmf_bind, PMF.map_bind]
+    conv_rhs => rw [← hc₂, SPMF.fmap_eq_map, bind_eq_pmf_bind, PMF.bind_map]
+    apply PMF.bind_congr; intro o ho
     cases o with
     | none => simp [PMF.pure_map]
     | some ab =>
       obtain ⟨a₁, a₂⟩ := ab
       simp only [Function.comp, Option.map]
-      rw [← spmf_fmap_eq_map]
+      rw [← SPMF.fmap_eq_map]
       exact (h a₁ a₂ ho).map_snd
 
 /-- Existential version of `IsCoupling.bind` -/
 theorem IsCoupling.exists_bind {α₁ α₂ β₁ β₂ : Type u}
-    {p : SubPMF α₁} {q : SubPMF α₂} {f : α₁ → SubPMF β₁} {g : α₂ → SubPMF β₂}
+    {p : SPMF α₁} {q : SPMF α₂} {f : α₁ → SPMF β₁} {g : α₂ → SPMF β₂}
     (c : Coupling p q)
-    (h : ∀ (a₁ : α₁) (a₂ : α₂), ∃ (d : SubPMF (β₁ × β₂)), IsCoupling d (f a₁) (g a₂)) :
-    ∃ (d : SubPMF (β₁ × β₂)), IsCoupling d (p >>= f) (q >>= g) :=
-  let d : (a₁ : α₁) → (a₂ : α₂) → SubPMF (β₁ × β₂) :=
+    (h : ∀ (a₁ : α₁) (a₂ : α₂), ∃ (d : SPMF (β₁ × β₂)), IsCoupling d (f a₁) (g a₂)) :
+    ∃ (d : SPMF (β₁ × β₂)), IsCoupling d (p >>= f) (q >>= g) :=
+  let d : (a₁ : α₁) → (a₂ : α₂) → SPMF (β₁ × β₂) :=
     fun a₁ a₂ => Classical.choose (h a₁ a₂)
   let hd : ∀ (a₁ : α₁) (a₂ : α₂), c.1.1 (some (a₁, a₂)) ≠ 0 → IsCoupling (d a₁ a₂) (f a₁) (g a₂) :=
     fun a₁ a₂ _ => Classical.choose_spec (h a₁ a₂)
   ⟨c.1 >>= λ (p : α₁ × α₂) => d p.1 p.2, IsCoupling.bind c d hd⟩
 
-/-- Every `SubPMF` has a diagonal self-coupling. -/
-theorem IsCoupling.refl (p : SubPMF α) :
+/-- Every `SPMF` has a diagonal self-coupling. -/
+theorem IsCoupling.refl (p : SPMF α) :
     IsCoupling (p >>= fun a => pure (a, a)) p p := by
   constructor <;> ext a <;> simp
 
 /-- Diagonal self-coupling witness. -/
-def Coupling.refl (p : SubPMF α) : Coupling p p :=
+noncomputable def Coupling.refl (p : SPMF α) : Coupling p p :=
   ⟨p >>= fun a => pure (a, a), IsCoupling.refl p⟩
 
-end SubPMF
+end SPMF
 
 end

--- a/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
+++ b/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
@@ -38,31 +38,10 @@ variable {α β : Type u} [Fintype α] [Fintype β]
 
 section Topology
 
--- To show compactness, we embed `SPMF (α × β)` into `Option (α × β) → ℝ`.
-
-omit [Fintype α] [Fintype β] in
-private lemma spmf_pure_eq (a : α) : (pure a : SPMF α) = PMF.pure (some a) := by
-  have : (pure a : SPMF α) = liftM (PMF.pure a) := by
-    simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
-  rw [this]; change (PMF.pure a).bind (fun x => PMF.pure (some x)) = _; rw [PMF.pure_bind]
-
-omit [Fintype α] [Fintype β] in
-private lemma spmf_fmap_eq_map (f : α → β) (c : SPMF α) :
-    (f <$> c : SPMF β) = PMF.map (Option.map f) c := by
-  have : (f <$> c : SPMF β) =
-    PMF.bind c (fun a => match a with
-      | some a' => (pure (f a') : SPMF β) | none => PMF.pure none) := by
-    show (c >>= (pure ∘ f)) = _; exact SPMF.bind_eq_pmf_bind
-  rw [this]; apply PMF.ext; intro x
-  simp only [PMF.bind_apply, PMF.map_apply]
-  congr 1; ext y; cases y with
-  | none => cases x <;> simp [PMF.pure_apply]
-  | some a => simp only [spmf_pure_eq, PMF.pure_apply]; cases x <;> simp
-
 lemma map_fst_eval (c : SPMF (α × β)) (a : α) :
     (Prod.fst <$> c) a = ∑ b, c (a, b) := by
   classical
-  erw [spmf_fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
+  erw [SPMF.fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
   have hsimp :
       ((if some a = Option.map Prod.fst (none : Option (α × β)) then c.gap else 0) +
           ∑ x : α × β, if some a = Option.map Prod.fst (some x : Option (α × β)) then c x else 0) =
@@ -85,7 +64,7 @@ lemma map_fst_eval (c : SPMF (α × β)) (a : α) :
 lemma map_snd_eval (c : SPMF (α × β)) (b : β) :
     (Prod.snd <$> c) b = ∑ a, c (a, b) := by
   classical
-  erw [spmf_fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
+  erw [SPMF.fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
   have hsimp :
       ((if some b = Option.map Prod.snd (none : Option (α × β)) then c.gap else 0) +
           ∑ x : α × β, if some b = Option.map Prod.snd (some x : Option (α × β)) then c x else 0) =
@@ -216,14 +195,7 @@ lemma mem_couplings_set_of_isCoupling {p : SPMF α} {q : SPMF β} (c : SPMF (α 
       exact PMF.apply_ne_top c _
     rw [h_sum_toReal] at h_toReal
     exact h_toReal
-  · have h_total : c.gap + ∑ z, c z = 1 := by
-      simpa [tsum_fintype, Fintype.sum_option] using c.tsum_coe
-    have h_some_le_one : ∑ z, c z ≤ 1 := by
-      calc
-        ∑ z, c z ≤ c.gap + ∑ z, c z := by
-          exact le_add_of_nonneg_left bot_le
-        _ = 1 := h_total
-    exact SPMF.toReal_gap_eq_one_sub_sum_toReal c
+  · exact SPMF.toReal_gap_eq_one_sub_sum_toReal c
 
 omit [Fintype α] [Fintype β] in
 private lemma sum_option_eq_one_of_none_eq_sub {γ : Type u} [Fintype γ]

--- a/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
+++ b/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
@@ -34,47 +34,47 @@ variable {α β : Type u} [Fintype α] [Fintype β]
 -- 2. Compactness
 -- 3. Attaining supremum
 
-/-! ## The space of SubPMFs as a bounded closed subset of `Option (α × β) → ℝ` -/
+/-! ## The space of SPMFs as a bounded closed subset of `Option (α × β) → ℝ` -/
 
 section Topology
 
--- To show compactness, we embed `SubPMF (α × β)` into `Option (α × β) → ℝ`.
+-- To show compactness, we embed `SPMF (α × β)` into `Option (α × β) → ℝ`.
 
 omit [Fintype α] [Fintype β] in
-private lemma spmf_pure_eq (a : α) : (pure a : SubPMF α) = PMF.pure (some a) := by
-  have : (pure a : SubPMF α) = liftM (PMF.pure a) := by
+private lemma spmf_pure_eq (a : α) : (pure a : SPMF α) = PMF.pure (some a) := by
+  have : (pure a : SPMF α) = liftM (PMF.pure a) := by
     simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
   rw [this]; change (PMF.pure a).bind (fun x => PMF.pure (some x)) = _; rw [PMF.pure_bind]
 
 omit [Fintype α] [Fintype β] in
-private lemma spmf_fmap_eq_map (f : α → β) (c : SubPMF α) :
-    (f <$> c : SubPMF β) = PMF.map (Option.map f) c := by
-  have : (f <$> c : SubPMF β) =
+private lemma spmf_fmap_eq_map (f : α → β) (c : SPMF α) :
+    (f <$> c : SPMF β) = PMF.map (Option.map f) c := by
+  have : (f <$> c : SPMF β) =
     PMF.bind c (fun a => match a with
-      | some a' => (pure (f a') : SubPMF β) | none => PMF.pure none) := by
-    show (c >>= (pure ∘ f)) = _; exact SubPMF.bind_eq_pmf_bind
+      | some a' => (pure (f a') : SPMF β) | none => PMF.pure none) := by
+    show (c >>= (pure ∘ f)) = _; exact SPMF.bind_eq_pmf_bind
   rw [this]; apply PMF.ext; intro x
   simp only [PMF.bind_apply, PMF.map_apply]
   congr 1; ext y; cases y with
   | none => cases x <;> simp [PMF.pure_apply]
   | some a => simp only [spmf_pure_eq, PMF.pure_apply]; cases x <;> simp
 
-lemma map_fst_eval (c : SubPMF (α × β)) (a : α) :
-    (Prod.fst <$> c) (some a) = ∑ b, c (some (a, b)) := by
+lemma map_fst_eval (c : SPMF (α × β)) (a : α) :
+    (Prod.fst <$> c) a = ∑ b, c (a, b) := by
   classical
-  rw [spmf_fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
+  erw [spmf_fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
   have hsimp :
-      ((if some a = Option.map Prod.fst (none : Option (α × β)) then c none else 0) +
-          ∑ x : α × β, if some a = Option.map Prod.fst (some x : Option (α × β)) then c (some x) else 0) =
-        ∑ x : α × β, if a = x.1 then c (some x) else 0 := by
+      ((if some a = Option.map Prod.fst (none : Option (α × β)) then c.gap else 0) +
+          ∑ x : α × β, if some a = Option.map Prod.fst (some x : Option (α × β)) then c x else 0) =
+        ∑ x : α × β, if a = x.1 then c x else 0 := by
     simp
   have hprod :
-      (∑ x : α × β, if a = x.1 then c (some x) else (0 : ℝ≥0∞)) =
-        ∑ a', ∑ b : β, if a = a' then c (some (a', b)) else (0 : ℝ≥0∞) := by
+      (∑ x : α × β, if a = x.1 then c x else (0 : ℝ≥0∞)) =
+        ∑ a', ∑ b : β, if a = a' then c (a', b) else (0 : ℝ≥0∞) := by
     simpa using
-      (Fintype.sum_prod_type' (f := fun a' b => if a = a' then c (some (a', b)) else (0 : ℝ≥0∞)))
-  have hmain : (∑ x : α × β, if a = x.1 then c (some x) else (0 : ℝ≥0∞)) =
-      ∑ b : β, c (some (a, b)) := by
+      (Fintype.sum_prod_type' (f := fun a' b => if a = a' then c (a', b) else (0 : ℝ≥0∞)))
+  have hmain : (∑ x : α × β, if a = x.1 then c x else (0 : ℝ≥0∞)) =
+      ∑ b : β, c (a, b) := by
     rw [hprod, Finset.sum_eq_single_of_mem a (by simp)]
     · simp
     · intro a' _ ha'
@@ -82,22 +82,22 @@ lemma map_fst_eval (c : SubPMF (α × β)) (a : α) :
       simp [ha'']
   simpa [hsimp] using hmain
 
-lemma map_snd_eval (c : SubPMF (α × β)) (b : β) :
-    (Prod.snd <$> c) (some b) = ∑ a, c (some (a, b)) := by
+lemma map_snd_eval (c : SPMF (α × β)) (b : β) :
+    (Prod.snd <$> c) b = ∑ a, c (a, b) := by
   classical
-  rw [spmf_fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
+  erw [spmf_fmap_eq_map, PMF.map_apply, tsum_fintype, Fintype.sum_option]
   have hsimp :
-      ((if some b = Option.map Prod.snd (none : Option (α × β)) then c none else 0) +
-          ∑ x : α × β, if some b = Option.map Prod.snd (some x : Option (α × β)) then c (some x) else 0) =
-        ∑ x : α × β, if b = x.2 then c (some x) else 0 := by
+      ((if some b = Option.map Prod.snd (none : Option (α × β)) then c.gap else 0) +
+          ∑ x : α × β, if some b = Option.map Prod.snd (some x : Option (α × β)) then c x else 0) =
+        ∑ x : α × β, if b = x.2 then c x else 0 := by
     simp
   have hprod :
-      (∑ x : α × β, if b = x.2 then c (some x) else (0 : ℝ≥0∞)) =
-        ∑ a : α, ∑ b', if b = b' then c (some (a, b')) else (0 : ℝ≥0∞) := by
+      (∑ x : α × β, if b = x.2 then c x else (0 : ℝ≥0∞)) =
+        ∑ a : α, ∑ b', if b = b' then c (a, b') else (0 : ℝ≥0∞) := by
     simpa using
-      (Fintype.sum_prod_type' (f := fun a b' => if b = b' then c (some (a, b')) else (0 : ℝ≥0∞)))
-  have hmain : (∑ x : α × β, if b = x.2 then c (some x) else (0 : ℝ≥0∞)) =
-      ∑ a : α, c (some (a, b)) := by
+      (Fintype.sum_prod_type' (f := fun a b' => if b = b' then c (a, b') else (0 : ℝ≥0∞)))
+  have hmain : (∑ x : α × β, if b = x.2 then c x else (0 : ℝ≥0∞)) =
+      ∑ a : α, c (a, b) := by
     rw [hprod]
     refine Finset.sum_congr rfl ?_
     intro a ha
@@ -116,8 +116,8 @@ private lemma pmf_none_eq {γ : Type u} [Fintype γ] (p : PMF (Option γ)) :
   exact ENNReal.eq_sub_of_add_eq' one_ne_top h
 
 omit [Fintype α] [Fintype β] in
-private lemma spmf_ext {γ : Type u} [Fintype γ] {p q : SubPMF γ}
-    (h : ∀ x, p (some x) = q (some x)) : p = q := by
+private lemma spmf_ext {γ : Type u} [Fintype γ] {p q : SPMF γ}
+    (h : ∀ x, p x = q x) : p = q := by
   refine PMF.ext fun x => ?_
   cases x with
   | none =>
@@ -126,21 +126,21 @@ private lemma spmf_ext {γ : Type u} [Fintype γ] {p q : SubPMF γ}
       exact h y
   | some x => exact h x
 
-def couplings_set (p : SubPMF α) (q : SubPMF β) : Set (Option (α × β) → ℝ) :=
+def couplings_set (p : SPMF α) (q : SPMF β) : Set (Option (α × β) → ℝ) :=
   { c | (∀ z, 0 ≤ c z) ∧
         (∀ z, c z ≤ 1) ∧
-        (∀ a, ∑ b, c (some (a, b)) = (p (some a)).toReal) ∧
-        (∀ b, ∑ a, c (some (a, b)) = (q (some b)).toReal) ∧
+        (∀ a, ∑ b, c (some (a, b)) = (p a).toReal) ∧
+        (∀ b, ∑ a, c (some (a, b)) = (q b).toReal) ∧
         c none = 1 - (∑ z, c (some z)) }
 
 -- 2. Prove this set is closed and bounded
-lemma isClosed_couplings_set (p : SubPMF α) (q : SubPMF β) :
+lemma isClosed_couplings_set (p : SPMF α) (q : SPMF β) :
     IsClosed (couplings_set p q) := by
   rw [show couplings_set p q =
       {c | ∀ z, 0 ≤ c z} ∩
       {c | ∀ z, c z ≤ 1} ∩
-      {c | ∀ a, ∑ b, c (some (a, b)) = (p (some a)).toReal} ∩
-      {c | ∀ b, ∑ a, c (some (a, b)) = (q (some b)).toReal} ∩
+      {c | ∀ a, ∑ b, c (some (a, b)) = (p a).toReal} ∩
+      {c | ∀ b, ∑ a, c (some (a, b)) = (q b).toReal} ∩
       {c | c none = 1 - (∑ z, c (some z))} by
     ext x
     simp only [couplings_set, mem_inter_iff, mem_setOf_eq]
@@ -155,12 +155,14 @@ lemma isClosed_couplings_set (p : SubPMF α) (q : SubPMF β) :
     have : {c : Option (α × β) → ℝ | ∀ z, c z ≤ 1} = ⋂ z, {c | c z ≤ 1} := by ext; simp
     rw [this]
     exact isClosed_iInter fun z => isClosed_le (continuous_apply z) continuous_const
-  have h3 : IsClosed {c : Option (α × β) → ℝ | ∀ a, ∑ b, c (some (a, b)) = (p (some a)).toReal} := by
-    have : {c : Option (α × β) → ℝ | ∀ a, ∑ b, c (some (a, b)) = (p (some a)).toReal} = ⋂ a, {c | ∑ b, c (some (a, b)) = (p (some a)).toReal} := by ext; simp
+  have h3 : IsClosed {c : Option (α × β) → ℝ | ∀ a, ∑ b, c (some (a, b)) = (p a).toReal} := by
+    have : {c : Option (α × β) → ℝ | ∀ a, ∑ b, c (some (a, b)) = (p a).toReal} =
+      ⋂ a, {c | ∑ b, c (some (a, b)) = (p a).toReal} := by ext; simp
     rw [this]
     exact isClosed_iInter fun a => isClosed_eq (continuous_finset_sum _ (fun b _ => continuous_apply _)) continuous_const
-  have h4 : IsClosed {c : Option (α × β) → ℝ | ∀ b, ∑ a, c (some (a, b)) = (q (some b)).toReal} := by
-    have : {c : Option (α × β) → ℝ | ∀ b, ∑ a, c (some (a, b)) = (q (some b)).toReal} = ⋂ b, {c | ∑ a, c (some (a, b)) = (q (some b)).toReal} := by ext; simp
+  have h4 : IsClosed {c : Option (α × β) → ℝ | ∀ b, ∑ a, c (some (a, b)) = (q b).toReal} := by
+    have : {c : Option (α × β) → ℝ | ∀ b, ∑ a, c (some (a, b)) = (q b).toReal} =
+      ⋂ b, {c | ∑ a, c (some (a, b)) = (q b).toReal} := by ext; simp
     rw [this]
     exact isClosed_iInter fun b => isClosed_eq (continuous_finset_sum _ (fun a _ => continuous_apply _)) continuous_const
   have h5 : IsClosed {c : Option (α × β) → ℝ | c none = 1 - (∑ z, c (some z))} := by
@@ -168,7 +170,7 @@ lemma isClosed_couplings_set (p : SubPMF α) (q : SubPMF β) :
 
   exact (((h1.inter h2).inter h3).inter h4).inter h5
 
-lemma isBounded_couplings_set (p : SubPMF α) (q : SubPMF β) :
+lemma isBounded_couplings_set (p : SPMF α) (q : SPMF β) :
     Bornology.IsBounded (couplings_set p q) := by
   rw [Metric.isBounded_iff]
   use 1
@@ -182,51 +184,46 @@ lemma isBounded_couplings_set (p : SubPMF α) (q : SubPMF β) :
   rw [Real.dist_eq]
   exact abs_sub_le_iff.mpr ⟨by linarith, by linarith⟩
 
-lemma isCompact_couplings_set (p : SubPMF α) (q : SubPMF β) :
+lemma isCompact_couplings_set (p : SPMF α) (q : SPMF β) :
     IsCompact (couplings_set p q) :=
   Metric.isCompact_of_isClosed_isBounded (isClosed_couplings_set p q) (isBounded_couplings_set p q)
 
-lemma mem_couplings_set_of_isCoupling {p : SubPMF α} {q : SubPMF β} (c : SubPMF (α × β))
-    (hc : SubPMF.IsCoupling c p q) :
-    (fun z => (c z).toReal) ∈ couplings_set p q := by
+lemma mem_couplings_set_of_isCoupling {p : SPMF α} {q : SPMF β} (c : SPMF (α × β))
+    (hc : SPMF.IsCoupling c p q) :
+    (fun z => (c.toPMF z).toReal) ∈ couplings_set p q := by
   simp only [couplings_set, mem_setOf_eq]
   refine ⟨fun z => ENNReal.toReal_nonneg, ?_, ?_, ?_, ?_⟩
   · intro z; have h := ENNReal.toReal_mono (by exact ENNReal.one_ne_top) (PMF.coe_le_one c z); exact h
   · intro a
-    have h_fst : (Prod.fst <$> c) (some a) = p (some a) := by rw [hc.map_fst]
-    have h_sum : (Prod.fst <$> c) (some a) = ∑ b, c (some (a, b)) := map_fst_eval c a
+    have h_fst : (Prod.fst <$> c) a = p a := by rw [hc.map_fst]
+    have h_sum : (Prod.fst <$> c) a = ∑ b, c (a, b) := map_fst_eval c a
     rw [h_sum] at h_fst
     have h_toReal := congrArg ENNReal.toReal h_fst
-    have h_sum_toReal : (∑ b, c (some (a, b))).toReal = ∑ b, (c (some (a, b))).toReal := by
+    have h_sum_toReal : (∑ b, c (a, b)).toReal = ∑ b, (c (a, b)).toReal := by
       apply ENNReal.toReal_sum
       intro b _
       exact PMF.apply_ne_top c _
     rw [h_sum_toReal] at h_toReal
     exact h_toReal
   · intro b
-    have h_snd : (Prod.snd <$> c) (some b) = q (some b) := by rw [hc.map_snd]
-    have h_sum : (Prod.snd <$> c) (some b) = ∑ a, c (some (a, b)) := map_snd_eval c b
+    have h_snd : (Prod.snd <$> c) b = q b := by rw [hc.map_snd]
+    have h_sum : (Prod.snd <$> c) b = ∑ a, c (a, b) := map_snd_eval c b
     rw [h_sum] at h_snd
     have h_toReal := congrArg ENNReal.toReal h_snd
-    have h_sum_toReal : (∑ a, c (some (a, b))).toReal = ∑ a, (c (some (a, b))).toReal := by
+    have h_sum_toReal : (∑ a, c (a, b)).toReal = ∑ a, (c (a, b)).toReal := by
       apply ENNReal.toReal_sum
       intro a _
       exact PMF.apply_ne_top c _
     rw [h_sum_toReal] at h_toReal
     exact h_toReal
-  · have h_total : c none + ∑ z, c (some z) = 1 := by
+  · have h_total : c.gap + ∑ z, c z = 1 := by
       simpa [tsum_fintype, Fintype.sum_option] using c.tsum_coe
-    have h_some_le_one : ∑ z, c (some z) ≤ 1 := by
+    have h_some_le_one : ∑ z, c z ≤ 1 := by
       calc
-        ∑ z, c (some z) ≤ c none + ∑ z, c (some z) := by
+        ∑ z, c z ≤ c.gap + ∑ z, c z := by
           exact le_add_of_nonneg_left bot_le
         _ = 1 := h_total
-    have h_sum : (c none).toReal = 1 - ∑ z, (c (some z)).toReal := by
-      rw [pmf_none_eq, ENNReal.toReal_sub_of_le h_some_le_one one_ne_top, ENNReal.toReal_sum]
-      · simp
-      · intro z _
-        exact PMF.apply_ne_top c _
-    exact h_sum
+    exact SPMF.toReal_gap_eq_one_sub_sum_toReal c
 
 omit [Fintype α] [Fintype β] in
 private lemma sum_option_eq_one_of_none_eq_sub {γ : Type u} [Fintype γ]
@@ -240,9 +237,9 @@ private lemma sum_option_eq_one_of_none_eq_sub {γ : Type u} [Fintype γ]
     linarith
   linarith
 
-private lemma exists_coupling_of_mem_couplings_set {p : SubPMF α} {q : SubPMF β}
+private lemma exists_coupling_of_mem_couplings_set {p : SPMF α} {q : SPMF β}
     {c : Option (α × β) → ℝ} (hc : c ∈ couplings_set p q) :
-    ∃ c' : SubPMF.Coupling p q, ∀ z, (c'.1.1 z).toReal = c z := by
+    ∃ c' : SPMF.Coupling p q, ∀ z, (c'.1.1 z).toReal = c z := by
   rcases hc with ⟨h_nonneg, _, h_row, h_col, h_none⟩
   have h_total_real : ∑ z : Option (α × β), c z = 1 := by
     exact sum_option_eq_one_of_none_eq_sub h_nonneg h_none
@@ -259,8 +256,8 @@ private lemma exists_coupling_of_mem_couplings_set {p : SubPMF α} {q : SubPMF �
                   (fun z _ => h_nonneg z))
       _ = 1 := by rw [h_total_real, ENNReal.ofReal_one]
   let c_pmf : PMF (Option (α × β)) := PMF.ofFintype (fun z => ENNReal.ofReal (c z)) h_total
-  let c_spmf : SubPMF (α × β) := c_pmf
-  have h_row_ennreal : ∀ a, ∑ b : β, c_spmf.1 (some (a, b)) = p (some a) := by
+  let c_spmf : SPMF (α × β) := c_pmf
+  have h_row_ennreal : ∀ a, ∑ b : β, c_spmf.1 (some (a, b)) = p a := by
     intro a
     calc
       ∑ b : β, c_spmf.1 (some (a, b))
@@ -277,9 +274,9 @@ private lemma exists_coupling_of_mem_couplings_set {p : SubPMF α} {q : SubPMF �
                 (s := (Finset.univ : Finset β))
                 (f := fun b => c (some (a, b)))
                 (fun b _ => h_nonneg (some (a, b))))
-      _ = ENNReal.ofReal ((p (some a)).toReal) := by rw [h_row a]
-      _ = p (some a) := by rw [ENNReal.ofReal_toReal (PMF.apply_ne_top p _)]
-  have h_col_ennreal : ∀ b, ∑ a : α, c_spmf.1 (some (a, b)) = q (some b) := by
+      _ = ENNReal.ofReal ((p a).toReal) := by rw [h_row a]
+      _ = p a := by rw [ENNReal.ofReal_toReal (by simp)]
+  have h_col_ennreal : ∀ b, ∑ a : α, c_spmf.1 (some (a, b)) = q b := by
     intro b
     calc
       ∑ a : α, c_spmf.1 (some (a, b))
@@ -296,23 +293,23 @@ private lemma exists_coupling_of_mem_couplings_set {p : SubPMF α} {q : SubPMF �
                 (s := (Finset.univ : Finset α))
                 (f := fun a => c (some (a, b)))
                 (fun a _ => h_nonneg (some (a, b))))
-      _ = ENNReal.ofReal ((q (some b)).toReal) := by rw [h_col b]
-      _ = q (some b) := by rw [ENNReal.ofReal_toReal (PMF.apply_ne_top q _)]
-  have hfst_some : ∀ a, (Prod.fst <$> c_spmf) (some a) = p (some a) := by
+      _ = ENNReal.ofReal ((q b).toReal) := by rw [h_col b]
+      _ = q b := by rw [ENNReal.ofReal_toReal (by simp)]
+  have hfst_some : ∀ a, (Prod.fst <$> c_spmf) a = p a := by
     intro a
     rw [map_fst_eval]
     exact h_row_ennreal a
-  have hsnd_some : ∀ b, (Prod.snd <$> c_spmf) (some b) = q (some b) := by
+  have hsnd_some : ∀ b, (Prod.snd <$> c_spmf) b = q b := by
     intro b
     rw [map_snd_eval]
     exact h_col_ennreal b
-  have hcpl : SubPMF.IsCoupling c_spmf p q := ⟨spmf_ext hfst_some, spmf_ext hsnd_some⟩
+  have hcpl : SPMF.IsCoupling c_spmf p q := ⟨spmf_ext hfst_some, spmf_ext hsnd_some⟩
   refine ⟨⟨c_spmf, hcpl⟩, ?_⟩
   intro z
   change (ENNReal.ofReal (c z)).toReal = c z
   exact ENNReal.toReal_ofReal (h_nonneg z)
 
-private lemma objective_eq_ofReal (c : SubPMF (α × β))
+private lemma objective_eq_ofReal (c : SPMF (α × β))
     (f : Option (α × β) → ℝ≥0∞) (hf : ∀ z, f z ≠ ⊤) :
     (∑' z, c.1 z * f z) = ENNReal.ofReal (∑ z, (c.1 z).toReal * (f z).toReal) := by
   rw [tsum_fintype]
@@ -332,11 +329,11 @@ private lemma objective_eq_ofReal (c : SubPMF (α × β))
               (fun z _ => mul_nonneg ENNReal.toReal_nonneg ENNReal.toReal_nonneg))
 
 -- 3. Attaining supremum
-lemma SubPMF.exists_max_coupling {p : SubPMF α} {q : SubPMF β}
+lemma SPMF.exists_max_coupling {p : SPMF α} {q : SPMF β}
     (f : Option (α × β) → ℝ≥0∞) (hf : ∀ z, f z ≠ ⊤)
-    (h_nonempty : Nonempty (SubPMF.Coupling p q)) :
-    ∃ (c : SubPMF.Coupling p q),
-      (⨆ c' : SubPMF.Coupling p q, ∑' (z : Option (α × β)), (c'.1.1 z) * f z) = ∑' (z : Option (α × β)), (c.1.1 z) * f z := by
+    (h_nonempty : Nonempty (SPMF.Coupling p q)) :
+    ∃ (c : SPMF.Coupling p q),
+      (⨆ c' : SPMF.Coupling p q, ∑' (z : Option (α × β)), (c'.1.1 z) * f z) = ∑' (z : Option (α × β)), (c.1.1 z) * f z := by
   let F : (Option (α × β) → ℝ) → ℝ := fun c => ∑ z, c z * (f z).toReal
   have hF_cont : Continuous F := continuous_finset_sum _ (fun z _ => (continuous_apply z).mul continuous_const)
   have h_comp := isCompact_couplings_set p q
@@ -367,6 +364,6 @@ lemma SubPMF.exists_max_coupling {p : SubPMF α} {q : SubPMF β}
       simpa [F, hc_max_eq] using (objective_eq_ofReal c_max_cpl.1 f hf)
     rw [h_obj_left, h_obj_right]
     exact ENNReal.ofReal_le_ofReal hmax_real
-  · exact le_iSup (f := fun c' : SubPMF.Coupling p q => ∑' z, c'.1.1 z * f z) c_max_cpl
+  · exact le_iSup (f := fun c' : SPMF.Coupling p q => ∑' z, c'.1.1 z * f z) c_max_cpl
 
 end Topology

--- a/ToMathlib/ProbabilityTheory/SPMF.lean
+++ b/ToMathlib/ProbabilityTheory/SPMF.lean
@@ -125,6 +125,11 @@ lemma zero_def : (0 : SPMF α) = failure := rfl
 lemma toPMF_zero : (0 : SPMF α).toPMF = PMF.pure none := rfl
 
 @[simp, grind =]
+lemma zero_apply (x : α) : (0 : SPMF α) x = 0 := by aesop
+
+end zero
+
+@[simp, grind =]
 lemma toPMF_bind (p : SPMF α) (q : α → SPMF β) :
     (p >>= q).toPMF = Option.elimM p.toPMF (PMF.pure none) (fun x => (q x).toPMF) := by
   simp [← run_eq_toPMF]
@@ -134,9 +139,7 @@ lemma toPMF_map (p : SPMF α) (f : α → β) : (f <$> p).toPMF = Option.map f <
   simp [← run_eq_toPMF]
 
 @[simp, grind =]
-lemma zero_apply (x : α) : (0 : SPMF α) x = 0 := by aesop
-
-end zero
+lemma mk_pure_some (x : α) : SPMF.mk (PMF.pure (some x)) = pure x := rfl
 
 @[simp, grind =]
 lemma tsum_toPMF_some_add_toPMF_none (p : SPMF α) :
@@ -164,21 +167,15 @@ lemma toPMF_none_eq_one_sub_tsum (p : SPMF α) :
 @[simp] lemma tsum_run_some_ne_top (p : SPMF α) : ∑' x, p.toPMF (some x) ≠ ⊤ :=
   ne_top_of_le_ne_top one_ne_top (p.tsum_run_some_eq_one_sub ▸ tsub_le_self)
 
-lemma run_none_eq_one_sub (p : SPMF α) :
-    p.toPMF none = 1 - ∑' x, p.toPMF (some x) := by
-  rw [p.tsum_coe.symm.trans (tsum_option _ ENNReal.summable)]
-  refine ENNReal.eq_sub_of_add_eq ?_ rfl
-  simp only [ne_eq, tsum_run_some_ne_top, not_false_eq_true]
-
 @[ext]
 lemma ext {p q : SPMF α} (h : ∀ x : α, p x = q x) : p = q := by
   simp [SPMF.apply_eq_toPMF_some] at h
   refine PMF.ext fun
     | some x => h x
     | none =>  calc p.toPMF none
-        _ = 1 - ∑' x, p.toPMF (some x) := by rw [run_none_eq_one_sub]
+        _ = 1 - ∑' x, p.toPMF (some x) := by grind
         _ = 1 - ∑' x, q.toPMF (some x) := by simp [h]
-        _ = q.toPMF none := by rw [run_none_eq_one_sub]
+        _ = q.toPMF none := by grind
 
 open Classical in
 lemma eq_liftM_iff_forall (p : SPMF α) (q : PMF α) :
@@ -203,7 +200,7 @@ lemma eq_liftM_iff_forall (p : SPMF α) (q : PMF α) :
 section support
 
 /-- The set of outputs with non-zero probability mass. -/
-protected def support {α : Type _} (p : SPMF α) : Set α :=
+protected def support {α : Type*} (p : SPMF α) : Set α :=
   Function.support (p : α → ℝ≥0∞)
 
 lemma support_def (p : SPMF α) :
@@ -253,9 +250,6 @@ end gap
 @[simp] lemma map_mk (p : PMF (Option α)) (f : α → β) :
     f <$> SPMF.mk p = SPMF.mk (Option.map f <$> p) := by aesop
 
-theorem pure_eq_pmf_pure {a : α} : (pure a : SPMF α) = PMF.pure a := by
-  simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
-
 theorem bind_eq_pmf_bind {p : SPMF α} {f : α → SPMF β} :
     (p >>= f) = PMF.bind p (fun a => match a with | some a' => f a' | none => PMF.pure none) := by
   simp [bind, OptionT.bind, PMF.instMonad, OptionT.mk]
@@ -265,22 +259,16 @@ theorem bind_eq_pmf_bind {p : SPMF α} {f : α → SPMF β} :
   simp [PMF.monad_map_eq_map]
 
 /-- `pure a` in `SPMF` equals `PMF.pure (some a)` as a PMF on `Option α`. -/
-protected lemma pure_eq_pure_some (a : α) : (pure a : SPMF α) = PMF.pure (some a) := by
-  have : (pure a : SPMF α) = liftM (PMF.pure a) := by
-    simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
-  rw [this]; change (PMF.pure a).bind (fun x => PMF.pure (some x)) = _; rw [PMF.pure_bind]
+protected lemma pure_eq_pure_some (a : α) :
+    (pure a : SPMF α) = SPMF.mk (PMF.pure (some a)) := by rfl
+
+@[simp, grind =]
+lemma toPMF_inj (p q : SPMF α) : p.toPMF = q.toPMF ↔ p = q := by aesop
 
 /-- The functor map for SPMF equals `PMF.map (Option.map f)`. -/
 protected lemma fmap_eq_map (f : α → β) (c : SPMF α) :
-    (f <$> c : SPMF β) = PMF.map (Option.map f) c := by
-  have : (f <$> c : SPMF β) =
-    PMF.bind c (fun a => match a with
-      | some a' => (pure (f a') : SPMF β) | none => PMF.pure none) := by
-    show (c >>= (pure ∘ f)) = _; exact bind_eq_pmf_bind
-  rw [this]; apply PMF.ext; intro x
-  simp only [PMF.bind_apply, PMF.map_apply]
-  congr 1; ext y; cases y with
-  | none => cases x <;> simp [PMF.pure_apply]
-  | some a => simp only [SPMF.pure_eq_pure_some, PMF.pure_apply]; cases x <;> simp
+    (f <$> c : SPMF β) = (PMF.map (Option.map f) c) :=
+  show (f <$> c : SPMF β) = SPMF.mk (PMF.map (Option.map f) c.toPMF)
+  by rw [← SPMF.toPMF_inj, SPMF.toPMF_map, SPMF.toPMF_mk, PMF.monad_map_eq_map]
 
 end SPMF

--- a/ToMathlib/ProbabilityTheory/SPMF.lean
+++ b/ToMathlib/ProbabilityTheory/SPMF.lean
@@ -3,11 +3,12 @@ Copyright (c) 2025 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
-import Mathlib.Probability.ProbabilityMassFunction.Monad
-import VCVio.Prelude
+module
+
+public import Mathlib.Probability.ProbabilityMassFunction.Monad
 import Batteries.Control.AlternativeMonad
 import ToMathlib.Control.Monad.Hom
-import ToMathlib.ProbabilityTheory.Coupling
+public import ToMathlib.General
 
 /-!
 # Sub-Probability Distributions
@@ -16,6 +17,8 @@ This file defines a type `SPMF` as a `PMF` extended with the option to fail.
 The probability of failure is the missing mass to make the `PMF` sum to `1`.
 -/
 
+@[expose] public section
+
 open ENNReal
 
 attribute [simp] PMF.coe_le_one PMF.apply_ne_top
@@ -23,6 +26,31 @@ attribute [simp] PMF.coe_le_one PMF.apply_ne_top
 universe u v w
 
 variable {α β γ : Type u}
+
+namespace PMF
+
+/-- A PMF that is zero at all points except `a` equals `PMF.pure a`. -/
+lemma eq_pure_of_forall_ne_eq_zero {γ : Type*} (p : PMF γ) (a : γ)
+    (h : ∀ x, x ≠ a → p x = 0) : p = PMF.pure a := by
+  ext x; by_cases hx : x = a
+  · subst hx; simp only [PMF.pure_apply, if_true]
+    rw [← p.tsum_coe]; exact (tsum_eq_single x (fun b hb => h b hb)).symm
+  · simp [PMF.pure_apply, hx, h x hx]
+
+/-- `PMF.bind` respects equality on the support. -/
+protected lemma bind_congr {γ δ : Type*} (p : PMF γ) (f g : γ → PMF δ)
+    (h : ∀ x, p x ≠ 0 → f x = g x) : p.bind f = p.bind g := by
+  ext y; simp only [PMF.bind_apply]; congr 1; ext x
+  by_cases hx : p x = 0 <;> simp [hx, h x]
+
+/-- If `PMF.map f c = PMF.pure b` and `f a ≠ b`, then `c a = 0`. -/
+lemma map_eq_pure_zero {γ δ : Type*} (f : γ → δ) (c : PMF γ) (b : δ)
+    (h : PMF.map f c = PMF.pure b) (a : γ) (ha : f a ≠ b) : c a = 0 := by
+  have key := congr_fun (congrArg DFunLike.coe h) (f a)
+  simp [PMF.map_apply, PMF.pure_apply, ha] at key
+  exact key a rfl
+
+end PMF
 
 /-- A subprobability mass function is a function `α → ℝ≥0∞` such that values have an infinite
 sum at most `1` represented by applying an `OptionT` transformer to the `PMF` monad.
@@ -87,6 +115,8 @@ lemma toPMF_failure : (failure : SPMF α).toPMF = PMF.pure none := rfl
 @[simp, grind =]
 lemma failure_apply (x : α) : (failure : SPMF α) x = 0 := by aesop
 
+section zero
+
 noncomputable instance : Zero (SPMF α) where zero := failure
 
 lemma zero_def : (0 : SPMF α) = failure := rfl
@@ -106,19 +136,28 @@ lemma toPMF_map (p : SPMF α) (f : α → β) : (f <$> p).toPMF = Option.map f <
 @[simp, grind =]
 lemma zero_apply (x : α) : (0 : SPMF α) x = 0 := by aesop
 
-@[simp] lemma tsum_toPMF_some_add_toPMF_none (p : SPMF α) :
+end zero
+
+@[simp, grind =]
+lemma tsum_toPMF_some_add_toPMF_none (p : SPMF α) :
     (∑' x, p.toPMF (some x)) + p.toPMF none = 1 := by
   rw [add_comm, ← tsum_option _ ENNReal.summable, p.toPMF.tsum_coe]
 
-@[simp] lemma run_none_add_tsum_run_some (p : SPMF α) :
+@[simp, grind =]
+lemma run_none_add_tsum_run_some (p : SPMF α) :
     p.toPMF none + (∑' x, p.toPMF (some x)) = 1 := by
   rw [← tsum_option _ ENNReal.summable, p.toPMF.tsum_coe]
 
 lemma tsum_run_some_eq_one_sub (p : SPMF α) :
     ∑' x, p.toPMF (some x) = 1 - p.toPMF none := by
   rw [← tsum_toPMF_some_add_toPMF_none p]
-  refine ENNReal.eq_sub_of_add_eq' ?_ rfl
-  simp
+  refine ENNReal.eq_sub_of_add_eq' (by simp) rfl
+
+@[grind =]
+lemma toPMF_none_eq_one_sub_tsum (p : SPMF α) :
+    p.toPMF none = 1 - ∑' x, p.toPMF (some x) := by
+  rw [← run_none_add_tsum_run_some p]
+  refine ENNReal.eq_sub_of_add_eq' (by simp) rfl
 
 @[simp, grind .] lemma apply_ne_top (p : SPMF α) (x : α) : p x ≠ ⊤ := by aesop
 
@@ -161,6 +200,8 @@ lemma eq_liftM_iff_forall (p : SPMF α) (q : PMF α) :
   simp
   rfl
 
+section support
+
 /-- The set of outputs with non-zero probability mass. -/
 protected def support {α : Type _} (p : SPMF α) : Set α :=
   Function.support (p : α → ℝ≥0∞)
@@ -181,41 +222,65 @@ lemma support_liftM (p : PMF α) : (liftM p : SPMF α).support = p.support := by
 @[simp, grind =]
 lemma support_pure (x : α) : (pure x : SPMF α).support = {x} := by aesop
 
+end support
+
+section gap
+
+/-- Gap between the total mass of `p : SPMF` and `1`, so `∑ x, p x + p.gap = 1`.
+TODO: use this to simplify the API around failure and needing `toPMF`/`run`. -/
+def gap (p : SPMF α) : ℝ≥0∞ := p.toPMF none
+
+@[grind =]
+lemma gap_eq_toPMF_none (p : SPMF α) : p.gap = p.toPMF none := rfl
+
+@[grind =]
+lemma gap_eq_one_sub_tsum (p : SPMF α) : p.gap = 1 - ∑' x : α, p x := by grind
+
+@[grind =]
+lemma toReal_gap_eq_one_sub_sum_toReal [Fintype α] (p : SPMF α) :
+    p.gap.toReal = 1 - ∑ x : α, (p x).toReal := by
+  simp [SPMF.gap_eq_one_sub_tsum]
+  rw [ENNReal.toReal_sub_of_le]
+  · simp
+    rw [ENNReal.toReal_sum]
+    simp
+  · refine le_of_le_of_eq ?_ (run_none_add_tsum_run_some p)
+    simp [SPMF.apply_eq_toPMF_some]
+  · simp
+
+end gap
+
 @[simp] lemma map_mk (p : PMF (Option α)) (f : α → β) :
     f <$> SPMF.mk p = SPMF.mk (Option.map f <$> p) := by aesop
 
-/-- Couplings specialized to VCVio's canonical `SPMF`. -/
-abbrev IsCoupling (c : SPMF (α × β)) (p : SPMF α) (q : SPMF β) : Prop :=
-  SubPMF.IsCoupling c p q
+theorem pure_eq_pmf_pure {a : α} : (pure a : SPMF α) = PMF.pure a := by
+  simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
 
-/-- Coupling witness type specialized to VCVio's canonical `SPMF`. -/
-def Coupling (p : SPMF α) (q : SPMF β) :=
-  { c : SPMF (α × β) // IsCoupling c p q }
+theorem bind_eq_pmf_bind {p : SPMF α} {f : α → SPMF β} :
+    (p >>= f) = PMF.bind p (fun a => match a with | some a' => f a' | none => PMF.pure none) := by
+  simp [bind, OptionT.bind, PMF.instMonad, OptionT.mk]
+  rfl
 
-/-- Bind rule for `SPMF` couplings. -/
-theorem IsCoupling.bind {α₁ α₂ β₁ β₂ : Type u}
-    {p : SPMF α₁} {q : SPMF α₂} {f : α₁ → SPMF β₁} {g : α₂ → SPMF β₂}
-    (c : Coupling p q) (d : (a₁ : α₁) → (a₂ : α₂) → SPMF (β₁ × β₂))
-    (h : ∀ (a₁ : α₁) (a₂ : α₂), c.1.1 (some (a₁, a₂)) ≠ 0 → IsCoupling (d a₁ a₂) (f a₁) (g a₂)) :
-    IsCoupling (c.1 >>= λ (p : α₁ × α₂) => d p.1 p.2) (p >>= f) (q >>= g) :=
-  SubPMF.IsCoupling.bind ⟨c.1, c.2⟩ d h
+@[simp] lemma PMF.map_some_apply_some (p : PMF α) (x : α) : (some <$> p) (some x) = p x := by
+  simp [PMF.monad_map_eq_map]
 
-/-- Existential bind rule for `SPMF` couplings. -/
-theorem IsCoupling.exists_bind {α₁ α₂ β₁ β₂ : Type u}
-    {p : SPMF α₁} {q : SPMF α₂} {f : α₁ → SPMF β₁} {g : α₂ → SPMF β₂}
-    (c : Coupling p q)
-    (h : ∀ (a₁ : α₁) (a₂ : α₂), ∃ (d : SPMF (β₁ × β₂)), IsCoupling d (f a₁) (g a₂)) :
-    ∃ (d : SPMF (β₁ × β₂)), IsCoupling d (p >>= f) (q >>= g) :=
-  SubPMF.IsCoupling.exists_bind ⟨c.1, c.2⟩ h
+/-- `pure a` in `SPMF` equals `PMF.pure (some a)` as a PMF on `Option α`. -/
+protected lemma pure_eq_pure_some (a : α) : (pure a : SPMF α) = PMF.pure (some a) := by
+  have : (pure a : SPMF α) = liftM (PMF.pure a) := by
+    simp [pure, liftM, OptionT.pure, monadLift, MonadLift.monadLift, OptionT.lift, PMF.instMonad]
+  rw [this]; change (PMF.pure a).bind (fun x => PMF.pure (some x)) = _; rw [PMF.pure_bind]
 
-/-- Diagonal self-coupling proof. -/
-theorem IsCoupling.refl (p : SPMF α) :
-    IsCoupling (p >>= fun a => pure (a, a)) p p :=
-  SubPMF.IsCoupling.refl p
-
-/-- Diagonal self-coupling witness. -/
-noncomputable def Coupling.refl (p : SPMF α) : Coupling p p :=
-  ⟨p >>= fun a => pure (a, a), IsCoupling.refl p⟩
-
+/-- The functor map for SPMF equals `PMF.map (Option.map f)`. -/
+protected lemma fmap_eq_map (f : α → β) (c : SPMF α) :
+    (f <$> c : SPMF β) = PMF.map (Option.map f) c := by
+  have : (f <$> c : SPMF β) =
+    PMF.bind c (fun a => match a with
+      | some a' => (pure (f a') : SPMF β) | none => PMF.pure none) := by
+    show (c >>= (pure ∘ f)) = _; exact bind_eq_pmf_bind
+  rw [this]; apply PMF.ext; intro x
+  simp only [PMF.bind_apply, PMF.map_apply]
+  congr 1; ext y; cases y with
+  | none => cases x <;> simp [PMF.pure_apply]
+  | some a => simp only [SPMF.pure_eq_pure_some, PMF.pure_apply]; cases x <;> simp
 
 end SPMF

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -32,7 +32,6 @@ import VCVio.EvalDist.Defs.AlternativeMonad
 import VCVio.EvalDist.Defs.Basic
 import VCVio.EvalDist.Defs.Instances
 import VCVio.EvalDist.Defs.NeverFails
-import VCVio.EvalDist.Defs.SPMF
 import VCVio.EvalDist.Defs.Support
 import VCVio.EvalDist.Fintype
 import VCVio.EvalDist.Instances.ErrorT

--- a/VCVio/EvalDist/Defs/Support.lean
+++ b/VCVio/EvalDist/Defs/Support.lean
@@ -3,7 +3,8 @@ Copyright (c) 2025 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
-import VCVio.EvalDist.Defs.SPMF
+import VCVio.Prelude
+import ToMathlib.ProbabilityTheory.SPMF
 
 /-!
 # Typeclasses for Denotational Monad Support

--- a/VCVio/EvalDist/Instances/OptionT.lean
+++ b/VCVio/EvalDist/Instances/OptionT.lean
@@ -186,26 +186,6 @@ lemma probFailure_lift [LawfulMonad m] (mx : m α) :
     Pr[⊥ | OptionT.lift mx] = Pr[⊥ | mx] := by
   simp [probFailure_eq]
 
-/-! ### SubPMF / SPMF bridge
-
-`SubPMF α` is `OptionT PMF α` and `SPMF α` is also `OptionT PMF α`, but they carry
-different `HasEvalSPMF` instances. These lemmas equate `probOutput` and `probEvent`
-across the two views. -/
-
-lemma probOutput_subpmf_eq_spmf (p : SPMF α) (x : α) :
-    @probOutput SubPMF OptionT.instMonad α (instHasEvalSPMF PMF) (p : SubPMF α) x =
-      @probOutput SPMF SPMF.instAlternativeMonad.toMonad α SPMF.instHasEvalSPMF p x := by
-  rw [probOutput_eq, PMF.probOutput_eq_apply, SPMF.probOutput_eq_apply]
-  rfl
-
-lemma probEvent_subpmf_eq_spmf (p : SPMF α) (q : α → Prop) :
-    @probEvent SubPMF OptionT.instMonad α (instHasEvalSPMF PMF) (p : SubPMF α) q =
-      @probEvent SPMF SPMF.instAlternativeMonad.toMonad α SPMF.instHasEvalSPMF p q := by
-  classical
-  rw [probEvent_eq_tsum_ite, probEvent_eq_tsum_ite]
-  refine tsum_congr fun x => ?_
-  by_cases hq : q x <;> simp [hq, probOutput_subpmf_eq_spmf]
-
 end HasEvalSPMF
 
 end OptionT

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -52,17 +52,17 @@ noncomputable instance instMAlgRelOrdered :
     constructor
     · intro h
       rcases h with ⟨c, hc⟩
-      have hcPure : _root_.SubPMF.IsCoupling c.1 (pure a) (pure b) := by
+      have hcPure : _root_.SPMF.IsCoupling c.1 (pure a) (pure b) := by
         simpa [evalDist_pure] using c.2
       have hcEq : c.1 = (pure (a, b) : SPMF (_ × _)) :=
-        (_root_.SubPMF.IsCoupling.pure_iff).1 hcPure
+        (_root_.SPMF.IsCoupling.pure_iff).1 hcPure
       have hmem : (a, b) ∈ support c.1 := by
         simp [hcEq, support_pure]
       exact hc (a, b) hmem
     · intro hR
       refine ⟨⟨(pure (a, b) : SPMF (_ × _)), ?_⟩, ?_⟩
-      · have hcPure : _root_.SubPMF.IsCoupling (pure (a, b) : SPMF (_ × _)) (pure a) (pure b) :=
-          (_root_.SubPMF.IsCoupling.pure_iff).2 rfl
+      · have hcPure : _root_.SPMF.IsCoupling (pure (a, b) : SPMF (_ × _)) (pure a) (pure b) :=
+          (_root_.SPMF.IsCoupling.pure_iff).2 rfl
         simpa [evalDist_pure] using hcPure
       · intro z hz
         have hzEq : z = (a, b) := by
@@ -145,7 +145,7 @@ lemma relTriple_pure_pure {a : α} {b : β} {R : RelPost α β} (h : R a b) :
     RelTriple (pure a : OracleComp spec₁ α) (pure b : OracleComp spec₂ β) R := by
   rw [relTriple_iff_relWP, relWP_iff_couplingPost]
   refine ⟨⟨pure (a, b), ?_⟩, fun z hz => ?_⟩
-  · simpa [evalDist_pure] using _root_.SubPMF.IsCoupling.pure_iff.mpr rfl
+  · simpa [evalDist_pure] using _root_.SPMF.IsCoupling.pure_iff.mpr rfl
   · have : z = (a, b) := by simpa [support_pure] using hz
     subst this; exact h
 

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -230,7 +230,7 @@ theorem relTriple'_iff_couplingPost
                   exact mem_finSupport_of_mem_support_evalDist (oa := ob) (x := x) hx
                 simp [packB, hxfin]
           _ = Pr[= y | evalDist ob] := by simp
-      have hsub_nonempty : Nonempty (SubPMF.Coupling pa pb) := by
+      have hsub_nonempty : Nonempty (SPMF.Coupling pa pb) := by
         rcases hne with ⟨c₀⟩
         refine ⟨⟨packPair <$> c₀.1, ?_⟩⟩
         constructor
@@ -253,20 +253,19 @@ theorem relTriple'_iff_couplingPost
         | none => simp [fSub]
         | some z =>
             by_cases hR : R z.1.1 z.2.1 <;> simp [fSub, RelPost.indicator, hR]
-      obtain ⟨cMaxSub, hMaxSub⟩ := SubPMF.exists_max_coupling
+      obtain ⟨cMaxSub, hMaxSub⟩ := SPMF.exists_max_coupling
         (p := pa) (q := pb) fSub hfSub hsub_nonempty
       have hsub_obj :
-          ∀ c : SubPMF.Coupling pa pb,
+          ∀ c : SPMF.Coupling pa pb,
             (∑' z : Option (A × B), c.1.1 z * fSub z) =
-              Pr[fun z : A × B => R z.1.1 z.2.1 | (c.1 : SubPMF (A × B))] := by
+              Pr[fun z : A × B => R z.1.1 z.2.1 | (c.1 : SPMF (A × B))] := by
         intro c
         rw [probEvent_eq_tsum_ite, tsum_option _ ENNReal.summable]
         simp [fSub, RelPost.indicator]
         refine Finset.sum_congr rfl ?_
         intro x hx
         by_cases hR : R x.1.1 x.2.1
-        · simp [hR, OptionT.probOutput_eq, PMF.probOutput_eq_apply]
-          rfl
+        · rfl
         · simp [hR]
       have hlift_obj :
           ∀ c : SPMF.Coupling (evalDist oa) (evalDist ob),
@@ -305,43 +304,43 @@ theorem relTriple'_iff_couplingPost
           Pr[((fun z : α × β => R z.1 z.2) ∘ valPair) | cMaxSub'.1]
         exact probEvent_map (mx := cMaxSub'.1) (f := valPair)
           (q := fun z : α × β => R z.1 z.2)
-      have hpush_obj' :
-          Pr[fun z : α × β => R z.1 z.2 | cMax.1] =
-            Pr[fun z : A × B => R z.1.1 z.2.1 | (cMaxSub.1 : SubPMF (A × B))] := by
-        change
-          @probEvent SPMF SPMF.instAlternativeMonad.toMonad (α × β) SPMF.instHasEvalSPMF
-              cMax.1 (fun z : α × β => R z.1 z.2) =
-            @probEvent SubPMF OptionT.instMonad (A × B) (OptionT.instHasEvalSPMF PMF)
-              (cMaxSub.1 : SubPMF (A × B))
-              (fun z : A × B => R z.1.1 z.2.1)
-        calc
-          @probEvent SPMF SPMF.instAlternativeMonad.toMonad (α × β) SPMF.instHasEvalSPMF
-              cMax.1 (fun z : α × β => R z.1 z.2)
-              =
-            @probEvent SPMF SPMF.instAlternativeMonad.toMonad (A × B) SPMF.instHasEvalSPMF
-              cMaxSub'.1 (fun z : A × B => R z.1.1 z.2.1) :=
-                hpush_obj
-          _ =
-            @probEvent SPMF SPMF.instAlternativeMonad.toMonad (A × B) SPMF.instHasEvalSPMF
-              cMaxSub.1 (fun z : A × B => R z.1.1 z.2.1) := by
-                rfl
-          _ =
-            @probEvent SubPMF OptionT.instMonad (A × B) (OptionT.instHasEvalSPMF PMF)
-              (cMaxSub.1 : SubPMF (A × B))
-              (fun z : A × B => R z.1.1 z.2.1) :=
-                (OptionT.probEvent_subpmf_eq_spmf cMaxSub.1 (fun z : A × B => R z.1.1 z.2.1)).symm
+      -- have hpush_obj' :
+      --     Pr[fun z : α × β => R z.1 z.2 | cMax.1] =
+      --       Pr[fun z : A × B => R z.1.1 z.2.1 | (cMaxSub.1 : SPMF (A × B))] := by
+      --   change
+      --     @probEvent SPMF SPMF.instAlternativeMonad.toMonad (α × β) SPMF.instHasEvalSPMF
+      --         cMax.1 (fun z : α × β => R z.1 z.2) =
+      --       @probEvent (OptionT PMF) OptionT.instMonad (A × B) (OptionT.instHasEvalSPMF PMF)
+      --         (cMaxSub.1 : SPMF (A × B))
+      --         (fun z : A × B => R z.1.1 z.2.1)
+      --   calc
+      --     @probEvent SPMF SPMF.instAlternativeMonad.toMonad (α × β) SPMF.instHasEvalSPMF
+      --         cMax.1 (fun z : α × β => R z.1 z.2)
+      --         =
+      --       @probEvent SPMF SPMF.instAlternativeMonad.toMonad (A × B) SPMF.instHasEvalSPMF
+      --         cMaxSub'.1 (fun z : A × B => R z.1.1 z.2.1) :=
+      --           hpush_obj
+      --     _ =
+      --       @probEvent SPMF SPMF.instAlternativeMonad.toMonad (A × B) SPMF.instHasEvalSPMF
+      --         cMaxSub.1 (fun z : A × B => R z.1.1 z.2.1) := by
+      --           rfl
+      --     _ =
+      --       @probEvent SPMF OptionT.instMonad (A × B) (OptionT.instHasEvalSPMF PMF)
+      --         (cMaxSub.1 : SPMF (A × B))
+      --         (fun z : A × B => R z.1.1 z.2.1) :=
+      --           (OptionT.probEvent_SPMF_eq_spmf cMaxSub.1 (fun z : A × B => R z.1.1 z.2.1)).symm
       have hsub_le_max :
-          ∀ c : SubPMF.Coupling pa pb,
-            Pr[fun z : A × B => R z.1.1 z.2.1 | (c.1 : SubPMF (A × B))] ≤
-              Pr[fun z : A × B => R z.1.1 z.2.1 | (cMaxSub.1 : SubPMF (A × B))] := by
+          ∀ c : SPMF.Coupling pa pb,
+            Pr[fun z : A × B => R z.1.1 z.2.1 | (c.1 : SPMF (A × B))] ≤
+              Pr[fun z : A × B => R z.1.1 z.2.1 | (cMaxSub.1 : SPMF (A × B))] := by
         intro c
         have hle :
             (∑' z : Option (A × B), c.1.1 z * fSub z) ≤
               (∑' z : Option (A × B), cMaxSub.1.1 z * fSub z) := by
           calc
             (∑' z : Option (A × B), c.1.1 z * fSub z)
-                ≤ (⨆ c' : SubPMF.Coupling pa pb, ∑' z : Option (A × B), c'.1.1 z * fSub z) :=
-                  le_iSup (f := fun c' : SubPMF.Coupling pa pb =>
+                ≤ (⨆ c' : SPMF.Coupling pa pb, ∑' z : Option (A × B), c'.1.1 z * fSub z) :=
+                  le_iSup (f := fun c' : SPMF.Coupling pa pb =>
                     ∑' z : Option (A × B), c'.1.1 z * fSub z) c
             _ = (∑' z : Option (A × B), cMaxSub.1.1 z * fSub z) := hMaxSub
         rw [hsub_obj c, hsub_obj cMaxSub] at hle
@@ -352,7 +351,7 @@ theorem relTriple'_iff_couplingPost
         unfold eRelWP
         refine iSup_le ?_
         intro c
-        let cLift : SubPMF.Coupling pa pb := ⟨packPair <$> c.1, by
+        let cLift : SPMF.Coupling pa pb := ⟨packPair <$> c.1, by
           constructor
           · calc
               Prod.fst <$> (packPair <$> c.1) = packA <$> (Prod.fst <$> c.1) := by
@@ -364,6 +363,7 @@ theorem relTriple'_iff_couplingPost
                 simp [packPair]
               _ = packB <$> evalDist ob := by rw [c.2.map_snd]
               _ = pb := rfl⟩
+
         calc
           ∑' z, Pr[= z | c.1] * RelPost.indicator R z.1 z.2
               = Pr[fun z : α × β => R z.1 z.2 | c.1] := by
@@ -371,13 +371,10 @@ theorem relTriple'_iff_couplingPost
                     indicator_objective_eq_probEvent (mx := c.1) (R := R)
           _ = Pr[fun z : A × B => R z.1.1 z.2.1 | packPair <$> c.1] := by
                 exact (hlift_obj c).symm
-          _ = Pr[fun z : A × B => R z.1.1 z.2.1 | (packPair <$> c.1 : SubPMF (A × B))] := by
-                exact (OptionT.probEvent_subpmf_eq_spmf (packPair <$> c.1)
-                  (fun z : A × B => R z.1.1 z.2.1)).symm
-          _ = Pr[fun z : A × B => R z.1.1 z.2.1 | (cLift.1 : SubPMF (A × B))] := by
-                rfl
-          _ ≤ Pr[fun z : A × B => R z.1.1 z.2.1 | cMaxSub.1] := hsub_le_max cLift
-          _ = Pr[fun z : α × β => R z.1 z.2 | cMax.1] := hpush_obj'.symm
+          _ ≤ Pr[fun z : α × β => R z.1 z.2 | cMax.1] := by
+            rw [hpush_obj]
+            refine le_trans ?_ (hsub_le_max cLift)
+            rw [hlift_obj]
       have hmax_ge : 1 ≤ Pr[fun z : α × β => R z.1 z.2 | cMax.1] := le_trans h hupper
       have hmax_eq : Pr[fun z : α × β => R z.1 z.2 | cMax.1] = 1 :=
         le_antisymm probEvent_le_one hmax_ge
@@ -429,7 +426,7 @@ theorem eRelTriple_pure (a : α) (b : β) (post : α → β → ℝ≥0∞) :
   unfold eRelTriple eRelWP
   have hc : SPMF.IsCoupling (pure (a, b) : SPMF (α × β))
       (evalDist (pure a : OracleComp spec₁ α)) (evalDist (pure b : OracleComp spec₂ β)) := by
-    simp [evalDist_pure]; exact SubPMF.IsCoupling.pure_iff.mpr rfl
+    simp [evalDist_pure]; exact SPMF.IsCoupling.pure_iff.mpr rfl
   apply le_iSup_of_le ⟨pure (a, b), hc⟩
   have key : ∑' z, Pr[= z | (pure (a, b) : SPMF (α × β))] * post z.1 z.2 = post a b := by
     rw [tsum_eq_single (a, b)]

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -304,31 +304,6 @@ theorem relTriple'_iff_couplingPost
           Pr[((fun z : α × β => R z.1 z.2) ∘ valPair) | cMaxSub'.1]
         exact probEvent_map (mx := cMaxSub'.1) (f := valPair)
           (q := fun z : α × β => R z.1 z.2)
-      -- have hpush_obj' :
-      --     Pr[fun z : α × β => R z.1 z.2 | cMax.1] =
-      --       Pr[fun z : A × B => R z.1.1 z.2.1 | (cMaxSub.1 : SPMF (A × B))] := by
-      --   change
-      --     @probEvent SPMF SPMF.instAlternativeMonad.toMonad (α × β) SPMF.instHasEvalSPMF
-      --         cMax.1 (fun z : α × β => R z.1 z.2) =
-      --       @probEvent (OptionT PMF) OptionT.instMonad (A × B) (OptionT.instHasEvalSPMF PMF)
-      --         (cMaxSub.1 : SPMF (A × B))
-      --         (fun z : A × B => R z.1.1 z.2.1)
-      --   calc
-      --     @probEvent SPMF SPMF.instAlternativeMonad.toMonad (α × β) SPMF.instHasEvalSPMF
-      --         cMax.1 (fun z : α × β => R z.1 z.2)
-      --         =
-      --       @probEvent SPMF SPMF.instAlternativeMonad.toMonad (A × B) SPMF.instHasEvalSPMF
-      --         cMaxSub'.1 (fun z : A × B => R z.1.1 z.2.1) :=
-      --           hpush_obj
-      --     _ =
-      --       @probEvent SPMF SPMF.instAlternativeMonad.toMonad (A × B) SPMF.instHasEvalSPMF
-      --         cMaxSub.1 (fun z : A × B => R z.1.1 z.2.1) := by
-      --           rfl
-      --     _ =
-      --       @probEvent SPMF OptionT.instMonad (A × B) (OptionT.instHasEvalSPMF PMF)
-      --         (cMaxSub.1 : SPMF (A × B))
-      --         (fun z : A × B => R z.1.1 z.2.1) :=
-      --           (OptionT.probEvent_SPMF_eq_spmf cMaxSub.1 (fun z : A × B => R z.1.1 z.2.1)).symm
       have hsub_le_max :
           ∀ c : SPMF.Coupling pa pb,
             Pr[fun z : A × B => R z.1.1 z.2.1 | (c.1 : SPMF (A × B))] ≤
@@ -373,7 +348,7 @@ theorem relTriple'_iff_couplingPost
                 exact (hlift_obj c).symm
           _ ≤ Pr[fun z : α × β => R z.1 z.2 | cMax.1] := by
             rw [hpush_obj]
-            refine le_trans ?_ (hsub_le_max cLift)
+            refine le_of_eq_of_le ?_ (hsub_le_max cLift)
             rw [hlift_obj]
       have hmax_ge : 1 ≤ Pr[fun z : α × β => R z.1 z.2 | cMax.1] := le_trans h hupper
       have hmax_eq : Pr[fun z : α × β => R z.1 z.2 | cMax.1] = 1 :=

--- a/VCVioWidgets.lean
+++ b/VCVioWidgets.lean
@@ -2,9 +2,9 @@ import VCVioWidgets.Component.RevealLocation
 import VCVioWidgets.GameHop.Anchor
 import VCVioWidgets.GameHop.Extract
 import VCVioWidgets.GameHop.Hints
-import VCVioWidgets.GameHop.Registry
 import VCVioWidgets.GameHop.Infer
 import VCVioWidgets.GameHop.Lookup
 import VCVioWidgets.GameHop.Model
 import VCVioWidgets.GameHop.Panel
+import VCVioWidgets.GameHop.Registry
 import VCVioWidgets.GameHop.Render


### PR DESCRIPTION
This merges the definitions of `SubPMF` and `SPMF`, and the APIs for both of them. Still just uses `OptionT PMF` internally to get the monad behavior for free.  Also moves some lemmas around to have better namespacing and import placement.

Universally adopts the contention: given `p : SPMF A`, `p x` is the mass of `x : A` defined by `p.toPMF x` and `p.gap` is `p.toPMF none`. We avoid writing `p (some x)` whenever possible as the implicitly is unfolding `SPMF` into a `PMF` which can cause strange tactic behavior. 

This also updates the workflow to use `lake exe mk_all` for testing the imports rather than the old bash script. Makes a difference with the new module system since the script has no upstream updates and the lake tool does.