### PR TITLE
Add DEM and KEM-DEM security games

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -7,6 +7,7 @@ import VCVio.CryptoFoundations.AsymmEncAlg.INDCPA.Oracle
 import VCVio.CryptoFoundations.Asymptotics.Negligible
 import VCVio.CryptoFoundations.Asymptotics.Security
 import VCVio.CryptoFoundations.CommitmentScheme
+import VCVio.CryptoFoundations.DataEncapMech
 import VCVio.CryptoFoundations.FiatShamir
 import VCVio.CryptoFoundations.FiatShamirWithAbort
 import VCVio.CryptoFoundations.Fischlin
@@ -21,6 +22,7 @@ import VCVio.CryptoFoundations.HardnessAssumptions.EntropySmoothing
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 import VCVio.CryptoFoundations.IdenSchemeWithAbort
+import VCVio.CryptoFoundations.KEMDEM
 import VCVio.CryptoFoundations.KeyEncapMech
 import VCVio.CryptoFoundations.PRF
 import VCVio.CryptoFoundations.PRG

--- a/VCVio/CryptoFoundations/DataEncapMech.lean
+++ b/VCVio/CryptoFoundations/DataEncapMech.lean
@@ -1,0 +1,88 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.ProbComp
+import VCVio.OracleComp.Coercions.SubSpec
+import VCVio.OracleComp.SimSemantics.Append
+
+/-!
+# Data Encapsulation Mechanisms
+
+This file defines monadic Data Encapsulation Mechanisms (DEMs), together with their basic
+correctness and IND-CPA security games.
+-/
+
+open OracleSpec OracleComp ENNReal
+
+universe u v
+
+/-- A data encapsulation mechanism with key space `K`, message space `M`, and ciphertext
+space `C`. -/
+structure DEMScheme (m : Type → Type u) (K M C : Type)
+    extends ExecutionMethod m where
+  keygen : m K
+  encrypt : K → M → m C
+  decrypt : K → C → m (Option M)
+
+namespace DEMScheme
+
+variable {m : Type → Type v} {K M C : Type}
+  (dem : DEMScheme m K M C)
+
+section Correct
+
+variable [DecidableEq M] [Monad m]
+
+/-- Correctness experiment: decrypting an honestly generated ciphertext should recover the
+original message. -/
+def CorrectExp (msg : M) : m Bool := do
+  let k ← dem.keygen
+  let c ← dem.encrypt k msg
+  let msg' ← dem.decrypt k c
+  return decide (msg' = some msg)
+
+/-- Perfect correctness of a DEM. -/
+def PerfectlyCorrect [HasEvalSPMF m] : Prop :=
+  ∀ msg, Pr[= true | dem.exec (dem.CorrectExp msg)] = 1
+
+end Correct
+
+section IND_CPA
+
+variable {ι : Type} {spec : OracleSpec ι}
+
+/-- Two-phase IND-CPA adversary for a DEM. The adversary first chooses two challenge messages,
+then distinguishes which one was encrypted. -/
+structure IND_CPA_Adversary (dem : DEMScheme (OracleComp spec) K M C) where
+  State : Type
+  chooseMessages : OracleComp spec (M × M × State)
+  distinguish : State → C → OracleComp spec Bool
+
+/-- IND-CPA real-or-random experiment for a DEM. -/
+def IND_CPA_Game {dem : DEMScheme (OracleComp spec) K M C}
+    (adversary : dem.IND_CPA_Adversary) : ProbComp Bool :=
+  dem.exec do
+    let b ← dem.lift_probComp ($ᵗ Bool)
+    let k ← dem.keygen
+    let (m₀, m₁, st) ← adversary.chooseMessages
+    let c ← dem.encrypt k (if b then m₀ else m₁)
+    let b' ← adversary.distinguish st c
+    return (b == b')
+
+/-- IND-CPA distinguishing advantage for a DEM. -/
+noncomputable def IND_CPA_Advantage {dem : DEMScheme (OracleComp spec) K M C}
+    (adversary : dem.IND_CPA_Adversary) : ℝ :=
+  (IND_CPA_Game adversary).boolBiasAdvantage
+
+/-- The IND-CPA advantage is definitionally the bias of the IND-CPA game. -/
+theorem IND_CPA_Advantage_eq_game_bias {dem : DEMScheme (OracleComp spec) K M C}
+    (adversary : dem.IND_CPA_Adversary) :
+    dem.IND_CPA_Advantage adversary = (dem.IND_CPA_Game adversary).boolBiasAdvantage := by
+  rfl
+
+end IND_CPA
+
+end DEMScheme

--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -1,0 +1,95 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.CryptoFoundations.KeyEncapMech
+import VCVio.CryptoFoundations.AsymmEncAlg.Defs
+
+/-!
+# KEM-DEM Composition
+
+This file defines a lightweight keyed DEM interface and shows that composing a perfectly
+correct KEM with a perfectly correct keyed DEM yields a perfectly correct asymmetric
+encryption scheme at the monadic probability level.
+-/
+
+open OracleSpec OracleComp ENNReal
+
+universe u
+
+/-- A keyed DEM with message space `M` and ciphertext space `C`. -/
+structure KeyedDEM (K M C : Type) where
+  encrypt : K → M → C
+  decrypt : K → C → Option M
+
+namespace KeyedDEM
+
+variable {K M C : Type}
+
+/-- A keyed DEM is perfectly correct when decrypting an encryption always recovers the message. -/
+def PerfectlyCorrect (dem : KeyedDEM K M C) : Prop :=
+  ∀ k msg, dem.decrypt k (dem.encrypt k msg) = some msg
+
+end KeyedDEM
+
+variable {m : Type → Type u} {K PK SK M C_kem C_dem : Type}
+
+/-- Compose a KEM with a keyed DEM to obtain an asymmetric encryption scheme. -/
+def composeWithDEM [Monad m]
+    (kem : KEMScheme m K PK SK C_kem) (dem : KeyedDEM K M C_dem) :
+    AsymmEncAlg m M PK SK (C_kem × C_dem) where
+  keygen := kem.keygen
+  encrypt := fun pk msg => do
+    let (c, k) ← kem.encaps pk
+    return (c, dem.encrypt k msg)
+  decrypt := fun sk ⟨c, ct⟩ => do
+    let kOpt ← kem.decaps sk c
+    match kOpt with
+    | some k => return (dem.decrypt k ct)
+    | none => return none
+  __ := kem.toExecutionMethod
+
+/-- From KEM correctness at the monadic probability level, every reachable decapsulation of an
+honest ciphertext returns the encapsulated key. -/
+private lemma kem_decaps_mem_support [Monad m] [DecidableEq K] [HasEvalSPMF m]
+    {kem : KEMScheme m K PK SK C_kem}
+    (hkem : Pr[=true | kem.CorrectExp] = 1)
+    {pk : PK} {sk : SK} (hks : (pk, sk) ∈ support kem.keygen)
+    {c : C_kem} {k : K} (hck : (c, k) ∈ support (kem.encaps pk))
+    {kOpt : Option K} (hkOpt : kOpt ∈ support (kem.decaps sk c)) :
+    kOpt = some k := by
+  have hsup : support kem.CorrectExp = {true} :=
+    (probOutput_eq_one_iff (mx := kem.CorrectExp) (x := true)).mp hkem |>.2
+  rw [KEMScheme.CorrectExp] at hsup
+  have : decide (kOpt = some k) ∈ ({true} : Set Bool) := by
+    rw [← hsup]
+    simp only [support_bind, support_pure, Set.mem_iUnion, Set.mem_singleton_iff,
+      decide_eq_decide, exists_prop, Prod.exists]
+    exact ⟨pk, sk, hks, c, k, hck, kOpt, hkOpt, Iff.rfl⟩
+  simpa using this
+
+/-- If a KEM and keyed DEM are perfectly correct, then their composition is perfectly correct at
+the monadic probability level. We work directly with `Pr` rather than the abstract `exec`
+interface, since the proof needs support-level facts about intermediate computations. -/
+theorem perfectlyCorrect_composeWithDEM [Monad m] [LawfulMonad m]
+    [DecidableEq M] [DecidableEq K] [HasEvalSPMF m]
+    {kem : KEMScheme m K PK SK C_kem} {dem : KeyedDEM K M C_dem}
+    (hkem : Pr[=true | kem.CorrectExp] = 1)
+    (hdem : dem.PerfectlyCorrect) :
+    ∀ msg, Pr[=true | (composeWithDEM kem dem).CorrectExp msg] = 1 := by
+  intro msg
+  simp only [AsymmEncAlg.CorrectExp, composeWithDEM]
+  rw [← hkem]
+  unfold KEMScheme.CorrectExp
+  simp only [bind_assoc]
+  apply probOutput_bind_congr
+  intro ⟨pk, sk⟩ hks
+  apply probOutput_bind_congr
+  intro ⟨c, k⟩ hck
+  simp only [pure_bind]
+  apply probOutput_bind_congr
+  intro kOpt hkOpt
+  have hkEq := kem_decaps_mem_support hkem hks hck hkOpt
+  subst hkEq
+  simp [hdem k msg]

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -96,4 +96,84 @@ noncomputable def IND_CCA_Advantage {kem : KEMScheme (OracleComp spec) K PK SK C
 
 end IND_CCA
 
+section IND_CPA
+
+variable {ι : Type} {spec : OracleSpec ι} [SampleableType K]
+
+/-- Two-phase IND-CPA adversary for a KEM. The adversary only gets access to the base oracle
+set `spec`, with no decapsulation oracle. -/
+structure IND_CPA_Adversary (kem : KEMScheme (OracleComp spec) K PK SK C) where
+  State : Type
+  preChallenge : PK → OracleComp spec State
+  postChallenge : State → C → K → OracleComp spec Bool
+
+/-- IND-CPA real-or-random experiment for a KEM. -/
+def IND_CPA_Game {kem : KEMScheme (OracleComp spec) K PK SK C}
+    (adversary : kem.IND_CPA_Adversary) : ProbComp Bool :=
+  kem.exec do
+    let (pk, _sk) ← kem.keygen
+    let st ← adversary.preChallenge pk
+    let b ← kem.lift_probComp ($ᵗ Bool)
+    let (cStar, kReal) ← kem.encaps pk
+    let kRand ← kem.lift_probComp ($ᵗ K)
+    let b' ← adversary.postChallenge st cStar (if b then kReal else kRand)
+    return (b == b')
+
+/-- IND-CPA distinguishing advantage for a KEM. -/
+noncomputable def IND_CPA_Advantage {kem : KEMScheme (OracleComp spec) K PK SK C}
+    (adversary : kem.IND_CPA_Adversary) : ℝ :=
+  (IND_CPA_Game adversary).boolBiasAdvantage
+
+/-- The IND-CPA advantage is definitionally the bias of the IND-CPA game. -/
+theorem IND_CPA_Advantage_eq_game_bias {kem : KEMScheme (OracleComp spec) K PK SK C}
+    (adversary : kem.IND_CPA_Adversary) :
+    IND_CPA_Advantage adversary = (IND_CPA_Game adversary).boolBiasAdvantage := by
+  rfl
+
+section ToINDCCA
+
+variable [DecidableEq C]
+
+/-- Trivial CPA-to-CCA embedding: lift the adversary's base-oracle queries into the combined
+oracle space without ever querying the decapsulation oracle. -/
+def IND_CPA_Adversary.toIND_CCA {kem : KEMScheme (OracleComp spec) K PK SK C}
+    (adversary : kem.IND_CPA_Adversary) : kem.IND_CCA_Adversary where
+  State := adversary.State
+  preChallenge pk := simulateQ
+    (show QueryImpl spec (OracleComp (spec + (C →ₒ Option K))) from
+      fun t => liftM (query (spec := spec) t))
+    (adversary.preChallenge pk)
+  postChallenge st c k := simulateQ
+    (show QueryImpl spec (OracleComp (spec + (C →ₒ Option K))) from
+      fun t => liftM (query (spec := spec) t))
+    (adversary.postChallenge st c k)
+
+/-- The IND-CPA game agrees with the IND-CCA game instantiated with the trivial CPA-to-CCA
+embedding, since the embedded adversary never queries the decapsulation oracle. -/
+theorem IND_CPA_Game_eq_IND_CCA_Game_toIND_CCA
+    {kem : KEMScheme (OracleComp spec) K PK SK C}
+    (adversary : kem.IND_CPA_Adversary) :
+    IND_CPA_Game adversary = IND_CCA_Game adversary.toIND_CCA := by
+  simp only [IND_CPA_Game, IND_CCA_Game, IND_CPA_Adversary.toIND_CCA,
+    IND_CCA_preChallengeImpl, IND_CCA_postChallengeImpl]
+  congr 1
+  simp only [← QueryImpl.simulateQ_compose]
+  have h : ∀ (impl₂ : QueryImpl (C →ₒ Option K) (OracleComp spec)),
+      (QueryImpl.ofLift spec (OracleComp spec) + impl₂) ∘ₛ
+        (fun t => liftM (query (spec := spec) t) :
+          QueryImpl spec (OracleComp (spec + (C →ₒ Option K)))) =
+      QueryImpl.id' spec := by
+    intro impl₂
+    ext t
+    simp only [QueryImpl.compose, QueryImpl.id']
+    change simulateQ (QueryImpl.id' spec + impl₂)
+      (liftM (liftM (OracleQuery.query (spec := spec) t) :
+        OracleQuery (spec + (C →ₒ Option K)) _)) = _
+    simp [simulateQ_query]
+  simp only [h, simulateQ_id']
+
+end ToINDCCA
+
+end IND_CPA
+
 end KEMScheme


### PR DESCRIPTION
## Summary
- add a monadic `DEMScheme` with correctness and IND-CPA definitions in `VCVio/CryptoFoundations/DataEncapMech.lean`
- extend `KEMScheme` with IND-CPA adversaries, the bias theorem, and the CPA-to-CCA comparison theorem in `VCVio/CryptoFoundations/KeyEncapMech.lean`
- add KEM-DEM composition and the `perfectlyCorrect_composeWithDEM` proof in `VCVio/CryptoFoundations/KEMDEM.lean`
- export the new modules from `VCVio.lean`

## Validation
- `lake env lean VCVio/CryptoFoundations/DataEncapMech.lean`
- `lake env lean VCVio/CryptoFoundations/KeyEncapMech.lean`
- `lake env lean VCVio/CryptoFoundations/KEMDEM.lean`
- `lake build`

Posted by Codex on behalf of Quang Dao. AI-authored with GPT-5.