### PR TITLE
Fill 8 sorry's with Aristotle proofs (Encoding + Ring.Smoke)

### DIFF
--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -34,21 +34,22 @@ private def packByte (bits : Fin 8 → Nat) : UInt8 :=
   (Nat.ofDigits 2 (List.ofFn bits)).toUInt8
 
 -- These finite bit-twiddling identities are auxiliary byte-level facts.
+set_option maxRecDepth 100000 in
 private theorem bitOf_packByte_fin :
     ∀ bits : Fin 8 → Fin 2, ∀ j : Fin 8,
       bitOf (packByte fun i => (bits i).val) j.val = (bits j).val := by
-  sorry
+  decide
 
 private theorem bitOf_lt_two_fin_aux :
     ∀ n : Fin (2 ^ 8), ∀ j : Fin 8, bitOf n.val.toUInt8 j.val < 2 := by
-  sorry
+  native_decide
 
 private theorem bitOf_lt_two_fin (b : UInt8) (j : Fin 8) : bitOf b j.val < 2 := by
   simpa using bitOf_lt_two_fin_aux ⟨b.toNat, UInt8.toNat_lt b⟩ j
 
 private theorem packByte_bitOf_fin :
     ∀ n : Fin (2 ^ 8), packByte (fun j => bitOf n.val.toUInt8 j.val) = n.val.toUInt8 := by
-  sorry
+  native_decide
 
 private theorem packByte_bitOf_byte (b : UInt8) :
     packByte (fun j => bitOf b j.val) = b := by
@@ -196,7 +197,7 @@ private theorem digitsAppend_getD_two_lt {d n bit : Nat} (hn : n < 2 ^ d) (hbit 
 
 private theorem digitsAppend_two_one_getD_zero :
     ∀ n : Fin 2, (Nat.digitsAppend 2 1 n.val).getD 0 0 = n.val := by
-  sorry
+  decide
 
 private theorem digitsAppend_two_one_getD_zero_mod (n : Nat) :
     (Nat.digitsAppend 2 1 (n % 2 ^ 1)).getD 0 0 = n % 2 := by

--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -34,22 +34,28 @@ private def packByte (bits : Fin 8 → Nat) : UInt8 :=
   (Nat.ofDigits 2 (List.ofFn bits)).toUInt8
 
 -- These finite bit-twiddling identities are auxiliary byte-level facts.
-set_option maxRecDepth 100000 in
+set_option maxRecDepth 1200 in
 private theorem bitOf_packByte_fin :
     ∀ bits : Fin 8 → Fin 2, ∀ j : Fin 8,
       bitOf (packByte fun i => (bits i).val) j.val = (bits j).val := by
-  decide
+  intro bits j; fin_cases j <;> revert bits <;> decide
+
+private theorem bitOf_lt_two (b : UInt8) (j : Nat) : bitOf b j < 2 := by
+  unfold bitOf
+  rw [UInt8.toNat_and, show (1 : UInt8).toNat = 1 from rfl,
+      show (2 : ℕ) = 2 ^ 1 from rfl]
+  exact Nat.and_lt_two_pow _ (by norm_num)
 
 private theorem bitOf_lt_two_fin_aux :
     ∀ n : Fin (2 ^ 8), ∀ j : Fin 8, bitOf n.val.toUInt8 j.val < 2 := by
-  native_decide
+  intro _ _; exact bitOf_lt_two _ _
 
-private theorem bitOf_lt_two_fin (b : UInt8) (j : Fin 8) : bitOf b j.val < 2 := by
-  simpa using bitOf_lt_two_fin_aux ⟨b.toNat, UInt8.toNat_lt b⟩ j
+private theorem bitOf_lt_two_fin (b : UInt8) (j : Fin 8) : bitOf b j.val < 2 :=
+  bitOf_lt_two b j.val
 
 private theorem packByte_bitOf_fin :
     ∀ n : Fin (2 ^ 8), packByte (fun j => bitOf n.val.toUInt8 j.val) = n.val.toUInt8 := by
-  native_decide
+  intro n; fin_cases n <;> rfl
 
 private theorem packByte_bitOf_byte (b : UInt8) :
     packByte (fun j => bitOf b j.val) = b := by

--- a/LatticeCrypto/Ring/Smoke.lean
+++ b/LatticeCrypto/Ring/Smoke.lean
@@ -75,16 +75,20 @@ noncomputable def piSemantics (Coeff : Type*) [CommRing Coeff] (n : Nat) :
     NegacyclicRingSemantics (piRing Coeff n) where
   quotientOf := NegacyclicQuotient.ofBackend (piBackend Coeff n)
   zero_sound := by
-    sorry
+    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
+    simp [piBackend, piRing, Finset.sum_const_zero, map_zero]
   add_sound := by
     intro f g
-    sorry
+    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
+    simp only [piBackend, piRing, Finset.sum_add_distrib, map_add]
   sub_sound := by
     intro f g
-    sorry
+    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
+    simp only [piBackend, piRing, Finset.sum_sub_distrib, map_sub]
   neg_sound := by
     intro f
-    sorry
+    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
+    simp only [piBackend, piRing, Finset.sum_neg_distrib, map_neg]
   mul_sound := by
     intro f g
     sorry


### PR DESCRIPTION
## Summary
- Replace 4 sorry's in `LatticeCrypto/MLKEM/Concrete/Encoding.lean` with kernel-safe proofs for byte-level bit-twiddling lemmas (`bitOf_packByte_fin`, `bitOf_lt_two_fin_aux`, `packByte_bitOf_fin`, `digitsAppend_two_one_getD_zero`)
- Replace 4 sorry's in `LatticeCrypto/Ring/Smoke.lean` with algebraic proofs for `piSemantics` additive fields (`zero_sound`, `add_sound`, `sub_sound`, `neg_sound`) via `unfold` + `simp` with `Finset.sum` lemmas
- `bitOf_lt_two` proved structurally via `UInt8.toNat_and` + `Nat.and_lt_two_pow` (no decide needed)
- `packByte_bitOf_fin` proved via `fin_cases n <;> rfl` (no native_decide)
- `bitOf_packByte_fin` proved via `fin_cases j <;> revert bits <;> decide` with `maxRecDepth 1200` (down from 100000)

Proofs generated by [Aristotle](https://aristotle.harmonic.fun) (Harmonic), audited, applied, and improved.

Closes #209, closes #210, closes #211, closes #212

## Test plan
- [x] `lake build LatticeCrypto.MLKEM.Concrete.Encoding` passes
- [x] `lake build LatticeCrypto.Ring.Smoke` passes
- [ ] CI build passes

*This PR was authored by Claude Opus 4.6 on behalf of Quang Dao, applying proofs from Harmonic's Aristotle API.*