### PR TITLE
chore: Standardize linter to align with Arklib and Mathlib

### DIFF
--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -36,6 +36,8 @@ bodies remain `sorry` for now.
 -/
 
 set_option autoImplicit false
+set_option linter.unusedDecidableInType false
+set_option linter.unusedFintypeInType false
 
 open OracleComp OracleSpec ENNReal OneWay
 
@@ -60,7 +62,6 @@ namespace br93AsymmEnc
 
 variable {tdp : TrapdoorPermutation PK SK Rand} {hash : Rand → M}
 
-set_option maxHeartbeats 400000 in
 omit [Inhabited Rand] [Fintype Rand] [DecidableEq Rand] [Inhabited M] [Fintype M]
   [SampleableType M] in
 /-- Correctness of BR93 follows from correctness of the underlying trapdoor permutation. -/

--- a/Examples/ElGamal/Basic.lean
+++ b/Examples/ElGamal/Basic.lean
@@ -115,8 +115,8 @@ private lemma IND_CPA_OneTime_game_evalDist_eq_ddhExpReal
     DiffieHellman.ddhExpReal, IND_CPA_OneTime_DDHReduction,
     elGamalAsymmEnc, ExecutionMethod.default]
   ext z
-  show Pr[= z | _] = Pr[= z | _]
-  simp
+  change Pr[= z | _] = Pr[= z | _]
+  simp only [bind_pure_comp, bind_map_left]
   -- Step 1: swap $ᵗBool past $ᵗF in LHS
   rw [probOutput_bind_bind_swap ($ᵗ Bool) ($ᵗ F)]
   -- Now LHS starts with $ᵗF. Use congr under $ᵗF.

--- a/Examples/FrankingProtocol.lean
+++ b/Examples/FrankingProtocol.lean
@@ -20,7 +20,7 @@
 
 -- -- helpers for converting String's & BitVec's
 -- def string_to_bitvec (s : String) : BitVec 256 :=
---   s.foldl (λ acc c => (acc.shiftLeft 8) + BitVec.ofNat 256 c.toNat) 0
+--   s.foldl (fun acc c => (acc.shiftLeft 8) + BitVec.ofNat 256 c.toNat) 0
 
 -- def bitvec_to_string (bv : BitVec 256) : String :=
 --   let rec chars (n : Nat) (acc : List Char) :=

--- a/Examples/MLKEM/Concrete/Encoding.lean
+++ b/Examples/MLKEM/Concrete/Encoding.lean
@@ -16,6 +16,7 @@ compression / decompression (FIPS 203 Section 4.2.1) operations.
 -/
 
 set_option autoImplicit false
+set_option linter.style.nativeDecide false
 
 namespace MLKEM.Concrete
 
@@ -381,7 +382,7 @@ private theorem byteDecode_byteEncode_of_bound {d : Nat} (hd : 0 < d) (f : Rq)
           _ ≤ ringDegree * d := Nat.mul_le_mul_right _ (Nat.succ_le_of_lt hi)
       simpa [hencodedBitsLen] using this
     simp [Array.getD, hij]
-  simp [byteDecode]
+  simp only [byteDecode, Array.getD_eq_getD_getElem?, Vector.getElem_ofFn]
   rw [hcoeffBitsInput]
   rw [hcoeffBits, hdigits, ofDigits_digitsAppend_two hcoeffBound]
   exact ZMod.natCast_zmod_val (f[i])
@@ -390,8 +391,8 @@ private theorem byteDecode_one_coeff (bytes : ByteArray) {i : Nat} (hi : i < rin
     ((byteDecode 1 bytes)[i] : Coeff).val = (bytesToBits bytes).getD i 0 := by
   have hbitMod : (bytesToBits bytes).getD i 0 < modulus := by
     exact lt_trans (bytesToBits_getD_lt_two bytes i) (by decide)
-  have hcast : (((bytesToBits bytes).getD i 0 : Nat) : Coeff).val = (bytesToBits bytes).getD i 0 := by
-    exact ZMod.val_cast_of_lt hbitMod
+  have hcast : (((bytesToBits bytes).getD i 0 : Nat) : Coeff).val = (bytesToBits bytes).getD i 0 :=
+    ZMod.val_cast_of_lt hbitMod
   simpa [byteDecode, Nat.ofDigits_singleton] using hcast
 
 /-! ## 12-bit public-key encoding -/
@@ -572,8 +573,8 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
     have hb1 :
         (getByteD (byteEncode12Poly f) (3 * pair + 1)).toNat = a / 256 + 16 * (b % 16) := by
       have hab' :
-          ZMod.val f.coeffs[2 * pair] / 256 + 16 * (ZMod.val f.coeffs[2 * pair + 1] % 16) < 256 := by
-        simpa [a, b] using hab
+          ZMod.val f.coeffs[2 * pair] / 256 + 16 * (ZMod.val f.coeffs[2 * pair + 1] % 16) < 256 :=
+        by simpa [a, b] using hab
       rw [getByteD_byteEncode12Poly (f := f) (j := 3 * pair + 1) (by omega)]
       simp [byteEncode12PolyByte, a, b, hdiv1, hmod1, Nat.mod_eq_of_lt hab']
     have hb2 :
@@ -808,11 +809,11 @@ private theorem byteDecodeVec_byteEncodeVec_of_bound {d k : Nat} (hd : 0 < d) (v
         simpa [byteEncode_size] using hj2
       have hjEnc : j < (byteEncode d (v[i]'hi)).size := by
         simpa [byteEncode_size] using hj
-      simp
+      simp only [Array.getElem_ofFn]
       rw [getByteD_byteEncodeVec (hd := hd) (v := v) (poly := i) (j := j) hi hj]
       rw [← ByteArray.getElem_eq_getElem_data (a := byteEncode d (v[i]'hi)) (h := hjEnc)]
       rw [getByteD_eq_getElem hjEnc]
-  simp [byteDecodeVec]
+  simp only [byteDecodeVec, Vector.getElem_ofFn]
   rw [hbytes]
   exact byteDecode_byteEncode_of_bound hd (f := v[i]'hi) (hbound := hbound ⟨i, hi⟩)
 

--- a/Examples/MLKEM/Concrete/NTT.lean
+++ b/Examples/MLKEM/Concrete/NTT.lean
@@ -214,6 +214,7 @@ private theorem applyMatrix_id (f : Rq) :
   let jFin : Fin ringDegree := ⟨j, hj⟩
   simp [applyMatrix, idMatrix]
 
+set_option linter.style.nativeDecide false
 private theorem invNTTMatrix_nttMatrix_entry :
     ∀ row col : Fin ringDegree,
       (∑ k : Fin ringDegree, invNTTMatrix row k * nttMatrix k col) = idMatrix row col := by

--- a/Examples/MLKEM/KPKE.lean
+++ b/Examples/MLKEM/KPKE.lean
@@ -41,14 +41,14 @@ instance [DecidableEq encoding.EncodedTHat] : DecidableEq (PublicKey params enco
   intro x y
   cases x
   cases y
-  simp
+  simp only [PublicKey.mk.injEq]
   infer_instance
 
 instance [DecidableEq encoding.EncodedTHat] : DecidableEq (SecretKey params encoding) := by
   intro x y
   cases x
   cases y
-  simp
+  simp only [SecretKey.mk.injEq]
   infer_instance
 
 instance [DecidableEq encoding.EncodedU] [DecidableEq encoding.EncodedV] :
@@ -56,7 +56,7 @@ instance [DecidableEq encoding.EncodedU] [DecidableEq encoding.EncodedV] :
   intro x y
   cases x
   cases y
-  simp
+  simp only [Ciphertext.mk.injEq]
   infer_instance
 
 /-- K-PKE key generation from an explicit 32-byte seed.

--- a/Examples/MLKEM/Ring.lean
+++ b/Examples/MLKEM/Ring.lean
@@ -93,8 +93,8 @@ namespace NTTRingOps
 variable (ops : NTTRingOps)
 
 /-- Transpose a row-major matrix over `T_q`. -/
-abbrev transpose (_ops : NTTRingOps) {rows cols : ℕ} (A : TqMatrix rows cols) : TqMatrix cols rows :=
-  LatticeCrypto.NTTRingOps.transpose A
+abbrev transpose (_ops : NTTRingOps) {rows cols : ℕ} (A : TqMatrix rows cols) :
+    TqMatrix cols rows := LatticeCrypto.NTTRingOps.transpose A
 
 /-- Apply NTT coordinate-wise to a vector over `R_q`. -/
 abbrev nttVec {k : ℕ} (v : RqVec k) : TqVec k :=

--- a/Examples/OneTimePad.lean
+++ b/Examples/OneTimePad.lean
@@ -89,7 +89,7 @@ lemma cipherGivenMsg_equiv (sp : ℕ) (msg₀ msg₁ : BitVec sp) :
   have hxor : Function.Bijective (fun x : BitVec sp => x ^^^ c) := by
     exact Function.Involutive.bijective fun x => by
       rw [BitVec.xor_assoc, BitVec.xor_self, BitVec.xor_zero]
-  show GameEquiv (($ᵗ BitVec sp) >>= fun k => pure (k ^^^ msg₀))
+  change GameEquiv (($ᵗ BitVec sp) >>= fun k => pure (k ^^^ msg₀))
     (($ᵗ BitVec sp) >>= fun k => pure (k ^^^ msg₁))
   by_equiv
   rvcstep using (fun k₁ k₂ => k₂ = k₁ ^^^ c)
@@ -100,7 +100,7 @@ lemma cipherGivenMsg_equiv (sp : ℕ) (msg₀ msg₁ : BitVec sp) :
   · intro k₁ k₂ hk
     subst hk
     apply Relational.relTriple_pure_pure
-    show k₁ ^^^ msg₀ = k₁ ^^^ c ^^^ msg₁
+    change k₁ ^^^ msg₀ = k₁ ^^^ c ^^^ msg₁
     simp only [show c = msg₀ ^^^ msg₁ from rfl,
       BitVec.xor_assoc, BitVec.xor_self, BitVec.xor_zero]
 

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -103,6 +103,7 @@ def idealCollisionExp (n : ℕ) : ProbComp Bool := do
 noncomputable def collisionProb (n : ℕ) : ℝ :=
   (Pr[= true | idealCollisionExp (S := S) (O := O) n]).toReal
 
+set_option linter.unusedSectionVars false in
 /-- Under the real PRF query implementation, querying the oracle `n` times produces the
 same outputs as the deterministic `streamOutputs`. -/
 private lemma simulateQ_prfReal_oracleOutputs (k : K) (n : ℕ) (s : S) :

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -23,6 +23,9 @@ The proof outline follows the standard switching argument:
 -/
 
 set_option autoImplicit false
+set_option linter.unusedSectionVars false
+set_option linter.unusedDecidableInType false
+set_option linter.unusedFintypeInType false
 
 open OracleComp OracleSpec ENNReal PRFScheme PRGScheme
 open List (Vector)
@@ -103,7 +106,6 @@ def idealCollisionExp (n : ℕ) : ProbComp Bool := do
 noncomputable def collisionProb (n : ℕ) : ℝ :=
   (Pr[= true | idealCollisionExp (S := S) (O := O) n]).toReal
 
-set_option linter.unusedSectionVars false in
 /-- Under the real PRF query implementation, querying the oracle `n` times produces the
 same outputs as the deterministic `streamOutputs`. -/
 private lemma simulateQ_prfReal_oracleOutputs (k : K) (n : ℕ) (s : S) :
@@ -151,7 +153,7 @@ theorem prgRealExp_eq_prfRealExp
       evalDist (PRFScheme.prfRealExp prf (prfReduction (S := S) (O := O) n adv)) := by
   simp only [PRGScheme.prgRealExp, PRFScheme.prfRealExp, prfReduction, streamPRG]
   simp_rw [simulateQ_prfReal_reduction]
-  show evalDist ((·, ·) <$> ($ᵗ K) <*> ($ᵗ S) >>=
+  change evalDist ((·, ·) <$> ($ᵗ K) <*> ($ᵗ S) >>=
     fun ks => adv (streamOutputs (prf.eval ks.1) n ks.2)) = _
   simp only [seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc, pure_bind, Function.comp_def]
   rw [evalDist_bind, evalDist_bind, hkey]

--- a/Examples/Pedersen.lean
+++ b/Examples/Pedersen.lean
@@ -26,6 +26,8 @@ Uses the same additive `Module F G` notation as `DiffieHellman.lean`:
 -/
 
 set_option autoImplicit false
+set_option linter.unusedDecidableInType false
+set_option linter.unusedFintypeInType false
 
 open OracleComp OracleSpec ENNReal DiffieHellman CommitmentScheme
 
@@ -65,7 +67,7 @@ theorem correct : (pedersenCommit (F := F) g).PerfectlyCorrect := by
   simp only [support_bind, support_pure, Set.mem_iUnion,
              Set.mem_singleton_iff] at hmem'
   obtain ⟨d', -, rfl, rfl⟩ := hmem'
-  show decide ((d' : F) • g + m • pp = d' • g + m • pp) = true
+  change decide ((d' : F) • g + m • pp = d' • g + m • pp) = true
   simp
 
 /-! ## Perfect hiding -/
@@ -74,7 +76,7 @@ omit [Fintype F] [DecidableEq F] [SampleableType F]
   [Fintype G] [SampleableType G] [DecidableEq G] in
 private lemma commit_fst_bijective (hg : Function.Bijective (· • g : F → G))
     (pp : G) (m : F) : Function.Bijective (fun d : F => d • g + m • pp) := by
-  show Function.Bijective ((· + m • pp) ∘ (· • g : F → G))
+  change Function.Bijective ((· + m • pp) ∘ (· • g : F → G))
   exact Function.Bijective.comp
     ⟨fun a b h => add_right_cancel h,
      fun y => ⟨y - m • pp, sub_add_cancel y (m • pp)⟩⟩

--- a/Examples/ProgramLogic/Unary.lean
+++ b/Examples/ProgramLogic/Unary.lean
@@ -121,7 +121,6 @@ example :
   vcstep?
   trivial
 -/
-
 example :
     ⦃1⦄ wrappedTrueStep (spec := spec) ⦃fun y => if y = true then 1 else 0⦄ := by
   vcstep with triple_wrappedTrueStep

--- a/Examples/RF_RP_Switching_alt.lean
+++ b/Examples/RF_RP_Switching_alt.lean
@@ -14,16 +14,16 @@ open OracleSpec OracleComp ENNReal
 -- /-- Security adversary for RF-RP distinguisher experiments. -/
 -- def RF_RP_Adv' (α : ℕ → Type) [∀ n, Fintype (α n)]
 --     [∀ n, Inhabited (α n)] [∀ n, DecidableEq (α n)] :=
---   BoundedAdversary (λ n ↦ (α n →ₒ α n)) (λ _ ↦ Unit) (λ _ ↦ Bool)
+--   BoundedAdversary (fun n ↦ (α n →ₒ α n)) (fun _ ↦ Unit) (fun _ ↦ Bool)
 
 -- /-- Security adversary for RF-RP distinguisher experiments.
 -- Note: We don't give the adversary a `unifSpec` oracle, it only has distinguisher pieces. -/
 -- def RF_RP_Adv (α : ℕ → Type) [∀ n, Fintype (α n)]
 --     [∀ n, Inhabited (α n)] [∀ n, DecidableEq (α n)] :=
---   BoundedAdversary (λ n ↦ (α n →ₒ α n)) (λ _ ↦ Unit) (λ _ ↦ Bool)
+--   BoundedAdversary (fun n ↦ (α n →ₒ α n)) (fun _ ↦ Unit) (fun _ ↦ Bool)
 
 -- def distinguisher {ι : Type} [DecidableEq ι] (spec : ℕ → OracleSpec ι) :=
---   BoundedAdversary spec (λ _ ↦ Unit) (λ _ ↦ Bool)
+--   BoundedAdversary spec (fun _ ↦ Unit) (fun _ ↦ Bool)
 
 -- variable {α : ℕ → Type} [∀ n, Fintype (α n)]
 --     [∀ n, Inhabited (α n)] [∀ n, DecidableEq (α n)]
@@ -31,7 +31,7 @@ open OracleSpec OracleComp ENNReal
 
 -- /-- Run a `RF_RP_Adv` using a random function to answer queries,
 -- implemented as a simulation with a random oracle. -/
--- def RF_Exp (adv : RF_RP_Adv α) : SecExp (λ n ↦ (α n →ₒ α n)) where
+-- def RF_Exp (adv : RF_RP_Adv α) : SecExp (fun n ↦ (α n →ₒ α n)) where
 --   main n := (· = true) <$> adv.run n ()
 --   baseState n := QueryCache (α n →ₒ α n)
 --   init_state _ := ∅
@@ -55,11 +55,11 @@ open OracleSpec OracleComp ENNReal
 
 -- Note: We could implement a `randUniqOracle` rather than do this ad hoc.
 -- unsure other use cases. -/
--- noncomputable def RP_Exp (adv : RF_RP_Adv α) : SecExp (λ n ↦ (α n →ₒ α n)) where
+-- noncomputable def RP_Exp (adv : RF_RP_Adv α) : SecExp (fun n ↦ (α n →ₒ α n)) where
 --   main n := (· = false) <$> adv.run n ()
 --   baseState n := QueryCache (α n →ₒ α n) × Finset (α n)
 --   init_state _ := (∅, ∅)
---   baseSimOracle _ := λ () t (cache, used) ↦ do
+--   baseSimOracle _ := fun () t (cache, used) ↦ do
 --     let (u, cache') ← cache.lookup_or_else () t ($ usedᶜ)
 --     return (u, cache', insert u used)
 
@@ -82,9 +82,9 @@ open OracleSpec OracleComp ENNReal
 --     (ε ε' : ℝ≥0∞) (s₁ : σ₁) (s₂ : σ₂)
 --     -- Simulation with
 --     (h₂ : ∀ view : QueryLog spec', good_view view →
---       [= view | (λ z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₂) (s₂, ∅) oa] ≥
---         (1 - ε') * [= view | (λ z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa])
---     (h₁ : [good_view | (λ z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa] ≥ 1 - ε) :
+--       [= view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₂) (s₂, ∅) oa] ≥
+--         (1 - ε') * [= view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa])
+--     (h₁ : [good_view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa] ≥ 1 - ε) :
 --     [= true | simulate' so₁ s₁ oa] + [= false | simulate' so₂ s₂ oa] ≤ ε + ε' := by
 --   sorry
 

--- a/Examples/RF_RP_Switching_alt.lean
+++ b/Examples/RF_RP_Switching_alt.lean
@@ -84,7 +84,7 @@ open OracleSpec OracleComp ENNReal
 --     (h₂ : ∀ view : QueryLog spec', good_view view →
 --       [= view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₂) (s₂, ∅) oa] ≥
 --         (1 - ε') * [= view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa])
---     (h₁ : [good_view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa] ≥ 1 - ε) :
+--    (h₁ : [good_view | (fun z ↦ z.2.2) <$> simulate (loggingOracle ∘ₛₒ so₁) (s₁, ∅) oa] ≥ 1 - ε) :
 --     [= true | simulate' so₁ s₁ oa] + [= false | simulate' so₂ s₂ oa] ≤ ε + ε' := by
 --   sorry
 

--- a/Examples/Regev.lean
+++ b/Examples/Regev.lean
@@ -29,13 +29,13 @@
 --     let s ←$ᵗ Vector (Fin p) n
 --     let e ← (Vector.Range m).mapM (fun _ ↦ errSampKG)
 --     return ((A, Vector.ofFn (Matrix.vecMul s.get A) + e), s)
---   encrypt := λ (A, y) msg ↦ do
+--   encrypt := fun (A, y) msg ↦ do
 --     let r2 ←$ᵗ Vector (Fin 2) m
 --     let r := (r2.map (Fin.castLE hp2.one_lt)).get
 --     let yr := dotProduct y.get r
 --     let signal := if msg then 0 else p / 2
 --     return (Vector.ofFn (Matrix.mulVec A r), yr + (Fin.ofNat p signal))
---   decrypt := λ s (a, b) ↦ do
+--   decrypt := fun s (a, b) ↦ do
 --     let sa := dotProduct s.get a.get
 --     let val := Fin.val (sa - b)
 --     return if val < p/4 then true else val > 3*p/4

--- a/Examples/Schnorr.lean
+++ b/Examples/Schnorr.lean
@@ -41,6 +41,8 @@ verification is `g^z = R · pk^c`.
 -/
 
 set_option autoImplicit false
+set_option linter.unusedDecidableInType false
+set_option linter.unusedFintypeInType false
 
 open OracleSpec OracleComp SigmaProtocol
 

--- a/Examples/SimpleTwoServerPIR.lean
+++ b/Examples/SimpleTwoServerPIR.lean
@@ -38,6 +38,7 @@ Port of EasyCrypt's `PIR.ec`.
 -/
 
 set_option autoImplicit false
+set_option linter.unusedDecidableInType false
 
 open OracleComp OracleSpec ENNReal
 
@@ -125,7 +126,7 @@ private lemma pirQuery_foldl_support
     pirResponse a ss.1 + pirResponse a ss.2 =
       pirResponse a init.1 + pirResponse a init.2 + if i₀ ∈ l then a i₀ else 0 := by
   induction l generalizing init with
-  | nil => simp [List.foldlM] at hss; subst hss; simp
+  | nil => simp only [List.foldlM, support_pure, Set.mem_singleton_iff] at hss; subst hss; simp
   | cons j rest ih =>
     rw [List.foldlM_cons] at hss
     rw [mem_support_bind_iff] at hss
@@ -140,17 +141,20 @@ private lemma pirQuery_foldl_support
     obtain ⟨b, _, hmid⟩ := hmid
     by_cases hj : j = i₀
     · subst hj
-      simp [hnodup.1] at hmid ⊢
+      simp only [↓reduceIte, support_pure, Set.mem_singleton_iff] at hmid
+      simp only [hnodup.1, ↓reduceIte, add_zero, List.mem_cons, or_false]
       -- mid is either (j :: init.1, init.2) or (init.1, j :: init.2)
-      rcases b with _ | _  <;> simp at hmid <;> subst hmid <;>
-        simp [pirResponse_cons] <;> abel
+      rcases b with _ | _  <;> simp only [Bool.false_eq_true, ↓reduceIte] at hmid
+        <;> subst hmid <;> simp [pirResponse_cons] <;> abel
     · have hij : i₀ ≠ j := Ne.symm hj
       simp only [hj, hij, ↓reduceIte, false_or, List.mem_cons] at hmid ⊢
       rcases b with _ | _
       · -- b = false: mid = init, unchanged
-        simp at hmid; subst hmid; rfl
+        simp only [Bool.false_eq_true, ↓reduceIte, support_pure, Set.mem_singleton_iff] at hmid
+        subst hmid; rfl
       · -- b = true: mid = (j :: init.1, j :: init.2)
-        simp at hmid; subst hmid; simp only [pirResponse_cons]; congr 1
+        simp only [↓reduceIte, support_pure, Set.mem_singleton_iff] at hmid
+        subst hmid; simp only [pirResponse_cons]; congr 1
         have h := hchar (a j)
         calc _ = (a j + a j) + (pirResponse a init.1 + pirResponse a init.2) := by abel
           _ = 0 + _ := by rw [h]
@@ -176,7 +180,7 @@ theorem pir_correct [DecidableEq W]
     rw [support_pure, Set.mem_singleton_iff] at hy
     have h := pirQuery_foldl_support hchar a i₀ (List.finRange N)
       (List.nodup_finRange N) ([], []) ss hss
-    simp [pirResponse] at h
+    simp only [pirResponse, List.foldl_nil, add_zero, List.mem_finRange, ↓reduceIte, zero_add] at h
     exact hy.trans h
   -- All outputs other than a i₀ have probability 0
   have hnot : ∀ y ≠ a i₀, Pr[= y | pirMain a i₀] = 0 :=
@@ -209,8 +213,9 @@ theorem pir_private (i₁ i₂ : Fin N) :
     simp only [ProgramLogic.Relational.EqRel] at hS
     rvcstep using (fun b₁ b₂ => b₁ = b₂)
     · intro b₁ b₂ hb; subst hb
-      cases b₁ <;> simp <;>
-        (split <;> split <;>
+      cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte,
+        ProgramLogic.Relational.relTriple_iff_relWP, ProgramLogic.Relational.relWP_iff_couplingPost]
+        <;> (split <;> split <;>
           apply ProgramLogic.Relational.relTriple_pure_pure <;>
           simp_all [ProgramLogic.Relational.EqRel])
     · exact ProgramLogic.Relational.relTriple_uniformSample_bij

--- a/ToMathlib/Control/Comonad/Basic.lean
+++ b/ToMathlib/Control/Comonad/Basic.lean
@@ -93,7 +93,7 @@ class Comonad (w : Type u → Type v) extends Coapplicative w, Extend w where
       1. `extend` over the first context, so we may look inside it,
       2. pair its extracted value with the *already* extracted value of `wb`.
 
-      This yields `w (α × β)` as required.  -/
+      This yields `w (α × β)` as required. -/
   coseq wa wb := extend wa (fun wa' => (extract wa', extract wb))
 
 -- Lawful Hierarchy --

--- a/ToMathlib/Control/Monad/Free.lean
+++ b/ToMathlib/Control/Monad/Free.lean
@@ -54,7 +54,7 @@ instance [Inhabited (f α)] : Inhabited (FreeMonad f α) := ⟨FreeMonad.lift de
 @[always_inline, inline]
 protected def bind : FreeMonad f α → (α → FreeMonad f β) → FreeMonad f β
   | FreeMonad.pure x, g => g x
-  | FreeMonad.roll x r, g => FreeMonad.roll x (λ u ↦ FreeMonad.bind (r u) g)
+  | FreeMonad.roll x r, g => FreeMonad.roll x (fun u ↦ FreeMonad.bind (r u) g)
 
 @[simp]
 lemma bind_pure (x : α) (r : α → FreeMonad f β) :
@@ -62,7 +62,7 @@ lemma bind_pure (x : α) (r : α → FreeMonad f β) :
 
 @[simp]
 lemma bind_roll (x : f α) (r : α → FreeMonad f β) (g : β → FreeMonad f γ) :
-    FreeMonad.bind (FreeMonad.roll x r) g = FreeMonad.roll x (λ u ↦ FreeMonad.bind (r u) g) := rfl
+    FreeMonad.bind (FreeMonad.roll x r) g = FreeMonad.roll x (fun u ↦ FreeMonad.bind (r u) g) := rfl
 
 @[simp]
 lemma bind_lift (x : f α) (r : α → FreeMonad f β) :
@@ -81,15 +81,15 @@ lemma monad_bind_def (x : FreeMonad f α) (g : α → FreeMonad f β) :
 
 instance : LawfulMonad (FreeMonad f) :=
   LawfulMonad.mk' (FreeMonad f)
-    (λ x ↦ by
-      induction' x with α x g r hr
-      · rfl
-      · exact congr_arg (FreeMonad.roll g) (funext λ u ↦ hr u))
-    (λ x f ↦ rfl)
-    (λ x f g ↦ by
-      induction' x with α x g r hr
-      · rfl
-      · exact congr_arg (FreeMonad.roll g) (funext λ u ↦ hr u))
+    (fun x ↦ by
+      induction x with -- α x g r hr
+      | pure x => rfl
+      | roll g r hr => exact congr_arg (FreeMonad.roll g) (funext fun u ↦ hr u))
+    (fun x f ↦ rfl)
+    (fun x f g ↦ by
+      induction x with
+      | pure x => rfl
+      | roll g r hr => exact congr_arg (FreeMonad.roll g) (funext fun u ↦ hr u))
 
 instance : MonadFunctor f (FreeMonad f) where
   monadMap g
@@ -98,7 +98,7 @@ instance : MonadFunctor f (FreeMonad f) where
 
 /-- Proving something about `FreeMonad f α` only requires two cases:
 * `pure x` for some `x : α`
-Note that we can't use `Sort v` instead of `Prop` due to universe levels.-/
+Note that we can't use `Sort v` instead of `Prop` due to universe levels. -/
 @[elab_as_elim]
 protected def inductionOn {C : FreeMonad f α → Prop}
     (pure : ∀ x, C (pure x))
@@ -106,12 +106,12 @@ protected def inductionOn {C : FreeMonad f α → Prop}
       (∀ y, C (r y)) → C (x >>= r)) :
     (oa : FreeMonad f α) → C oa
   | FreeMonad.pure x => pure x
-  | FreeMonad.roll x r => roll x _ (λ u ↦
+  | FreeMonad.roll x r => roll x _ (fun u ↦
       FreeMonad.inductionOn pure roll (r u))
 
 section construct
 
-/-- Shoulde be possible to unify with the above-/
+/-- Shoulde be possible to unify with the above. -/
 @[elab_as_elim]
 protected def construct {C : FreeMonad f α → Type*}
     (pure : (x : α) → C (pure x))
@@ -119,7 +119,7 @@ protected def construct {C : FreeMonad f α → Type*}
       ((y : β) → C (r y)) → C (x >>= r)) :
     (oa : FreeMonad f α) → C oa
   | .pure x => pure x
-  | .roll x r => roll x _ (λ u ↦ FreeMonad.construct pure roll (r u))
+  | .roll x r => roll x _ (fun u ↦ FreeMonad.construct pure roll (r u))
 
 variable {C : FreeMonad f α → Type*} (h_pure : (x : α) → C (pure x))
   (h_roll : {β : Type u} → (x : f β) → (r : β → FreeMonad f α) →
@@ -131,7 +131,7 @@ lemma construct_pure (y : α) : FreeMonad.construct h_pure h_roll (pure y) = h_p
 @[simp]
 lemma construct_roll (x : f β) (r : β → FreeMonad f α) :
     (FreeMonad.construct h_pure h_roll (roll x r) : C (roll x r)) =
-      (h_roll x r (λ u ↦ FreeMonad.construct h_pure h_roll (r u))) := rfl
+      (h_roll x r (fun u ↦ FreeMonad.construct h_pure h_roll (r u))) := rfl
 
 end construct
 
@@ -142,7 +142,7 @@ variable {m : Type u → Type w} (s : {α : Type u} → f α → m α)
 protected def mapM_aux [Pure m] [Bind m] (s : {α : Type u} → f α → m α) :
     (oa : FreeMonad f α) → m α
   | .pure x => pure x
-  | .roll x r => s x >>= λ u ↦ (r u).mapM_aux s
+  | .roll x r => s x >>= fun u ↦ (r u).mapM_aux s
 
 protected def mapM' (m : Type u → Type w) [Monad m] [LawfulMonad m]
     (s : {α : Type u} → f α → m α) : FreeMonad f →ᵐ m where
@@ -159,11 +159,11 @@ lemma mapM'_lift [Monad m] [LawfulMonad m]
     FreeMonad.mapM' m s (FreeMonad.lift x) = s x := by
   simp [FreeMonad.mapM', FreeMonad.lift, FreeMonad.mapM_aux]
 
-/-- Canonical mapping of a free monad into any other monad, given a map on the base functor, -/
+/-- Canonical mapping of a free monad into any other monad, given a map on the base functor. -/
 protected def mapM [Pure m] [Bind m] :
     (oa : FreeMonad f α) → (s : {α : Type u} → f α → m α) → m α
   | .pure x, _ => pure x
-  | .roll x r, s => s x >>= λ u ↦ (r u).mapM s
+  | .roll x r, s => s x >>= fun u ↦ (r u).mapM s
 
 variable [Monad m]
 
@@ -175,7 +175,7 @@ lemma mapM_pure (x : α) : (FreeMonad.pure x : FreeMonad f α).mapM s = pure x :
 
 @[simp]
 lemma mapM_roll (x : f α) (r : α → FreeMonad f β) :
-    (FreeMonad.roll x r).mapM s = s x >>= λ u ↦ (r u).mapM s := rfl
+    (FreeMonad.roll x r).mapM s = s x >>= fun u ↦ (r u).mapM s := rfl
 
 end mapM
 
@@ -194,7 +194,7 @@ section depth
   maximum depth of its children. -/
 noncomputable def depth : FreeMonad f α → ℕ∞
   | .pure _ => 0
-  | .roll _ r => 1 + iSup (λ u ↦ depth (r u))
+  | .roll _ r => 1 + iSup (fun u ↦ depth (r u))
 
 @[simp]
 lemma depth_pure {x : α} : depth (pure x : FreeMonad f α) = 0 := rfl
@@ -204,13 +204,13 @@ lemma depth_pure' {x : α} : depth (FreeMonad.pure x : FreeMonad f α) = 0 := rf
 
 @[simp]
 lemma depth_roll {x : f α} {r : α → FreeMonad f β} :
-    depth (roll x r : FreeMonad f β) = 1 + iSup (λ u ↦ depth (r u)) := rfl
+    depth (roll x r : FreeMonad f β) = 1 + iSup (fun u ↦ depth (r u)) := rfl
 
 @[simp]
 noncomputable def depthBindAux {f : Type u → Type v} {α β : Type u} :
     FreeMonad f α → (α → FreeMonad f β) → ℕ∞
   | .pure x, g => depth (g x)
-  | .roll _ r, g => 1 + iSup (λ u ↦ depthBindAux (r u) g)
+  | .roll _ r, g => 1 + iSup (fun u ↦ depthBindAux (r u) g)
 
 /-- The depth of a bind computation can be defined _exactly_
   using the definition of bind (but might not be very revealing) -/
@@ -221,17 +221,18 @@ lemma depth_bind_eq {x : FreeMonad f α} {g : α → FreeMonad f β} :
   | roll x r hr => simp_all [depthBindAux, FreeMonad.monad_bind_def]
 
 lemma depth_bind_le {x : FreeMonad f α} {g : α → FreeMonad f β} :
-    depth (x >>= g) ≤ depth x + iSup (λ u ↦ depth (g u)) := by
+    depth (x >>= g) ≤ depth x + iSup (fun u ↦ depth (g u)) := by
   induction x using FreeMonad.inductionOn with
-  | pure x => simp; exact le_iSup_iff.mpr fun b a ↦ a x
+  | pure x => simp only [monad_pure_def, monad_bind_def, bind_pure, depth_pure', zero_add]
+              exact le_iSup_iff.mpr fun b a ↦ a x
   | roll x r hr =>
-    simp_all
+    simp_all only [monad_bind_def, monadLift_eq_lift, bind_lift, bind_roll, depth_roll]
     calc
       _ ≤ 1 + ⨆ u, (r u).depth + ⨆ v, (g v).depth := by
         gcongr; exact hr _
       _ ≤ 1 + (⨆ u, (r u).depth) + ⨆ v, (g v).depth := by
         rw [add_assoc]
-        gcongr; simp; intro b; gcongr; exact le_iSup_iff.mpr fun b_1 a ↦ a b
+        gcongr; simp only [iSup_le_iff]; intro b; gcongr; exact le_iSup_iff.mpr fun b_1 a ↦ a b
 
 lemma depth_eq_zero_iff {x : FreeMonad f α} : depth x = 0 ↔ ∃ y, x = pure y := by
   induction x using FreeMonad.inductionOn with
@@ -244,7 +245,9 @@ lemma depth_eq_one_iff {x : FreeMonad f α} : depth x = 1 ↔
   | pure x' => simp
   | roll y r _hr =>
     rename_i β
-    simp
+    simp only [monadLift_eq_lift, monad_bind_def, bind_lift, depth_roll,
+      isAddLeftRegular_iff_isAddRegular, ne_eq, ENat.one_ne_top, not_false_eq_true,
+      IsAddRegular.of_ne_top, IsAddLeftRegular.add_left_eq_self_iff, ENat.iSup_eq_zero, roll.injEq]
     constructor <;> intro h
     · exact ⟨β, y, r, ⟨⟨rfl, by simp, by simp⟩, h⟩⟩
     · obtain ⟨β', y_1, r_1, ⟨⟨hβ, hy, hr⟩, hr'⟩⟩ := h

--- a/ToMathlib/Control/Monad/Ordered.lean
+++ b/ToMathlib/Control/Monad/Ordered.lean
@@ -130,7 +130,7 @@ class MonadLift.LE (m : Type u → Type v) (n : Type u → Type w) [Monad m] [Or
   monadLift_le {α} (a : m α) : φ.monadLift a ≤ₘ ψ.monadLift a
 
 /-- If the target monad `n` is ordered, then we have a preorder on the monad lifts from `m` to `n`.
-  -/
+ -/
 instance {m n} [Monad m] [OrderedMonad n] : Preorder (MonadLift m n) where
   le := fun φ ψ => ∀ {α : Type u} (a : m α), φ.monadLift a ≤ₘ ψ.monadLift a
   le_refl _ := by intro α a; simp only [ge_iff_le, le_refl]

--- a/ToMathlib/Control/Monad/RelationalAlgebra.lean
+++ b/ToMathlib/Control/Monad/RelationalAlgebra.lean
@@ -216,8 +216,8 @@ noncomputable instance instOptionTRight :
             | none => ⊥
             | some b => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (g b).run collapse)
         ≤
-        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run
-          (fun a ob => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (gRun ob) collapse) := by
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run (fun a ob =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (gRun ob) collapse) := by
       apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
       intro a ob
       cases ob with
@@ -260,8 +260,8 @@ noncomputable instance instOptionTLeft :
             | none => ⊥
             | some a => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a).run (g b) collapse)
         ≤
-        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y
-          (fun oa b => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun oa) (g b) collapse) := by
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y (fun oa b =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun oa) (g b) collapse) := by
       apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
       intro oa b
       cases oa with
@@ -276,8 +276,8 @@ noncomputable instance instOptionTLeft :
             | none => ⊥
             | some a => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a).run (g b) collapse)
         ≤
-        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y
-          (fun oa b => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun oa) (g b) collapse) := by
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y (fun oa b =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun oa) (g b) collapse) := by
       simpa [collapse] using hmono
     exact le_trans hmono' <|
       by
@@ -317,8 +317,8 @@ noncomputable instance instExceptTRight (ε : Type u) :
             | Except.ok b =>
                 MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (g b).run collapse)
         ≤
-        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run
-          (fun a eb => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (gRun eb) collapse) := by
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x y.run (fun a eb =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a) (gRun eb) collapse) := by
       apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
       intro a eb
       cases eb with
@@ -364,8 +364,8 @@ noncomputable instance instExceptTLeft (ε : Type u) :
             | Except.ok a =>
                 MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (f a).run (g b) collapse)
         ≤
-        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y
-          (fun ea b => MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun ea) (g b) collapse) := by
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) x.run y (fun ea b =>
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (l := l) (fRun ea) (g b) collapse) := by
       apply MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l)
       intro ea b
       cases ea with

--- a/ToMathlib/Control/Monad/Relative.lean
+++ b/ToMathlib/Control/Monad/Relative.lean
@@ -111,7 +111,7 @@ variable {C₁ : Type u₁} [Category.{v₁} C₁] {D₁ : Type u₂} [Category.
   {J₁ : C₁ ⥤ D₁} {J₂ : C₂ ⥤ D₂}
 
 /-- The product of two relative monads is a relative monad on the corresponding product categories.
-  -/
+ -/
 @[simps!]
 def prod (M₁ : RelativeMonad C₁ D₁ J₁) (M₂ : RelativeMonad C₂ D₂ J₂) :
     RelativeMonad (C₁ × C₂) (D₁ × D₂) (Functor.prod J₁ J₂) where

--- a/ToMathlib/Control/OptionT.lean
+++ b/ToMathlib/Control/OptionT.lean
@@ -55,7 +55,7 @@ protected def mapM {m : Type u → Type v} {n : Type u → Type w}
 --     cases x <;> simp
 
 /-- Bundled version of `mapM`.
-dtumad: we should probably just pick one of these (probably the hom class non-bundled approach)-/
+dtumad: we should probably just pick one of these (probably the hom class non-bundled approach). -/
 protected def mapM' {m : Type u → Type v} {n : Type u → Type w}
     [Monad m] [AlternativeMonad n] [LawfulMonad n] [LawfulAlternative n]
     (f : m →ᵐ n) : OptionT m →ᵐ n where
@@ -65,12 +65,9 @@ protected def mapM' {m : Type u → Type v} {n : Type u → Type w}
   toFun_pure' x := by
     simp
   toFun_bind' x y := by
-    simp [Option.elimM]
+    simp only [run_bind, Option.elimM, MonadHom.toFun_bind', bind_assoc]
     congr 1
-    ext x
-    cases x
-    simp
-    simp
+    ext x; cases x; all_goals simp
 
 @[simp]
 lemma mapM'_lift {m : Type u → Type v} {n : Type u → Type w}
@@ -98,7 +95,7 @@ lemma liftM_elimM {m} [Monad m] {α β}
     {n} [Monad n] [MonadLiftT m n] [LawfulMonadLiftT m n] :
     (liftM (Option.elimM x y z) : n β) =
       Option.elimM (liftM x : n (Option α)) (liftM y) (fun x => liftM (z x)) := by
-  simp [Option.elimM]
+  simp only [Option.elimM, liftM_bind]
   refine bind_congr fun x => by cases x <;> simp
 
 end OptionT

--- a/ToMathlib/Control/StateT.lean
+++ b/ToMathlib/Control/StateT.lean
@@ -53,6 +53,6 @@ lemma run_failure' [Monad m] [Alternative m] :
 
 @[simp]
 lemma mk_pure_eq_pure [Monad m] (x : α) :
-  StateT.mk (λ s ↦ pure (x, s)) = (pure x : StateT σ m α) := rfl
+  StateT.mk (fun s ↦ pure (x, s)) = (pure x : StateT σ m α) := rfl
 
 end StateT

--- a/ToMathlib/Control/WriterT.lean
+++ b/ToMathlib/Control/WriterT.lean
@@ -178,7 +178,7 @@ lemma run_failure [Monoid ω] {α : Type u} : (failure : WriterT ω m α).run = 
 instance [Monoid ω] [LawfulMonad m] : LawfulMonadLift m (WriterT ω m) where
   monadLift_pure x := map_pure (·, 1) x
   monadLift_bind {α β} x y := by
-    show WriterT.mk _ = WriterT.mk _
+    change WriterT.mk _ = WriterT.mk _
     simp [monadLift_def, WriterT.mk]
 
 end fail

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -67,13 +67,13 @@ lemma toReal_sub_le_abs_toReal_sub (a b : ℝ≥0∞) :
 end ENNReal
 
 @[simp, grind =]
-lemma fst_map_prod_map {m : Type u → Type v} [Monad m] [LawfulMonad m] {α β γ δ : Type u}
+lemma fst_map_prod_map {m : Type u → Type v} [Functor m] [LawfulFunctor m] {α β γ δ : Type u}
     (mx : m (α × β)) (f : α → γ) (g : β → δ) :
     Prod.fst <$> Prod.map f g <$> mx = (f ∘ Prod.fst) <$> mx := by
   simp [Functor.map_map]; rfl
 
 @[simp, grind =]
-lemma snd_map_prod_map {m : Type u → Type v} [Monad m] [LawfulMonad m] {α β γ δ : Type u}
+lemma snd_map_prod_map {m : Type u → Type v} [Functor m] [LawfulFunctor m] {α β γ δ : Type u}
     (mx : m (α × β)) (f : α → γ) (g : β → δ) :
     Prod.snd <$> Prod.map f g <$> mx = (g ∘ Prod.snd) <$> mx := by
   simp [Functor.map_map]; rfl

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -66,6 +66,18 @@ lemma toReal_sub_le_abs_toReal_sub (a b : ℝ≥0∞) :
 
 end ENNReal
 
+@[simp, grind =]
+lemma fst_map_prod_map {m : Type u → Type v} [Monad m] [LawfulMonad m] {α β γ δ : Type u}
+    (mx : m (α × β)) (f : α → γ) (g : β → δ) :
+    Prod.fst <$> Prod.map f g <$> mx = (f ∘ Prod.fst) <$> mx := by
+  simp [Functor.map_map]; rfl
+
+@[simp, grind =]
+lemma snd_map_prod_map {m : Type u → Type v} [Monad m] [LawfulMonad m] {α β γ δ : Type u}
+    (mx : m (α × β)) (f : α → γ) (g : β → δ) :
+    Prod.snd <$> Prod.map f g <$> mx = (g ∘ Prod.snd) <$> mx := by
+  simp [Functor.map_map]; rfl
+
 @[simp]
 lemma List.prod_map_const {α M : Type*} [CommMonoid M] (xs : List α) (c : M) :
     (xs.map (fun _ => c)).prod = c ^ xs.length := by

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -34,11 +34,11 @@ lemma one_sub_one_sub_mul_one_sub {x y : ℝ≥0∞} (hx : x ≤ 1) (hy : y ≤ 
     calc (1 - x) * (1 - y) ≤ 1 * 1 := by
           exact mul_le_mul' (tsub_le_self) (tsub_le_self)
         _ = 1 := one_mul 1
-  rw [← ENNReal.toReal_eq_toReal_iff']
-  rw [ENNReal.toReal_sub_of_le, ENNReal.toReal_mul, ENNReal.toReal_sub_of_le,
+  rw [← ENNReal.toReal_eq_toReal_iff' (by aesop) (by aesop),
+    ENNReal.toReal_sub_of_le, ENNReal.toReal_mul, ENNReal.toReal_sub_of_le,
     ENNReal.toReal_sub_of_le, ENNReal.toReal_sub_of_le, ENNReal.toReal_add, ENNReal.toReal_mul]
-  simp
-  linarith
+  · simp
+    linarith
   all_goals try aesop
 
 lemma list_prod_natCast_ne_top {ι : Type*} (f : ι → ℕ) (js : List ι) :
@@ -83,7 +83,8 @@ lemma List.prod_map_const {α M : Type*} [CommMonoid M] (xs : List α) (c : M) :
     (xs.map (fun _ => c)).prod = c ^ xs.length := by
   induction xs with
   | nil => simp
-  | cons _ _ ih => simp only [List.map_cons, List.prod_cons, ih, List.length_cons, pow_succ, mul_comm]
+  | cons _ _ ih => simp only [List.map_cons, List.prod_cons, ih,
+      List.length_cons, pow_succ, mul_comm]
 
 section sum_thing
 
@@ -136,7 +137,7 @@ lemma PMF.apply_eq_one_sub_tsum_ite {α} [DecidableEq α] (p : PMF α) (x : α) 
   rw [← p.tsum_coe]
   rw [Summable.tsum_eq_add_tsum_ite' x ENNReal.summable]
   refine ENNReal.eq_sub_of_add_eq' ?_ rfl
-  simp [ne_eq, ENNReal.add_eq_top, apply_ne_top, false_or]
+  simp only [ne_eq, ENNReal.add_eq_top, apply_ne_top, false_or]
   refine ne_top_of_le_ne_top ENNReal.one_ne_top ?_
   refine le_trans ?_ (le_of_eq p.tsum_coe)
   refine ENNReal.tsum_le_tsum fun x => ?_
@@ -178,8 +179,8 @@ end abs
 open BigOperators ENNReal
 
 lemma Fintype.sum_inv_card (α : Type*) [Fintype α] [Nonempty α] :
-  Finset.sum Finset.univ (λ _ ↦ (Fintype.card α)⁻¹ : α → ℝ≥0∞) = 1 := by
-  rw [Finset.sum_eq_card_nsmul (λ _ _ ↦ rfl), Finset.card_univ,
+  Finset.sum Finset.univ (fun _ ↦ (Fintype.card α)⁻¹ : α → ℝ≥0∞) = 1 := by
+  rw [Finset.sum_eq_card_nsmul (fun _ _ ↦ rfl), Finset.card_univ,
     nsmul_eq_mul, ENNReal.mul_inv_cancel] <;> simp
 
 section List.Vector
@@ -219,7 +220,7 @@ lemma Prod.mk.injective2 {α β : Type*} :
 
 lemma Function.injective2_swap_iff {α β γ : Type*} (f : α → β → γ) :
     (Function.swap f).Injective2 ↔ f.Injective2 :=
-  ⟨λ h _ _ _ _ h' ↦ and_comm.1 (h h'), λ h _ _ _ _ h' ↦ and_comm.1 (h h')⟩
+  ⟨fun h _ _ _ _ h' ↦ and_comm.1 (h h'), fun h _ _ _ _ h' ↦ and_comm.1 (h h')⟩
 
 @[simp] theorem Finset.image_const_univ {α β} [DecidableEq β]  [Fintype α]
     [Nonempty α] (b : β) : (Finset.univ.image fun _ : α => b) = singleton b :=
@@ -241,7 +242,7 @@ lemma List.countP_eq_sum_fin_ite {α : Type*} (xs : List α) (p : α → Bool) :
 
 lemma List.card_filter_getElem_eq {α : Type*} [DecidableEq α]
     (xs : List α) (x : α) :
-    (Finset.filter (λ i : Fin (xs.length) ↦ xs[i] = x) Finset.univ).card =
+    (Finset.filter (fun i : Fin (xs.length) ↦ xs[i] = x) Finset.univ).card =
       xs.count x := by
   rw [List.count, ← List.countP_eq_sum_fin_ite]
   simp only [Fin.getElem_fin, beq_iff_eq, Finset.sum_boole, Nat.cast_id]
@@ -352,11 +353,11 @@ calc (∑ x ∈ s, if p x then r else 0 : β) = (∑ x ∈ s, if p x then 1 else
 lemma Finset.count_toList {α} [DecidableEq α] (x : α) (s : Finset α) :
     s.toList.count x = if x ∈ s then 1 else 0 := by
   by_cases hx : x ∈ s
-  · simp [hx]
+  · simp only [hx, ↓reduceIte]
     refine List.count_eq_one_of_mem ?_ ?_
     · exact nodup_toList s
     · simp [hx]
-  · simp [hx]
+  · simp only [hx, ↓reduceIte]
     refine List.count_eq_zero_of_not_mem ?_
     simp [hx]
 
@@ -373,7 +374,7 @@ lemma BitVec.toFin_bijective (n : ℕ) :
 
 instance (n : ℕ) : Fintype (BitVec n) := by
   refine Fintype.ofBijective (α := Fin (2 ^ n)) ?_ ?_
-  · refine λ x ↦ ?_
+  · refine fun x ↦ ?_
     refine BitVec.ofFin x
   · refine ⟨?_, ?_⟩
     · intro i j
@@ -464,22 +465,21 @@ theorem vectorofFn_get {α : Type} {n : ℕ} (v : Fin n → α) : (Vector.ofFn v
 theorem vectorAdd_get {α : Type} {n : ℕ} [Add α] [Zero α]
  (vx : Vector α n) (vy : Vector α n)
  : (vx + vy).get = vx.get + vy.get := by
-  show (Vector.ofFn (vx.get + vy.get)).get = vx.get + vy.get
+  change (Vector.ofFn (vx.get + vy.get)).get = vx.get + vy.get
   simp
 
 end add
 
 end Vector
 
-open Classical
-
+open Classical in
 lemma tsum_option {α β : Type*} [AddCommMonoid α] [TopologicalSpace α]
     [ContinuousAdd α] [T2Space α]
     (f : Option β → α) (hf : Summable (Function.update f none 0)) :
     ∑' x : Option β, f x = f none + ∑' x : β, f (some x) := by
   refine (Summable.tsum_eq_add_tsum_ite' none hf).trans ?_
   refine congr_arg (f none + ·) ?_
-  refine tsum_eq_tsum_of_ne_zero_bij (λ x ↦ some x.1) ?_ ?_ ?_
+  refine tsum_eq_tsum_of_ne_zero_bij (fun x ↦ some x.1) ?_ ?_ ?_
   · intro x y
     simp [SetCoe.ext_iff]
   · intro x
@@ -499,7 +499,7 @@ theorem PMF.bind_eq_zero {α β : Type _} {p : PMF α} {f : α → PMF β} {b : 
 
 theorem PMF.heq_iff {α β : Type u} {pa : PMF α} {pb : PMF β} (h : α = β) :
     HEq pa pb ↔ ∀ x, pa x = pb (cast h x) := by
-  subst h; simp; constructor <;> intro h'
+  subst h; simp only [heq_eq_eq, cast_eq]; constructor <;> intro h'
   · intro x; rw [h']
   · ext x; rw [h' x]
 
@@ -524,6 +524,7 @@ lemma PMF.uniformOfFintype_map_of_bijective {α β : Type*} [Fintype α] [Fintyp
   simp only [PMF.map_apply, PMF.uniformOfFintype_apply, heq, hf.1.eq_iff, eq_comm (a := a)]
   convert tsum_ite_eq a (fun _ : α => ((Fintype.card β : ENNReal)⁻¹))
 
+open Classical in
 /-- This doesn't get applied properly without `Classical` so add with high priority. -/
 @[simp high] lemma PMF.some_map_apply_some {α} (p : PMF α) (x : α) :
     (p.map Option.some) (some x) = p x := by simp
@@ -555,7 +556,7 @@ lemma List.foldlM_range {m : Type u → Type v} [Monad m] [LawfulMonad m]
   | succ n hn =>
       intro init
       simp only [List.finRange_succ, List.foldlM_cons, Fin.foldlM_succ]
-      refine congr_arg (_ >>= ·) (funext λ x ↦ ?_)
+      refine congr_arg (_ >>= ·) (funext fun x ↦ ?_)
       rw [← hn, List.foldlM_map]
 
 lemma list_mapM_loop_eq {m : Type u → Type v} [Monad m] [LawfulMonad m]
@@ -567,7 +568,7 @@ lemma list_mapM_loop_eq {m : Type u → Type v} [Monad m] [LawfulMonad m]
   | cons x xs h =>
       intro ys
       simp only [List.mapM.loop, map_bind]
-      refine congr_arg (f x >>= ·) (funext λ x ↦ ?_)
+      refine congr_arg (f x >>= ·) (funext fun x ↦ ?_)
       simp [h (x :: ys), h [x]]
 
 /-! ### `forIn` / `foldlM` bridge for imperative-style loops

--- a/ToMathlib/PFunctor/Basic.lean
+++ b/ToMathlib/PFunctor/Basic.lean
@@ -436,7 +436,8 @@ section Lemmas
 
 @[ext (iff := false)]
 theorem ext {P Q : PFunctor.{uA, uB}} (h : P.A = Q.A) (h' : ∀ a, P.B a = Q.B (h ▸ a)) : P = Q := by
-  cases P; cases Q; simp at h h' ⊢; subst h; simp_all; funext; exact h' _
+  cases P; cases Q; simp only [mk.injEq] at h h' ⊢; subst h;
+  simp_all only [heq_eq_eq, true_and]; funext; exact h' _
 
 lemma X_eq_linear_pUnit : X = linear PUnit := rfl
 lemma X_eq_purePower_pUnit : X = purePower PUnit := rfl

--- a/ToMathlib/PFunctor/Free.lean
+++ b/ToMathlib/PFunctor/Free.lean
@@ -56,7 +56,7 @@ lemma monadLift_eq_lift (x : P.Obj α) : (x : FreeM P α) = FreeM.lift x := rfl
 @[always_inline, inline]
 protected def bind : FreeM P α → (α → FreeM P β) → FreeM P β
   | FreeM.pure x, g => g x
-  | FreeM.roll x r, g => FreeM.roll x (λ u ↦ FreeM.bind (r u) g)
+  | FreeM.roll x r, g => FreeM.roll x (fun u ↦ FreeM.bind (r u) g)
 
 @[simp]
 lemma bind_pure (x : α) (r : α → FreeM P β) :
@@ -64,7 +64,7 @@ lemma bind_pure (x : α) (r : α → FreeM P β) :
 
 @[simp]
 lemma bind_roll (a : P.A) (r : P.B a → FreeM P β) (g : β → FreeM P γ) :
-    FreeM.bind (FreeM.roll a r) g = FreeM.roll a (λ u ↦ FreeM.bind (r u) g) := rfl
+    FreeM.bind (FreeM.roll a r) g = FreeM.roll a (fun u ↦ FreeM.bind (r u) g) := rfl
 
 @[simp]
 lemma bind_lift (x : P.Obj α) (r : α → FreeM P β) :
@@ -89,15 +89,15 @@ lemma monad_bind_def (x : FreeM P α) (g : α → FreeM P β) :
 
 instance : LawfulMonad (FreeM P) :=
   LawfulMonad.mk' (FreeM P)
-    (λ x ↦ by
+    (fun x ↦ by
       induction x with
       | pure _ => rfl
-      | roll a _ h => refine congr_arg (FreeM.roll a) (funext λ i ↦ h i))
-    (λ x f ↦ rfl)
-    (λ x f g ↦ by
+      | roll a _ h => refine congr_arg (FreeM.roll a) (funext fun i ↦ h i))
+    (fun x f ↦ rfl)
+    (fun x f g ↦ by
       induction x with
       | pure _ => rfl
-      | roll a _ h => refine congr_arg (FreeM.roll a) (funext λ i ↦ h i))
+      | roll a _ h => refine congr_arg (FreeM.roll a) (funext fun i ↦ h i))
 
 lemma pure_inj (x y : α) : FreeM.pure (P := P) x = FreeM.pure y ↔ x = y := by simp
 
@@ -114,25 +114,25 @@ lemma pure_inj (x y : α) : FreeM.pure (P := P) x = FreeM.pure y ↔ x = y := by
 /-- Proving a predicate `C` of `FreeM P α` requires two cases:
 * `pure x` for some `x : α`
 * `roll x r h` for some `x : P.A`, `r : P.B x → FreeM P α`, and `h : ∀ y, C (r y)`
-Note that we can't use `Sort v` instead of `Prop` due to universe levels.-/
+Note that we can't use `Sort v` instead of `Prop` due to universe levels. -/
 @[elab_as_elim]
 protected def inductionOn {C : FreeM P α → Prop}
     (pure : ∀ x, C (pure x))
     (roll : (x : P.A) → (r : P.B x → FreeM P α) → (∀ y, C (r y)) → C (FreeM.roll x r)) :
     (oa : FreeM P α) → C oa
   | FreeM.pure x => pure x
-  | FreeM.roll x r => roll x _ (λ u ↦ FreeM.inductionOn pure roll (r u))
+  | FreeM.roll x r => roll x _ (fun u ↦ FreeM.inductionOn pure roll (r u))
 
 section construct
 
-/-- Shoulde be possible to unify with the above-/
+/-- Shoulde be possible to unify with the above -/
 @[elab_as_elim]
 protected def construct {C : FreeM P α → Type*}
     (pure : (x : α) → C (pure x))
     (roll : (x : P.A) → (r : P.B x → FreeM P α) → ((y : P.B x) → C (r y)) → C (FreeM.roll x r)) :
     (oa : FreeM P α) → C oa
   | .pure x => pure x
-  | .roll x r => roll x _ (λ u ↦ FreeM.construct pure roll (r u))
+  | .roll x r => roll x _ (fun u ↦ FreeM.construct pure roll (r u))
 
 variable {C : FreeM P α → Type*} (h_pure : (x : α) → C (pure x))
   (h_roll : (x : P.A) → (r : P.B x → FreeM P α) → ((y : P.B x) → C (r y)) → C (FreeM.roll x r))
@@ -154,7 +154,7 @@ variable {m : Type uB → Type v} {α : Type uB}
 /-- Canonical mapping of `FreeM P` into any other monad, given a map `s : (a : P.A) → m (P.B a)`. -/
 protected def mapM [Pure m] [Bind m] (s : (a : P.A) → m (P.B a)) : FreeM P α → m α
   | .pure a => Pure.pure a
-  | .roll a r => (s a) >>= (λ u ↦ (r u).mapM s)
+  | .roll a r => (s a) >>= (fun u ↦ (r u).mapM s)
 
 variable [Monad m] (s : (a : P.A) → m (P.B a))
 
@@ -194,7 +194,7 @@ lemma mapM_seq {α β}
 
 @[simp]
 lemma mapM_lift (s : (a : P.A) → m (P.B a)) (x : P.Obj α) :
-    FreeM.mapM s (FreeM.lift x) = s x.1 >>= (λ u ↦ (pure (x.2 u)).mapM s) := by
+    FreeM.mapM s (FreeM.lift x) = s x.1 >>= (fun u ↦ (pure (x.2 u)).mapM s) := by
   simp [FreeM.mapM]
 
 @[simp]

--- a/ToMathlib/ProbabilityTheory/Coupling.lean
+++ b/ToMathlib/ProbabilityTheory/Coupling.lean
@@ -58,7 +58,8 @@ theorem IsCoupling.pure_iff {α β : Type u} {a : α} {b : β} {c : SPMF (α × 
     rw [SPMF.fmap_eq_map] at h1 h2
     change PMF.map (Option.map Prod.fst) c = PMF.pure (some a) at h1
     change PMF.map (Option.map Prod.snd) c = PMF.pure (some b) at h2
-    rw [show (pure (a, b) : SPMF (α × β)) = PMF.pure (some (a, b)) from SPMF.pure_eq_pure_some (a, b)]
+    rw [show (pure (a, b) : SPMF (α × β)) = PMF.pure (some (a, b))
+        from SPMF.pure_eq_pure_some (a, b)]
     exact PMF.eq_pure_of_forall_ne_eq_zero c (some (a, b)) fun x hx => by
       cases x with
       | none => exact PMF.map_eq_pure_zero _ c _ h1 none (by simp)
@@ -73,7 +74,7 @@ theorem IsCoupling.pure_iff {α β : Type u} {a : α} {b : β} {c : SPMF (α × 
 
 theorem IsCoupling.none_iff {α β : Type u} {c : SPMF (α × β)} :
     IsCoupling c (failure : SPMF α) (failure : SPMF β) ↔ c = failure := by
-  simp [failure]
+  simp only [failure]
   constructor
   · intro ⟨h1, h2⟩
     rw [SPMF.fmap_eq_map] at h1
@@ -96,7 +97,7 @@ theorem IsCoupling.bind {α₁ α₂ β₁ β₂ : Type u}
     {p : SPMF α₁} {q : SPMF α₂} {f : α₁ → SPMF β₁} {g : α₂ → SPMF β₂}
     (c : Coupling p q) (d : (a₁ : α₁) → (a₂ : α₂) → SPMF (β₁ × β₂))
     (h : ∀ (a₁ : α₁) (a₂ : α₂), c.1.1 (some (a₁, a₂)) ≠ 0 → IsCoupling (d a₁ a₂) (f a₁) (g a₂)) :
-    IsCoupling (c.1 >>= λ (p : α₁ × α₂) => d p.1 p.2) (p >>= f) (q >>= g) := by
+    IsCoupling (c.1 >>= fun (p : α₁ × α₂) => d p.1 p.2) (p >>= f) (q >>= g) := by
   obtain ⟨hc₁, hc₂⟩ := c.2
   constructor
   · rw [SPMF.fmap_eq_map, bind_eq_pmf_bind, PMF.map_bind]
@@ -130,7 +131,7 @@ theorem IsCoupling.exists_bind {α₁ α₂ β₁ β₂ : Type u}
     fun a₁ a₂ => Classical.choose (h a₁ a₂)
   let hd : ∀ (a₁ : α₁) (a₂ : α₂), c.1.1 (some (a₁, a₂)) ≠ 0 → IsCoupling (d a₁ a₂) (f a₁) (g a₂) :=
     fun a₁ a₂ _ => Classical.choose_spec (h a₁ a₂)
-  ⟨c.1 >>= λ (p : α₁ × α₂) => d p.1 p.2, IsCoupling.bind c d hd⟩
+  ⟨c.1 >>= fun (p : α₁ × α₂) => d p.1 p.2, IsCoupling.bind c d hd⟩
 
 /-- Every `SPMF` has a diagonal self-coupling. -/
 theorem IsCoupling.refl (p : SPMF α) :

--- a/ToMathlib/ProbabilityTheory/FinRatPMF.lean
+++ b/ToMathlib/ProbabilityTheory/FinRatPMF.lean
@@ -283,7 +283,7 @@ private lemma list_prob_eq_zero [DecidableEq α] {l : List (α × ℚ≥0)} {x :
   suffices l.filter (fun a => a.1 = x) = [] by simp [this]
   rw [List.filter_eq_nil_iff]
   simp only [List.mem_toFinset, List.mem_map] at hx
-  exact fun a ha => by simp; intro heq; exact hx ⟨a, ha, heq ▸ rfl⟩
+  exact fun a ha => by simp only [decide_eq_true_eq]; intro heq; exact hx ⟨a, ha, heq ▸ rfl⟩
 
 private lemma list_sum_prob_eq [DecidableEq α] (l : List (α × ℚ≥0)) :
     (l.map Prod.fst |>.toFinset).sum
@@ -381,7 +381,7 @@ private lemma filter_eq_singleton_of_nodup [DecidableEq α] {l : List α} (hnd :
         cases hx with
         | head => exact False.elim (hax rfl)
         | tail _ hx' => exact hx'
-      simp [hax]
+      simp only [hax, decide_false, Bool.false_eq_true, not_false_eq_true, List.filter_cons_of_neg]
       exact ih hndtl hx'
 
 /-- Point probabilities for `uniformList` on a duplicate-free list. -/
@@ -528,7 +528,7 @@ private lemma list_sum_prob_mul_eq [DecidableEq α] (l : List (α × ℚ≥0)) (
             rw [Finset.sum_insert hm, hzero, zero_mul, zero_add]
             exact ih
 
-private lemma probOfList_bind_eq_sum [DecidableEq α] [DecidableEq β]
+private lemma probOfList_bind_eq_sum [DecidableEq β]
     (l : List (α × ℚ≥0)) (g : α → Raw β) (y : β) :
     probOfList (l.flatMap (fun (a, p) => (g a).toList.map (fun (b, q) => (b, p * q)))) y =
       (l.map (fun (a, p) => p * (g a).prob y)).sum := by
@@ -712,9 +712,11 @@ private lemma snd_ne_zero_of_mem_normalizeMap_toList [BEq α] [Hashable α]
   | none => simp [hacc] at hsome
   | some q =>
     by_cases hq : q = 0
-    · simp [hacc, hq] at hsome
+    · simp only [ne_eq, decide_not, hacc, hq, Option.filter_eq_some_iff, Option.some.injEq,
+        Bool.not_eq_eq_eq_not, Bool.not_true, decide_eq_false_iff_not] at hsome
       exact False.elim (hsome.2 hsome.1.symm)
-    · simp [hacc] at hsome
+    · simp only [ne_eq, decide_not, hacc, Option.filter_eq_some_iff, Option.some.injEq,
+        Bool.not_eq_eq_eq_not, Bool.not_true, decide_eq_false_iff_not] at hsome
       exact hsome.2
 
 private lemma normalizeMap_keys_eq_support [DecidableEq α] [BEq α] [Hashable α]
@@ -736,7 +738,8 @@ protected def normalize [DecidableEq α] [BEq α] [Hashable α] [LawfulBEq α] [
       normalizeMap_keys_eq_support p
     calc
       (((normalizeMap p).toList.map Prod.snd).sum) =
-          (((normalizeMap p).toList.map Prod.fst).toFinset.sum (probOfList (normalizeMap p).toList)) := by
+          (((normalizeMap p).toList.map Prod.fst).toFinset.sum
+            (probOfList (normalizeMap p).toList)) := by
         symm
         exact list_sum_prob_eq (normalizeMap p).toList
       _ = p.support.sum p.prob := by
@@ -852,7 +855,7 @@ lemma SameDist.support_eq [DecidableEq α] {p q : Raw α} (h : SameDist p q) :
   ext x
   rw [Raw.mem_support_iff, Raw.mem_support_iff, h.prob_eq x]
 
-lemma SameDist.bind_congr [DecidableEq α] [DecidableEq β] {p q : Raw α}
+lemma SameDist.bind_congr {p q : Raw α}
     {f g : α → Raw β} (hpq : SameDist p q) (hfg : ∀ x, SameDist (f x) (g x)) :
     SameDist (p >>= f) (q >>= g) := by
   intro y
@@ -872,7 +875,7 @@ lemma SameDist.bind_congr [DecidableEq α] [DecidableEq β] {p q : Raw α}
   intro x hx
   rw [hpq x, hfg x y]
 
-lemma SameDist.map_congr [DecidableEq α] [DecidableEq β] {p q : Raw α}
+lemma SameDist.map_congr {p q : Raw α}
     (hpq : SameDist p q) (f : α → β) :
     SameDist (f <$> p) (f <$> q) := by
   simpa [Functor.map] using
@@ -989,7 +992,8 @@ noncomputable def toPMF (p : FinRatPMF α) : PMF α := by
   classical
   rw [show (pure a : FinRatPMF α) = mk (Raw.pure a) by rfl, toPMF_mk, Raw.toPMF_pure]
 
-lemma toPMF_out (p : FinRatPMF α) : toPMF p = @Raw.toPMF _ (Classical.decEq _) (Quotient.out p) := by
+lemma toPMF_out (p : FinRatPMF α) :
+    toPMF p = @Raw.toPMF _ (Classical.decEq _) (Quotient.out p) := by
   classical
   refine Quotient.inductionOn p ?_
   intro q
@@ -1122,7 +1126,6 @@ instance [DecidableEq α] : BEq (Raw α) where
 
 @[simp] lemma beq_iff_sameDist [DecidableEq α] (p q : Raw α) :
     (p == q) = true ↔ SameDist p q := by
-  show decide (SameDist p q) = true ↔ SameDist p q
-  simp
+  change decide (SameDist p q) = true ↔ SameDist p q; simp
 
 end FinRatPMF

--- a/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
+++ b/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
@@ -38,6 +38,7 @@ variable {α β : Type u} [Fintype α] [Fintype β]
 
 section Topology
 
+set_option linter.unusedFintypeInType false in
 lemma map_fst_eval (c : SPMF (α × β)) (a : α) :
     (Prod.fst <$> c) a = ∑ b, c (a, b) := by
   classical
@@ -61,6 +62,7 @@ lemma map_fst_eval (c : SPMF (α × β)) (a : α) :
       simp [ha'']
   simpa [hsimp] using hmain
 
+set_option linter.unusedFintypeInType false in
 lemma map_snd_eval (c : SPMF (α × β)) (b : β) :
     (Prod.snd <$> c) b = ∑ a, c (a, b) := by
   classical
@@ -90,20 +92,12 @@ lemma map_snd_eval (c : SPMF (α × β)) (b : β) :
 omit [Fintype α] [Fintype β] in
 private lemma pmf_none_eq {γ : Type u} [Fintype γ] (p : PMF (Option γ)) :
     p none = 1 - ∑ x, p (some x) := by
-  have h := p.tsum_coe
-  rw [tsum_fintype, Fintype.sum_option] at h
-  exact ENNReal.eq_sub_of_add_eq' one_ne_top h
+  refine (SPMF.gap_eq_one_sub_tsum p).trans (congr_arg _ (tsum_eq_sum ?_))
+  simp
 
 omit [Fintype α] [Fintype β] in
-private lemma spmf_ext {γ : Type u} [Fintype γ] {p q : SPMF γ}
-    (h : ∀ x, p x = q x) : p = q := by
-  refine PMF.ext fun x => ?_
-  cases x with
-  | none =>
-      rw [pmf_none_eq, pmf_none_eq]
-      congr with y
-      exact h y
-  | some x => exact h x
+private lemma spmf_ext {γ : Type u} {p q : SPMF γ}
+    (h : ∀ x, p x = q x) : p = q := SPMF.ext h
 
 def couplings_set (p : SPMF α) (q : SPMF β) : Set (Option (α × β) → ℝ) :=
   { c | (∀ z, 0 ≤ c z) ∧
@@ -125,7 +119,6 @@ lemma isClosed_couplings_set (p : SPMF α) (q : SPMF β) :
     simp only [couplings_set, mem_inter_iff, mem_setOf_eq]
     tauto
   ]
-
   have h1 : IsClosed {c : Option (α × β) → ℝ | ∀ z, 0 ≤ c z} := by
     have : {c : Option (α × β) → ℝ | ∀ z, 0 ≤ c z} = ⋂ z, {c | 0 ≤ c z} := by ext; simp
     rw [this]
@@ -138,15 +131,17 @@ lemma isClosed_couplings_set (p : SPMF α) (q : SPMF β) :
     have : {c : Option (α × β) → ℝ | ∀ a, ∑ b, c (some (a, b)) = (p a).toReal} =
       ⋂ a, {c | ∑ b, c (some (a, b)) = (p a).toReal} := by ext; simp
     rw [this]
-    exact isClosed_iInter fun a => isClosed_eq (continuous_finset_sum _ (fun b _ => continuous_apply _)) continuous_const
+    exact isClosed_iInter fun a => isClosed_eq (continuous_finset_sum _
+      (fun b _ => continuous_apply _)) continuous_const
   have h4 : IsClosed {c : Option (α × β) → ℝ | ∀ b, ∑ a, c (some (a, b)) = (q b).toReal} := by
     have : {c : Option (α × β) → ℝ | ∀ b, ∑ a, c (some (a, b)) = (q b).toReal} =
       ⋂ b, {c | ∑ a, c (some (a, b)) = (q b).toReal} := by ext; simp
     rw [this]
-    exact isClosed_iInter fun b => isClosed_eq (continuous_finset_sum _ (fun a _ => continuous_apply _)) continuous_const
+    exact isClosed_iInter fun b => isClosed_eq (continuous_finset_sum _
+      (fun a _ => continuous_apply _)) continuous_const
   have h5 : IsClosed {c : Option (α × β) → ℝ | c none = 1 - (∑ z, c (some z))} := by
-    exact isClosed_eq (continuous_apply _) (continuous_const.sub (continuous_finset_sum _ (fun z _ => continuous_apply _)))
-
+    exact isClosed_eq (continuous_apply _) (continuous_const.sub (continuous_finset_sum _
+      (fun z _ => continuous_apply _)))
   exact (((h1.inter h2).inter h3).inter h4).inter h5
 
 lemma isBounded_couplings_set (p : SPMF α) (q : SPMF β) :
@@ -172,7 +167,7 @@ lemma mem_couplings_set_of_isCoupling {p : SPMF α} {q : SPMF β} (c : SPMF (α 
     (fun z => (c.toPMF z).toReal) ∈ couplings_set p q := by
   simp only [couplings_set, mem_setOf_eq]
   refine ⟨fun z => ENNReal.toReal_nonneg, ?_, ?_, ?_, ?_⟩
-  · intro z; have h := ENNReal.toReal_mono (by exact ENNReal.one_ne_top) (PMF.coe_le_one c z); exact h
+  · intro z; exact ENNReal.toReal_mono (by exact ENNReal.one_ne_top) (PMF.coe_le_one c z)
   · intro a
     have h_fst : (Prod.fst <$> c) a = p a := by rw [hc.map_fst]
     have h_sum : (Prod.fst <$> c) a = ∑ b, c (a, b) := map_fst_eval c a
@@ -300,22 +295,23 @@ private lemma objective_eq_ofReal (c : SPMF (α × β))
               (f := fun z => (c.1 z).toReal * (f z).toReal)
               (fun z _ => mul_nonneg ENNReal.toReal_nonneg ENNReal.toReal_nonneg))
 
+set_option linter.unusedFintypeInType false in
 -- 3. Attaining supremum
 lemma SPMF.exists_max_coupling {p : SPMF α} {q : SPMF β}
     (f : Option (α × β) → ℝ≥0∞) (hf : ∀ z, f z ≠ ⊤)
     (h_nonempty : Nonempty (SPMF.Coupling p q)) :
     ∃ (c : SPMF.Coupling p q),
-      (⨆ c' : SPMF.Coupling p q, ∑' (z : Option (α × β)), (c'.1.1 z) * f z) = ∑' (z : Option (α × β)), (c.1.1 z) * f z := by
+      (⨆ c' : SPMF.Coupling p q, ∑' (z : Option (α × β)), (c'.1.1 z) * f z) =
+        ∑' (z : Option (α × β)), (c.1.1 z) * f z := by
   let F : (Option (α × β) → ℝ) → ℝ := fun c => ∑ z, c z * (f z).toReal
-  have hF_cont : Continuous F := continuous_finset_sum _ (fun z _ => (continuous_apply z).mul continuous_const)
+  have hF_cont : Continuous F := continuous_finset_sum _
+    (fun z _ => (continuous_apply z).mul continuous_const)
   have h_comp := isCompact_couplings_set p q
-
   -- Show set is nonempty
   obtain ⟨c0⟩ := h_nonempty
   have h_nonempty_set : (couplings_set p q).Nonempty := by
     use fun z => (c0.1.1 z).toReal
     exact mem_couplings_set_of_isCoupling c0.1 c0.2
-
   -- Using compact max theorem
   have h_exists := h_comp.exists_isMaxOn h_nonempty_set hF_cont.continuousOn
   obtain ⟨c_max, hc_max_in, hc_max_prop⟩ := h_exists

--- a/ToMathlib/ProbabilityTheory/SPMF.lean
+++ b/ToMathlib/ProbabilityTheory/SPMF.lean
@@ -47,7 +47,7 @@ protected lemma bind_congr {γ δ : Type*} (p : PMF γ) (f g : γ → PMF δ)
 lemma map_eq_pure_zero {γ δ : Type*} (f : γ → δ) (c : PMF γ) (b : δ)
     (h : PMF.map f c = PMF.pure b) (a : γ) (ha : f a ≠ b) : c a = 0 := by
   have key := congr_fun (congrArg DFunLike.coe h) (f a)
-  simp [PMF.map_apply, PMF.pure_apply, ha] at key
+  simp only [map_apply, pure_apply, ha, ↓reduceIte, ENNReal.tsum_eq_zero, ite_eq_right_iff] at key
   exact key a rfl
 
 end PMF
@@ -77,7 +77,7 @@ noncomputable instance : AlternativeMonad SPMF := OptionT.instAlternativeMonadOf
 noncomputable instance : LawfulAlternative SPMF := OptionT.instLawfulAlternativeOfLawfulMonad PMF
 noncomputable instance : LawfulMonad SPMF := OptionT.instLawfulMonad
 
-/-- Expose the lifting operations from `PMF` to `SPMF` given by `OptionT.lift`-/
+/-- Expose the lifting operations from `PMF` to `SPMF` given by `OptionT.lift`. -/
 noncomputable instance : MonadLift PMF SPMF where monadLift := OptionT.lift
 instance : LawfulMonadLift PMF SPMF := OptionT.instLawfulMonadLift
 
@@ -101,7 +101,8 @@ lemma toPMF_liftM (p : PMF α) : (liftM p : SPMF α).toPMF = p := rfl
 
 @[simp, grind =]
 lemma liftM_apply (p : PMF α) (x : α) : (liftM p : SPMF α) x = p x := by
-  simp [apply_eq_toPMF_some]
+  simp only [apply_eq_toPMF_some, toPMF_liftM, PMF.monad_pure_eq_pure, PMF.monad_bind_eq_bind,
+    PMF.bind_apply, PMF.pure_apply, Option.some.injEq, mul_ite, mul_one, mul_zero]
   refine (tsum_eq_single x ?_).trans ?_ <;> aesop
 
 @[simp, grind =]
@@ -169,7 +170,7 @@ lemma toPMF_none_eq_one_sub_tsum (p : SPMF α) :
 
 @[ext]
 lemma ext {p q : SPMF α} (h : ∀ x : α, p x = q x) : p = q := by
-  simp [SPMF.apply_eq_toPMF_some] at h
+  simp only [apply_eq_toPMF_some] at h
   refine PMF.ext fun
     | some x => h x
     | none =>  calc p.toPMF none
@@ -236,9 +237,9 @@ lemma gap_eq_one_sub_tsum (p : SPMF α) : p.gap = 1 - ∑' x : α, p x := by gri
 @[grind =]
 lemma toReal_gap_eq_one_sub_sum_toReal [Fintype α] (p : SPMF α) :
     p.gap.toReal = 1 - ∑ x : α, (p x).toReal := by
-  simp [SPMF.gap_eq_one_sub_tsum]
+  simp only [gap_eq_one_sub_tsum, tsum_fintype]
   rw [ENNReal.toReal_sub_of_le]
-  · simp
+  · simp only [toReal_one, _root_.sub_right_inj]
     rw [ENNReal.toReal_sum]
     simp
   · refine le_of_le_of_eq ?_ (run_none_add_tsum_run_some p)

--- a/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/GenericLift.lean
@@ -159,9 +159,6 @@ private lemma IND_CPA_hybridLR_counted_run'_evalDist_eq_above
   simp only [StateT.run', evalDist_map]
   exact congrArg (fun d => Prod.fst <$> d) hrun
 
--- @[simp]
--- lemma liftM
-
 /-- Planned semantic bridge: resuming the paused prefix simulation with the chosen branch should
 match the corresponding counted LR hybrid on the same sample space. This is the core local
 decomposition lemma needed for the generic step-adversary proof. -/

--- a/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/GenericLift.lean
@@ -351,7 +351,7 @@ private lemma IND_CPA_stepPrefix_resume_eq_hybridLR
               have hsel :
                   (if st.2 < if branch then k + 1 else k then mm.1 else mm.2) = mm.1 :=
                 if_pos hkLt
-              simp [map_eq_bind_pure_comp]
+              simp only [StateT.run'_eq, map_eq_bind_pure_comp]
               rw [hsel]
               refine probOutput_bind_congr' (encAlg'.encrypt pk mm.1) x ?_
               intro c
@@ -451,7 +451,7 @@ private lemma IND_CPA_stepPrefix_resume_eq_hybridLR
                   (if st.2 < if branch then k + 1 else k then mm.1 else mm.2) =
                     (if branch then mm.1 else mm.2) := by
                 cases branch <;> simp [hEq]
-              simp [map_eq_bind_pure_comp]
+              simp only [StateT.run'_eq, map_eq_bind_pure_comp]
               rw [hsel]
               refine probOutput_bind_congr' (encAlg'.encrypt pk (if branch then mm.1 else mm.2))
                 x ?_
@@ -563,7 +563,7 @@ private lemma IND_CPA_stepAdversary_game_eq_hybridBranch [Inhabited M]
   intro x
   refine probOutput_bind_congr' ($ᵗ Bool : ProbComp Bool) x ?_
   intro bit
-  show Pr[= x | do
+  change Pr[= x | do
       let (pk, _sk) ← encAlg'.keygen
       let (m₁, m₂, state) ←
         (IND_CPA_stepAdversary (encAlg' := encAlg') adversary k).chooseMessages pk
@@ -579,7 +579,7 @@ private lemma IND_CPA_stepAdversary_game_eq_hybridBranch [Inhabited M]
     (refine probOutput_bind_congr' encAlg'.keygen x ?_) <;>
     intro pk_sk <;>
     simp only [IND_CPA_stepAdversary, bind_assoc] <;>
-    (show (evalDist _) x = (evalDist _) x) <;>
+    (change (evalDist _) x = (evalDist _) x) <;>
     congr 1
   · rename_i pk_sk
     have hresume := IND_CPA_stepPrefix_resume_eq_hybridLR (encAlg' := encAlg')

--- a/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/GenericLift.lean
@@ -159,6 +159,9 @@ private lemma IND_CPA_hybridLR_counted_run'_evalDist_eq_above
   simp only [StateT.run', evalDist_map]
   exact congrArg (fun d => Prod.fst <$> d) hrun
 
+-- @[simp]
+-- lemma liftM
+
 /-- Planned semantic bridge: resuming the paused prefix simulation with the chosen branch should
 match the corresponding counted LR hybrid on the same sample space. This is the core local
 decomposition lemma needed for the generic step-adversary proof. -/
@@ -192,38 +195,6 @@ private lemma IND_CPA_stepPrefix_resume_eq_hybridLR
           apply evalDist_ext
           intro x
           rw [IND_CPA_stepPrefix_query_inl]
-          have hleft :
-              Pr[= x | do
-                let __discr ←
-                  (do
-                    let u ← liftM (query (spec := unifSpec) tu)
-                    IND_CPA_stepPrefix (encAlg' := encAlg') pk k (oa u)).run st
-                match __discr.1 with
-                | .done a => pure a
-                | .paused mm cont =>
-                    let c ← encAlg'.encrypt pk (if branch then mm.1 else mm.2)
-                    (simulateQ (encAlg'.IND_CPA_queryImpl_hybridLR_counted pk k) (cont c)).run'
-                      (QueryCache.cacheQuery __discr.2.1 mm c, __discr.2.2 + 1)] =
-              Pr[= x | do
-                let u ← ($ᵗ (unifSpec.Range tu) : ProbComp (unifSpec.Range tu))
-                let __discr ← (IND_CPA_stepPrefix (encAlg' := encAlg') pk k (oa u)).run st
-                match __discr.1 with
-                | .done a => pure a
-                | .paused mm cont =>
-                    let c ← encAlg'.encrypt pk (if branch then mm.1 else mm.2)
-                    (simulateQ (encAlg'.IND_CPA_queryImpl_hybridLR_counted pk k) (cont c)).run'
-                      (QueryCache.cacheQuery __discr.2.1 mm c, __discr.2.2 + 1)] := by
-            change Pr[= x | do
-              let u ← ($ᵗ (unifSpec.Range tu) : ProbComp (unifSpec.Range tu))
-              let __discr ← (IND_CPA_stepPrefix (encAlg' := encAlg') pk k (oa u)).run st
-              match __discr.1 with
-              | .done a => pure a
-              | .paused mm cont =>
-                  let c ← encAlg'.encrypt pk (if branch then mm.1 else mm.2)
-                  (simulateQ (encAlg'.IND_CPA_queryImpl_hybridLR_counted pk k) (cont c)).run'
-                    (QueryCache.cacheQuery __discr.2.1 mm c, __discr.2.2 + 1)] = _
-            rfl
-          rw [hleft]
           have hquery :
               (simulateQ
                 (encAlg'.IND_CPA_queryImpl_hybridLR_counted pk (if branch then k + 1 else k))

--- a/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/IND_CPA/Oracle.lean
@@ -616,7 +616,7 @@ lemma IND_CPA_hybridLR_counted_run_eq_of_ge
   | inl tu =>
       rfl
   | inr mm =>
-      show (IND_CPA_countedChallengeOracle pk
+      change (IND_CPA_countedChallengeOracle pk
           (fun n mm => if n < k then mm.1 else mm.2) mm).run st =
         (IND_CPA_countedChallengeOracle pk
           (fun n mm => if n < k + 1 then mm.1 else mm.2) mm).run st

--- a/VCVio/CryptoFoundations/Asymptotics/Negligible.lean
+++ b/VCVio/CryptoFoundations/Asymptotics/Negligible.lean
@@ -25,10 +25,10 @@ open ENNReal Asymptotics Filter
 
 /-- A function `f` is negligible if it decays faster than any polynomial function. -/
 def negligible (f : ℕ → ℝ≥0∞) : Prop :=
-  SuperpolynomialDecay atTop (λ x ↦ ↑x) f
+  SuperpolynomialDecay atTop (fun x ↦ ↑x) f
 
 @[simp] def negligible_iff (f : ℕ → ℝ≥0∞) :
-    negligible f ↔ SuperpolynomialDecay atTop (λ x ↦ ↑x) f := Iff.rfl
+    negligible f ↔ SuperpolynomialDecay atTop (fun x ↦ ↑x) f := Iff.rfl
 
 lemma negligible_zero : negligible 0 := superpolynomialDecay_zero _ _
 
@@ -58,6 +58,7 @@ theorem negligible_const_mul {f : ℕ → ℝ≥0∞} (hf : negligible f)
   simp only [mul_zero] at h
   exact h.congr (fun n => by rw [mul_left_comm])
 
+set_option linter.unusedDecidableInType false in
 /-- A finite sum of negligible functions is negligible. -/
 theorem negligible_sum {ι : Type*} [DecidableEq ι] {s : Finset ι} {f : ι → ℕ → ℝ≥0∞}
     (h : ∀ i ∈ s, negligible (f i)) :
@@ -74,7 +75,7 @@ theorem negligible_sum {ι : Type*} [DecidableEq ι] {s : Finset ι} {f : ι →
 Absorbs polynomial powers of the parameter into the superpolynomial decay. -/
 theorem negligible_pow_mul {f : ℕ → ℝ≥0∞} (hf : negligible f) (d : ℕ) :
     negligible (fun n => (↑n : ℝ≥0∞) ^ d * f n) := fun k => by
-  show Tendsto (fun (n : ℕ) => (↑n : ℝ≥0∞) ^ k * ((↑n : ℝ≥0∞) ^ d * f n)) atTop (nhds 0)
+  change Tendsto (fun (n : ℕ) => (↑n : ℝ≥0∞) ^ k * ((↑n : ℝ≥0∞) ^ d * f n)) atTop (nhds 0)
   simp_rw [← mul_assoc, ← pow_add]
   exact hf (k + d)
 

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -152,7 +152,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
           let r ← $ᵗ Ω
           let s ← σ.respond pk sk e r
           pure (σ.verify pk c r s)) by
-    show StateT.run' (simulateQ (idImpl + ro) (do
+    change StateT.run' (simulateQ (idImpl + ro) (do
         let (pk, sk) ← (FiatShamir σ hr M).keygen
         let sig ← (FiatShamir σ hr M).sign pk sk msg
         (FiatShamir σ hr M).verify pk msg sig)) ∅ = _
@@ -166,7 +166,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
         (simulateQ (idImpl + ro) (liftM oa) >>= rest).run' s =
           oa >>= fun x => (rest x).run' s := by
       intro α β oa rest s
-      show Prod.fst <$> ((simulateQ (idImpl + ro) (liftM oa) >>= rest).run s) =
+      change Prod.fst <$> ((simulateQ (idImpl + ro) (liftM oa) >>= rest).run s) =
         oa >>= fun x => Prod.fst <$> (rest x).run s
       rw [StateT.run_bind, hrunLift]
       simp [map_bind]
@@ -190,7 +190,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
           $ᵗ Ω >>= fun r =>
             (rest r).run' ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r) := by
       intro β q rest
-      show Prod.fst <$> ((ro q >>= rest).run ∅) =
+      change Prod.fst <$> ((ro q >>= rest).run ∅) =
         $ᵗ Ω >>= fun r =>
           Prod.fst <$> (rest r).run ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r)
       simp only [ro, randomOracle, QueryImpl.withCaching_apply, StateT.run_bind,
@@ -206,7 +206,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
         (ro q >>= rest).run' ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r) =
           (rest r).run' ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r) := by
       intro β q r rest
-      show Prod.fst <$> ((ro q >>= rest).run
+      change Prod.fst <$> ((ro q >>= rest).run
           ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r)) =
         Prod.fst <$> (rest r).run
           ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r)
@@ -245,6 +245,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
             pure (σ.verify pk c r s))
           (post := fun y => if y = true then 1 else 0))
 
+set_option linter.unusedDecidableInType false
 /-- Pointcheval-Stern style Fiat-Shamir reduction statement.
 
 To obtain a meaningful EUF-CMA theorem we need:

--- a/VCVio/CryptoFoundations/Fork.lean
+++ b/VCVio/CryptoFoundations/Fork.lean
@@ -108,11 +108,12 @@ theorem probEvent_fork_fst_eq_probEvent_pair (s : Fin (qb i + 1)) :
       x₁ x₂ hmem with ⟨t, h₁, h₂⟩
     simp [h₁, h₂]
 
-omit [spec.DecidableEq] in
+omit [spec.DecidableEq] [DecidableEq ι] in
 private lemma probEvent_uniform_eq_seedSlot_le_inv (s : Fin (qb i + 1))
     (seed : QuerySeed spec) :
     let h : ℝ≥0∞ := ↑(Fintype.card (spec.Range i))
     Pr[fun u : spec.Range i => (seed i)[↑s]? = some u | liftComp ($ᵗ spec.Range i) spec] ≤ h⁻¹ := by
+  classical
   simp only
   by_cases hnone : (seed i)[↑s]? = none
   · simp [hnone]
@@ -125,7 +126,7 @@ private lemma probEvent_uniform_eq_seedSlot_le_inv (s : Fin (qb i + 1))
     rw [this]
     exact le_of_eq (seededOracle.probEvent_liftComp_uniformSample_eq_of_eq u₀)
 
-omit [spec.DecidableEq] in
+omit [spec.DecidableEq] [DecidableEq ι] in
 private lemma probEvent_uniform_eq_seedSlot_eq_inv_of_get (s : Fin (qb i + 1))
     (seed : QuerySeed spec) {u₀ : spec.Range i}
     (hu₀ : (seed i)[↑s]? = some u₀) :
@@ -402,7 +403,7 @@ private lemma sq_probOutput_main_le_noGuardComp (s : Fin (qb i + 1)) :
           cf <$> (simulateQ seededOracle main).run' σ' := by
         intro σ'
         simp only [simulateQ_map]
-        show Prod.fst <$> (Prod.map cf id <$> (simulateQ seededOracle main).run σ') =
+        change Prod.fst <$> (Prod.map cf id <$> (simulateQ seededOracle main).run σ') =
           cf <$> (Prod.fst <$> (simulateQ seededOracle main).run σ')
         simp [Functor.map_map]
       have hWF := seededOracle.tsum_probOutput_generateSeed_weight_takeAtIndex
@@ -509,7 +510,8 @@ theorem le_probOutput_fork (s : Fin (qb i + 1)) :
         Pr[= z | f <$> fork main qb js i cf] +
           Pr[= (some s : Option (Fin (qb i + 1))) | collisionComp] := by
     simp only [noGuardComp, collisionComp]
-    simp [fork, f, z]
+    simp only [liftComp_eq_liftM, StateT.run'_eq, bind_pure_comp, Functor.map_map, bind_map_left,
+      fork, Fin.getElem?_fin, map_bind, z, f]
     refine (probOutput_bind_congr_le_add
       (mx := (liftComp (generateSeed spec qb js) spec : OracleComp spec (QuerySeed spec)))
       (y := z) (z₁ := z) (z₂ := (some s : Option (Fin (qb i + 1))))) ?_
@@ -533,7 +535,7 @@ theorem le_probOutput_fork (s : Fin (qb i + 1)) :
     | some t =>
         by_cases hts : t = s
         · cases hts
-          simp [z]
+          simp only [map_bind, z]
           refine (probOutput_bind_congr_le_add
             (mx := (liftComp ($ᵗ spec.Range i) spec : OracleComp spec (spec.Range i)))
             (y := z) (z₁ := z) (z₂ := (some s : Option (Fin (qb i + 1))))) ?_

--- a/VCVio/CryptoFoundations/SigmaProtocol.lean
+++ b/VCVio/CryptoFoundations/SigmaProtocol.lean
@@ -33,7 +33,7 @@ structure SigmaProtocol
     (S W PC SC Ω P : Type) (p : S → W → Bool) where
   /-- Given a statement `s`, make a commitment to prove that you have a valid witness `w`. -/
   commit (s : S) (w : W) : ProbComp (PC × SC)
-  /-- Given a previous secret commitment `sc`, repond to the challenge `ω`-/
+  /-- Given a previous secret commitment `sc`, repond to the challenge `ω`. -/
   respond (s : S) (w : W) (sc : SC) (ω : Ω) : ProbComp P
   /-- Deterministic function to check that the proof `p` satisfies the challenge `ω`. -/
   verify (s : S) (pc : PC) (ω : Ω) (p : P) : Bool

--- a/VCVio/CryptoFoundations/SymmEncAlg.lean
+++ b/VCVio/CryptoFoundations/SymmEncAlg.lean
@@ -146,9 +146,11 @@ def ciphertextRowsEqualAt (encAlg : SymmEncAlg M K C Q) (sp : ℕ) : Prop :=
     Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp sp msg₀] =
       Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp sp msg₁]
 
+
 theorem perfectSecrecyAtAllPriors_iff_ciphertextRowsEqualAt
-    (encAlg : SymmEncAlg M K C Q) (sp : ℕ) [Fintype (M sp)] :
+    (encAlg : SymmEncAlg M K C Q) (sp : ℕ) [Finite (M sp)] :
     encAlg.perfectSecrecyAtAllPriors sp ↔ encAlg.ciphertextRowsEqualAt sp := by
+  have : Fintype (M sp) := Fintype.ofFinite (M sp)
   constructor
   · intro hAll msg₀ msg₁ σ
     haveI : Nonempty (M sp) := ⟨msg₀⟩
@@ -336,7 +338,7 @@ Note: the converse direction requires stronger prior expressivity assumptions th
 `perfectSecrecyAt` currently encodes; see `perfectSecrecyAtAllPriors`. -/
 theorem perfectSecrecyAt_of_uniformKey_of_uniqueKey
     (encAlg : SymmEncAlg M K C Q) (sp : ℕ)
-    [Fintype (M sp)] [Fintype (K sp)] [Fintype (C sp)]
+    [Finite (M sp)] [Fintype (K sp)] [Finite (C sp)]
     (deterministicEnc : ∀ (k : K sp) (msg : M sp),
       ∃ c, support (simulateQ encAlg.impl (encAlg.encrypt k msg)) = {c}) :
     ((∀ k : K sp, Pr[= k | simulateQ encAlg.impl (encAlg.keygen sp)] =

--- a/VCVio/EvalDist/BitVec.lean
+++ b/VCVio/EvalDist/BitVec.lean
@@ -16,8 +16,7 @@ The `SampleableType (BitVec n)` instance is defined in
 
 open BitVec
 
-variable {α β γ : Type _}
-    {m : Type _ → Type _} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
+variable {α β γ : Type _} {m : Type _ → Type _} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
 
 @[simp, grind =]
 lemma probOutput_ofFin_map {n : ℕ} (mx : m (Fin (2 ^ n))) (x : BitVec n) :
@@ -30,6 +29,6 @@ lemma probOutput_bitVec_toFin_map {n : ℕ} (mx : m (BitVec n)) (x : Fin (2 ^ n)
 lemma probOutput_xor_map {n : ℕ} (mx : m (BitVec n)) (x y : BitVec n) :
     Pr[= y | (x ^^^ ·) <$> mx] = Pr[= x ^^^ y | mx] := by
   have hinj : Function.Injective (x ^^^ ·) := fun a b h => by
-    have := congrArg (x ^^^ ·) h; simp at this; exact this
+    have := congrArg (x ^^^ ·) h; simp only [xor_self_xor] at this; exact this
   conv_lhs => rw [show y = x ^^^ (x ^^^ y) by simp]
   exact probOutput_map_injective mx hinj (x ^^^ y)

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -216,7 +216,7 @@ end zero
 lemma probEvent_eq_tsum_subtype_mem_support (mx : m α) (p : α → Prop) :
     Pr[p | mx] = ∑' x : {x ∈ support mx | p x}, Pr[= x | mx] := by
   simp_rw [probEvent_eq_tsum_subtype, tsum_subtype]
-  refine tsum_congr (λ x ↦ ?_)
+  refine tsum_congr (fun x ↦ ?_)
   by_cases hpx : p x
   · refine (if_pos hpx).trans ?_
     by_cases hx : x ∈ support mx
@@ -229,19 +229,19 @@ lemma probEvent_eq_tsum_subtype_support_ite (mx : m α) (p : α → Prop) [Decid
     Pr[p | mx] = ∑' x : support mx, if p x then Pr[= x | mx] else 0 :=
 calc
   Pr[p | mx] = (∑' x, if p x then Pr[= x | mx] else 0) := by rw [probEvent_eq_tsum_ite mx p]
-  _ = ∑' x, (support mx).indicator (λ x ↦ if p x then Pr[= x | mx] else 0) x := by
-    refine tsum_congr (λ x ↦ ?_)
+  _ = ∑' x, (support mx).indicator (fun x ↦ if p x then Pr[= x | mx] else 0) x := by
+    refine tsum_congr (fun x ↦ ?_)
     unfold Set.indicator
     split_ifs with h1 h2 h2 <;> simp [h1, h2]
   _ = ∑' x : support mx, if p x then Pr[= x | mx] else 0 := by
-    rw [tsum_subtype (support mx) (λ x ↦ if p x then Pr[= x | mx] else 0)]
+    rw [tsum_subtype (support mx) (fun x ↦ if p x then Pr[= x | mx] else 0)]
 
 lemma probEvent_eq_sum_filter_finSupport [HasEvalFinset m] [DecidableEq α]
     (mx : m α) (p : α → Prop) [DecidablePred p] :
     Pr[p | mx] = ∑ x ∈ (finSupport mx).filter p, Pr[= x | mx] :=
   (probEvent_eq_tsum_ite mx p).trans <|
     (tsum_eq_sum' <| by simp; tauto).trans
-      (Finset.sum_congr rfl <| λ x hx ↦ if_pos (Finset.mem_filter.1 hx).2)
+      (Finset.sum_congr rfl <| fun x hx ↦ if_pos (Finset.mem_filter.1 hx).2)
 
 lemma probEvent_eq_sum_finSupport_ite [HasEvalFinset m] [DecidableEq α]
     (mx : m α) (p : α → Prop) [DecidablePred p] :

--- a/VCVio/EvalDist/Defs/Instances.lean
+++ b/VCVio/EvalDist/Defs/Instances.lean
@@ -101,8 +101,9 @@ lemma probOutput_eq_ite [DecidableEq α] (x : Id α) (y : α) :
   aesop
 
 @[simp, grind =]
-lemma probEvent_eq_ite [DecidableEq α] (x : Id α) (p : α → Prop) [DecidablePred p] :
+lemma probEvent_eq_ite (x : Id α) (p : α → Prop) [DecidablePred p] :
     Pr[p | x] = if p x.run then 1 else 0 := by
+  classical
   simp [probEvent_eq_sum_finSupport_ite]
 
 lemma probFailure_eq_zero (x : Id α) : Pr[⊥ | x] = 0 := by aesop

--- a/VCVio/EvalDist/Defs/NeverFails.lean
+++ b/VCVio/EvalDist/Defs/NeverFails.lean
@@ -57,7 +57,7 @@ lemma probFailure_eq_zero' [HasEvalSPMF m]
 
 namespace HasEvalPMF
 
-/-- A computation in a monad with `HasEvalPMF` can't fail as outputs sum to probability `1`.  -/
+/-- A computation in a monad with `HasEvalPMF` can't fail as outputs sum to probability `1`. -/
 instance [HasEvalPMF m] (mx : m α) : NeverFail mx where
   probFailure_eq_zero := probFailure_eq_zero mx
 
@@ -176,15 +176,12 @@ instance instSeq [LawfulMonad m] {mf : m (α → β)} {mx : m α}
 /-- If `mx` and `my` never fail, then `mx <* my` never fails. -/
 @[simp, grind .]
 instance instSeqLeft [LawfulMonad m] {mx : m α} {my : m β}
-    [hx : NeverFail mx] [hy : NeverFail my] : NeverFail (mx <* my) := by
-  simp [seqLeft_eq]; exact ⟨inferInstance, inferInstance⟩
+    [hx : NeverFail mx] [hy : NeverFail my] : NeverFail (mx <* my) := by aesop
 
 /-- If `mx` and `my` never fail, then `mx *> my` never fails. -/
 @[simp, grind .]
 instance instSeqRight [LawfulMonad m] {mx : m α} {my : m β}
-    [hx : NeverFail mx] [hy : NeverFail my] : NeverFail (mx *> my) := by
-  simp [seqRight_eq]; exact ⟨inferInstance, inferInstance⟩
-
+    [hx : NeverFail mx] [hy : NeverFail my] : NeverFail (mx *> my) := by aesop
 
 example [LawfulMonad m] (mx : m α) [h : NeverFail mx] : NeverFail (do
     let x ← mx

--- a/VCVio/EvalDist/Defs/Support.lean
+++ b/VCVio/EvalDist/Defs/Support.lean
@@ -100,7 +100,7 @@ lemma finSupport_eqRec {m} [hm : Monad m] [hms : HasEvalSet m] [hmfs : HasEvalFi
 
 section decidable
 
-/-- Membership in the support of computations in  -/
+/-- Membership in the support of computations in. -/
 protected class HasEvalSet.Decidable (m : Type u → Type v) [Monad m] [HasEvalSet m] where
   mem_support_decidable {α : Type u} (mx : m α) : DecidablePred (· ∈ support mx)
 

--- a/VCVio/EvalDist/Fintype.lean
+++ b/VCVio/EvalDist/Fintype.lean
@@ -39,9 +39,7 @@ lemma probEvent_bind_eq_sum_fintype [HasEvalSPMF m]
 /-- Union bound: the probability that *some* event `E i` holds is at most the sum of the
 individual probabilities, over a finite index set `s`. -/
 lemma probEvent_exists_finset_le_sum [HasEvalSPMF m]
-    {ι : Type u} (s : Finset ι) (mx : m α) (E : ι → α → Prop)
-    [DecidablePred (fun x => ∃ i ∈ s, E i x)]
-    [∀ i, DecidablePred (E i)] :
+    {ι : Type u} (s : Finset ι) (mx : m α) (E : ι → α → Prop) :
     Pr[(fun x => ∃ i ∈ s, E i x) | mx] ≤ s.sum (fun i => Pr[E i | mx]) := by
   classical
   refine Finset.induction_on s (by simp) ?_

--- a/VCVio/EvalDist/Instances/ErrorT.lean
+++ b/VCVio/EvalDist/Instances/ErrorT.lean
@@ -52,11 +52,11 @@ noncomputable instance (ε : Type u) (m : Type u → Type v) [Monad m] [HasEvalS
     HasEvalSet (ExceptT ε m) where
   toSet.toFun α mx := Except.ok ⁻¹' (support mx.run)
   toSet.toFun_pure' x := Set.ext fun y => by
-    show Except.ok y ∈ support (pure (Except.ok x) : m _) ↔ y = x
+    change Except.ok y ∈ support (pure (Except.ok x) : m _) ↔ y = x
     simp
   toSet.toFun_bind' mx f := Set.ext fun x => by
     simp only [Set.mem_preimage, Set.bind_def, Set.mem_iUnion₂]
-    show Except.ok x ∈ support (mx.run >>= ExceptT.bindCont f) ↔ _
+    change Except.ok x ∈ support (mx.run >>= ExceptT.bindCont f) ↔ _
     rw [mem_support_bind_iff]
     constructor
     · rintro ⟨r, hr, hx⟩
@@ -142,12 +142,12 @@ noncomputable def toSPMF' [HasEvalPMF m] : ExceptT ε m →ᵐ SPMF where
       | Except.error _ => failure
   toFun_pure' x := by simp
   toFun_bind' mx f := by
-    show HasEvalSPMF.toSPMF (mx.run >>= ExceptT.bindCont f) >>= _ = _
+    change HasEvalSPMF.toSPMF (mx.run >>= ExceptT.bindCont f) >>= _ = _
     simp only [MonadHom.toFun_bind', bind_assoc]
     congr 1; funext r
     cases r with
     | ok a =>
-      show HasEvalSPMF.toSPMF (f a).run >>= _ =
+      change HasEvalSPMF.toSPMF (f a).run >>= _ =
         pure a >>= fun b => HasEvalSPMF.toSPMF (f b).run >>= _
       simp
     | error e => simp [ExceptT.bindCont]
@@ -195,11 +195,12 @@ lemma probFailure_eq (mx : ExceptT ε m α) :
   simp only [probFailure_def, probEvent_eq_tsum_indicator, probOutput_def]
   rw [show evalDist mx = (HasEvalSPMF.toSPMF mx.run >>= fun r =>
       match r with | Except.ok a => pure a | Except.error _ => failure : SPMF α) from rfl]
-  simp [SPMF.toPMF_bind, Option.elimM, PMF.bind_apply, tsum_option,
-    SPMF.apply_eq_toPMF_some, evalDist_def]
+  simp only [SPMF.run_eq_toPMF, SPMF.toPMF_bind, Option.elimM, PMF.monad_bind_eq_bind,
+    PMF.bind_apply, ENNReal.summable, tsum_option, Option.elim_none, PMF.pure_apply, ↓reduceIte,
+    mul_one, Option.elim_some, evalDist_def, SPMF.apply_eq_toPMF_some, ne_eq, PMF.apply_ne_top,
+    not_false_eq_true, add_right_inj_of_ne_top]
   refine tsum_congr fun r => ?_
   cases r <;> simp [SPMF.toPMF_failure, SPMF.toPMF_pure]
-
 
 lemma probOutput_liftM [LawfulMonad m] (mx : m α) (x : α) :
     Pr[= x | (liftM mx : ExceptT ε m α)] = Pr[= x | mx] := by

--- a/VCVio/EvalDist/Instances/OptionT.lean
+++ b/VCVio/EvalDist/Instances/OptionT.lean
@@ -106,11 +106,12 @@ noncomputable instance (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
   toSPMF := OptionT.mapM' HasEvalSPMF.toSPMF
   support_eq mx := by
     ext x
-    simp [mem_support_iff, OptionT.mapM']
+    simp only [mem_support_iff, OptionT.mapM', SPMF.mem_support_iff, SPMF.bind_apply_eq_tsum, ne_eq,
+      ENNReal.tsum_eq_zero, mul_eq_zero, not_forall, not_or]
     constructor
-    · simp [mem_support_iff_evalDist_apply_ne_zero]
+    · simp only [mem_support_iff_evalDist_apply_ne_zero, ne_eq]
       refine fun h => ⟨some x, by simpa using h⟩
-    · simp [mem_support_iff_evalDist_apply_ne_zero]
+    · simp only [mem_support_iff_evalDist_apply_ne_zero, ne_eq, forall_exists_index, and_imp]
       intro x
       cases x <;> aesop
 
@@ -128,7 +129,7 @@ lemma evalDist_eq (mx : OptionT m α) :
 lemma probOutput_eq (mx : OptionT m α) (x : α) :
     Pr[= x | mx] = Pr[= some x | mx.run] := by
   simp only [probOutput_def]
-  show (OptionT.mapM' HasEvalSPMF.toSPMF mx) x = HasEvalSPMF.toSPMF mx.run (some x)
+  change (OptionT.mapM' HasEvalSPMF.toSPMF mx) x = HasEvalSPMF.toSPMF mx.run (some x)
   rw [show (OptionT.mapM' HasEvalSPMF.toSPMF mx : SPMF α) =
     HasEvalSPMF.toSPMF mx.run >>= fun y =>
       match y with | some a => pure a | none => failure from rfl]

--- a/VCVio/EvalDist/Instances/ReaderT.lean
+++ b/VCVio/EvalDist/Instances/ReaderT.lean
@@ -89,7 +89,7 @@ variable [HasEvalSPMF m] (ρ0 : ρ)
 @[simp] lemma evalSPMF_bind (mx : ReaderT ρ m α) (f : α → ReaderT ρ m β) :
     HasEvalSPMF.readerAt ρ0 (mx >>= f) =
       HasEvalSPMF.readerAt ρ0 mx >>= fun x => HasEvalSPMF.readerAt ρ0 (f x) := by
-  simp [HasEvalSPMF.readerAt, MonadHom.comp_apply]
+  simp only [HasEvalSPMF.readerAt, MonadHom.comp_apply, evalAt_apply]
   apply MonadHom.toFun_bind'
 
 end evalDist_lemmas
@@ -100,13 +100,14 @@ variable [HasEvalPMF m] (ρ0 : ρ)
 
 @[simp] lemma evalPMF_pure (x : α) :
     HasEvalPMF.readerAt ρ0 (pure x : ReaderT ρ m α) = HasEvalPMF.toPMF (pure x : m α) := by
-  simp [HasEvalPMF.readerAt]
+  simp only [HasEvalPMF.readerAt, MonadHom.comp_apply, evalAt_apply, MonadHom.toFun_pure',
+    PMF.monad_pure_eq_pure]
   apply MonadHom.toFun_pure'
 
 @[simp] lemma evalPMF_bind (mx : ReaderT ρ m α) (f : α → ReaderT ρ m β) :
     HasEvalPMF.readerAt ρ0 (mx >>= f) =
       HasEvalPMF.readerAt ρ0 mx >>= fun x => HasEvalPMF.readerAt ρ0 (f x) := by
-  simp [HasEvalPMF.readerAt, MonadHom.comp_apply]
+  simp only [HasEvalPMF.readerAt, MonadHom.comp_apply, evalAt_apply, PMF.monad_bind_eq_bind]
   apply MonadHom.toFun_bind'
 
 end evalPMF_lemmas

--- a/VCVio/EvalDist/List.lean
+++ b/VCVio/EvalDist/List.lean
@@ -37,12 +37,12 @@ lemma cons_mem_finSupport_seq_map_cons_iff [LawfulMonad m] [HasEvalFinset m] [De
   simp_rw [mem_finSupport_iff_mem_support]
   exact cons_mem_support_seq_map_cons_iff mx my x xs
 
-lemma probOutput_cons_seq_map_cons_eq_mul [LawfulMonad m] [DecidableEq α]
+lemma probOutput_cons_seq_map_cons_eq_mul [LawfulMonad m]
     (mx : m α) (my : m (List α)) (x : α) (xs : List α) :
     Pr[= x :: xs | cons <$> mx <*> my] = Pr[= x | mx] * Pr[= xs | my] :=
   probOutput_seq_map_eq_mul_of_injective2 mx my cons injective2_cons x xs
 
-lemma probOutput_cons_seq_map_cons_eq_mul' [LawfulMonad m] [DecidableEq α]
+lemma probOutput_cons_seq_map_cons_eq_mul' [LawfulMonad m]
     (mx : m α) (my : m (List α)) (x : α) (xs : List α) :
     Pr[= x :: xs | (fun xs x => x :: xs) <$> my <*> mx] =
       Pr[= x | mx] * Pr[= xs | my] :=
@@ -81,9 +81,9 @@ lemma probFailure_list_mapM_loop (xs : List α) (f : α → m β) (ys : List β)
       rw [probFailure_bind_eq_sub_mul _ _ (1 - (List.map (fun x ↦ 1 - Pr[⊥|f x]) xs).prod)]
       · congr 2
         rw [AddLECancellable.tsub_tsub_cancel_of_le]
-        simp only [ENNReal.addLECancellable_iff_ne, ne_eq, ENNReal.sub_eq_top_iff,
-          ENNReal.one_ne_top, false_and, not_false_eq_true]
-        refine (List.prod_le_pow_card _ 1 <| by simp).trans (le_of_eq <| one_pow _)
+        · simp only [ENNReal.addLECancellable_iff_ne, ne_eq, ENNReal.sub_eq_top_iff,
+            ENNReal.one_ne_top, false_and, not_false_eq_true]
+        · refine (List.prod_le_pow_card _ 1 <| by simp).trans (le_of_eq <| one_pow _)
       · simp
       · simp [h]
 
@@ -165,10 +165,10 @@ lemma probOutput_bind_eq_mul {mx : m α} {my : α → m β} {y : β} (x : α)
   grind [= mul_eq_zero]
 
 @[simp]
-lemma probOutput_cons_map [LawfulMonad m] [DecidableEq α]
-    (mx : m (List α)) (x : α) (xs : List α) :
+lemma probOutput_cons_map [LawfulMonad m] (mx : m (List α)) (x : α) (xs : List α) :
     Pr[= xs | cons x <$> mx] =
       if hxs : xs = [] then 0 else Pr[= xs.head hxs | (pure x : m α)] * Pr[= xs.tail | mx] := by
+  classical
   split
   case isTrue h =>
     subst h
@@ -196,14 +196,16 @@ lemma probOutput_list_mapM [LawfulMonad m] (xs : List α) (f : α → m β) (ys 
   | cons x xs ih =>
       intro ys
       split_ifs with hys
-      · simp at hys
+      · simp only [length_cons] at hys
         obtain ⟨y, ys, rfl⟩ := List.exists_cons_of_length_eq_add_one hys
         simp only [mapM_cons, bind_pure_comp, zipWith_cons_cons, prod_cons]
         rw [probOutput_bind_eq_mul y]
-        simp [ih]
-        clear *- hys
-        aesop
-        simp
+        · simp only [probOutput_cons_map, reduceCtorEq, ↓reduceDIte, head_cons, probOutput_pure,
+            ↓reduceIte, tail_cons, ih, mul_ite, one_mul, mul_zero, ite_eq_left_iff, zero_eq_mul,
+            probOutput_eq_zero_iff, prod_eq_zero_iff]
+          clear *- hys
+          aesop
+        · simp
       · refine probOutput_eq_zero_of_not_mem_support ?_
         simp only [mapM_cons, support_bind, Set.mem_iUnion, not_exists]
         intro y _ zs hzs
@@ -227,13 +229,15 @@ lemma probOutput_list_mapM' [LawfulMonad m] (xs : List α) (f : α → m β) (ys
   | cons x xs ih =>
       intro ys
       split_ifs with hys
-      · simp at hys
+      · simp only [length_cons] at hys
         obtain ⟨y, ys, rfl⟩ := List.exists_cons_of_length_eq_add_one hys
         simp only [mapM'_cons, bind_pure_comp, zipWith_cons_cons, prod_cons]
         rw [probOutput_bind_eq_mul y]
-        simp [ih]
-        clear *- hys
-        aesop
+        · simp only [probOutput_cons_map, reduceCtorEq, ↓reduceDIte, head_cons, probOutput_pure,
+          ↓reduceIte, tail_cons, ih, mul_ite, one_mul, mul_zero, ite_eq_left_iff, zero_eq_mul,
+          probOutput_eq_zero_iff, prod_eq_zero_iff]
+          clear *- hys
+          aesop
         simp
       · refine probOutput_eq_zero_of_not_mem_support ?_
         simp only [List.mapM'_cons, support_bind, Set.mem_iUnion, not_exists]
@@ -269,23 +273,20 @@ lemma support_seq_map_vector_cons [LawfulMonad m] :
     exact ⟨xs.head, hh, xs.tail, ht, List.Vector.cons_head_tail xs⟩
 
 @[simp]
-lemma probOutput_seq_map_vector_cons_eq_mul [LawfulMonad m] [DecidableEq α]
-    (xs : List.Vector α (n + 1)) :
+lemma probOutput_seq_map_vector_cons_eq_mul [LawfulMonad m] (xs : List.Vector α (n + 1)) :
     Pr[= xs | (· ::ᵥ ·) <$> mx <*> my] = Pr[= xs.head | mx] * Pr[= xs.tail | my] := by
   rw [← probOutput_seq_map_eq_mul_of_injective2 mx my _ Vector.injective2_cons,
     List.Vector.cons_head_tail]
 
 @[simp]
-lemma probOutput_seq_map_vector_cons_eq_mul' [LawfulMonad m] [DecidableEq α]
-    (xs : List.Vector α (n + 1)) :
+lemma probOutput_seq_map_vector_cons_eq_mul' [LawfulMonad m] (xs : List.Vector α (n + 1)) :
     Pr[= xs | (fun xs x => x ::ᵥ xs) <$> my <*> mx] =
     Pr[= xs.head | mx] * Pr[= xs.tail | my] :=
   (probOutput_seq_map_swap mx my (· ::ᵥ ·) xs).trans
     (probOutput_seq_map_vector_cons_eq_mul mx my xs)
 
 @[simp]
-lemma probOutput_vector_toList [LawfulMonad m] [DecidableEq α]
-    (mx' : m (List.Vector α n))
+lemma probOutput_vector_toList [LawfulMonad m] (mx' : m (List.Vector α n))
     (xs : List α) : Pr[= xs | List.Vector.toList <$> mx'] =
       if h : xs.length = n then Pr[= (⟨xs, h⟩ : List.Vector α n) | mx'] else 0 := by
   split_ifs with h

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -139,8 +139,8 @@ lemma probOutput_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (y 
 @[grind =]
 lemma probEvent_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (q : β → Prop) :
     Pr[q | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[q | my x] := by
-  simp [probEvent_eq_tsum_indicator, probOutput_bind_eq_tsum,
-    Set.indicator, ← ENNReal.tsum_mul_left]
+  simp only [probEvent_eq_tsum_indicator, Set.indicator, Set.mem_setOf_eq, probOutput_bind_eq_tsum,
+    ← ENNReal.tsum_mul_left, mul_ite, mul_zero]
   rw [ENNReal.tsum_comm]
   refine tsum_congr fun x => by split_ifs <;> simp
 

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -191,7 +191,7 @@ lemma probOutput_map_eq_probOutput_apply
     Pr[= y | f <$> mx] = Pr[= g y | mx] := by aesop
 
 @[simp, grind =]
-lemma probOutput_map_equiv {α β : Type u} (e : α ≃ β) (mx : m α) (y : β) :
+lemma probOutput_map_equiv (e : α ≃ β) (mx : m α) (y : β) :
     Pr[= y | e <$> mx] = Pr[= e.symm y | mx] := by aesop
 
 end inverse

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -190,6 +190,10 @@ lemma probOutput_map_eq_probOutput_apply
     (hl : f (g y) = y) (hr : ∀ y, g (f y) = y) :
     Pr[= y | f <$> mx] = Pr[= g y | mx] := by aesop
 
+@[simp, grind =]
+lemma probOutput_map_equiv {α β : Type u} (e : α ≃ β) (mx : m α) (y : β) :
+    Pr[= y | e <$> mx] = Pr[= e.symm y | mx] := by aesop
+
 end inverse
 
 section injective
@@ -209,6 +213,7 @@ lemma probOutput_map_eq_probOutput_invFunOn [Nonempty α]
   rw [dif_pos hy]
   rw [(Classical.choose_spec hy).2]
 
+@[grind .]
 lemma probOutput_map_injective (mx : m α) {f : α → β} (hf : f.Injective) (x : α) :
     Pr[= f x | f <$> mx] = Pr[= x | mx] := by
   aesop

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -43,7 +43,7 @@ lemma evalDist_map_eq_of_evalDist_eq [HasEvalSPMF m] [LawfulMonad m]
     evalDist (f <$> mx) = evalDist (f <$> my) := by
   simpa [evalDist_map] using congrArg (fun p => f <$> p) h
 
-lemma probOutput_map_eq_of_evalDist_eq [HasEvalSPMF m] [LawfulMonad m] [DecidableEq β]
+lemma probOutput_map_eq_of_evalDist_eq [HasEvalSPMF m] [LawfulMonad m]
     {mx my : m α} (h : evalDist mx = evalDist my) (f : α → β) (y : β) :
     Pr[= y | f <$> mx] = Pr[= y | f <$> my] := by
   exact (evalDist_ext_iff.mp (evalDist_map_eq_of_evalDist_eq h f)) y
@@ -70,7 +70,7 @@ lemma probOutput_map_eq_tsum_subtype (y : β) :
     Pr[= y | f <$> mx] = ∑' x : {x ∈ support mx | y = f x}, Pr[= x | mx] := by
   simp only [map_eq_bind_pure_comp, tsum_subtype _, probOutput_bind_eq_tsum, Function.comp_apply,
     Set.indicator, Set.mem_setOf_eq]
-  refine (tsum_congr (λ x ↦ ?_))
+  refine (tsum_congr (fun x ↦ ?_))
   by_cases hy : y = f x <;> by_cases hx : x ∈ support mx <;> simp [hy, hx]
 
 lemma probOutput_map_eq_tsum (y : β) :
@@ -127,7 +127,7 @@ lemma probOutput_map_eq_single {mx : m α} {f : α → β} {y : β}
     (x : α) (h : ∀ x' ∈ support mx, y = f x' → x = x') (h' : f x = y) :
     Pr[= y | f <$> mx] = Pr[= x | mx] := by
   rw [probOutput_map_eq_tsum]
-  refine (tsum_eq_single x (λ x' hx' ↦ ?_)).trans (by rw [h', probOutput_pure_self, mul_one])
+  refine (tsum_eq_single x (fun x' hx' ↦ ?_)).trans (by rw [h', probOutput_pure_self, mul_one])
   specialize h x'
   simp only [mul_eq_zero, probOutput_eq_zero_iff, support_pure, Set.mem_singleton_iff]
   tauto

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -221,9 +221,9 @@ lemma support_seq_map_swap [HasEvalSet m] :
     support (Function.swap f <$> my <*> mx) = support (f <$> mx <*> my) := by
   simp only [support_seq_map_eq_image2, Set.image2_swap f]
 
-lemma finSupport_seq_map_swap [HasEvalSet m] [HasEvalFinset m]
-    [DecidableEq α] [DecidableEq β] [DecidableEq γ] :
+lemma finSupport_seq_map_swap [HasEvalSet m] [HasEvalFinset m] [DecidableEq γ] :
     finSupport (Function.swap f <$> my <*> mx) = finSupport (f <$> mx <*> my) := by
+  classical
   simp only [finSupport_seq_map_eq_image2, Finset.image₂_swap f]
 
 end swap

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -207,24 +207,20 @@ lemma probOutput_seq_map_swap [HasEvalSPMF m]  (z : γ) :
   refine tsum_congr fun x' => tsum_congr fun y' => ?_
   rw [mul_comm (Pr[= y' | my])]
 
-@[simp]
 lemma evalDist_seq_map_swap [HasEvalSPMF m] :
     evalDist (Function.swap f <$> my <*> mx) = evalDist (f <$> mx <*> my) := by
   have : DecidableEq γ := Classical.decEq γ
   exact evalDist_ext (probOutput_seq_map_swap mx my f)
 
-@[simp]
 lemma probEvent_seq_map_swap [HasEvalSPMF m] (p : γ → Prop) :
     Pr[p | Function.swap f <$> my <*> mx] = Pr[p | f <$> mx <*> my] := by
   have : DecidableEq γ := Classical.decEq γ
   simp only [probEvent_eq_tsum_indicator, probOutput_seq_map_swap]
 
-@[simp]
 lemma support_seq_map_swap [HasEvalSet m] :
     support (Function.swap f <$> my <*> mx) = support (f <$> mx <*> my) := by
   simp only [support_seq_map_eq_image2, Set.image2_swap f]
 
-@[simp]
 lemma finSupport_seq_map_swap [HasEvalSet m] [HasEvalFinset m]
     [DecidableEq α] [DecidableEq β] [DecidableEq γ] :
     finSupport (Function.swap f <$> my <*> mx) = finSupport (f <$> mx <*> my) := by

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -26,6 +26,9 @@ section seq
     support (mf <*> mx) = ⋃ f ∈ support mf, f '' support mx := by
   simp [seq_eq_bind_map]
 
+lemma mem_support_seq_iff [HasEvalSet m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) (y : β) :
+    y ∈ support (mf <*> mx) ↔ ∃ f ∈ support mf, ∃ x ∈ support mx, f x = y := by simp
+
 @[simp] lemma finSupport_seq [HasEvalSet m] [HasEvalFinset m] [LawfulMonad m]
     [DecidableEq (α → β)] [DecidableEq α] [DecidableEq β]
     (mf : m (α → β)) (mx : m α) :
@@ -165,11 +168,11 @@ lemma probOutput_seq_map_eq_tsum_ite [HasEvalSPMF m] [DecidableEq γ]
 
 section injective2
 
-lemma probOutput_seq_map_eq_mul_of_injective2 [HasEvalSPMF m] [DecidableEq γ]
+lemma probOutput_seq_map_eq_mul_of_injective2 [HasEvalSPMF m]
     (hf : f.Injective2) (x : α) (y : β) :
     Pr[= f x y | f <$> mx <*> my] = Pr[= x | mx] * Pr[= y | my] := by
   rw [probOutput_seq_map_eq_tsum]
-  simp only [probOutput_pure, mul_ite, mul_one, mul_zero]
+  simp only [probOutput_pure_eq_indicator, Set.indicator, mul_ite, mul_zero]
   refine (tsum_eq_single x fun x' hx' => ?_).trans ?_
   · exact ENNReal.tsum_eq_zero.mpr fun b =>
       if_neg (show f x y ≠ f x' b from fun h' => hx' (hf h').1.symm)
@@ -197,10 +200,9 @@ end injective2
 
 section swap
 
-@[simp]
-lemma probOutput_seq_map_swap [HasEvalSPMF m] [DecidableEq γ] (z : γ) :
+lemma probOutput_seq_map_swap [HasEvalSPMF m]  (z : γ) :
     Pr[= z | Function.swap f <$> my <*> mx] = Pr[= z | f <$> mx <*> my] := by
-  simp only [probOutput_seq_map_eq_tsum_ite, Function.swap]
+  simp only [probOutput_seq_map_eq_tsum, Function.swap]
   rw [ENNReal.tsum_comm]
   refine tsum_congr fun x' => tsum_congr fun y' => ?_
   rw [mul_comm (Pr[= y' | my])]

--- a/VCVio/EvalDist/Option.lean
+++ b/VCVio/EvalDist/Option.lean
@@ -69,8 +69,9 @@ lemma probOutput_some_map_option_map {f : α → β} (hf : f.Injective) (x : α)
   cases a <;> cases b <;> simp_all [Option.map, hf.eq_iff]
 
 @[simp]
-lemma probOutput_none_map_option_map [DecidableEq β] (f : α → β) :
+lemma probOutput_none_map_option_map (f : α → β) :
     Pr[= none | Option.map f <$> mx] = Pr[= none | mx] := by
+  classical
   rw [probOutput_map_eq_tsum_ite]
   refine (tsum_eq_single none fun x hx => ?_).trans (by simp)
   cases x with

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -57,7 +57,7 @@ lemma probEvent_fst_map (mx : m (α × β)) (p : α → Prop) :
 
 /-- NOTE: Added since we don't choose to set the general `probEvent_map` to `simp`. -/
 @[simp low, grind =]
-lemma probEvent_snd (mx : m (α × β)) (p : β → Prop) :
+lemma probEvent_snd_map (mx : m (α × β)) (p : β → Prop) :
     Pr[p | Prod.snd <$> mx] = Pr[fun y => p y.2 | mx] := by grind
 
 omit [LawfulMonad m] in

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -70,8 +70,9 @@ lemma probEvent_snd_map (mx : m (α × β)) (p : β → Prop) :
 
 omit [LawfulMonad m] in
 @[simp, grind =]
-lemma probEvent_fst_eq_snd [DecidableEq α] (mx : m (α × α)) :
+lemma probEvent_fst_eq_snd (mx : m (α × α)) :
     Pr[fun z => z.1 = z.2 | mx] = ∑' x : α, Pr[= (x, x) | mx] := by
+  classical
   rw [probEvent_eq_tsum_ite, ENNReal.tsum_prod']
   refine tsum_congr fun x => ?_
   refine (tsum_eq_single x fun b hb => ?_).trans (by simp)

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -15,28 +15,14 @@ open ENNReal Prod
 
 universe u v
 
-variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
-  {α β γ δ : Type u}
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalSPMF m] {α β γ δ : Type u}
 
 omit [LawfulMonad m] in
-lemma probOutput_prod_mk_eq_probEvent [DecidableEq α] [DecidableEq β]
-    (mx : m (α × β)) (x : α) (y : β) :
+lemma probOutput_prod_mk_eq_probEvent (mx : m (α × β)) (x : α) (y : β) :
     Pr[= (x, y) | mx] = Pr[fun z => z.1 = x ∧ z.2 = y | mx] := by
   simp [← probEvent_eq_eq_probOutput, Prod.eq_iff_fst_eq_snd_eq]
 
-omit [HasEvalSPMF m] in
-@[simp]
-lemma fst_map_prod_map (mx : m (α × β)) (f : α → γ) (g : β → δ) :
-    Prod.fst <$> Prod.map f g <$> mx = (f ∘ Prod.fst) <$> mx := by
-  simp [Functor.map_map]; rfl
-
-omit [HasEvalSPMF m] in
-@[simp]
-lemma snd_map_prod_map (mx : m (α × β)) (f : α → γ) (g : β → δ) :
-    Prod.snd <$> Prod.map f g <$> mx = (g ∘ Prod.snd) <$> mx := by
-  simp [Functor.map_map]; rfl
-
-@[simp]
+@[simp, grind =]
 lemma probOutput_fst_map_eq_tsum (mx : m (α × β)) (x : α) :
     Pr[= x | Prod.fst <$> mx] = ∑' y, Pr[= (x, y) | mx] := by
   have : DecidableEq α := Classical.decEq _
@@ -45,13 +31,12 @@ lemma probOutput_fst_map_eq_tsum (mx : m (α × β)) (x : α) :
   refine (tsum_eq_single x ?_).trans (by simp)
   intro a ha; simp [Ne.symm ha]
 
-@[simp]
-lemma probOutput_fst_map_eq_sum [Fintype β]
-    (mx : m (α × β)) (x : α) :
+@[simp, grind =]
+lemma probOutput_fst_map_eq_sum [Fintype β] (mx : m (α × β)) (x : α) :
     Pr[= x | Prod.fst <$> mx] = ∑ y, Pr[= (x, y) | mx] := by
   rw [probOutput_fst_map_eq_tsum, tsum_fintype]
 
-@[simp]
+@[simp, grind =]
 lemma probOutput_snd_map_eq_tsum (mx : m (α × β)) (y : β) :
     Pr[= y | Prod.snd <$> mx] = ∑' x, Pr[= (x, y) | mx] := by
   have : DecidableEq β := Classical.decEq _
@@ -60,13 +45,23 @@ lemma probOutput_snd_map_eq_tsum (mx : m (α × β)) (y : β) :
   refine tsum_congr fun _ => (tsum_eq_single y ?_).trans (by simp)
   intro b hb; simp [Ne.symm hb]
 
-@[simp]
-lemma probOutput_snd_map_eq_sum [Fintype α]
-    (mx : m (α × β)) (y : β) :
+@[simp, grind =]
+lemma probOutput_snd_map_eq_sum [Fintype α] (mx : m (α × β)) (y : β) :
     Pr[= y | Prod.snd <$> mx] = ∑ x, Pr[= (x, y) | mx] := by
   rw [probOutput_snd_map_eq_tsum, tsum_fintype]
 
+/-- NOTE: Added since we don't choose to set the general `probEvent_map` to `simp`. -/
+@[simp low, grind =]
+lemma probEvent_fst_map (mx : m (α × β)) (p : α → Prop) :
+    Pr[p | Prod.fst <$> mx] = Pr[fun x => p x.1 | mx] := by grind
+
+/-- NOTE: Added since we don't choose to set the general `probEvent_map` to `simp`. -/
+@[simp low, grind =]
+lemma probEvent_snd (mx : m (α × β)) (p : β → Prop) :
+    Pr[p | Prod.snd <$> mx] = Pr[fun y => p y.2 | mx] := by grind
+
 omit [LawfulMonad m] in
+@[simp, grind =]
 lemma probEvent_fst_eq_snd [DecidableEq α] (mx : m (α × α)) :
     Pr[fun z => z.1 = z.2 | mx] = ∑' x : α, Pr[= (x, x) | mx] := by
   rw [probEvent_eq_tsum_ite, ENNReal.tsum_prod']
@@ -74,40 +69,74 @@ lemma probEvent_fst_eq_snd [DecidableEq α] (mx : m (α × α)) :
   refine (tsum_eq_single x fun b hb => ?_).trans (by simp)
   exact if_neg (Ne.symm hb)
 
+section prod_mk
+
+variable (mx : m α) (my : m β) (f : α → γ) (g : β → δ)
+
 @[simp]
-lemma probOutput_seq_map_prod_mk_eq_mul [DecidableEq α] [DecidableEq β]
-    (mx : m α) (my : m β) (x : α) (y : β) :
-    Pr[= (x, y) | Prod.mk <$> mx <*> my] = Pr[= x | mx] * Pr[= y | my] :=
-  probOutput_seq_map_eq_mul_of_injective2 mx my Prod.mk Prod.mk.injective2 x y
+lemma probOutput_seq_map_prod_mk_eq_mul (z : α × β) :
+    Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] :=
+  probOutput_seq_map_eq_mul_of_injective2 mx my Prod.mk Prod.mk.injective2 z.1 z.2
 
-lemma probOutput_seq_map_prod_map_eq_mul [DecidableEq γ] [DecidableEq δ]
-    (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (z : γ × δ) :
-    Pr[= z | (fun a b => (f a, g b)) <$> mx <*> my] =
-      Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
-  rcases z with ⟨x, y⟩
-  have hseq : (fun a b => (f a, g b)) <$> mx <*> my =
-      Prod.mk <$> (f <$> mx) <*> (g <$> my) := by
+@[simp high]
+lemma support_seq_map_prod_mk : support (Prod.mk <$> mx <*> my) = support mx ×ˢ support my := by
+  simp [Set.ext_iff]
+
+lemma finSupport_seq_map_prod_mk [HasEvalFinset m] [DecidableEq α] [DecidableEq β] :
+    finSupport (Prod.mk <$> mx <*> my) = Finset.product (finSupport mx) (finSupport my) := by
+  simp
+
+@[simp]
+lemma probOutput_seq_map_prod_mk_map_eq_mul (z : γ × δ) :
+    Pr[= z | (f ·, g ·) <$> mx <*> my] = Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
+  have hseq : (f ·, g ·) <$> mx <*> my = Prod.mk <$> (f <$> mx) <*> (g <$> my) := by
     simp [seq_eq_bind_map, Functor.map_map]
-  rw [hseq]
-  exact probOutput_seq_map_prod_mk_eq_mul (f <$> mx) (g <$> my) x y
+  rw [hseq, probOutput_seq_map_prod_mk_eq_mul]
 
-lemma probOutput_bind_bind_prod_mk_eq_mul [DecidableEq γ] [DecidableEq δ]
+@[simp]
+lemma probOutput_seq_map_prod_mk_map_eq_mul' (z : γ × δ) :
+    Pr[= z | (fun y x => (f x, g y)) <$> my <*> mx] =
+      Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
+  rw [← probOutput_seq_map_swap]; simp
+
+@[simp]
+lemma probOutput_bind_map_prod_mk_eq_mul (z : γ × δ) :
+    Pr[= z | do let x ← mx; (f x, g ·) <$> my] = Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
+  simpa [seq_eq_bind_map, map_eq_bind_pure_comp] using
+    probOutput_seq_map_prod_mk_map_eq_mul mx my f g z
+
+@[simp]
+lemma probOutput_bind_map_prod_mk_eq_mul'
+    (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (z : γ × δ) :
+    Pr[= z | do let y ← my; (f ·, g y) <$> mx] = Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
+  simpa [seq_eq_bind_map, map_eq_bind_pure_comp] using
+    probOutput_seq_map_prod_mk_map_eq_mul' mx my f g z
+
+@[simp high]
+lemma support_seq_map_prod_mk_eq_sprod :
+    support ((f ·, g ·) <$> mx <*> my) = (f '' support mx) ×ˢ (g '' support my) := by
+  simp [Set.ext_iff]; grind
+
+lemma finSupport_seq_map_prod_mk_eq_product [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
+    [DecidableEq γ] [DecidableEq δ] : finSupport ((f ·, g ·) <$> mx <*> my) =
+      ((finSupport mx).image f).product ((finSupport my).image g) := by
+  -- TODO: find the problem with using just `simp` in this proof
+  simp only [finSupport_eq_iff_support_eq_coe]; simp
+
+lemma probOutput_bind_bind_prod_mk_eq_mul
     (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (z : γ × δ) :
     Pr[= z | do let x ← mx; let y ← my; return (f x, g y)] =
-      Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
-  simpa [seq_eq_bind_map] using
-    probOutput_seq_map_prod_map_eq_mul mx my f g z
+      Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by simp
 
 @[simp]
-lemma probOutput_bind_bind_prod_mk_eq_mul' [DecidableEq γ] [DecidableEq δ]
+lemma probOutput_bind_bind_prod_mk_eq_mul'
     (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (x : γ) (y : δ) :
     Pr[= (x, y) | do let a ← mx; let b ← my; return (f a, g b)] =
       Pr[= x | f <$> mx] * Pr[= y | g <$> my] :=
   probOutput_bind_bind_prod_mk_eq_mul mx my f g (x, y)
 
 @[simp]
-lemma probOutput_prod_mk_fst_map [DecidableEq α] [DecidableEq β]
-    (mx : m α) (y : β) (z : α × β) :
+lemma probOutput_prod_mk_fst_map [DecidableEq β] (mx : m α) (y : β) (z : α × β) :
     Pr[= z | (·, y) <$> mx] = if z.2 = y then Pr[= z.1 | mx] else 0 := by
   split
   · next h =>
@@ -120,8 +149,7 @@ lemma probOutput_prod_mk_fst_map [DecidableEq α] [DecidableEq β]
     exact h (by obtain ⟨_, _, ha⟩ := hmem; exact ha ▸ rfl)
 
 @[simp]
-lemma probOutput_prod_mk_snd_map [DecidableEq α] [DecidableEq β]
-    (my : m β) (x : α) (z : α × β) :
+lemma probOutput_prod_mk_snd_map [DecidableEq α] (my : m β) (x : α) (z : α × β) :
     Pr[= z | (x, ·) <$> my] = if z.1 = x then Pr[= z.2 | my] else 0 := by
   split
   · next h =>
@@ -132,3 +160,5 @@ lemma probOutput_prod_mk_snd_map [DecidableEq α] [DecidableEq β]
     intro hmem
     simp [support_map] at hmem
     exact h (by obtain ⟨_, _, ha⟩ := hmem; exact ha ▸ rfl)
+
+end prod_mk

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -22,7 +22,7 @@ lemma probOutput_prod_mk_eq_probEvent (mx : m (α × β)) (x : α) (y : β) :
     Pr[= (x, y) | mx] = Pr[fun z => z.1 = x ∧ z.2 = y | mx] := by
   simp [← probEvent_eq_eq_probOutput, Prod.eq_iff_fst_eq_snd_eq]
 
-@[simp, grind =]
+@[grind =]
 lemma probOutput_fst_map_eq_tsum (mx : m (α × β)) (x : α) :
     Pr[= x | Prod.fst <$> mx] = ∑' y, Pr[= (x, y) | mx] := by
   have : DecidableEq α := Classical.decEq _
@@ -31,12 +31,12 @@ lemma probOutput_fst_map_eq_tsum (mx : m (α × β)) (x : α) :
   refine (tsum_eq_single x ?_).trans (by simp)
   intro a ha; simp [Ne.symm ha]
 
-@[simp, grind =]
+@[grind =]
 lemma probOutput_fst_map_eq_sum [Fintype β] (mx : m (α × β)) (x : α) :
     Pr[= x | Prod.fst <$> mx] = ∑ y, Pr[= (x, y) | mx] := by
   rw [probOutput_fst_map_eq_tsum, tsum_fintype]
 
-@[simp, grind =]
+@[grind =]
 lemma probOutput_snd_map_eq_tsum (mx : m (α × β)) (y : β) :
     Pr[= y | Prod.snd <$> mx] = ∑' x, Pr[= (x, y) | mx] := by
   have : DecidableEq β := Classical.decEq _
@@ -45,18 +45,26 @@ lemma probOutput_snd_map_eq_tsum (mx : m (α × β)) (y : β) :
   refine tsum_congr fun _ => (tsum_eq_single y ?_).trans (by simp)
   intro b hb; simp [Ne.symm hb]
 
-@[simp, grind =]
+@[grind =]
 lemma probOutput_snd_map_eq_sum [Fintype α] (mx : m (α × β)) (y : β) :
     Pr[= y | Prod.snd <$> mx] = ∑ x, Pr[= (x, y) | mx] := by
   rw [probOutput_snd_map_eq_tsum, tsum_fintype]
 
-/-- NOTE: Added since we don't choose to set the general `probEvent_map` to `simp`. -/
-@[simp low, grind =]
+@[grind =]
+lemma probOutput_fst_map_eq_probEvent (mx : m (α × β)) (x : α) :
+    Pr[= x | Prod.fst <$> mx] = Pr[fun z => z.1 = x | mx] := by grind
+
+/-- Unlike `probEvent_map` this unfolds the function composition automatically. -/
+@[simp high, grind =]
 lemma probEvent_fst_map (mx : m (α × β)) (p : α → Prop) :
     Pr[p | Prod.fst <$> mx] = Pr[fun x => p x.1 | mx] := by grind
 
-/-- NOTE: Added since we don't choose to set the general `probEvent_map` to `simp`. -/
-@[simp low, grind =]
+@[grind =]
+lemma probOutput_snd_map_eq_probEvent (mx : m (α × β)) (y : β) :
+    Pr[= y | Prod.snd <$> mx] = Pr[fun z => z.2 = y | mx] := by grind
+
+/-- Unlike `probEvent_map` this unfolds the function composition automatically. -/
+@[simp high, grind =]
 lemma probEvent_snd_map (mx : m (α × β)) (p : β → Prop) :
     Pr[p | Prod.snd <$> mx] = Pr[fun y => p y.2 | mx] := by grind
 
@@ -73,7 +81,7 @@ section prod_mk
 
 variable (mx : m α) (my : m β) (f : α → γ) (g : β → δ)
 
-@[simp]
+@[simp high]
 lemma probOutput_seq_map_prod_mk_eq_mul (z : α × β) :
     Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] :=
   probOutput_seq_map_eq_mul_of_injective2 mx my Prod.mk Prod.mk.injective2 z.1 z.2
@@ -120,45 +128,32 @@ lemma support_seq_map_prod_mk_eq_sprod :
 lemma finSupport_seq_map_prod_mk_eq_product [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
     [DecidableEq γ] [DecidableEq δ] : finSupport ((f ·, g ·) <$> mx <*> my) =
       ((finSupport mx).image f).product ((finSupport my).image g) := by
-  -- TODO: find the problem with using just `simp` in this proof
-  simp only [finSupport_eq_iff_support_eq_coe]; simp
+  simp [Finset.ext_iff]; grind
 
 lemma probOutput_bind_bind_prod_mk_eq_mul
     (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (z : γ × δ) :
     Pr[= z | do let x ← mx; let y ← my; return (f x, g y)] =
       Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by simp
 
-@[simp]
 lemma probOutput_bind_bind_prod_mk_eq_mul'
     (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (x : γ) (y : δ) :
     Pr[= (x, y) | do let a ← mx; let b ← my; return (f a, g b)] =
-      Pr[= x | f <$> mx] * Pr[= y | g <$> my] :=
-  probOutput_bind_bind_prod_mk_eq_mul mx my f g (x, y)
+      Pr[= x | f <$> mx] * Pr[= y | g <$> my] := by simp
 
 @[simp]
 lemma probOutput_prod_mk_fst_map [DecidableEq β] (mx : m α) (y : β) (z : α × β) :
-    Pr[= z | (·, y) <$> mx] = if z.2 = y then Pr[= z.1 | mx] else 0 := by
-  split
-  · next h =>
-    subst h
-    exact probOutput_map_injective mx (fun _ _ hab => (Prod.mk.inj hab).1) z.1
-  · next h =>
-    rw [probOutput_eq_zero_iff]
-    intro hmem
-    simp [support_map] at hmem
-    exact h (by obtain ⟨_, _, ha⟩ := hmem; exact ha ▸ rfl)
+    Pr[= z | (·, y) <$> mx] = if z.2 = y then Pr[= z.1 | mx] else 0 :=
+  calc Pr[= z | (·, y) <$> mx]
+    _ = Pr[= z | Prod.mk <$> mx <*> pure y] := by simp; rfl
+    _ = if z.2 = y then Pr[= z.1 | mx] else 0 := by simp only [probOutput_seq_map_prod_mk_eq_mul,
+      probOutput_pure, mul_ite, mul_one, mul_zero]
 
 @[simp]
 lemma probOutput_prod_mk_snd_map [DecidableEq α] (my : m β) (x : α) (z : α × β) :
-    Pr[= z | (x, ·) <$> my] = if z.1 = x then Pr[= z.2 | my] else 0 := by
-  split
-  · next h =>
-    subst h
-    exact probOutput_map_injective my (fun _ _ hab => (Prod.mk.inj hab).2) z.2
-  · next h =>
-    rw [probOutput_eq_zero_iff]
-    intro hmem
-    simp [support_map] at hmem
-    exact h (by obtain ⟨_, _, ha⟩ := hmem; exact ha ▸ rfl)
+    Pr[= z | (x, ·) <$> my] = if z.1 = x then Pr[= z.2 | my] else 0 :=
+  calc Pr[= z | (x, ·) <$> my]
+    _ = Pr[= z | Prod.mk <$> pure x <*> my] := by simp [seq_eq_bind_map]; rfl
+    _ = if z.1 = x then Pr[= z.2 | my] else 0 := by simp only [probOutput_seq_map_prod_mk_eq_mul,
+      probOutput_pure, ite_mul, one_mul, zero_mul]
 
 end prod_mk

--- a/VCVio/EvalDist/TVDist.lean
+++ b/VCVio/EvalDist/TVDist.lean
@@ -95,13 +95,12 @@ lemma tvDist_bind_right_le [LawfulMonad m] {β : Type u} (f : α → m β) (mx m
   exact SPMF.tvDist_bind_right_le _ _ _
 
 /-! ### TV distance bounds -/
-
 lemma tvDist_le_probEvent_of_probOutput_eq_of_not
     {mx my : m α} [NeverFail mx] [NeverFail my]
-    (p : α → Prop) [DecidablePred p]
-    (h_eq : ∀ x, ¬p x → Pr[= x | mx] = Pr[= x | my])
+    (p : α → Prop) (h_eq : ∀ x, ¬p x → Pr[= x | mx] = Pr[= x | my])
     (h_event_eq : Pr[p | mx] = Pr[p | my]) :
     tvDist mx my ≤ Pr[p | mx].toReal := by
+  classical
   rw [tvDist, SPMF.tvDist, PMF.tvDist]
   refine ENNReal.toReal_mono probEvent_ne_top ?_
   rw [PMF.etvDist, tsum_option _ ENNReal.summable]

--- a/VCVio/OracleComp/Coercions/Add.lean
+++ b/VCVio/OracleComp/Coercions/Add.lean
@@ -57,7 +57,7 @@ end add_left
 
 section add_right
 
-/-- Add additional oracles to the left side of the exiting ones-/
+/-- Add additional oracles to the left side of the exiting ones. -/
 instance subSpec_add_right : spec₂ ⊂ₒ (spec₁ + spec₂) where
   monadLift | q => .mk (.inr q.input) q.cont
   liftM_map | ⟨t, g⟩ => by simp [liftM, monadLift]

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -118,7 +118,7 @@ lemma liftComp_query (q : OracleQuery spec α) :
 @[simp]
 lemma liftComp_bind (mx : OracleComp spec α) (ob : α → OracleComp spec β) :
     liftComp (mx >>= ob) superSpec =
-      liftComp mx superSpec >>= λ x ↦ liftComp (ob x) superSpec := by
+      liftComp mx superSpec >>= fun x ↦ liftComp (ob x) superSpec := by
   grind
 
 @[simp]
@@ -224,7 +224,8 @@ instance [MonadLift (OracleQuery spec) (OracleQuery superSpec)] :
     rfl
   monadLift_bind mx my := by
     apply OptionT.ext
-    simp [MonadLift.monadLift, OptionT.run_bind, Option.elimM, simulateQ_bind]
+    simp only [MonadLift.monadLift, OptionT.run_bind, Option.elimM, simulateQ_bind, OptionT.mk_bind,
+      OptionT.run_monadLift, monadLift_self, OptionT.run_mk, bind_map_left, Option.elim_some]
     refine bind_congr ?_
     intro x
     cases x <;> simp

--- a/VCVio/OracleComp/Constructions/GenerateSeed.lean
+++ b/VCVio/OracleComp/Constructions/GenerateSeed.lean
@@ -57,10 +57,11 @@ lemma generateSeed_zero :
     {seed : QuerySeed spec | ∀ i, (seed i).length = qc i * js.count i} := by
   induction js with
   | nil =>
-    simp; ext seed; simp
+    simp only [generateSeed_nil, support_pure, List.count_nil, mul_zero,
+      List.length_eq_zero_iff]; ext seed; simp only [Set.mem_singleton_iff, Set.mem_setOf_eq]
     constructor
     · intro h; rw [h]; simp
-    · intro h; funext i; have := h i; simp at this; exact this
+    · intro h; funext i; simpa using h i
   | cons j js ih =>
     ext seed
     simp only [generateSeed_cons, Set.mem_setOf_eq]

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -53,13 +53,13 @@ lemma probOutput_uniformSample [Fintype α] (x : α) :
   refine ENNReal.eq_inv_of_mul_eq_one_left ?_
   simp_rw [this, Finset.mul_sum, mul_one]
   rw [← sum_probOutput_eq_one (mx := $ᵗ α) (by aesop)]
-  exact Finset.sum_congr rfl λ y _ ↦ SampleableType.probOutput_selectElem_eq x y
+  exact Finset.sum_congr rfl fun y _ ↦ SampleableType.probOutput_selectElem_eq x y
 
 @[grind .]
 lemma probOutput_uniformSample_inj (x y : α) : Pr[= x | $ᵗ α] = Pr[= y | $ᵗ α] :=
   SampleableType.probOutput_selectElem_eq _ _
 
-lemma probOutput_map_bijective_uniformSample [Fintype α]
+lemma probOutput_map_bijective_uniformSample
     {f : α → α} (hf : Function.Bijective f) (x : α) :
     Pr[= x | f <$> ($ᵗ α)] = Pr[= x | $ᵗ α] := by
   obtain ⟨x', rfl⟩ := hf.surjective x
@@ -291,7 +291,6 @@ instance (α : Type) (n : ℕ) [SampleableType α] : SampleableType (Vector α n
         probOutput_seq_map_eq_mul_of_injective2 _ _ _ hpush x.pop x.back,
         probOutput_seq_map_eq_mul_of_injective2 _ _ _ hpush y.pop y.back,
         probOutput_uniformSample_inj, ih x.pop y.pop]
-
 
 /-- A function from `Fin n` to a `SampleableType` is also `SampleableType`. -/
 instance instSampleableTypeFinFunc {n : ℕ} {α : Type} [SampleableType α] :

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -180,14 +180,14 @@ lemma probEvent_uniformSample [Fintype α] (p : α → Prop) [DecidablePred p] :
 
 section instances
 
-instance SampleableType.Fin (n : ℕ) : SampleableType (Fin (n + 1)) where
+def SampleableType.Fin (n : ℕ) : SampleableType (Fin (n + 1)) where
   selectElem := $[0..n]
   mem_support_selectElem := by simp
   probOutput_selectElem_eq := by simp
 
 instance (n : ℕ) [hn : NeZero n] : SampleableType (Fin n) := by
   cases n with
-  | zero => simp at hn
+  | zero => have := hn.out; contradiction
   | succ n => exact SampleableType.Fin n
 
 instance (α : Type) [Unique α] : SampleableType α where
@@ -280,49 +280,31 @@ instance (α : Type) (n : ℕ) [SampleableType α] : SampleableType (Vector α n
   mem_support_selectElem x := by induction n with
   | zero => simp
   | succ m ih =>
-    simp [ih]
-    use x.pop, x.back
-    apply Vector.push_pop_back
+      have : ∃ ys y, Vector.push ys y = x := ⟨x.pop, x.back, Vector.push_pop_back x⟩
+      simpa [ih] using this
   probOutput_selectElem_eq x y := by induction n with
-  | zero =>
-    have : x=y := by
-      apply Vector.ext
-      rintro i hi
-      linarith
-    simp [this]
+  | zero => rw [show x = y by grind]
   | succ m ih =>
-    classical
-    have hpush : Function.Injective2 (fun (xs : Vector α m) (x : α) => Vector.push xs x) := by
-      intro xs ys x y hxy
-      rcases Vector.push_eq_push.mp hxy with ⟨hxy', hxs⟩
-      exact ⟨hxs, hxy'⟩
-    rw [← Vector.push_pop_back x, ← Vector.push_pop_back y]
-    rw [probOutput_seq_map_eq_mul_of_injective2 _ _
-      (fun (xs : Vector α m) (x : α) => Vector.push xs x)
-      hpush x.pop x.back]
-    rw [probOutput_seq_map_eq_mul_of_injective2 _ _
-      (fun (xs : Vector α m) (x : α) => Vector.push xs x)
-      hpush y.pop y.back]
-    have hback : Pr[= x.back | $ᵗ α] = Pr[= y.back | $ᵗ α] := by
-      simpa [uniformSample] using
-        (SampleableType.probOutput_selectElem_eq (β := α) x.back y.back)
-    rw [hback]
-    exact congrArg (fun z => z * Pr[= y.back | $ᵗ α]) (ih x.pop y.pop)
+      have hpush : Function.Injective2 (fun (xs : Vector α m) (x : α) => Vector.push xs x) := by
+        intro xs ys x y hxy; simp [Vector.push_eq_push.mp hxy]
+      rw [← Vector.push_pop_back x, ← Vector.push_pop_back y,
+        probOutput_seq_map_eq_mul_of_injective2 _ _ _ hpush x.pop x.back,
+        probOutput_seq_map_eq_mul_of_injective2 _ _ _ hpush y.pop y.back,
+        probOutput_uniformSample_inj, ih x.pop y.pop]
+
 
 /-- A function from `Fin n` to a `SampleableType` is also `SampleableType`. -/
-instance instSampleableTypeFinFunc {n : ℕ} {α : Type} [SampleableType α] [DecidableEq α] :
-    SampleableType (Fin n → α) := by
-  letI instVectorFinFuncEquiv: (Vector α n) ≃ (Fin n → α) :=
+instance instSampleableTypeFinFunc {n : ℕ} {α : Type} [SampleableType α] :
+    SampleableType (Fin n → α) :=
+  SampleableType.ofEquiv
     { toFun := fun v i => v.get i
       invFun := Vector.ofFn
       left_inv := fun v => Vector.ext fun i hi => by simp [Vector.ofFn, Vector.get]
       right_inv := fun f => funext fun i => by simp [Vector.get, Vector.ofFn] }
-  exact SampleableType.ofEquiv (instVectorFinFuncEquiv)
 
 /-- Select a uniform element from `Matrix α n` by selecting each row independently. -/
-instance (α : Type) (n m : ℕ) [SampleableType α] [DecidableEq α] :
-    SampleableType (Matrix (Fin n) (Fin m) α) := by
-  simpa [Matrix] using (inferInstance : SampleableType (Fin n → Fin m → α))
+instance (α : Type) (n m : ℕ) [SampleableType α] : SampleableType (Matrix (Fin n) (Fin m) α) :=
+  inferInstanceAs (SampleableType (Fin n → Fin m → α))
 
 end instances
 

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -216,9 +216,8 @@ def SampleableType.ofEquiv {α β : Type} [SampleableType α] (e : α ≃ β) : 
 /-- Any finitely enumerable type can be sampled uniformly using the underlying equivalence. -/
 instance FinEnum.SampleableType (α : Type)
     [h : FinEnum α] [Nonempty α] : SampleableType α := by
-  convert SampleableType.ofEquiv h.equiv.symm
   have : NeZero (card α) := NeZero.mk FinEnum.card_ne_zero
-  infer_instance
+  exact SampleableType.ofEquiv h.equiv.symm
 
 instance (n : ℕ) [NeZero n] : FinEnum (ZMod n) where
   card := n

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -216,7 +216,7 @@ def SampleableType.ofEquiv {α β : Type} [SampleableType α] (e : α ≃ β) : 
 /-- Any finitely enumerable type can be sampled uniformly using the underlying equivalence. -/
 instance FinEnum.SampleableType (α : Type)
     [h : FinEnum α] [Nonempty α] : SampleableType α := by
-  have : NeZero (card α) := NeZero.mk FinEnum.card_ne_zero
+  have : NeZero (FinEnum.card α) := NeZero.mk FinEnum.card_ne_zero
   exact SampleableType.ofEquiv h.equiv.symm
 
 instance (n : ℕ) [NeZero n] : FinEnum (ZMod n) where

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -6,7 +6,9 @@ Authors: Devon Tuma, Quang Dao
 import VCVio.OracleComp.ProbComp
 import VCVio.EvalDist.BitVec
 import VCVio.EvalDist.Bool
+import VCVio.EvalDist.Prod
 import Init.Data.UInt.Lemmas
+import Mathlib.Data.FinEnum
 
 /-!
 # Uniform Selection Over a Type
@@ -52,6 +54,10 @@ lemma probOutput_uniformSample [Fintype α] (x : α) :
   simp_rw [this, Finset.mul_sum, mul_one]
   rw [← sum_probOutput_eq_one (mx := $ᵗ α) (by aesop)]
   exact Finset.sum_congr rfl λ y _ ↦ SampleableType.probOutput_selectElem_eq x y
+
+@[grind .]
+lemma probOutput_uniformSample_inj (x y : α) : Pr[= x | $ᵗ α] = Pr[= y | $ᵗ α] :=
+  SampleableType.probOutput_selectElem_eq _ _
 
 lemma probOutput_map_bijective_uniformSample [Fintype α]
     {f : α → α} (hf : Function.Bijective f) (x : α) :
@@ -174,6 +180,16 @@ lemma probEvent_uniformSample [Fintype α] (p : α → Prop) [DecidablePred p] :
 
 section instances
 
+instance SampleableType.Fin (n : ℕ) : SampleableType (Fin (n + 1)) where
+  selectElem := $[0..n]
+  mem_support_selectElem := by simp
+  probOutput_selectElem_eq := by simp
+
+instance (n : ℕ) [hn : NeZero n] : SampleableType (Fin n) := by
+  cases n with
+  | zero => simp at hn
+  | succ n => exact SampleableType.Fin n
+
 instance (α : Type) [Unique α] : SampleableType α where
   selectElem := return default
   mem_support_selectElem x := Unique.eq_default x ▸ (by simp)
@@ -189,106 +205,73 @@ instance (α β : Type) [Fintype α] [Fintype β] [Inhabited α] [Inhabited β]
     [SampleableType α] [SampleableType β] : SampleableType (α × β) where
   selectElem := (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)
   mem_support_selectElem x := by simp
-  probOutput_selectElem_eq x y := by
-    classical
-    rcases x with ⟨x₁, x₂⟩
-    rcases y with ⟨y₁, y₂⟩
-    rw [probOutput_seq_map_eq_mul_of_injective2 ($ᵗ α) ($ᵗ β) Prod.mk
-      (fun _ _ _ _ h => by cases h; aesop) x₁ x₂]
-    rw [probOutput_seq_map_eq_mul_of_injective2 ($ᵗ α) ($ᵗ β) Prod.mk
-      (fun _ _ _ _ h => by cases h; aesop) y₁ y₂]
-    simp [probOutput_uniformSample]
-
-/-- Nonempty `Fin` types can be selected from, using implicit casting of `Fin (n - 1 + 1)`. -/
-instance (n : ℕ) : SampleableType (Fin (n + 1)) where
-  selectElem := $[0..n]
-  mem_support_selectElem := by simp
   probOutput_selectElem_eq x y := by simp
 
-/-- Version of `Fin` selection using the `NeZero` typeclass, avoiding the need for `n + 1`. -/
-instance (n : ℕ) [hn : NeZero n] : SampleableType (Fin n) where
-  selectElem :=
-    (Fin.cast (by
-      simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-        (Nat.succ_pred (NeZero.ne n)))) <$> ($ᵗ (Fin (n - 1 + 1)))
-  mem_support_selectElem x := by
-    have hx : ∃ y : Fin (n - 1 + 1),
-        Fin.cast (by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n))) y = x := by
-      refine ⟨Fin.cast (by
-        simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-          (Nat.succ_pred (NeZero.ne n)).symm) x, ?_⟩
-      simp [Fin.cast_cast
-        (h := by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n)).symm)
-        (h' := by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n)))
-        (i := x)]
-    simpa [support_map] using hx
-  probOutput_selectElem_eq x y := by
-    have hx : Pr[= x |
-        (Fin.cast (by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n)))) <$> ($ᵗ (Fin (n - 1 + 1)))] =
-        Pr[= Fin.cast (by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n)).symm) x | $ᵗ (Fin (n - 1 + 1))] := by
-      simpa using
-        (probOutput_map_injective ($ᵗ (Fin (n - 1 + 1)))
-          (Fin.cast_injective (by
-            simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-              (Nat.succ_pred (NeZero.ne n))))
-          (Fin.cast (by
-            simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-              (Nat.succ_pred (NeZero.ne n)).symm) x))
-    have hy : Pr[= y |
-        (Fin.cast (by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n)))) <$> ($ᵗ (Fin (n - 1 + 1)))] =
-        Pr[= Fin.cast (by
-          simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-            (Nat.succ_pred (NeZero.ne n)).symm) y | $ᵗ (Fin (n - 1 + 1))] := by
-      simpa using
-        (probOutput_map_injective ($ᵗ (Fin (n - 1 + 1)))
-          (Fin.cast_injective (by
-            simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-              (Nat.succ_pred (NeZero.ne n))))
-          (Fin.cast (by
-            simpa [Nat.pred_eq_sub_one, Nat.succ_eq_add_one] using
-              (Nat.succ_pred (NeZero.ne n)).symm) y))
-    rw [hx, hy]
-    exact SampleableType.probOutput_selectElem_eq _ _
+/-- A type equivalent to a `SampleableType` is also `SampleableType`. -/
+def SampleableType.ofEquiv {α β : Type} [SampleableType α] (e : α ≃ β) : SampleableType β where
+  selectElem := e <$> ($ᵗ α)
+  mem_support_selectElem := fun x => by simp
+  probOutput_selectElem_eq := fun x y => by grind
 
-/-- Version of `ZMod` selection using the `NeZero` typeclass, matching `Fin n`. -/
-instance (n : ℕ) [hn : NeZero n] : SampleableType (ZMod n) where
-  selectElem := (ZMod.finEquiv n) <$> ($ᵗ Fin n)
-  mem_support_selectElem x := by
-    rw [support_map]
-    refine ⟨(ZMod.finEquiv n).symm x, ?_, by simp⟩
-    simp
-  probOutput_selectElem_eq x y := by
-    calc
-      Pr[= x | (ZMod.finEquiv n) <$> ($ᵗ Fin n)] =
-          Pr[= (ZMod.finEquiv n).symm x | $ᵗ Fin n] := by
-            simpa using
-              (probOutput_map_injective ($ᵗ Fin n) (ZMod.finEquiv n).injective
-                ((ZMod.finEquiv n).symm x))
-      _ = Pr[= (ZMod.finEquiv n).symm y | $ᵗ Fin n] := by
-            exact SampleableType.probOutput_selectElem_eq _ _
-      _ = Pr[= y | (ZMod.finEquiv n) <$> ($ᵗ Fin n)] := by
-            symm
-            simpa using
-              (probOutput_map_injective ($ᵗ Fin n) (ZMod.finEquiv n).injective
-                ((ZMod.finEquiv n).symm y))
+/-- Any finitely enumerable type can be sampled uniformly using the underlying equivalence. -/
+instance FinEnum.SampleableType (α : Type)
+    [h : FinEnum α] [Nonempty α] : SampleableType α := by
+  convert SampleableType.ofEquiv h.equiv.symm
+  have : NeZero (card α) := NeZero.mk FinEnum.card_ne_zero
+  infer_instance
 
-/-- Choose a random bit-vector by converting a random number between `0` and `2 ^ n`. -/
-instance (n : ℕ) : SampleableType (BitVec n) where
-  selectElem := BitVec.ofFin <$> ($ᵗ Fin (2 ^ n))
-  mem_support_selectElem x := by aesop
-  probOutput_selectElem_eq x y := by grind
+instance (n : ℕ) [NeZero n] : FinEnum (ZMod n) where
+  card := n
+  equiv := (ZMod.finEquiv n).symm.toEquiv
+
+instance (n : ℕ) : FinEnum (BitVec n) where
+  card := 2 ^ n
+  equiv := ⟨BitVec.toFin, BitVec.ofFin, fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum UInt8 where
+  card := 2 ^ 8
+  equiv := ⟨UInt8.toFin, UInt8.ofFin, fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum UInt16 where
+  card := 2 ^ 16
+  equiv := ⟨UInt16.toFin, UInt16.ofFin, fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum UInt32 where
+  card := 2 ^ 32
+  equiv := ⟨UInt32.toFin, UInt32.ofFin, fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum UInt64 where
+  card := 2 ^ 64
+  equiv := ⟨UInt64.toFin, UInt64.ofFin, fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum USize where
+  card := 2 ^ System.Platform.numBits
+  equiv := ⟨USize.toFin, USize.ofFin, fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum Int8 where
+  card := 2 ^ 8
+  equiv := ⟨BitVec.toFin ∘ Int8.toBitVec, Int8.ofBitVec ∘ BitVec.ofFin,
+    fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum Int16 where
+  card := 2 ^ 16
+  equiv := ⟨BitVec.toFin ∘ Int16.toBitVec, Int16.ofBitVec ∘ BitVec.ofFin,
+    fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum Int32 where
+  card := 2 ^ 32
+  equiv := ⟨BitVec.toFin ∘ Int32.toBitVec, Int32.ofBitVec ∘ BitVec.ofFin,
+    fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum Int64 where
+  card := 2 ^ 64
+  equiv := ⟨BitVec.toFin ∘ Int64.toBitVec, Int64.ofBitVec ∘ BitVec.ofFin,
+    fun x => by simp, fun x => by simp⟩
+
+instance : FinEnum ISize where
+  card := 2 ^ System.Platform.numBits
+  equiv := ⟨BitVec.toFin ∘ ISize.toBitVec, ISize.ofBitVec ∘ BitVec.ofFin,
+    fun x => by simp, fun x => by simp⟩
 
 /-- Select a uniform element from `Vector α n` by independently selecting `α` at each index. -/
 instance (α : Type) (n : ℕ) [SampleableType α] : SampleableType (Vector α n) where
@@ -327,64 +310,14 @@ instance (α : Type) (n : ℕ) [SampleableType α] : SampleableType (Vector α n
     rw [hback]
     exact congrArg (fun z => z * Pr[= y.back | $ᵗ α]) (ih x.pop y.pop)
 
-/-- A type equivalent to a `SampleableType` is also `SampleableType`. -/
-def SampleableType.ofEquiv {α β : Type} [DecidableEq α] [DecidableEq β] [SampleableType α]
-    (e : α ≃ β) : SampleableType β where
-  selectElem := e <$> ($ᵗ α)
-  mem_support_selectElem := fun x => by simp [support_map]
-  probOutput_selectElem_eq := fun x y => by
-    calc
-      Pr[= x | e <$> ($ᵗ α)] = Pr[= e.symm x | ($ᵗ α)] := by
-        simpa using probOutput_map_injective ($ᵗ α) e.injective (e.symm x)
-      _ = Pr[= e.symm y | ($ᵗ α)] := by
-        exact SampleableType.probOutput_selectElem_eq (e.symm x) (e.symm y)
-      _ = Pr[= y | e <$> ($ᵗ α)] := by
-        symm
-        simpa using probOutput_map_injective ($ᵗ α) e.injective (e.symm y)
-
-/-- Unsigned machine words inherit uniform sampling from the corresponding
-fixed-width bitvectors. -/
-instance : SampleableType UInt8 :=
-  SampleableType.ofEquiv
-    { toFun := UInt8.ofBitVec
-      invFun := UInt8.toBitVec
-      left_inv := by intro x; simp
-      right_inv := by intro x; simp }
-
-instance : SampleableType UInt16 :=
-  SampleableType.ofEquiv
-    { toFun := UInt16.ofBitVec
-      invFun := UInt16.toBitVec
-      left_inv := by intro x; simp
-      right_inv := by intro x; simp }
-
-instance : SampleableType UInt32 :=
-  SampleableType.ofEquiv
-    { toFun := UInt32.ofBitVec
-      invFun := UInt32.toBitVec
-      left_inv := by intro x; simp
-      right_inv := by intro x; simp }
-
-instance : SampleableType UInt64 :=
-  SampleableType.ofEquiv
-    { toFun := UInt64.ofBitVec
-      invFun := UInt64.toBitVec
-      left_inv := by intro x; simp
-      right_inv := by intro x; simp }
-
 /-- A function from `Fin n` to a `SampleableType` is also `SampleableType`. -/
 instance instSampleableTypeFinFunc {n : ℕ} {α : Type} [SampleableType α] [DecidableEq α] :
     SampleableType (Fin n → α) := by
-  letI instVectorFinFuncEquiv: (_root_.Vector α n) ≃ (Fin n → α) :=
+  letI instVectorFinFuncEquiv: (Vector α n) ≃ (Fin n → α) :=
     { toFun := fun v i => v.get i
-      invFun := _root_.Vector.ofFn
-      left_inv := fun v => by
-        ext i
-        simp only [Vector.ofFn, Vector.get, Fin.val_cast, Vector.getElem_toArray, Vector.getElem_mk,
-          Array.getElem_ofFn]
-      right_inv := fun f => by
-        funext i
-        simp only [Vector.get, Vector.ofFn, Fin.val_cast, Array.getElem_ofFn, Fin.eta] }
+      invFun := Vector.ofFn
+      left_inv := fun v => Vector.ext fun i hi => by simp [Vector.ofFn, Vector.get]
+      right_inv := fun f => funext fun i => by simp [Vector.get, Vector.ofFn] }
   exact SampleableType.ofEquiv (instVectorFinFuncEquiv)
 
 /-- Select a uniform element from `Matrix α n` by selecting each row independently. -/

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -29,7 +29,7 @@ NOTE: currently proofs using this should reduce to `simulateQ`. A full API would
 def supportWhen (o : QueryImpl spec Set) (mx : OracleComp spec α) : Set α :=
   simulateQ (r := SetM) o mx
 
-/-- The `support` instance for `OracleComp`, defined as  -/
+/-- The `support` instance for `OracleComp`, defined as -/
 instance hasEvalSet : HasEvalSet (OracleComp spec) where
   toSet := simulateQ' (r := SetM) fun _ : spec.Domain => Set.univ
 
@@ -281,7 +281,7 @@ lemma probOutput_guard_eq_sub_probOutput_guard_not {α : Type} {oa : OracleComp 
       1 - Pr[= () | (do let a ← oa; guard (¬ p a) : OptionT (OracleComp spec) Unit)] := by
   rw [probOutput_bind_guard_eq_probEvent, probOutput_bind_guard_eq_probEvent]
   have h := probEvent_compl oa p
-  simp at h
+  simp only [HasEvalPMF.probFailure_eq_zero, tsub_zero] at h
   exact ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top probEvent_le_one) h
 
 end guard
@@ -307,7 +307,7 @@ lemma evalDist_simulateQ_run'_eq_evalDist {σ τ : Type u}
     intro s
     simp only [simulateQ_bind, simulateQ_query, OracleQuery.cont_query, id_map,
       OracleQuery.input_query]
-    show evalDist (Prod.fst <$> ((so t).run s >>= fun p =>
+    change evalDist (Prod.fst <$> ((so t).run s >>= fun p =>
       (simulateQ so (mx p.1)).run p.2)) = _
     rw [@map_bind (OracleComp spec), show (fun p : spec.Range t × σ =>
         Prod.fst <$> (simulateQ so (mx p.1)).run p.2) =
@@ -318,7 +318,7 @@ lemma evalDist_simulateQ_run'_eq_evalDist {σ τ : Type u}
       ((so t).run' s >>= mx) from
       (bind_map_left (m := OracleComp spec) Prod.fst ((so t).run s) mx).symm]
     rw [evalDist_bind, h t s]
-    show OptionT.lift (PMF.uniformOfFintype (spec.Range t)) >>= (fun u => evalDist (mx u)) = _
+    change OptionT.lift (PMF.uniformOfFintype (spec.Range t)) >>= (fun u => evalDist (mx u)) = _
     rw [show (fun u => evalDist (mx u)) = evalDist ∘ mx from rfl, ← evalDist_query_bind]
 
 /-- Stronger version with computational hypothesis: if the implementation passes through

--- a/VCVio/OracleComp/FinRatPMF.lean
+++ b/VCVio/OracleComp/FinRatPMF.lean
@@ -48,7 +48,8 @@ local instance instSpecFintypeOfFinEnum : spec.Fintype where
                 (Raw.uniform (α := spec.Range t)) x
       _ = (Fintype.card (spec.Range t) : ℚ≥0)⁻¹ := Raw.prob_uniform (α := spec.Range t) x
   rw [PMF.uniformOfFintype_apply]
-  change (((@Raw.prob _ (Classical.decEq _) (Raw.uniform (α := spec.Range t)) x : NNReal) : ENNReal))
+  change (((@Raw.prob _ (Classical.decEq _)
+    (Raw.uniform (α := spec.Range t)) x : NNReal) : ENNReal))
       = ((Fintype.card (spec.Range t) : ENNReal)⁻¹)
   calc
     (((@Raw.prob _ (Classical.decEq _) (Raw.uniform (α := spec.Range t)) x : NNReal) : ENNReal))
@@ -132,13 +133,15 @@ def twoCoinQueries : OracleComp coinSpec Nat := do
   let b2 <- OracleComp.coin
   pure (cond b1 1 0 + cond b2 1 0)
 
--- #eval FinRatPMF.Raw.coin
--- #eval xorTwoCoins
--- #eval xorTwoCoins.normalize
--- #eval threeCoinCount.normalize
--- #eval! simulateQ (FinRatPMF.finRatImpl (spec := coinSpec)) twoCoinQueries
--- #eval! (simulateQ (FinRatPMF.finRatImpl (spec := coinSpec)) twoCoinQueries).normalize
--- #eval! (((simulateQ (FinRatPMF.finRatImpl (spec := coinSpec)) twoCoinQueries).normalize.prob 1 : ℚ≥0) : ℚ)
+/-
+#eval FinRatPMF.Raw.coin
+#eval xorTwoCoins
+#eval xorTwoCoins.normalize
+#eval threeCoinCount.normalize
+#eval! simulateQ (FinRatPMF.finRatImpl (spec := coinSpec)) twoCoinQueries
+#eval! (simulateQ (FinRatPMF.finRatImpl (spec := coinSpec)) twoCoinQueries).normalize
+#eval! (simulateQ (FinRatPMF.finRatImpl (spec := coinSpec)) twoCoinQueries).normalize.prob 1)
+-/
 
 end Demo
 end FinRatPMF

--- a/VCVio/OracleComp/OracleComp.lean
+++ b/VCVio/OracleComp/OracleComp.lean
@@ -72,7 +72,7 @@ protected lemma failure_def : (failure : OptionT (OracleComp spec) α) = OptionT
 
 protected lemma orElse_def (oa oa' : OptionT (OracleComp spec) α) : (oa <|> oa') = OptionT.mk
     (do match ← OptionT.run oa with | some a => pure (some a) | _  => OptionT.run oa') := by
-  simp [HOrElse.hOrElse, OrElse.orElse, Alternative.orElse, OptionT.orElse]
+  simp only [HOrElse.hOrElse, OrElse.orElse, Alternative.orElse, OptionT.orElse]
   refine congr_arg OptionT.mk <| bind_congr fun x => by aesop
 
 @[aesop unsafe apply, grind =>]
@@ -223,10 +223,9 @@ section inj
 and the second computation does something pure with the result. -/
 @[simp] lemma bind_eq_pure_iff (oa : OracleComp spec α) (ob : α → OracleComp spec β) (y : β) :
     oa >>= ob = pure y ↔ ∃ x : α, oa = pure x ∧ ob x = pure y := by
-  refine ⟨λ h ↦ ?_, λ h ↦ let ⟨x, ⟨h, h'⟩⟩ := h; h ▸ h'⟩
-  simp [OracleComp.pure_def, PFunctor.FreeM.monad_bind_def] at h
-  rw [PFunctor.FreeM.bind_eq_pure_iff] at h
-  exact h
+  refine ⟨fun h ↦ ?_, fun h ↦ let ⟨x, ⟨h, h'⟩⟩ := h; h ▸ h'⟩
+  simp only [PFunctor.FreeM.monad_bind_def, OracleComp.pure_def] at h
+  rwa [PFunctor.FreeM.bind_eq_pure_iff] at h
 
 /-- Binding two computations gives a pure operation iff the first computation is pure
 and the second computation does something pure with the result. -/

--- a/VCVio/OracleComp/OracleComp.lean
+++ b/VCVio/OracleComp/OracleComp.lean
@@ -89,7 +89,7 @@ lemma ite_bind (p : Prop) [Decidable p] (oa oa' : OracleComp spec α)
   apply_ite (· >>= ob) p oa oa'
 
 /-- Nicer induction rule for `OracleComp` that uses monad notation.
-Allows inductive definitions on compuations by considering the three cases:
+Allows inductive definitions on computations by considering the two cases:
 * `return x` / `pure x` for any `x`
 * `do let u ← query i t; oa u` (with inductive results for `oa u`)
 See `oracleComp_emptySpec_equiv` for an example of using this in a proof.

--- a/VCVio/OracleComp/OracleContext.lean
+++ b/VCVio/OracleComp/OracleContext.lean
@@ -18,8 +18,7 @@ universe u v w z
 open OracleSpec OracleComp Polynomial MvPolynomial
 
 /-- An `OracleContext ι m` bundles a specification `spec` of oracles with input set `ι`
-and an implementation of the oracles in terms of the monad `m`.
-Structures can extend this to get  -/
+and an implementation of the oracles in terms of the monad `m`. -/
 structure OracleContext (ι : Type u) (m : Type v → Type w) :
       Type (max u v w + 1) where
   spec : OracleSpec.{u,v} ι

--- a/VCVio/OracleComp/OracleQuery.lean
+++ b/VCVio/OracleComp/OracleQuery.lean
@@ -20,7 +20,7 @@ defined to be the object type of the corresponding `PFunctor`.
 In particular an element of `OracleQuery spec α` consists of an input value `t : spec.Domain`,
 and a continuation `f : spec.Range t → α` specifying what to do with the result.
 See `OracleQuery.query` for the case when the continuation `f` just returns the query result. -/
-def OracleQuery {ι : Type u} (spec : OracleSpec.{u,v} ι) :
+def OracleQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) :
     Type w → Type (max u v w) :=
   PFunctor.Obj spec.toPFunctor
 
@@ -69,6 +69,11 @@ extensionally equal continuation on the results of the query. -/
 @[ext] lemma ext {α} {q q' : OracleQuery spec α}
     (h : q.input = q'.input) (h' : q.cont ≍ q'.cont) : q = q' := Sigma.ext h h'
 
+/-- Version of `OracleQuery.ext` that avoids using `HEq` when the inputs are the same. -/
+lemma ext' {α} (t : spec.Domain) {cont cont' : spec.Range t → α}
+    (h : cont = cont') : (⟨t, cont⟩ : OracleQuery spec α) = ⟨t, cont'⟩ := by
+  simpa [funext_iff] using h
+
 /-- If an oracle exists and the output type is non-empty then the type of queries is non-empty. -/
 instance {α} [Inhabited ι] [Inhabited α] : Inhabited (OracleQuery spec α) :=
   inferInstanceAs (Inhabited ((t : spec.Domain) × (spec.Range t → α)))
@@ -77,13 +82,12 @@ instance {α} [Inhabited ι] [Inhabited α] : Inhabited (OracleQuery spec α) :=
 instance {α} [h : IsEmpty ι] : IsEmpty (OracleQuery spec α) :=
   inferInstanceAs (IsEmpty ((t : spec.Domain) × (spec.Range t → α)))
 
-/-- If there is a at most one oracle and output, then ther is at most one query.-/
-instance {α} [h : Subsingleton ι] [h' : Subsingleton α] :
-    Subsingleton (OracleQuery spec α) where
-  allEq := fun ⟨t, f⟩ ⟨u, g⟩ => by
-    cases h.allEq t u
-    simp [OracleQuery.ext_iff, funext_iff]
-    refine fun x => h'.allEq (f x) (g x)
+/-- If there is a at most one oracle and output, then ther is at most one query. -/
+instance {α} [h : Subsingleton ι] [h' : Subsingleton α] : Subsingleton (OracleQuery spec α) where
+  allEq := fun ⟨t, cont⟩ ⟨t', cont'⟩ => by
+    cases show t = t' from h.allEq t t'
+    have h' : Subsingleton (spec.Range t → α) := by infer_instance
+    exact OracleQuery.ext' t (h'.allEq cont cont')
 
 /-- Query an oracle on in input `t` to get a result in the corresponding `range t`.
 Note: could consider putting this in the `OracleQuery` monad, type inference struggles tho. -/

--- a/VCVio/OracleComp/OracleSpec.lean
+++ b/VCVio/OracleComp/OracleSpec.lean
@@ -56,9 +56,8 @@ instance {spec : OracleSpec ι} [h : spec.DecidableEq] (t : spec.Domain) :
 /-- Type-class gadget to enable probability notation for computation over an `OracleSpec`.
 Can be defined for any `spec` with `spec.Range` finite and inhabited, but generally should
 only be instantied for things like `coinSpec` or `unifSpec`.
-dtumad: we should examine if this should be used more strictly in `evalDist` stuff.
-We could require computations without this tag to provide their own `PMF` embedding,
-even if it can be inferred implicitly. -/
+TODO: Examine if this should be used as a requirement in `evalDist` instances.
+Just forces more explicit differentiation of when the semantics should apply. -/
 protected class IsProbSpec (spec : OracleSpec ι) [spec.Inhabited] [spec.Fintype]
 
 section ofFn
@@ -197,21 +196,20 @@ end OracleSpec
 
 /-- Access to a coin flipping oracle. Because of termination rules in Lean this is slightly
 weaker than `unifSpec`, as we have only finitely many coin flips. -/
-@[reducible] def coinSpec : OracleSpec.{0,0} Unit := Unit →ₒ Bool
+@[reducible] def coinSpec : OracleSpec.{0, 0} Unit := Unit →ₒ Bool
 
 section unifSpec
 
 /-- Access to oracles for uniformly selecting from `Fin (n + 1)` for arbitrary `n : ℕ`.
-By adding `1` to the index we avoid selection from the empty type `Fin 0 ≃ empty`.-/
+By adding `1` to the index we avoid selection from the empty type `Fin 0 ≃ empty`. -/
 @[inline, reducible] def unifSpec : OracleSpec ℕ :=
   OracleSpec.ofFn fun n => Fin (n + 1)
 
 end unifSpec
 
 section probSpec
-/-- dt: should or shouldn't we switch to this. Compare to `(· + m) <$> $[0..n]`.
-One question is that we may have empty selection
-Select uniformly from a range (not starting from zero).-/
+/-- NOTE: There isn't really any built in
+Select uniformly from a range (not starting from zero). -/
 @[inline, reducible] def probSpec : OracleSpec (ℕ × ℕ) :=
   OracleSpec.ofFn fun (_n, m) => Fin (m + 1)
 

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -91,7 +91,7 @@ If the final result needs to be a `Type` and not a `Prop`, see `OracleComp.const
 @[elab_as_elim]
 protected def inductionOn {α} {C : ProbComp α → Prop}
     (pure : (a : α) → C (pure a))
-    (query_bind : (n : ℕ) → (mx : Fin (n + 1) → ProbComp α) → (∀ n, C (mx n)) → C ($[0..n] >>= mx))
+    (query_bind : (n : ℕ) → (mx : Fin (n + 1) → ProbComp α) → (∀ m, C (mx m)) → C ($[0..n] >>= mx))
     (oa : ProbComp α) : C oa :=
   PFunctor.FreeM.inductionOn pure query_bind oa
 

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -83,7 +83,7 @@ lemma probFailure_uniformFin (n : ℕ) :
     Pr[⊥ | do $[0..n]] = 0 := by aesop
 
 /-- Nicer induction rule for `ProbComp` that uses monad notation.
-Allows inductive definitions on compuations by considering the three cases:
+Allows inductive definitions on computations by considering the two cases:
 * `return x` / `pure x` for any `x`
 * `do let u ← $[0..n]; oa u` (with inductive results for `oa u`)
 See `oracleComp_emptySpec_equiv` for an example of using this in a proof.

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -125,7 +125,8 @@ lemma uniformRange_eq_uniformFin (n : ℕ) (hn : 0 < n) : $[0⋯n] = $[0..n] := 
 @[simp, grind =]
 lemma probOutput_uniformRange (n m : ℕ) (k : Fin (m + 1)) (h : n < m) :
     Pr[= k | uniformRange n m h] = if n ≤ k then (m - n + 1 : ℝ≥0∞)⁻¹ else 0 := by
-  simp[uniformRange, probOutput_map_eq_sum_finSupport_ite, Fin.ext_iff]
+  simp only [uniformRange, probOutput_map_eq_sum_finSupport_ite, finSupport_uniformFin, Fin.ext_iff,
+    probOutput_uniformFin, natCast_sub, Finset.sum_boole', nsmul_eq_mul]
   by_cases hn : n ≤ k
   · simp only [hn, ↓reduceIte]
     refine trans ?_ (one_mul _)
@@ -135,7 +136,10 @@ lemma probOutput_uniformRange (n m : ℕ) (k : Fin (m + 1)) (h : n < m) :
     ext i
     simp [Fin.ext_iff]
     omega
-  · simp [hn]
+  · simp only [hn, ↓reduceIte, mul_eq_zero, Nat.cast_eq_zero, Finset.card_eq_zero,
+      Finset.filter_eq_empty_iff, Finset.mem_univ, forall_const, ENNReal.inv_eq_zero, add_eq_top,
+      sub_eq_top_iff, natCast_ne_top, ne_eq, not_false_eq_true, and_true, one_ne_top, or_self,
+      or_false]
     fin_omega
 
 @[simp, grind =]
@@ -214,7 +218,7 @@ prefix : 75 "$!" => uniformSelect!
 variable {cont : Type u} {β : Type}
 
 /-- Given a non-failing uniform selection operation we also have a potentially failing one,
-using `OptionT.lift`  -/
+using `OptionT.lift` -/
 instance hasUniformSelect_of_hasUniformSelect!
     [h : HasUniformSelect! cont β] : HasUniformSelect cont β where
   uniformSelect cont := OptionT.lift ($! cont)
@@ -288,7 +292,9 @@ lemma probOutput_uniformSelectList [DecidableEq α] (xs : List α) (x : α) :
     Pr[p | $ xs] = (xs.countP p : ℝ≥0∞) / xs.length := match xs with
   | [] => by simp
   | y :: ys => by
-    simp [uniformSelectList_cons]
+    simp only [uniformSelectList_cons, Fin.getElem_fin, liftM_map, probEvent_map,
+      OptionT.probEvent_liftM, probEvent_uniformFin, Function.comp_apply,
+      Fin.countP_eq_countP_map_finRange, Nat.cast_add, Nat.cast_one, List.length_cons]
     congr 2
     exact List.countP_finRange_getElem (y :: ys) (fun b => decide (p b))
 
@@ -309,7 +315,8 @@ lemma uniformSelectVector_def : $! xs = (xs[·]) <$> $[0..n] := rfl
 @[simp, grind =]
 lemma support_uniformSelectVector : support ($! xs) = {x | x ∈ xs.toList} := by
   ext x
-  simp [uniformSelectVector_def, support_map]
+  simp only [uniformSelectVector_def, Fin.getElem_fin, support_map, support_uniformFin,
+    Set.image_univ, Set.mem_range, Vector.mem_toList_iff, Set.mem_setOf_eq]
   rw [← Vector.mem_toList_iff]
   simpa [Fin.exists_iff, Vector.getElem_toList] using
     (List.mem_iff_getElem (a := x) (l := xs.toList)).symm
@@ -324,7 +331,7 @@ lemma finSupport_uniformSelectVector [DecidableEq α] :
 @[simp, grind =]
 lemma probOutput_uniformSelectVector [DecidableEq α] (x : α) :
     Pr[= x | $! xs] = xs.count x / (n + 1) := by
-  simp [uniformSelectVector_def]
+  simp only [uniformSelectVector_def, Fin.getElem_fin]
   rw [probOutput_map_eq_sum_finSupport_ite]
   simp [div_eq_mul_inv]
   congr 2
@@ -334,7 +341,9 @@ lemma probOutput_uniformSelectVector [DecidableEq α] (x : α) :
 lemma probEvent_uniformSelectVector (p : α → Prop) [DecidablePred p] :
     Pr[p | $ xs] = xs.toList.countP p / (n + 1) := by
   rw [uniformSelect_eq_liftM_uniformSelect!]
-  simp [uniformSelectVector_def, probEvent_eq_sum_fintype_ite]
+  simp only [uniformSelectVector_def, Fin.getElem_fin, liftM_map, probEvent_map,
+    probEvent_eq_sum_fintype_ite, Function.comp_apply, OptionT.probOutput_liftM,
+    probOutput_uniformFin, Finset.sum_boole', nsmul_eq_mul, Vector.countP_toList]
   rw [div_eq_mul_inv]
   congr 1
   simpa [eq_comm] using (Vector.card_eq_countP xs p)
@@ -354,7 +363,7 @@ lemma uniformSelectListVector_def : $! xs = (xs[·]) <$> $[0..n] := rfl
 @[simp, grind =]
 lemma probOutput_uniformSelectListVector [DecidableEq α] (x : α) :
     Pr[= x | $! xs] = xs.toList.count x / (n + 1) := by
-  simp [uniformSelectListVector_def]
+  simp only [uniformSelectListVector_def, Fin.getElem_fin, Vector.getElem_eq_get, Fin.eta]
   rw [probOutput_map_eq_sum_finSupport_ite]
   simp [div_eq_mul_inv]
   congr 2
@@ -363,7 +372,9 @@ lemma probOutput_uniformSelectListVector [DecidableEq α] (x : α) :
 @[simp, grind =]
 lemma probEvent_uniformSelectListVector (p : α → Prop) [DecidablePred p] :
     Pr[p | $! xs] = xs.toList.countP p / (n + 1) := by
-  simp [uniformSelectListVector_def, probEvent_eq_sum_fintype_ite]
+  simp only [uniformSelectListVector_def, Fin.getElem_fin, Vector.getElem_eq_get, Fin.eta,
+    probEvent_map, probEvent_eq_sum_fintype_ite, Function.comp_apply, probOutput_uniformFin,
+    Finset.sum_boole', nsmul_eq_mul]
   rw [div_eq_mul_inv]
   congr 1
   simpa [eq_comm] using (List.Vector.card_eq_countP xs p)
@@ -384,7 +395,7 @@ variable {α : Type} (s : Finset α)
 lemma uniformSelectFinset_def : $ s = $ s.toList := rfl
 
 @[simp, grind =]
-lemma support_uniformSelectFinset [DecidableEq α] :
+lemma support_uniformSelectFinset :
     support ($ s) = if s.Nonempty then ↑s else ∅ := by
   aesop (add norm uniformSelectFinset_def)
 
@@ -398,10 +409,12 @@ lemma probOutput_uniformSelectFinset [DecidableEq α] (x : α) :
     Pr[= x | $ s] = if x ∈ s then (s.card : ℝ≥0∞)⁻¹ else 0 := by
   aesop (add norm uniformSelectFinset_def)
 
+set_option linter.unusedDecidableInType false in
 @[simp, grind =]
 lemma probEvent_uniformSelectFinset [DecidableEq α] (p : α → Prop) [DecidablePred p] :
     Pr[p | $ s] = {x ∈ s | p x}.card / s.card := by
-  simp [uniformSelectFinset_def, List.countP_eq_length_filter]
+  simp only [uniformSelectFinset_def, probEvent_uniformSelectList, List.countP_eq_length_filter,
+    Finset.length_toList]
   congr 2
   rw [← List.toFinset_card_of_nodup (l := s.toList.filter fun x => decide (p x))]
   · simp [List.toFinset_filter]

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -82,6 +82,19 @@ lemma probEvent_uniformFin (n : ℕ) (p : Fin (n + 1) → Prop) [DecidablePred p
 lemma probFailure_uniformFin (n : ℕ) :
     Pr[⊥ | do $[0..n]] = 0 := by aesop
 
+/-- Nicer induction rule for `ProbComp` that uses monad notation.
+Allows inductive definitions on compuations by considering the three cases:
+* `return x` / `pure x` for any `x`
+* `do let u ← $[0..n]; oa u` (with inductive results for `oa u`)
+See `oracleComp_emptySpec_equiv` for an example of using this in a proof.
+If the final result needs to be a `Type` and not a `Prop`, see `OracleComp.construct`. -/
+@[elab_as_elim]
+protected def inductionOn {α} {C : ProbComp α → Prop}
+    (pure : (a : α) → C (pure a))
+    (query_bind : (n : ℕ) → (mx : Fin (n + 1) → ProbComp α) → (∀ n, C (mx n)) → C ($[0..n] >>= mx))
+    (oa : ProbComp α) : C oa :=
+  PFunctor.FreeM.inductionOn pure query_bind oa
+
 end uniformFin
 
 section uniformRange

--- a/VCVio/OracleComp/QueryTracking/CachingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingOracle.lean
@@ -63,12 +63,11 @@ lemma withCaching_cache_le [LawfulMonad m] [HasEvalSet m]
     have hrun : (pure u : StateT spec.QueryCache m (spec.Range t)).run cache₀ =
         pure (u, cache₀) := rfl
     rw [hrun] at hz
-    simp at hz; rw [hz]
+    simp only [support_pure, Set.mem_singleton_iff] at hz; rw [hz]
   | none =>
     simp only [ht, StateT.run_bind] at hz
     have hlift : (liftM (so t) : StateT spec.QueryCache m (spec.Range t)).run cache₀ =
-        so t >>= fun v => pure (v, cache₀) := by
-      show StateT.lift (so t) cache₀ = _; rfl
+        so t >>= fun v => pure (v, cache₀) := rfl
     rw [hlift, bind_assoc] at hz
     simp only [pure_bind] at hz
     rcases (mem_support_bind_iff _ _ _).1 hz with ⟨v, _, hmod⟩
@@ -76,12 +75,12 @@ lemma withCaching_cache_le [LawfulMonad m] [HasEvalSet m]
         StateT spec.QueryCache m (spec.Range t)).run cache₀ =
         pure (v, cache₀.cacheQuery t v) := rfl
     rw [this] at hmod
-    simp at hmod
+    simp only [support_pure, Set.mem_singleton_iff] at hmod
     rw [hmod]
     exact QueryCache.le_cacheQuery cache₀ ht
 
 /-- `withCaching` preserves the invariant `(cache₀ ≤ ·)` (the cache only grows). -/
-lemma PreservesInv.withCaching_le {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀}
+lemma PreservesInv.withCaching_le {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀}
     [DecidableEq ι₀] [spec₀.DecidableEq]
     (so : QueryImpl spec₀ ProbComp) (cache₀ : QueryCache spec₀) :
     QueryImpl.PreservesInv (so.withCaching) (cache₀ ≤ ·) :=
@@ -106,14 +105,14 @@ lemma apply_eq (t : spec.Domain) : cachingOracle t =
           modifyGet fun cache => (u, cache.cacheQuery t u)) := rfl
 
 @[simp]
-lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀} [DecidableEq ι₀]
+lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (cache : QueryCache spec₀) :
     Pr[⊥ | (simulateQ (cachingOracle (spec := spec₀)) oa).run cache] = Pr[⊥ | oa] := by
   simp only [HasEvalPMF.probFailure_eq_zero]
 
 @[simp]
-lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀} [DecidableEq ι₀]
+lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (cache : QueryCache spec₀) :
     NeverFail ((simulateQ (cachingOracle (spec := spec₀)) oa).run cache) ↔ NeverFail oa := by

--- a/VCVio/OracleComp/QueryTracking/CostModel.lean
+++ b/VCVio/OracleComp/QueryTracking/CostModel.lean
@@ -166,7 +166,7 @@ theorem probEvent_cost_gt_mul_le_expectedCost
     (oa : OracleComp spec α) (cm : CostModel spec ω) (val : ω → ℝ≥0∞) (t : ℝ≥0∞) :
     Pr[fun z => t < val z.2 | costDist oa cm] * t ≤ expectedCost oa cm val := by
   rw [probEvent_eq_wp_indicator]
-  show wp (costDist oa cm) (fun z => if t < val z.2 then 1 else 0) * t ≤
+  change wp (costDist oa cm) (fun z => if t < val z.2 then 1 else 0) * t ≤
     wp (costDist oa cm) (fun z => val z.2)
   calc wp (costDist oa cm) (fun z => if t < val z.2 then 1 else 0) * t
       = wp (costDist oa cm) (fun z => t * (if t < val z.2 then 1 else 0)) := by
@@ -175,7 +175,7 @@ theorem probEvent_cost_gt_mul_le_expectedCost
         apply wp_mono
         intro z
         split_ifs with h
-        · simp; exact le_of_lt h
+        · simpa using le_of_lt h
         · simp
 
 /-- **Markov's inequality for cost distributions** (division form). -/

--- a/VCVio/OracleComp/QueryTracking/CountingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CountingOracle.lean
@@ -104,13 +104,13 @@ lemma run_simulateQ_bind_fst (oa : OracleComp spec α) (ob : α → OracleComp s
   rw [← bind_map_left Prod.fst, fst_map_run_simulateQ]
 
 @[simp]
-lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀} [DecidableEq ι₀]
+lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type} (oa : OracleComp spec₀ α) :
     Pr[⊥ | (simulateQ (countingOracle (spec := spec₀)) oa).run] = Pr[⊥ | oa] := by
   simp only [HasEvalPMF.probFailure_eq_zero]
 
 @[simp]
-lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀} [DecidableEq ι₀]
+lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) :
     NeverFail (simulateQ (countingOracle (spec := spec₀)) oa).run ↔ NeverFail oa := by
@@ -118,7 +118,7 @@ lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι�
     HasEvalPMF.probFailure_eq_zero, HasEvalPMF.probFailure_eq_zero]
 
 @[simp]
-lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀} [DecidableEq ι₀]
+lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (p : α → Prop) :
     Pr[fun z => p z.1 | (simulateQ (countingOracle (spec := spec₀)) oa).run] = Pr[p | oa] := by
@@ -126,7 +126,7 @@ lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι�
     ← probEvent_map, fst_map_run_simulateQ]
 
 @[simp]
-lemma probOutput_fst_map_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0,0} ι₀} [DecidableEq ι₀]
+lemma probOutput_fst_map_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (countingOracle (spec := spec₀)) oa).run] =

--- a/VCVio/OracleComp/QueryTracking/Enforcement.lean
+++ b/VCVio/OracleComp/QueryTracking/Enforcement.lean
@@ -65,7 +65,7 @@ theorem fst_map_run_simulateQ
     rw [isPerIndexQueryBound_query_bind_iff] at h
     obtain ⟨hpos, hcont⟩ := h
     simp only [simulateQ_query_bind]
-    show Prod.fst <$> ((enforceOracle (spec := spec) t).run qb >>=
+    change Prod.fst <$> ((enforceOracle (spec := spec) t).run qb >>=
       fun p => (simulateQ enforceOracle (mx p.1)).run p.2) = liftM (query t) >>= mx
     rw [run_apply, if_pos hpos]
     simp only [map_eq_bind_pure_comp, Function.comp, bind_assoc, pure_bind]

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -52,7 +52,7 @@ namespace loggingOracle
 
 
 @[simp]
-lemma probFailure_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
+lemma probFailure_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) :
     Pr[⊥ | (WriterT.run
@@ -61,19 +61,19 @@ lemma probFailure_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
   simp only [HasEvalPMF.probFailure_eq_zero]
 
 @[simp]
-lemma fst_map_run_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
+lemma fst_map_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     (oa : OracleComp spec α) :
     Prod.fst <$> (simulateQ (loggingOracle (spec := spec)) oa).run = oa := by
   rw [loggingOracle, QueryImpl.fst_map_run_withLogging, simulateQ_ofLift_eq_self]
 
 @[simp]
-lemma run_simulateQ_bind_fst {spec : OracleSpec.{0,0} ι} {α β : Type}
+lemma run_simulateQ_bind_fst {spec : OracleSpec.{0, 0} ι} {α β : Type}
     (oa : OracleComp spec α) (ob : α → OracleComp spec β) :
     ((simulateQ (loggingOracle (spec := spec)) oa).run >>= fun x => ob x.1) = oa >>= ob := by
   rw [← bind_map_left Prod.fst, fst_map_run_simulateQ]
 
 @[simp]
-lemma NeverFail_run_simulateQ_iff {spec : OracleSpec.{0,0} ι} {α : Type}
+lemma NeverFail_run_simulateQ_iff {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) :
     NeverFail (simulateQ (loggingOracle (spec := spec)) oa).run ↔ NeverFail oa := by
@@ -81,7 +81,7 @@ lemma NeverFail_run_simulateQ_iff {spec : OracleSpec.{0,0} ι} {α : Type}
     HasEvalPMF.probFailure_eq_zero, HasEvalPMF.probFailure_eq_zero]
 
 @[simp]
-lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
+lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) (p : α → Prop) :
     Pr[fun z => p z.1 | (simulateQ (loggingOracle (spec := spec)) oa).run] = Pr[p | oa] := by
@@ -89,7 +89,7 @@ lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
     ← probEvent_map, fst_map_run_simulateQ]
 
 @[simp]
-lemma probOutput_fst_map_run_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
+lemma probOutput_fst_map_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (loggingOracle (spec := spec)) oa).run] =
@@ -98,7 +98,7 @@ lemma probOutput_fst_map_run_simulateQ {spec : OracleSpec.{0,0} ι} {α : Type}
 
 end loggingOracle
 
-/-- Add a query log to a computation using a logging oracle.  -/
+/-- Add a query log to a computation using a logging oracle. -/
 @[reducible] def OracleComp.withQueryLog {α} (mx : OracleComp spec α) :
     OracleComp spec (α × QueryLog spec) :=
   WriterT.run (simulateQ (QueryImpl.ofLift spec (OracleComp spec)).withLogging mx)

--- a/VCVio/OracleComp/QueryTracking/QueryBound.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryBound.lean
@@ -63,8 +63,7 @@ lemma isQueryBound_query_iff (t : ι) (b : B)
     (canQuery : ι → B → Prop) (cost : ι → B → B) :
     IsQueryBound (liftM (query (spec := spec) t) : OracleComp spec _) b canQuery cost ↔
     canQuery t b := by
-  show (canQuery t b ∧ ∀ _ : spec t, True) ↔ _
-  simp
+  simp [IsQueryBound]
 
 private lemma isQueryBound_map_aux (oa : OracleComp spec α) (f : α → β)
     (canQuery : ι → B → Prop) (cost : ι → B → B) :
@@ -142,8 +141,7 @@ lemma isPerIndexQueryBound_query_bind_iff (t : ι) (mx : spec t → OracleComp s
 lemma isPerIndexQueryBound_query_iff (t : ι) (qb : ι → ℕ) :
     IsPerIndexQueryBound (liftM (query (spec := spec) t) : OracleComp spec _) qb ↔
     0 < qb t := by
-  show (0 < qb t ∧ ∀ _ : spec t, True) ↔ _
-  simp
+  simp [IsPerIndexQueryBound]
 
 private lemma update_le_update {qb qb' : ι → ℕ} {t : ι} (hle : qb ≤ qb') :
     Function.update qb t (qb t - 1) ≤ Function.update qb' t (qb' t - 1) := by

--- a/VCVio/OracleComp/QueryTracking/RandomOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle.lean
@@ -43,7 +43,7 @@ uniformly and caches the result. This ensures consistency: same input → same o
 
 namespace randomOracle
 
-variable {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec.{0,0} ι₀}
+variable {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec.{0, 0} ι₀}
   [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
 
 lemma apply_eq (t : spec₀.Domain) :
@@ -77,7 +77,7 @@ This is definitionally equal to `uniformSampleImpl.withPregen` (from `SeededOrac
 
 namespace eagerRandomOracle
 
-variable {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec.{0,0} ι₀}
+variable {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec.{0, 0} ι₀}
   [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
 
 lemma apply_eq (t : spec₀.Domain) :
@@ -102,7 +102,7 @@ theorem evalDist_simulateQ_run'_empty [spec₀.Fintype] [spec₀.Inhabited]
     have hsimp : (eagerRandomOracle t >>= fun u =>
         simulateQ eagerRandomOracle (f u)).run' (∅ : QuerySeed spec₀) =
         $ᵗ spec₀.Range t >>= fun u => (simulateQ eagerRandomOracle (f u)).run' ∅ := by
-      show Prod.fst <$> ((eagerRandomOracle t).run ∅ >>= fun p =>
+      change Prod.fst <$> ((eagerRandomOracle t).run ∅ >>= fun p =>
           (simulateQ eagerRandomOracle (f p.1)).run p.2) =
         $ᵗ spec₀.Range t >>= fun u => Prod.fst <$> (simulateQ eagerRandomOracle (f u)).run ∅
       have h : (eagerRandomOracle t).run (∅ : QuerySeed spec₀) =
@@ -119,16 +119,16 @@ end eagerRandomOracle
 /-- Helper: the `run'` of the eager oracle bind reduces to uniform sampling
 when `seed t = []`. -/
 private lemma eagerRandomOracle_run'_nil {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0,0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
+    {spec₀ : OracleSpec.{0, 0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
     {α : Type} (t : spec₀.Domain) (f : spec₀.Range t → OracleComp spec₀ α)
     (seed : QuerySeed spec₀) (ht : seed t = []) :
     (eagerRandomOracle t >>= fun u => simulateQ eagerRandomOracle (f u)).run' seed =
     ($ᵗ spec₀.Range t) >>= fun u => (simulateQ eagerRandomOracle (f u)).run' seed := by
-  show Prod.fst <$> ((eagerRandomOracle t).run seed >>= fun p =>
+  change Prod.fst <$> ((eagerRandomOracle t).run seed >>= fun p =>
       (simulateQ eagerRandomOracle (f p.1)).run p.2) = _
   have h : (eagerRandomOracle (spec := spec₀) t).run seed =
       (fun u => (u, seed)) <$> ($ᵗ spec₀.Range t) := by
-    show (match seed t with
+    change (match seed t with
         | v :: vs => pure (v, Function.update seed t vs)
         | [] => (·, seed) <$> ($ᵗ spec₀.Range t)) = _
     rw [ht]
@@ -137,17 +137,17 @@ private lemma eagerRandomOracle_run'_nil {ι₀ : Type} [DecidableEq ι₀]
 /-- Helper: the `run'` of the eager oracle bind consumes the head
 when `seed t = u :: us`. -/
 private lemma eagerRandomOracle_run'_cons {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0,0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
+    {spec₀ : OracleSpec.{0, 0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
     {α : Type} (t : spec₀.Domain) (f : spec₀.Range t → OracleComp spec₀ α)
     (seed : QuerySeed spec₀) (u : spec₀.Range t) (us : List (spec₀.Range t))
     (ht : seed t = u :: us) :
     (eagerRandomOracle t >>= fun v => simulateQ eagerRandomOracle (f v)).run' seed =
     (simulateQ eagerRandomOracle (f u)).run' (Function.update seed t us) := by
-  show Prod.fst <$> ((eagerRandomOracle t).run seed >>= fun p =>
+  change Prod.fst <$> ((eagerRandomOracle t).run seed >>= fun p =>
       (simulateQ eagerRandomOracle (f p.1)).run p.2) = _
   have h : (eagerRandomOracle (spec := spec₀) t).run seed =
       pure (u, Function.update seed t us) := by
-    show (match seed t with
+    change (match seed t with
         | v :: vs => pure (v, Function.update seed t vs)
         | [] => (·, seed) <$> ($ᵗ spec₀.Range t)) = _
     rw [ht]
@@ -160,7 +160,7 @@ seed values are i.i.d. uniform, exactly matching fresh oracle queries.
 This is the analog of `seededOracle.evalDist_liftComp_generateSeed_bind_simulateQ_run'`
 but for `eagerRandomOracle` (which falls back to `ProbComp` rather than `OracleComp spec`). -/
 theorem eagerRandomOracle_evalDist_generateSeed_bind {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0,0} ι₀}
+    {spec₀ : OracleSpec.{0, 0} ι₀}
     [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
     [spec₀.Fintype] [spec₀.Inhabited]
     {α : Type} (oa : OracleComp spec₀ α)

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -62,7 +62,8 @@ def generateSeedCounts (n : ι → ℕ) : List ι → ProbComp (OracleSpec.Query
   induction is with
   | nil =>
     ext seed
-    simp [generateSeedCounts]
+    simp only [generateSeedCounts, support_pure, Set.mem_singleton_iff, List.not_mem_nil,
+      ↓reduceIte, List.length_eq_zero_iff, Set.mem_setOf_eq]
     constructor
     · intro h
       subst h
@@ -185,7 +186,7 @@ namespace seededOracle
 
 /-- The probability that a lifted uniform sample equals a fixed value is `(card α)⁻¹`. -/
 lemma probEvent_liftComp_uniformSample_eq_of_eq
-    {ι : Type} {spec : OracleSpec ι} [DecidableEq ι]
+    {ι : Type} {spec : OracleSpec ι}
     [(i : ι) → SampleableType (spec.Range i)]
     [unifSpec ⊂ₒ spec] [OracleSpec.LawfulSubSpec unifSpec spec]
     [spec.Fintype] [spec.Inhabited]
@@ -277,7 +278,7 @@ private lemma evalDist_liftComp_generateSeed_bind_simulateQ_run'
         | none => liftM (query t) >>= fun u => (simulateQ seededOracle (mx u)).run' s
         | some (u, s') => (simulateQ seededOracle (mx u)).run' s' := by
       intro s
-      show Prod.fst <$>
+      change Prod.fst <$>
         (seededOracle t >>= fun u => simulateQ seededOracle (mx u)).run s = _
       rw [run_bind_query_eq_pop]
       cases s.pop t with
@@ -431,7 +432,6 @@ lemma probOutput_generateSeed_bind_map_simulateQ
     (probOutput_generateSeed_bind_simulateQ_bind (qc := qc) (js := js)
       (oa := oa) (ob := fun x => pure (f x)) (y := y))
 
-set_option maxHeartbeats 800000 in
 /-- Adding a uniform value at index `i` to a seed does not change the distribution of
 running a computation with the seeded oracle. This is because the extra value replaces
 what would otherwise be a fresh uniform oracle response. -/
@@ -450,9 +450,7 @@ lemma evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue
   | pure x =>
     intro σ
     have hrun' : ∀ s, (simulateQ seededOracle (pure x : OracleComp spec₀ α)).run' s =
-        (pure x : OracleComp spec₀ α) := fun s => by
-      show Prod.fst <$> (pure (x, s) : OracleComp spec₀ _) = pure x
-      rw [map_pure]
+        (pure x : OracleComp spec₀ α) := fun s => by simp
     apply evalDist_ext; intro a
     simp_rw [hrun']
     rw [probOutput_bind_const]
@@ -469,7 +467,7 @@ lemma evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue
         | none => liftM (query t) >>= fun r => (simulateQ seededOracle (mx r)).run' s
         | some (r, s') => (simulateQ seededOracle (mx r)).run' s' := by
       intro s
-      show Prod.fst <$>
+      change Prod.fst <$>
         (seededOracle t >>= fun r => simulateQ seededOracle (mx r)).run s = _
       rw [run_bind_query_eq_pop]
       cases s.pop t with
@@ -538,7 +536,7 @@ lemma evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue
           rw [QuerySeed.pop_eq_some_of_cons _ _ u₀ rest hlist]
           suffices Function.update (σ.addValue i v) t rest =
               QuerySeed.addValue (Function.update σ t rest) i v by rw [this]
-          show Function.update (Function.update σ i (σ i ++ [v])) t rest =
+          change Function.update (Function.update σ i (σ i ++ [v])) t rest =
             Function.update (Function.update σ t rest) i
               ((Function.update σ t rest) i ++ [v])
           conv_rhs =>
@@ -584,7 +582,6 @@ lemma evalDist_liftComp_replicate_uniformSample_bind_simulateQ_run'_addValues
     rw [← evalDist_bind]
     exact evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue σ i oa
 
-set_option maxHeartbeats 4000000 in
 /-- Truncating the seed at oracle `i₀` to only the first `k` entries does not change
 the distribution when averaging over seeds from `generateSeed`. -/
 lemma evalDist_liftComp_generateSeed_bind_simulateQ_run'_takeAtIndex
@@ -615,7 +612,7 @@ lemma evalDist_liftComp_generateSeed_bind_simulateQ_run'_takeAtIndex
         | none => liftM (query t) >>= fun u => (simulateQ seededOracle (mx u)).run' s
         | some (u, s') => (simulateQ seededOracle (mx u)).run' s' := by
       intro s
-      show Prod.fst <$>
+      change Prod.fst <$>
         (seededOracle t >>= fun u => simulateQ seededOracle (mx u)).run s = _
       rw [run_bind_query_eq_pop]
       cases s.pop t with
@@ -802,7 +799,6 @@ lemma probOutput_generateSeed_bind_map_simulateQ_takeAtIndex
   rw [hcomp]
   exact congrFun (congrArg DFunLike.coe (by simp only [evalDist_map, h])) y
 
-set_option maxHeartbeats 8000000 in
 /-- Weighted takeAtIndex faithfulness: a prefix-dependent weight `h` preserves the
 faithfulness equality between full-seed and truncated-seed simulation.
 This generalizes the basic takeAtIndex faithfulness by allowing multiplication
@@ -837,7 +833,7 @@ lemma tsum_probOutput_generateSeed_weight_takeAtIndex
         | none => liftM (query t) >>= fun u => (simulateQ seededOracle (mx u)).run' s
         | some (u, s') => (simulateQ seededOracle (mx u)).run' s' := by
       intro s
-      show Prod.fst <$>
+      change Prod.fst <$>
         (seededOracle t >>= fun u => simulateQ seededOracle (mx u)).run s = _
       rw [run_bind_query_eq_pop]
       cases s.pop t with

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -990,15 +990,7 @@ lemma tsum_probOutput_generateSeed_weight_takeAtIndex
           have hcard_ne_top : (↑(Fintype.card (spec₀.Range t)) : ENNReal) ≠ ⊤ := by
             exact ENNReal.natCast_ne_top (n := Fintype.card (spec₀.Range t))
           rw [← mul_assoc, ENNReal.mul_inv_cancel hcard_ne_zero hcard_ne_top, one_mul]
-          have hrun'_eq : ∀ i : spec₀.Range t,
-              (simulateQ seededOracle (mx i)).run' (s'.takeAtIndex t 0) =
-                (fun x ↦ x.1) <$> (simulateQ seededOracle (mx i)).run (s'.takeAtIndex t 0) := by
-            intro i; rfl
-          simp_rw [hrun'_eq]
-          exact (tsum_fintype (L := .unconditional _)
-            (f := fun i : spec₀.Range t =>
-              Pr[= x | (fun x ↦ x.1) <$> (simulateQ seededOracle (mx i)).run
-                (s'.takeAtIndex t 0)]))
+          simp
         · -- Case 2a: t = i₀, k > 0 — both pop some, k decreases
           have hk_pos : 0 < k := Nat.pos_of_ne_zero hk
           simp only [QuerySeed.pop_takeAtIndex_prependValues_self _ _ _ hk_pos]

--- a/VCVio/OracleComp/QueryTracking/Structures.lean
+++ b/VCVio/OracleComp/QueryTracking/Structures.lean
@@ -236,7 +236,7 @@ def single [DecidableEq ι] (i : ι) : QueryCount ι := Function.update 0 i 1
 @[simp]
 lemma single_le_iff_pos [DecidableEq ι] (i : ι) (qc : QueryCount ι) :
     single i ≤ qc ↔ 0 < qc i := by
-  simp [single, Function.update, Pi.hasLe]
+  simp only [Pi.hasLe, single, Function.update, eq_rec_constant, Pi.zero_apply, dite_eq_ite]
   constructor <;> intro h
   · have : 1 ≤ qc i := by simpa using h i
     exact this
@@ -451,7 +451,7 @@ lemma eq_of_prependValues_eq (seed rest : QuerySeed spec)
     (h : rest.prependValues xs = seed) :
     xs = (seed i).take n ∧ rest = Function.update seed i ((seed i).drop n) := by
   have hi : xs ++ rest i = seed i := by
-    have := congrArg (· i) h; simp [prependValues] at this; exact this
+    have := congrArg (· i) h; simpa [prependValues] using this
   constructor
   · calc xs = (xs ++ rest i).take xs.length := by simp
       _ = (seed i).take n := by rw [hi, hlen]
@@ -462,8 +462,7 @@ lemma eq_of_prependValues_eq (seed rest : QuerySeed spec)
       have : rest i = (xs ++ rest i).drop xs.length := by simp
       rw [this, hi, hlen]
     · have hj' : rest j = seed j := by
-        have := congrArg (· j) h; simp [prependValues, Function.update_of_ne hj] at this
-        exact this
+        have := congrArg (· j) h; simpa [prependValues, Function.update_of_ne hj] using this
       simp [Function.update_of_ne hj, hj']
 
 lemma eq_of_prependValues_singleton_eq (seed rest : QuerySeed spec)
@@ -538,7 +537,7 @@ lemma cons_of_pop_eq_some (seed : QuerySeed spec) (i : ι)
   | nil =>
     simp [hsi] at h
   | cons u0 us =>
-    simp [hsi] at h
+    simp only [hsi, Option.some.injEq, Prod.mk.injEq] at h
     rcases h with ⟨hu, hrest⟩
     subst hu hrest
     simp
@@ -552,7 +551,7 @@ lemma rest_eq_update_tail_of_pop_eq_some (seed : QuerySeed spec) (i : ι)
   | nil =>
     simp [hsi] at h
   | cons u0 us =>
-    simp [hsi] at h
+    simp only [hsi, Option.some.injEq, Prod.mk.injEq] at h
     rcases h with ⟨hu, hrest⟩
     subst hu hrest
     simp

--- a/VCVio/OracleComp/SimSemantics/Append.lean
+++ b/VCVio/OracleComp/SimSemantics/Append.lean
@@ -22,7 +22,7 @@ to this definition for greater flexibility. -/
 protected def add (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m) :
     QueryImpl (spec₁ + spec₂) m | .inl t => impl₁ t | .inr t => impl₂ t
 
-/-- Add two `QueryImpl` to get an implementation on the sum of the two `OracleSpec`.-/
+/-- Add two `QueryImpl` to get an implementation on the sum of the two `OracleSpec`. -/
 instance : HAdd (QueryImpl spec₁ m) (QueryImpl spec₂ m) (QueryImpl (spec₁ + spec₂) m) where
   hAdd := QueryImpl.add
 
@@ -59,7 +59,7 @@ private lemma simulateQ_add_liftM_left (t : spec₁'.Domain) :
     simulateQ (impl₁' + impl₂')
       (liftM (OracleQuery.query (spec := spec₁') t) : OracleComp (spec₁' + spec₂') _) =
     impl₁' t := by
-  show simulateQ (impl₁' + impl₂')
+  change simulateQ (impl₁' + impl₂')
     (liftM (liftM (OracleQuery.query (spec := spec₁') t) : OracleQuery (spec₁' + spec₂') _)) = _
   simp [simulateQ_query]
 
@@ -67,7 +67,7 @@ private lemma simulateQ_add_liftM_right (t : spec₂'.Domain) :
     simulateQ (impl₁' + impl₂')
       (liftM (OracleQuery.query (spec := spec₂') t) : OracleComp (spec₁' + spec₂') _) =
     impl₂' t := by
-  show simulateQ (impl₁' + impl₂')
+  change simulateQ (impl₁' + impl₂')
     (liftM (liftM (OracleQuery.query (spec := spec₂') t) : OracleQuery (spec₁' + spec₂') _)) = _
   simp [simulateQ_query]
 

--- a/VCVio/OracleComp/SimSemantics/StateT.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT.lean
@@ -52,8 +52,8 @@ adding back any state at the end of the computation. -/
 lemma StateT_run_simulateQ_eq_map_run'_simulateQ {α} [Subsingleton σ]
     (oa : OracleComp spec α) (s s' : σ) :
     (simulateQ so oa).run s = (·, s') <$> (simulateQ so oa).run' s := by
-  have : (λ x : α × σ ↦ (x.1, s')) = id :=
-    funext λ (x, s) ↦ Prod.eq_iff_fst_eq_snd_eq.2 ⟨rfl, Subsingleton.elim _ _⟩
+  have : (fun x : α × σ ↦ (x.1, s')) = id :=
+    funext fun (x, s) ↦ Prod.eq_iff_fst_eq_snd_eq.2 ⟨rfl, Subsingleton.elim _ _⟩
   simp [this]
 
 lemma StateT_run'_simulateQ_eq_self {α} (so : QueryImpl spec (StateT σ (OracleComp spec)))

--- a/VCVio/ProgramLogic/Notation.lean
+++ b/VCVio/ProgramLogic/Notation.lean
@@ -70,7 +70,7 @@ theorem GameEquiv.trans {g₁ g₂ g₃ : OracleComp spec₁ α}
 
 theorem GameEquiv.probOutput_eq {g₁ g₂ : OracleComp spec₁ α}
     (h : GameEquiv g₁ g₂) (x : α) : Pr[= x | g₁] = Pr[= x | g₂] := by
-  show evalDist g₁ x = evalDist g₂ x; rw [h]
+  change evalDist g₁ x = evalDist g₂ x; rw [h]
 
 /-! ## Prop-to-ℝ≥0∞ indicator -/
 
@@ -179,7 +179,7 @@ lemma triple_propInd_iff_probEvent_eq_one {ι : Type u} {spec : OracleSpec ι}
     [spec.Fintype] [spec.Inhabited] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) :
     Triple (spec := spec) ⌜True⌝ oa (fun x => ⌜p x⌝) ↔ Pr[p | oa] = 1 := by
-  show ⌜True⌝ ≤ wp oa (fun x => ⌜p x⌝) ↔ Pr[p | oa] = 1
+  change ⌜True⌝ ≤ wp oa (fun x => ⌜p x⌝) ↔ Pr[p | oa] = 1
   rw [propInd_true, ← probEvent_eq_wp_propInd]
   exact one_le_probEvent_iff
 
@@ -188,7 +188,7 @@ lemma triple_propInd_iff_le_probEvent {ι : Type u} {spec : OracleSpec ι}
     [spec.Fintype] [spec.Inhabited] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) (r : ℝ≥0∞) :
     Triple (spec := spec) r oa (fun x => ⌜p x⌝) ↔ r ≤ Pr[p | oa] := by
-  show r ≤ wp oa (fun x => ⌜p x⌝) ↔ r ≤ Pr[p | oa]
+  change r ≤ wp oa (fun x => ⌜p x⌝) ↔ r ≤ Pr[p | oa]
   rw [← probEvent_eq_wp_propInd]
 
 /-! ## Expectation-level bridge lemmas -/

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -289,7 +289,7 @@ lemma relTriple_query_bij (t : spec₁.Domain)
   · constructor
     · simp
     · simp only [map_bind, map_pure, evalDist_query]
-      show f <$> (liftM (PMF.uniformOfFintype (spec₁.Range t)) : SPMF _) =
+      change f <$> (liftM (PMF.uniformOfFintype (spec₁.Range t)) : SPMF _) =
         (liftM (PMF.uniformOfFintype (spec₁.Range t)) : SPMF _)
       rw [show f <$> (liftM (PMF.uniformOfFintype (spec₁.Range t)) : SPMF _) =
         (liftM (f <$> PMF.uniformOfFintype (spec₁.Range t)) : SPMF _) from by simp]

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -233,45 +233,16 @@ lemma relTriple_eqRel_of_probOutput_eq {oa : OracleComp spec₁ α} {ob : Oracle
 
 /-- Equality-relation relational triples imply equality of point output probabilities. -/
 lemma probOutput_eq_of_relTriple_eqRel {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ α}
-    (h : RelTriple oa ob (EqRel α)) (x : α) :
-    Pr[= x | oa] = Pr[= x | ob] := by
+    (h : RelTriple oa ob (EqRel α)) (x : α) : Pr[= x | oa] = Pr[= x | ob] := by
   rcases (relTriple_iff_relWP (oa := oa) (ob := ob) (R := EqRel α)).1 h with ⟨c, hc⟩
-  have hfst :
-      Pr[= x | Prod.fst <$> c.1] = Pr[= x | oa] := by
+  have hfst : Pr[= x | Prod.fst <$> c.1] = Pr[= x | oa] := by
     simpa [probOutput_def] using congrArg (fun p : SPMF α => p x) c.2.map_fst
-  have hsnd :
-      Pr[= x | Prod.snd <$> c.1] = Pr[= x | ob] := by
+  have hsnd : Pr[= x | Prod.snd <$> c.1] = Pr[= x | ob] := by
     simpa [probOutput_def] using congrArg (fun p : SPMF α => p x) c.2.map_snd
-  have hmap_fst :
-      Pr[= x | Prod.fst <$> c.1] = Pr[(fun z : α × α => z.1 = x) | c.1] := by
-    calc
-      Pr[= x | Prod.fst <$> c.1]
-          = Pr[(fun a : α => a = x) | Prod.fst <$> c.1] := by
-              simp
-      _ = Pr[(fun z : α × α => z.1 = x) | c.1] := by
-            simpa [Function.comp] using
-              (probEvent_map (mx := c.1) (f := Prod.fst) (q := fun a : α => a = x))
-  have hmap_snd :
-      Pr[(fun z : α × α => z.2 = x) | c.1] = Pr[= x | Prod.snd <$> c.1] := by
-    calc
-      Pr[(fun z : α × α => z.2 = x) | c.1]
-          = Pr[(fun a : α => a = x) | Prod.snd <$> c.1] := by
-              simpa [Function.comp] using
-                (probEvent_map (mx := c.1) (f := Prod.snd) (q := fun a : α => a = x)).symm
-      _ = Pr[= x | Prod.snd <$> c.1] := by
-            simp
-  have hevent :
-      Pr[(fun z : α × α => z.1 = x) | c.1] = Pr[(fun z : α × α => z.2 = x) | c.1] := by
-    refine probEvent_ext (mx := c.1) ?_
-    intro z hz
-    have hzEq : z.1 = z.2 := hc z hz
-    constructor <;> intro hx <;> simpa [hzEq] using hx
-  calc
-    Pr[= x | oa] = Pr[= x | Prod.fst <$> c.1] := hfst.symm
-    _ = Pr[(fun z : α × α => z.1 = x) | c.1] := hmap_fst
-    _ = Pr[(fun z : α × α => z.2 = x) | c.1] := hevent
-    _ = Pr[= x | Prod.snd <$> c.1] := hmap_snd
-    _ = Pr[= x | ob] := hsnd
+  have hevent : Pr[(fun z : α × α => z.1 = x) | c.1] = Pr[(fun z : α × α => z.2 = x) | c.1] := by
+    refine probEvent_ext (mx := c.1) fun z hz => ?_
+    have hzEq : z.1 = z.2 := hc z hz; grind
+  grind only [= probOutput_fst_map_eq_probEvent, = probOutput_snd_map_eq_probEvent]
 
 /-- Equality-relation relational triples imply equality of evaluation distributions. -/
 lemma evalDist_eq_of_relTriple_eqRel {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ α}

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -36,6 +36,7 @@ indicator R      1-ε, indicator R    1, indicator(=)
 ```
 -/
 
+set_option linter.style.openClassical false
 open scoped Classical
 open ENNReal OracleSpec OracleComp
 
@@ -70,7 +71,7 @@ private lemma coupling_tsum_probOutput_eq_one
 private lemma spmf_bind_const_of_no_failure {p : SPMF α} (hp : Pr[⊥ | p] = 0) (q : SPMF β) :
     (p >>= fun _ => q) = q := by
   apply SPMF.ext; intro y
-  show Pr[= y | p >>= fun _ => q] = Pr[= y | q]
+  change Pr[= y | p >>= fun _ => q] = Pr[= y | q]
   rw [probOutput_bind_eq_tsum, ENNReal.tsum_mul_right, tsum_probOutput_eq_sub, hp,
     tsub_zero, one_mul]
 
@@ -85,18 +86,19 @@ private lemma nonempty_spmf_coupling
     change (evalDist ob).toPMF none = 0; exact probFailure_eq_zero (mx := ob)
   let c : SPMF (α × β) := p >>= fun (a : α) => q >>= fun (b : β) => pure (a, b)
   refine ⟨⟨c, ?_, ?_⟩⟩
-  · show Prod.fst <$> c = p
+  · change Prod.fst <$> c = p
     simp only [c, map_bind, map_pure]
     conv_rhs => rw [← bind_pure p]
     congr 1; funext a
     exact spmf_bind_const_of_no_failure hq (pure a)
-  · show Prod.snd <$> c = q
+  · change Prod.snd <$> c = q
     simp only [c, map_bind, map_pure]
     have : (fun (_ : α) => q >>= fun (b : β) => pure b) = fun _ => q := by
       funext _; exact bind_pure q
     rw [this]
     exact spmf_bind_const_of_no_failure hp q
 
+set_option linter.unusedDecidableInType false
 -- TODO: move to ToMathlib
 private lemma Finset_sum_iSup_le_iSup_sum {ι : Type*} {J : ι → Type*}
     [DecidableEq ι] [hne : ∀ i, Nonempty (J i)]
@@ -261,7 +263,7 @@ theorem relTriple'_iff_couplingPost
               Pr[fun z : A × B => R z.1.1 z.2.1 | (c.1 : SPMF (A × B))] := by
         intro c
         rw [probEvent_eq_tsum_ite, tsum_option _ ENNReal.summable]
-        simp [fSub, RelPost.indicator]
+        simp only [RelPost.indicator, mul_zero, mul_ite, mul_one, tsum_fintype, zero_add, fSub]
         refine Finset.sum_congr rfl ?_
         intro x hx
         by_cases hR : R x.1.1 x.2.1
@@ -338,7 +340,6 @@ theorem relTriple'_iff_couplingPost
                 simp [packPair]
               _ = packB <$> evalDist ob := by rw [c.2.map_snd]
               _ = pb := rfl⟩
-
         calc
           ∑' z, Pr[= z | c.1] * RelPost.indicator R z.1 z.2
               = Pr[fun z : α × β => R z.1 z.2 | c.1] := by
@@ -401,7 +402,7 @@ theorem eRelTriple_pure (a : α) (b : β) (post : α → β → ℝ≥0∞) :
   unfold eRelTriple eRelWP
   have hc : SPMF.IsCoupling (pure (a, b) : SPMF (α × β))
       (evalDist (pure a : OracleComp spec₁ α)) (evalDist (pure b : OracleComp spec₂ β)) := by
-    simp [evalDist_pure]; exact SPMF.IsCoupling.pure_iff.mpr rfl
+    simpa only [evalDist_pure] using SPMF.IsCoupling.pure_iff.mpr rfl
   apply le_iSup_of_le ⟨pure (a, b), hc⟩
   have key : ∑' z, Pr[= z | (pure (a, b) : SPMF (α × β))] * post z.1 z.2 = post a b := by
     rw [tsum_eq_single (a, b)]
@@ -439,7 +440,7 @@ theorem eRelTriple_bind
     eRelTriple pre (oa >>= fa) (ob >>= fb) post := by
   have hstep : eRelTriple pre oa ob (fun a b => eRelWP (fa a) (fb b) post) :=
     eRelTriple_conseq le_rfl (fun a b => hfg a b) hxy
-  show pre ≤ eRelWP (oa >>= fa) (ob >>= fb) post
+  change pre ≤ eRelWP (oa >>= fa) (ob >>= fb) post
   refine le_trans hstep ?_
   show eRelWP oa ob (fun a b => eRelWP (fa a) (fb b) post) ≤
     eRelWP (oa >>= fa) (ob >>= fb) post
@@ -627,18 +628,18 @@ private lemma tsum_min_le_eRelWP
     | some (a, b) => (if a = b then min (P a) (Q a) else 0) + rP a * rQ b * δ⁻¹
   have hfst_sum : ∀ a, ∑' b, cf (some (a, b)) = P a := by
     intro a
-    show ∑' b, ((if a = b then min (P a) (Q a) else 0) + rP a * rQ b * δ⁻¹) = P a
+    change ∑' b, ((if a = b then min (P a) (Q a) else 0) + rP a * rQ b * δ⁻¹) = P a
     rw [ENNReal.tsum_add]
     rw [tsum_eq_single a (fun b hb => if_neg (Ne.symm hb))]
     simp only [ite_true]
     simp_rw [show ∀ b, rP a * rQ b * δ⁻¹ = (rP a * δ⁻¹) * rQ b
         from fun b => mul_right_comm _ _ _]
     rw [ENNReal.tsum_mul_left, hδ_eq_rQ, mul_assoc, mul_comm δ⁻¹ δ, hmul_δ]
-    show min (P a) (Q a) + (P a - min (P a) (Q a)) = P a
+    change min (P a) (Q a) + (P a - min (P a) (Q a)) = P a
     exact add_tsub_cancel_of_le (min_le_left _ _)
   have hsnd_sum : ∀ b, ∑' a, cf (some (a, b)) = Q b := by
     intro b
-    show ∑' a, ((if a = b then min (P a) (Q a) else 0) + rP a * rQ b * δ⁻¹) = Q b
+    change ∑' a, ((if a = b then min (P a) (Q a) else 0) + rP a * rQ b * δ⁻¹) = Q b
     rw [ENNReal.tsum_add]
     conv_lhs => arg 1; rw [show
       (fun a => if a = b then min (P a) (Q a) else (0 : ℝ≥0∞)) =
@@ -657,7 +658,7 @@ private lemma tsum_min_le_eRelWP
         simp only [hrQ0, zero_mul]
       · rw [mul_assoc, ENNReal.inv_mul_cancel hδ0 hδ_ne_top, mul_one]
     rw [htsum_rQ]
-    show min (Q b) (P b) + (Q b - min (Q b) (P b)) = Q b
+    change min (Q b) (P b) + (Q b - min (Q b) (P b)) = Q b
     exact add_tsub_cancel_of_le (min_le_left _ _)
   have hcf_sum : ∑' x, cf x = 1 := by
     rw [tsum_option _ ENNReal.summable, show cf none = 0 from rfl, zero_add]
@@ -674,7 +675,7 @@ private lemma tsum_min_le_eRelWP
     apply SPMF.ext; intro a
     rw [show (Prod.fst <$> c_spmf) a = Pr[= a | Prod.fst <$> c_spmf] from rfl,
       probOutput_map_eq_tsum_ite c_spmf Prod.fst a]
-    show ∑' z : α × α, (if a = z.1 then cf (some z) else 0) = P a
+    change ∑' z : α × α, (if a = z.1 then cf (some z) else 0) = P a
     rw [ENNReal.tsum_prod']; dsimp only [Prod.fst]
     simp_rw [hite_tsum]
     rw [tsum_eq_single a (fun a' (ha' : a' ≠ a) => if_neg (Ne.symm ha'))]
@@ -683,7 +684,7 @@ private lemma tsum_min_le_eRelWP
     apply SPMF.ext; intro b
     rw [show (Prod.snd <$> c_spmf) b = Pr[= b | Prod.snd <$> c_spmf] from rfl,
       probOutput_map_eq_tsum_ite c_spmf Prod.snd b]
-    show ∑' z : α × α, (if b = z.2 then cf (some z) else 0) = Q b
+    change ∑' z : α × α, (if b = z.2 then cf (some z) else 0) = Q b
     rw [ENNReal.tsum_prod', ENNReal.tsum_comm]; dsimp only [Prod.snd]
     simp_rw [hite_tsum]
     rw [tsum_eq_single b (fun b' (hb' : b' ≠ b) => if_neg (Ne.symm hb'))]
@@ -699,7 +700,7 @@ private lemma tsum_min_le_eRelWP
     · simp [RelPost.indicator, EqRel, Ne.symm hb]
   calc ∑' a, min (P a) (Q a)
       ≤ ∑' a, cf (some (a, a)) := ENNReal.tsum_le_tsum fun a => by
-        show min (P a) (Q a) ≤ (if a = a then min (P a) (Q a) else 0) + _
+        change min (P a) (Q a) ≤ (if a = a then min (P a) (Q a) else 0) + _
         simp
     _ = ∑' z : α × α, Pr[= z | c.1] * RelPost.indicator (EqRel α) z.1 z.2 :=
         hobj_eq.symm

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -63,7 +63,8 @@ theorem relTriple_simulateQ_run
       MAlgRelOrdered.relWP_pure, true_and]
     exact hs
   | query_bind t oa ih =>
-    simp [StateT.run_bind]
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind, relTriple_iff_relWP, relWP_iff_couplingPost]
     exact (relTriple_bind (himpl t s₁ s₂ hs) (fun ⟨u₁, s₁'⟩ ⟨u₂, s₂'⟩ ⟨eq_u, hs'⟩ => by
       dsimp at eq_u hs' ⊢; subst eq_u; exact ih u₁ s₁' s₂' hs')) trivial
 
@@ -332,7 +333,7 @@ variable [spec.Fintype] [spec.Inhabited]
 private lemma probOutput_simulateQ_run_eq_zero_of_bad
     {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
     (impl : QueryImpl spec (StateT σ (OracleComp spec)))
-    (bad : σ → Prop) [DecidablePred bad]
+    (bad : σ → Prop)
     (h_mono : ∀ (t : spec.Domain) (s : σ), bad s →
       ∀ x ∈ support ((impl t).run s), bad x.2)
     (oa : OracleComp spec α) (s₀ : σ) (h_bad : bad s₀)
@@ -342,19 +343,21 @@ private lemma probOutput_simulateQ_run_eq_zero_of_bad
   | pure a =>
     rw [simulateQ_pure]
     show Pr[= (x, s) | (pure a : StateT σ (OracleComp spec) α).run s₀] = 0
-    simp [Prod.ext_iff]
+    simp only [StateT.run_pure, probOutput_eq_zero_iff, support_pure, Set.mem_singleton_iff,
+      Prod.ext_iff, not_and]
     rintro rfl rfl
     exact hs h_bad
   | query_bind t oa ih =>
-    simp [StateT.run_bind]
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind, probOutput_eq_zero_iff, support_bind, Set.mem_iUnion, exists_prop,
+      Prod.exists, not_exists, not_and]
     intro u s' h_mem
     rw [← probOutput_eq_zero_iff]
     exact ih u s' (h_mono t s₀ h_bad (u, s') h_mem)
 
 private lemma probOutput_simulateQ_run_eq_of_not_bad
     {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
-    (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
-    (bad : σ → Prop) [DecidablePred bad]
+    (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec))) (bad : σ → Prop)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →
       (impl₁ t).run s = (impl₂ t).run s)
     (h_mono₁ : ∀ (t : spec.Domain) (s : σ), bad s →
@@ -374,14 +377,15 @@ private lemma probOutput_simulateQ_run_eq_of_not_bad
     by_cases h_bad : bad s₀
     · rw [probOutput_simulateQ_run_eq_zero_of_bad impl₁ bad h_mono₁ _ s₀ h_bad x s hs,
           probOutput_simulateQ_run_eq_zero_of_bad impl₂ bad h_mono₂ _ s₀ h_bad x s hs]
-    · simp [StateT.run_bind]
+    · simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind]
       rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum, h_agree t s₀ h_bad]
       exact tsum_congr (fun ⟨u, s'⟩ => by congr 1; exact ih u s')
 
 private lemma probEvent_not_bad_eq
     {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
-    (bad : σ → Prop) [DecidablePred bad]
+    (bad : σ → Prop)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →
       (impl₁ t).run s = (impl₂ t).run s)
     (h_mono₁ : ∀ (t : spec.Domain) (s : σ), bad s →
@@ -391,6 +395,7 @@ private lemma probEvent_not_bad_eq
     (oa : OracleComp spec α) (s₀ : σ) :
     Pr[fun x => ¬bad x.2 | (simulateQ impl₁ oa).run s₀] =
     Pr[fun x => ¬bad x.2 | (simulateQ impl₂ oa).run s₀] := by
+  classical
   rw [probEvent_eq_tsum_ite, probEvent_eq_tsum_ite]
   refine tsum_congr (fun ⟨a, s⟩ => ?_)
   split_ifs with h
@@ -401,7 +406,7 @@ private lemma probEvent_not_bad_eq
 private lemma probEvent_bad_eq
     {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
-    (bad : σ → Prop) [DecidablePred bad]
+    (bad : σ → Prop)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →
       (impl₁ t).run s = (impl₂ t).run s)
     (h_mono₁ : ∀ (t : spec.Domain) (s : σ), bad s →
@@ -443,7 +448,7 @@ bad-to-non-bad transitions in each implementation independently. -/
 theorem tvDist_simulateQ_le_probEvent_bad
     {σ : Type}
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
-    (bad : σ → Prop) [DecidablePred bad]
+    (bad : σ → Prop)
     (oa : OracleComp spec α) (s₀ : σ)
     (h_init : ¬bad s₀)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →

--- a/VCVio/ProgramLogic/Unary/HoareTriple.lean
+++ b/VCVio/ProgramLogic/Unary/HoareTriple.lean
@@ -157,7 +157,7 @@ theorem wp_mono (oa : OracleComp spec α) {post post' : α → ℝ≥0∞}
 @[game_rule] theorem wp_map
     (f : α → β) (oa : OracleComp spec α) (post : β → ℝ≥0∞) :
     wp (f <$> oa) post = wp oa (post ∘ f) := by
-  show wp (oa >>= fun a => pure (f a)) post = wp oa (post ∘ f)
+  change wp (oa >>= fun a => pure (f a)) post = wp oa (post ∘ f)
   rw [wp_bind]
   congr 1
   funext a
@@ -166,7 +166,7 @@ theorem wp_mono (oa : OracleComp spec α) {post post' : α → ℝ≥0∞}
 /-- General unfolding: `wp` as weighted sum over output probabilities. -/
 theorem wp_eq_tsum (oa : OracleComp spec α) (post : α → ℝ≥0∞) :
     wp oa post = ∑' x, Pr[= x | oa] * post x := by
-  show μ (oa >>= fun a => pure (post a)) = _
+  change μ (oa >>= fun a => pure (post a)) = _
   rw [μ_bind_eq_tsum]
   refine tsum_congr fun x => ?_
   have : μ (pure (post x) : OracleComp spec ℝ≥0∞) = post x := by
@@ -209,7 +209,7 @@ theorem triple_bind_wp {pre : ℝ≥0∞} {oa : OracleComp spec α}
     {ob : α → OracleComp spec β} {post : β → ℝ≥0∞}
     (h : Triple (spec := spec) pre oa (fun x => wp (ob x) post)) :
     Triple pre (oa >>= ob) post := by
-  show pre ≤ wp (oa >>= ob) post
+  change pre ≤ wp (oa >>= ob) post
   rw [wp_bind]; exact h
 
 theorem triple_pure (x : α) (post : α → ℝ≥0∞) :
@@ -335,14 +335,14 @@ theorem triple_probOutput_indicator (oa : OracleComp spec α) [DecidableEq α] (
 theorem le_probEvent_iff_triple_indicator (oa : OracleComp spec α) (p : α → Prop)
     [DecidablePred p] (r : ℝ≥0∞) :
     r ≤ Pr[p | oa] ↔ Triple (spec := spec) r oa (fun x => if p x then 1 else 0) := by
-  show r ≤ Pr[p | oa] ↔ r ≤ wp oa (fun x => if p x then 1 else 0)
+  change r ≤ Pr[p | oa] ↔ r ≤ wp oa (fun x => if p x then 1 else 0)
   rw [probEvent_eq_wp_indicator]
 
 /-- Lower bounds on `probOutput` are exactly singleton-indicator triples. -/
 theorem le_probOutput_iff_triple_indicator (oa : OracleComp spec α) [DecidableEq α]
     (x : α) (r : ℝ≥0∞) :
     r ≤ Pr[= x | oa] ↔ Triple (spec := spec) r oa (fun y => if y = x then 1 else 0) := by
-  show r ≤ Pr[= x | oa] ↔ r ≤ wp oa (fun y => if y = x then 1 else 0)
+  change r ≤ Pr[= x | oa] ↔ r ≤ wp oa (fun y => if y = x then 1 else 0)
   rw [probOutput_eq_wp_indicator]
 
 /-- The support event of an `OracleComp` occurs almost surely. -/
@@ -389,21 +389,21 @@ theorem triple_replicate_succ {pre : ℝ≥0∞} {oa : OracleComp spec α} {n : 
     {post : List α → ℝ≥0∞}
     (h : Triple pre oa (fun x => wp (oa.replicate n) (fun xs => post (x :: xs)))) :
     Triple pre (oa.replicate (n + 1)) post := by
-  show pre ≤ wp (oa.replicate (n + 1)) post
+  change pre ≤ wp (oa.replicate (n + 1)) post
   rw [wp_replicate_succ]; exact h
 
 theorem triple_list_mapM_cons {pre : ℝ≥0∞} {x : α} {xs : List α}
     {f : α → OracleComp spec β} {post : List β → ℝ≥0∞}
     (h : Triple pre (f x) (fun y => wp (xs.mapM f) (fun ys => post (y :: ys)))) :
     Triple pre ((x :: xs).mapM f) post := by
-  show pre ≤ wp ((x :: xs).mapM f) post
+  change pre ≤ wp ((x :: xs).mapM f) post
   rw [wp_list_mapM_cons]; exact h
 
 theorem triple_list_foldlM_cons {pre : ℝ≥0∞} {x : α} {xs : List α}
     {f : σ → α → OracleComp spec σ} {init : σ} {post : σ → ℝ≥0∞}
     (h : Triple pre (f init x) (fun s => wp (xs.foldlM f s) post)) :
     Triple pre ((x :: xs).foldlM f init) post := by
-  show pre ≤ wp ((x :: xs).foldlM f init) post
+  change pre ≤ wp ((x :: xs).foldlM f init) post
   rw [wp_list_foldlM_cons]; exact h
 
 /-! ## Loop invariant rules -/
@@ -474,7 +474,7 @@ theorem triple_list_mapM {I : ℝ≥0∞}
 lemma probOutput_congr_evalDist {oa ob : OracleComp spec α}
     (h : evalDist oa = evalDist ob) (x : α) :
     Pr[= x | oa] = Pr[= x | ob] := by
-  show evalDist oa x = evalDist ob x
+  change evalDist oa x = evalDist ob x
   rw [h]
 
 lemma μ_congr_evalDist {oa ob : OracleComp spec ℝ≥0∞}
@@ -486,7 +486,7 @@ lemma μ_congr_evalDist {oa ob : OracleComp spec ℝ≥0∞}
 lemma wp_congr_evalDist {oa ob : OracleComp spec α}
     (h : evalDist oa = evalDist ob) (post : α → ℝ≥0∞) :
     wp oa post = wp ob post := by
-  show μ (oa >>= fun a => pure (post a)) = μ (ob >>= fun a => pure (post a))
+  change μ (oa >>= fun a => pure (post a)) = μ (ob >>= fun a => pure (post a))
   exact μ_congr_evalDist (by simp [h])
 
 lemma μ_cross_congr_evalDist {ι' : Type*} {spec' : OracleSpec ι'}
@@ -496,7 +496,7 @@ lemma μ_cross_congr_evalDist {ι' : Type*} {spec' : OracleSpec ι'}
     @μ _ spec' _ _ oa = μ ob := by
   simp only [μ]
   exact tsum_congr fun x => by
-    show evalDist oa x * x = evalDist ob x * x
+    change evalDist oa x * x = evalDist ob x * x
     rw [h]
 
 end OracleComp.ProgramLogic

--- a/VCVio/ProgramLogic/Unary/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Unary/SimulateQ.lean
@@ -56,7 +56,7 @@ then `wp` of the simulated computation equals `wp` of the original. -/
     [h : spec ⊂ₒ superSpec] [LawfulSubSpec spec superSpec]
     (mx : OracleComp spec α) (post : α → ℝ≥0∞) :
     wp (liftComp mx superSpec) post = wp mx post := by
-  show @μ _ superSpec _ _ (liftComp mx superSpec >>= fun a => pure (post a)) =
+  change @μ _ superSpec _ _ (liftComp mx superSpec >>= fun a => pure (post a)) =
        μ (mx >>= fun a => pure (post a))
   exact μ_cross_congr_evalDist
     (by simp only [evalDist_bind, evalDist_liftComp, evalDist_pure])

--- a/docs/agents/crypto.md
+++ b/docs/agents/crypto.md
@@ -174,7 +174,7 @@ Defined in `VCVio/CryptoFoundations/Asymptotics/`.
 ### Negligible functions (`Negligible.lean`)
 
 ```lean
-def negligible (f : ℕ → ℝ≥0∞) : Prop := SuperpolynomialDecay atTop (λ x ↦ ↑x) f
+def negligible (f : ℕ → ℝ≥0∞) : Prop := SuperpolynomialDecay atTop (fun x ↦ ↑x) f
 ```
 
 Closure properties: `negligible_add`, `negligible_const_mul`, `negligible_sum`,

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,8 @@ package VCVio where
     ⟨`autoImplicit, false⟩,
     ⟨`relaxedAutoImplicit, false⟩,
     ⟨`weak.linter.mathlibStandardSet, true⟩,
-    ⟨`weak.linter.style.whitespace, false⟩ -- causes too many false positives with notation]
+    ⟨`linter.modulesUpperCamelCase, false⟩, -- not good with a lot of common crypto abbreviations
+    ⟨`weak.linter.style.whitespace, false⟩ -- causes too many false positives with notation
   ]
 
 require "leanprover-community" / "mathlib" @ git "v4.28.0"

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -4,18 +4,8 @@ open Lake DSL
 -- TODO: update linters and remove all errors in library
 -- should probably adopt conventions similar to `Batteries`.
 abbrev vcvLinters : Array LeanOption := #[
-  -- ⟨`linter.docPrime, true⟩,
-  ⟨`linter.hashCommand, true⟩,
-  ⟨`linter.oldObtain, true,⟩,
-  ⟨`linter.refine, true⟩,
-  ⟨`linter.style.cdot, true⟩,
-  ⟨`linter.style.dollarSyntax, true⟩,
-  ⟨`linter.style.longLine, false⟩, -- temp
-  ⟨`linter.style.longFile, .ofNat 1500⟩,
-  ⟨`linter.pythonStyle, false⟩,
-  ⟨`linter.modulesUpperCamelCase, false⟩,
-  ⟨`linter.style.missingEnd, true⟩,
-  ⟨`linter.style.setOption, true⟩
+  ⟨`linter.mathlibStandardSet, true⟩,
+  ⟨`linter.style.whitespace, false⟩ -- causes too many false positives with notation
 ]
 
 package VCVio where

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -1,35 +1,26 @@
 import Lake
 open Lake DSL
 
--- TODO: update linters and remove all errors in library
--- should probably adopt conventions similar to `Batteries`.
-abbrev vcvLinters : Array LeanOption := #[
-  ⟨`linter.mathlibStandardSet, true⟩,
-  ⟨`linter.style.whitespace, false⟩ -- causes too many false positives with notation
-]
-
 package VCVio where
   -- Settings applied to both builds and interactive editing
   leanOptions := #[
     ⟨`pp.unicode.fun, true⟩, -- pretty-prints `fun a ↦ b`
     ⟨`pp.proofs.withType, false⟩,
     ⟨`autoImplicit, false⟩,
-    ⟨`relaxedAutoImplicit, false⟩]
-    ++ vcvLinters.map fun s ↦
-      { s with name := `weak ++ s.name }
+    ⟨`relaxedAutoImplicit, false⟩,
+    ⟨`weak.linter.mathlibStandardSet, true⟩,
+    ⟨`weak.linter.style.whitespace, false⟩ -- causes too many false positives with notation]
+  ]
 
 require "leanprover-community" / "mathlib" @ git "v4.28.0"
 
 /-- Main library. -/
-@[default_target]
-lean_lib VCVio
+@[default_target] lean_lib VCVio
 
 /-- Example constructions of cryptographic primitives. -/
 lean_lib Examples
-
 /-- Optional proof widget experiments and visualizations. -/
 lean_lib VCVioWidgets
-
 /-- Seperate section of the project for things that should be ported. -/
 lean_lib ToMathlib
 

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -9,7 +9,7 @@ package VCVio where
     ⟨`autoImplicit, false⟩,
     ⟨`relaxedAutoImplicit, false⟩,
     ⟨`weak.linter.mathlibStandardSet, true⟩,
-    ⟨`linter.modulesUpperCamelCase, false⟩, -- not good with a lot of common crypto abbreviations
+    ⟨`weak.linter.modulesUpperCamelCase, false⟩, -- not good with a lot of common crypto abbreviations
     ⟨`weak.linter.style.whitespace, false⟩ -- causes too many false positives with notation
   ]
 


### PR DESCRIPTION
Enables a stronger `weak.linter.mathlibStandardSet` than the previous custom list of lints, and fixes all corresponding warnings that arise.

Probably the biggest gain from this is much better discipline about unneeded `DecidableEq`/`Fintype` instances. Using `simp only` should also be much more stable in longer AI generated proofs.