### PR TITLE
Prove useHint norm bound and hint recovery composition

### DIFF
--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -1861,7 +1861,20 @@ theorem concreteRounding_useHint_correct_of_isApproved (p : Params)
 theorem concreteRounding_useHint_bound_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) (h : Hint) :
     LatticeCrypto.cInfNorm (r - highBitsShift p (useHint p h r)) ≤ 2 * p.gamma2 + 1 := by
-  sorry
+  apply LatticeCrypto.cInfNorm_le_iff.mpr
+  intro j
+  have hcoeff : (r - highBitsShift p (useHint p h r)).get j =
+      r.get j -
+        (((2 * p.gamma2 : ℕ) : Coeff) *
+          (useHintCoeff (h.get j) (r.get j) p.gamma2 : Coeff)) := by
+    rw [Vector.get_eq_getElem, Vector.getElem_sub]
+    simp only [Vector.get_eq_getElem]
+    congr 1
+    have := highBitsShift_useHint_get p h r j
+    simp only [Vector.get_eq_getElem] at this
+    exact this
+  rw [hcoeff]
+  exact useHintCoeff_shift_sub_bound_of_isApproved p hp (h.get j) (r.get j)
 
 theorem concreteRounding_hide_low_of_isApproved (p : Params)
     (hp : p.isApproved) (r s : Rq) (b : ℕ) :

--- a/LatticeCrypto/MLDSA/Signature.lean
+++ b/LatticeCrypto/MLDSA/Signature.lean
@@ -143,6 +143,21 @@ private lemma rq_add_neg_cancel (a b : Rq) : a + b + (-b) = a := by
   show ((coeffRing.add (coeffRing.add a b) (coeffRing.neg b)) : Rq).get ⟨i, hi⟩ = a.get ⟨i, hi⟩
   simp [add_neg_cancel_right]
 
+private lemma neg_rq_get (f : Rq) (i : Fin ringDegree) : (-f).get i = -(f.get i) := by
+  change (coeffRing.neg f).get i = _
+  simp [LatticeCrypto.vectorNegacyclicRing, Vector.get_ofFn]
+
+private lemma polyNorm_neg (f : Rq) : polyNorm (-f) = polyNorm f := by
+  unfold polyNorm normOps
+  simp only [LatticeCrypto.zmodPolyNormOps, LatticeCrypto.normOpsOfCenteredView]
+  unfold LatticeCrypto.cInfNormOf
+  apply Finset.sup_congr rfl
+  intro i _
+  simp only [LatticeCrypto.zmodCenteredCoeffView, polyBackend,
+    LatticeCrypto.vectorNegacyclicRing, LatticeCrypto.vectorBackend]
+  rw [neg_rq_get]
+  exact LatticeCrypto.centeredRepr_natAbs_neg _
+
 /-! ### Correctness -/
 
 private lemma fipsSignLoop_exists
@@ -198,7 +213,13 @@ lemma useHint_makeHint_eq_highBits
     (h_s_bound : polyNorm s_j ≤ p.beta) :
     prims.useHint (prims.makeHint (-ct0_j) (r_j + ct0_j)) (r_j + ct0_j) =
       prims.highBits w_j := by
-  sorry
+  have h_neg_norm : polyNorm (-ct0_j) ≤ p.gamma2 := by
+    rw [polyNorm_neg]; exact h_norm_ct0
+  rw [h_useHint_makeHint (-ct0_j) (r_j + ct0_j) h_neg_norm]
+  rw [rq_add_neg_cancel r_j ct0_j]
+  have h2 : polyNorm (prims.lowBits r_j) + p.beta < p.gamma2 := by omega
+  rw [← h_hide_low r_j s_j p.beta h_s_bound h2]
+  rw [h_r_eq, rq_sub_add_cancel w_j s_j]
 
 /-- When all signing norm bounds hold, UseHint recovers the original commitment:
 `UseHintVec(MakeHintVec(-ct₀, w - cs₂ + ct₀), w - cs₂ + ct₀) = HighBitsVec(w)`.


### PR DESCRIPTION
## Summary
- Prove `concreteRounding_useHint_bound_of_isApproved` (Rounding.lean) — coefficient-wise reduction via `cInfNorm_le_iff` to existing `useHintCoeff_shift_sub_bound_of_isApproved`
- Prove `useHint_makeHint_eq_highBits` (Signature.lean) — 3-step rewrite: negate, cancel, hide-low
- Add helper lemmas `neg_rq_get` and `polyNorm_neg` for negation norm preservation

Closes #216, closes #221

Proofs generated by [Aristotle](https://aristotle.harmonic.fun) (Harmonic), audited and applied (no `set_option` overrides needed).

## Test plan
- [x] `lake build LatticeCrypto.MLDSA.Concrete.Rounding` passes
- [x] `lake build LatticeCrypto.MLDSA.Signature` passes
- [ ] CI build passes

*This PR was authored by Claude Opus 4.6 on behalf of Quang Dao, applying proofs from Harmonic's Aristotle API.*