### PR TITLE
feat(RandomOracle): prove `eagerRandomOracle_evalDist_generateSeed_bind`

### DIFF
--- a/VCVio/OracleComp/QueryTracking/RandomOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle.lean
@@ -116,6 +116,43 @@ theorem evalDist_simulateQ_run'_empty [spec₀.Fintype] [spec₀.Inhabited]
 
 end eagerRandomOracle
 
+/-- Helper: the `run'` of the eager oracle bind reduces to uniform sampling
+when `seed t = []`. -/
+private lemma eagerRandomOracle_run'_nil {ι₀ : Type} [DecidableEq ι₀]
+    {spec₀ : OracleSpec.{0,0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
+    {α : Type} (t : spec₀.Domain) (f : spec₀.Range t → OracleComp spec₀ α)
+    (seed : QuerySeed spec₀) (ht : seed t = []) :
+    (eagerRandomOracle t >>= fun u => simulateQ eagerRandomOracle (f u)).run' seed =
+    ($ᵗ spec₀.Range t) >>= fun u => (simulateQ eagerRandomOracle (f u)).run' seed := by
+  show Prod.fst <$> ((eagerRandomOracle t).run seed >>= fun p =>
+      (simulateQ eagerRandomOracle (f p.1)).run p.2) = _
+  have h : (eagerRandomOracle (spec := spec₀) t).run seed =
+      (fun u => (u, seed)) <$> ($ᵗ spec₀.Range t) := by
+    show (match seed t with
+        | v :: vs => pure (v, Function.update seed t vs)
+        | [] => (·, seed) <$> ($ᵗ spec₀.Range t)) = _
+    rw [ht]
+  rw [h]; simp [map_bind, bind_map_left]
+
+/-- Helper: the `run'` of the eager oracle bind consumes the head
+when `seed t = u :: us`. -/
+private lemma eagerRandomOracle_run'_cons {ι₀ : Type} [DecidableEq ι₀]
+    {spec₀ : OracleSpec.{0,0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
+    {α : Type} (t : spec₀.Domain) (f : spec₀.Range t → OracleComp spec₀ α)
+    (seed : QuerySeed spec₀) (u : spec₀.Range t) (us : List (spec₀.Range t))
+    (ht : seed t = u :: us) :
+    (eagerRandomOracle t >>= fun v => simulateQ eagerRandomOracle (f v)).run' seed =
+    (simulateQ eagerRandomOracle (f u)).run' (Function.update seed t us) := by
+  show Prod.fst <$> ((eagerRandomOracle t).run seed >>= fun p =>
+      (simulateQ eagerRandomOracle (f p.1)).run p.2) = _
+  have h : (eagerRandomOracle (spec := spec₀) t).run seed =
+      pure (u, Function.update seed t us) := by
+    show (match seed t with
+        | v :: vs => pure (v, Function.update seed t vs)
+        | [] => (·, seed) <$> ($ᵗ spec₀.Range t)) = _
+    rw [ht]
+  rw [h, pure_bind]; rfl
+
 /-- The eager random oracle, averaged over a uniformly sampled seed, matches the
 fresh independent-query semantics of `evalDist`. This is because the pre-sampled
 seed values are i.i.d. uniform, exactly matching fresh oracle queries.
@@ -131,4 +168,78 @@ theorem eagerRandomOracle_evalDist_generateSeed_bind {ι₀ : Type} [DecidableEq
     evalDist (do
       let seed ← generateSeed spec₀ qc js
       (simulateQ (eagerRandomOracle (spec := spec₀)) oa).run' seed) = evalDist oa := by
-  sorry
+  classical
+  revert qc js
+  induction oa using OracleComp.inductionOn with
+  | pure a => intro qc js; apply evalDist_ext; intro; simp
+  | query_bind t f ih =>
+    intro qc js; apply evalDist_ext; intro x
+    have hsimQ : ∀ seed : QuerySeed spec₀,
+        (simulateQ eagerRandomOracle (liftM (query t) >>= f)).run' seed =
+        (eagerRandomOracle t >>= fun u => simulateQ eagerRandomOracle (f u)).run' seed :=
+      fun _ => by congr 1
+    simp_rw [hsimQ]
+    rw [probOutput_bind_eq_tsum (liftM (query t)) f x]
+    simp_rw [probOutput_query t]
+    rw [probOutput_bind_eq_tsum]
+    have hih : ∀ u, ∑' seed, Pr[= seed | generateSeed spec₀ qc js] *
+        Pr[= x | (simulateQ eagerRandomOracle (f u)).run' seed] = Pr[= x | f u] := fun u => by
+      rw [← probOutput_bind_eq_tsum]; exact congrFun (congrArg DFunLike.coe (ih u qc js)) x
+    by_cases hcount : qc t * js.count t = 0
+    · -- Seed empty at t: fall back to uniform sampling
+      have hnil : ∀ seed ∈ support (generateSeed spec₀ qc js), seed t = [] :=
+        fun s hs => eq_nil_of_mem_support_generateSeed spec₀ qc js s t hs hcount
+      have hstep : ∀ seed,
+          Pr[= seed | generateSeed spec₀ qc js] *
+            Pr[= x | (eagerRandomOracle t >>= fun u =>
+              simulateQ eagerRandomOracle (f u)).run' seed] =
+          Pr[= seed | generateSeed spec₀ qc js] *
+            (∑' u, (↑(Fintype.card (spec₀.Range t)))⁻¹ *
+              Pr[= x | (simulateQ eagerRandomOracle (f u)).run' seed]) := by
+        intro seed
+        by_cases hs : seed ∈ support (generateSeed spec₀ qc js)
+        · rw [eagerRandomOracle_run'_nil t f seed (hnil seed hs), probOutput_bind_eq_tsum]
+          simp only [probOutput_uniformSample]
+        · simp [(probOutput_eq_zero_iff _ _).mpr hs]
+      simp_rw [hstep, ENNReal.tsum_mul_left, ← mul_assoc,
+        mul_comm (Pr[= _ | generateSeed _ _ _]) _, mul_assoc, ENNReal.tsum_mul_left]
+      congr 1
+      simp_rw [← ENNReal.tsum_mul_left (a := Pr[= _ | generateSeed _ _ _])]
+      rw [ENNReal.tsum_comm]; congr 1; ext u; exact hih u
+    · -- Seed non-empty at t: consume head value
+      have hpos : 0 < qc t * js.count t := Nat.pos_of_ne_zero (by omega)
+      have hstep : ∀ seed,
+          Pr[= seed | generateSeed spec₀ qc js] *
+            Pr[= x | (eagerRandomOracle t >>= fun u =>
+              simulateQ eagerRandomOracle (f u)).run' seed] =
+          Pr[= seed | generateSeed spec₀ qc js] *
+            (match seed t with
+              | u :: us => Pr[= x | (simulateQ eagerRandomOracle (f u)).run'
+                  (Function.update seed t us)]
+              | [] => 0) := by
+        intro seed
+        by_cases hs : seed ∈ support (generateSeed spec₀ qc js)
+        · obtain ⟨u, us, hc⟩ :=
+            exists_cons_of_mem_support_generateSeed spec₀ qc js seed t hs hpos
+          rw [eagerRandomOracle_run'_cons t f seed u us hc, hc]
+        · simp [(probOutput_eq_zero_iff _ _).mpr hs]
+      simp_rw [hstep]
+      rw [← (QuerySeed.prependValues_singleton_injective t).tsum_eq (by
+        intro seed hseed; simp only [Function.mem_support] at hseed
+        have hmem : seed ∈ support (generateSeed spec₀ qc js) := by
+          by_contra h; exact hseed (by simp [(probOutput_eq_zero_iff _ _).mpr h])
+        obtain ⟨u, us, hc⟩ :=
+          exists_cons_of_mem_support_generateSeed spec₀ qc js seed t hmem hpos
+        exact ⟨(u, Function.update seed t us),
+          QuerySeed.eq_prependValues_of_pop_eq_some
+            (QuerySeed.pop_eq_some_of_cons seed t u us hc)⟩)]
+      simp only [QuerySeed.prependValues, List.singleton_append,
+        Function.update_self, Function.update_idem, Function.update_eq_self]
+      rw [ENNReal.tsum_prod']; congr 1; ext u
+      simp only [show ∀ b : QuerySeed spec₀,
+          Function.update (u, b).2 t ((u, b).1 :: (u, b).2 t) = b.prependValues [u] from
+        fun b => by simp [QuerySeed.prependValues]]
+      simp_rw [probOutput_generateSeed_prependValues spec₀ qc js u _ hpos,
+        mul_assoc, ENNReal.tsum_mul_left]
+      congr 1; rw [← probOutput_bind_eq_tsum]
+      exact congrFun (congrArg DFunLike.coe (ih u _ js.dedup)) x


### PR DESCRIPTION
This PR proves `eagerRandomOracle_evalDist_generateSeed_bind`: the eager random oracle, averaged over a uniformly sampled seed, matches the fresh independent-query semantics of `evalDist`.

Closes #130

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>