### PR TITLE
Strengthen execution method semantics

### DIFF
--- a/VCVio/CryptoFoundations/AsymmEncAlg/Defs.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/Defs.lean
@@ -18,7 +18,7 @@ universe u v w
 /-- An `AsymmEncAlg` with message space `M`, key spaces `PK` and `SK`, and ciphertexts in `C`.
 `m` is the monad used to execute key generation, encryption, and decryption.
 It extends `ExecutionMethod m`, typically `ExecutionMethod.default`. -/
-structure AsymmEncAlg (m : Type → Type u) (M PK SK C : Type)
+structure AsymmEncAlg (m : Type → Type u) [Monad m] (M PK SK C : Type)
     extends ExecutionMethod m where
   keygen : m (PK × SK)
   encrypt : (pk : PK) → (msg : M) →  m C
@@ -29,7 +29,7 @@ structure AsymmEncAlg (m : Type → Type u) (M PK SK C : Type)
 Key generation runs in `m`, while encryption and decryption become pure once the randomness type
 `R` is supplied explicitly. This is the natural refinement used by FO-style transforms, where the
 coins are sampled externally or derived from an oracle. -/
-structure AsymmEncAlg.ExplicitCoins (m : Type → Type u) (M PK SK R C : Type)
+structure AsymmEncAlg.ExplicitCoins (m : Type → Type u) [Monad m] (M PK SK R C : Type)
     extends ExecutionMethod m where
   keygen : m (PK × SK)
   encrypt : (pk : PK) → (msg : M) → (coins : R) → C
@@ -39,12 +39,12 @@ abbrev PKE_Alg := AsymmEncAlg
 
 namespace AsymmEncAlg
 
-variable {m : Type → Type v} {M PK SK C : Type}
+variable {m : Type → Type v} [Monad m] {M PK SK C : Type}
   (encAlg : AsymmEncAlg m M PK SK C)
 
 section Correct
 
-variable [DecidableEq M] [Monad m]
+variable [DecidableEq M]
 
 /-- Correctness experiment: returns `true` iff decrypting the ciphertext recovers the message.
 
@@ -65,15 +65,15 @@ end Correct
 
 namespace ExplicitCoins
 
-variable {m : Type → Type v} {M PK SK R C : Type}
+variable {m : Type → Type v} [Monad m] {M PK SK R C : Type}
   (encAlg : AsymmEncAlg.ExplicitCoins m M PK SK R C)
 
 /-- Forget the explicit-coins presentation by sampling the coins through the ambient execution
 method. -/
-def toAsymmEncAlg [Monad m] [SampleableType R] : AsymmEncAlg m M PK SK C where
+def toAsymmEncAlg [SampleableType R] : AsymmEncAlg m M PK SK C where
   keygen := encAlg.keygen
   encrypt := fun pk msg => do
-    let r ← encAlg.lift_probComp ($ᵗ R)
+    let r ← encAlg.liftProbComp ($ᵗ R)
     return encAlg.encrypt pk msg r
   decrypt := fun sk c => return (encAlg.decrypt sk c)
   __ := encAlg.toExecutionMethod

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCCA.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCCA.lean
@@ -20,12 +20,10 @@ universe u v w
 
 namespace AsymmEncAlg
 
-variable {m : Type → Type v} {M PK SK C : Type}
+variable {m : Type → Type v} [Monad m] {M PK SK C : Type}
   (encAlg : AsymmEncAlg m M PK SK C)
 
 section decryptionOracle
-
-variable [Monad m]
 
 /-- Oracle that uses a secret key to respond to decryption requests.
 Invalid ciphertexts become oracle failure in `OptionT`. -/
@@ -74,7 +72,7 @@ def IND_CCA_Game {encAlg : AsymmEncAlg (OracleComp spec) M PK SK C}
     let (pk, sk) ← encAlg.keygen
     let (m₀, m₁, st) ← simulateQ (encAlg.IND_CCA_preChallengeImpl sk)
       (adversary.chooseMessages pk)
-    let b ← encAlg.lift_probComp ($ᵗ Bool)
+    let b ← encAlg.liftProbComp ($ᵗ Bool)
     let cStar ← encAlg.encrypt pk (if b then m₀ else m₁)
     let b' ← simulateQ (encAlg.IND_CCA_postChallengeImpl sk cStar)
       (adversary.distinguish st cStar)

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/OneTime.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/OneTime.lean
@@ -18,7 +18,7 @@ universe v
 
 namespace AsymmEncAlg
 
-variable {m : Type → Type v} {M PK SK C : Type}
+variable {m : Type → Type v} [Monad m] {M PK SK C : Type}
 
 section IND_CPA_TwoPhase
 
@@ -33,12 +33,20 @@ structure IND_CPA_Adv (encAlg : AsymmEncAlg m M PK SK C) where
 variable {encAlg : AsymmEncAlg (OracleComp spec) M PK SK C}
   (adv : IND_CPA_Adv encAlg)
 
+/-- Fixed-branch one-time IND-CPA experiment for an asymmetric encryption algorithm. -/
+def IND_CPA_OneTime_Exp (b : Bool) : ProbComp Bool :=
+  encAlg.exec do
+    let (pk, _) ← encAlg.keygen
+    let (m₁, m₂, state) ← adv.chooseMessages pk
+    let c ← encAlg.encrypt pk (if b then m₁ else m₂)
+    adv.distinguish state c
+
 /-- One-time IND-CPA experiment for an asymmetric encryption algorithm:
 sample keys, let the adversary choose challenge messages, encrypt one branch, and return whether
 the adversary guessed the hidden bit. -/
 def IND_CPA_OneTime_Game : ProbComp Bool :=
   encAlg.exec do
-    let b : Bool ← encAlg.lift_probComp ($ᵗ Bool)
+    let b : Bool ← encAlg.liftProbComp ($ᵗ Bool)
     let (pk, _) ← encAlg.keygen
     let (m₁, m₂, state) ← adv.chooseMessages pk
     let msg := if b then m₁ else m₂

--- a/VCVio/CryptoFoundations/DataEncapMech.lean
+++ b/VCVio/CryptoFoundations/DataEncapMech.lean
@@ -19,14 +19,14 @@ open OracleSpec OracleComp ENNReal
 
 /-- A data encapsulation mechanism with key space `K`, message space `M`, and ciphertext space
 `C`. The key is supplied externally, matching the proof-ladders DEM model. -/
-structure DEMScheme (m : Type → Type u) (K M C : Type)
+structure DEMScheme (m : Type → Type u) [Monad m] (K M C : Type)
     extends ExecutionMethod m where
   encrypt : K → M → m C
   decrypt : K → C → m M
 
 namespace DEMScheme
 
-variable {m : Type → Type v} {K M C : Type}
+variable {m : Type → Type v} [Monad m] {K M C : Type}
   (dem : DEMScheme m K M C)
 
 /-- Reinterpret a DEM under a different execution method without changing its algorithms. This is
@@ -38,7 +38,7 @@ def withExecutionMethod (execMethod : ExecutionMethod m) : DEMScheme m K M C whe
 
 section Correct
 
-variable [DecidableEq M] [Monad m]
+variable [DecidableEq M]
 
 /-- Correctness experiment for a DEM under an externally supplied key. -/
 def CorrectExp (k : K) (msg : M) : m Bool := do
@@ -69,7 +69,7 @@ structure IND_CPA_Adversary (_dem : DEMScheme (OracleComp spec) K M C) where
 def IND_CPA_Exp {dem : DEMScheme (OracleComp spec) K M C}
     (adversary : dem.IND_CPA_Adversary) (b : Bool) : ProbComp Bool :=
   dem.exec do
-    let k ← dem.lift_probComp ($ᵗ K)
+    let k ← dem.liftProbComp ($ᵗ K)
     let (m₀, m₁, st) ← adversary.chooseMessages
     let c ← dem.encrypt k (if b then m₁ else m₀)
     adversary.distinguish st c
@@ -78,8 +78,8 @@ def IND_CPA_Exp {dem : DEMScheme (OracleComp spec) K M C}
 def IND_CPA_Game {dem : DEMScheme (OracleComp spec) K M C}
     (adversary : dem.IND_CPA_Adversary) : ProbComp Bool :=
   dem.exec do
-    let b ← dem.lift_probComp ($ᵗ Bool)
-    let k ← dem.lift_probComp ($ᵗ K)
+    let b ← dem.liftProbComp ($ᵗ Bool)
+    let k ← dem.liftProbComp ($ᵗ K)
     let (m₀, m₁, st) ← adversary.chooseMessages
     let c ← dem.encrypt k (if b then m₁ else m₀)
     let b' ← adversary.distinguish st c

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -41,28 +41,33 @@ def FiatShamir (sigmaAlg : SigmaProtocol X W PC SC Ω P p)
   verify := fun pk m (c, s) => do
     let r' ← query (spec := unifSpec + (M × PC →ₒ Ω)) (Sum.inr (m, c))
     return sigmaAlg.verify pk c r' s
-  exec comp :=
+  SemState := (M × PC →ₒ Ω).QueryCache
+  execSem :=
+    let ro : QueryImpl (M × PC →ₒ Ω)
+      (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp) := randomOracle
+    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+      (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp)
+    simulateQ' (idImpl + ro)
+  initState := ∅
+  exec := fun comp =>
     let ro : QueryImpl (M × PC →ₒ Ω)
       (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp) := randomOracle
     let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
       (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp)
     StateT.run' (simulateQ (idImpl + ro) comp) ∅
-  lift_probComp := monadLift
-  exec_lift_probComp c := by
+  exec_eq_execSem := by
+    intro α comp
+    rfl
+  liftProbComp := MonadHom.ofLift ProbComp (OracleComp (unifSpec + (M × PC →ₒ Ω)))
+  execSem_liftProbComp := by
+    ext α c s
     let ro : QueryImpl (M × PC →ₒ Ω)
       (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp) := randomOracle
-    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
-      (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp)
-    change StateT.run' (simulateQ (idImpl + ro) (monadLift c)) ∅ = c
-    rw [show simulateQ (idImpl + ro) (monadLift c) = simulateQ idImpl c by
-      simpa [MonadLift.monadLift] using
-        (QueryImpl.simulateQ_add_liftComp_left (impl₁' := idImpl) (impl₂' := ro) c)]
-    have hid : ∀ t s, (idImpl t).run' s = query t := by
-      intro t s
-      rfl
     simpa using
-      (StateT_run'_simulateQ_eq_self (so := idImpl) (h := hid) (oa := c)
-        (s := (∅ : (M × PC →ₒ Ω).QueryCache)))
+      congrArg (fun st => st.run s) <|
+      (ExecutionMethod.execSem_liftProbComp_withStateOracle
+        (stateImpl := ro)
+        (c := c))
 
 namespace FiatShamir
 

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -87,28 +87,33 @@ def FiatShamirWithAbort (ids : IdenSchemeWithAbort S W W' St C Z p)
     | some (w', z) =>
       let c ← query (spec := unifSpec + (M × W' →ₒ C)) (Sum.inr (m, w'))
       return ids.verify pk w' c z
-  exec comp :=
+  SemState := (M × W' →ₒ C).QueryCache
+  execSem :=
+    let ro : QueryImpl (M × W' →ₒ C)
+      (StateT ((M × W' →ₒ C).QueryCache) ProbComp) := randomOracle
+    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+      (StateT ((M × W' →ₒ C).QueryCache) ProbComp)
+    simulateQ' (idImpl + ro)
+  initState := ∅
+  exec := fun comp =>
     let ro : QueryImpl (M × W' →ₒ C)
       (StateT ((M × W' →ₒ C).QueryCache) ProbComp) := randomOracle
     let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
       (StateT ((M × W' →ₒ C).QueryCache) ProbComp)
     StateT.run' (simulateQ (idImpl + ro) comp) ∅
-  lift_probComp := monadLift
-  exec_lift_probComp c := by
+  exec_eq_execSem := by
+    intro α comp
+    rfl
+  liftProbComp := MonadHom.ofLift ProbComp (OracleComp (unifSpec + (M × W' →ₒ C)))
+  execSem_liftProbComp := by
+    ext α c s
     let ro : QueryImpl (M × W' →ₒ C)
       (StateT ((M × W' →ₒ C).QueryCache) ProbComp) := randomOracle
-    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
-      (StateT ((M × W' →ₒ C).QueryCache) ProbComp)
-    change StateT.run' (simulateQ (idImpl + ro) (monadLift c)) ∅ = c
-    rw [show simulateQ (idImpl + ro) (monadLift c) = simulateQ idImpl c by
-      simpa [MonadLift.monadLift] using
-        (QueryImpl.simulateQ_add_liftComp_left
-          (impl₁' := idImpl) (impl₂' := ro) c)]
-    have hid : ∀ t s, (idImpl t).run' s = query t := by
-      intro t s; rfl
     simpa using
-      (StateT_run'_simulateQ_eq_self (so := idImpl) (h := hid) (oa := c)
-        (s := (∅ : (M × W' →ₒ C).QueryCache)))
+      congrArg (fun st => st.run s) <|
+      (ExecutionMethod.execSem_liftProbComp_withStateOracle
+        (stateImpl := ro)
+        (c := c))
 
 namespace FiatShamirWithAbort
 

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -138,28 +138,33 @@ def Fischlin (σ : SigmaProtocol X W PC SC Ω P p)
     let allVerified := (List.finRange ρ).all fun i => (results i).1
     let hashSum := (List.finRange ρ).foldl (fun acc i => acc + (results i).2) 0
     return (allVerified && decide (hashSum ≤ S))
-  exec comp :=
+  SemState := (fischlinROSpec X PC Ω P ρ b M).QueryCache
+  execSem :=
+    let roSpec := fischlinROSpec X PC Ω P ρ b M
+    let ro : QueryImpl roSpec (StateT roSpec.QueryCache ProbComp) := randomOracle
+    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+      (StateT roSpec.QueryCache ProbComp)
+    simulateQ' (idImpl + ro)
+  initState := ∅
+  exec := fun comp =>
     let roSpec := fischlinROSpec X PC Ω P ρ b M
     let ro : QueryImpl roSpec (StateT roSpec.QueryCache ProbComp) := randomOracle
     let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
       (StateT roSpec.QueryCache ProbComp)
     StateT.run' (simulateQ (idImpl + ro) comp) ∅
-  lift_probComp := monadLift
-  exec_lift_probComp c := by
+  exec_eq_execSem := by
+    intro α comp
+    rfl
+  liftProbComp := MonadHom.ofLift ProbComp (OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M))
+  execSem_liftProbComp := by
+    ext α c s
     let roSpec := fischlinROSpec X PC Ω P ρ b M
     let ro : QueryImpl roSpec (StateT roSpec.QueryCache ProbComp) := randomOracle
-    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
-      (StateT roSpec.QueryCache ProbComp)
-    change StateT.run' (simulateQ (idImpl + ro) (monadLift c)) ∅ = c
-    rw [show simulateQ (idImpl + ro) (monadLift c) = simulateQ idImpl c by
-      simpa [MonadLift.monadLift] using
-        (QueryImpl.simulateQ_add_liftComp_left (impl₁' := idImpl) (impl₂' := ro) c)]
-    have hid : ∀ t s, (idImpl t).run' s = query t := by
-      intro t s
-      rfl
     simpa using
-      (StateT_run'_simulateQ_eq_self (so := idImpl) (h := hid) (oa := c)
-        (s := (∅ : roSpec.QueryCache)))
+      congrArg (fun st => st.run s) <|
+      (ExecutionMethod.execSem_liftProbComp_withStateOracle
+        (stateImpl := ro)
+        (c := c))
 
 namespace Fischlin
 

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/Defs.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/Defs.lean
@@ -90,25 +90,48 @@ end OW_CPA
 
 end AsymmEncAlg.ExplicitCoins
 
-/-- Executing a lifted `ProbComp` in a public random-oracle world ignores the oracle state and
-collapses back to the original probabilistic computation. -/
-theorem exec_lift_probComp_withHashOracle
+/-- In a public random-oracle world, lifted `ProbComp` computations ignore the oracle state even
+before the initial cache is chosen. -/
+theorem execSem_liftProbComp_withHashOracle
     {ι : Type} {hashSpec : OracleSpec ι} {σ : Type}
-    (hashImpl : QueryImpl hashSpec (StateT σ ProbComp)) (s : σ)
+    (hashImpl : QueryImpl hashSpec (StateT σ ProbComp))
     {α : Type} (c : ProbComp α) :
-    StateT.run' (simulateQ
+    simulateQ
       ((QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp) + hashImpl)
-      (monadLift c)) s = c := by
+      (monadLift c) =
+        (MonadHom.ofLift ProbComp (StateT σ ProbComp)) c := by
   let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp)
-  change StateT.run' (simulateQ (idImpl + hashImpl) (monadLift c)) s = c
+  ext s
   rw [show simulateQ (idImpl + hashImpl) (monadLift c) = simulateQ idImpl c by
     simpa [MonadLift.monadLift] using
       (QueryImpl.simulateQ_add_liftComp_left (impl₁' := idImpl) (impl₂' := hashImpl) c)]
-  have hid : ∀ t s', (idImpl t).run' s' = query t := by
-    intro t s'
-    rfl
+  change (simulateQ idImpl c).run s = ((MonadHom.ofLift ProbComp (StateT σ ProbComp)) c).run s
+  have hrun :
+      ∀ {β : Type} (oa : ProbComp β) (s : σ),
+        (simulateQ idImpl oa).run s = (fun x => (x, s)) <$> oa := by
+    intro β oa
+    induction oa using OracleComp.inductionOn with
+    | pure x =>
+        intro s
+        simp
+    | query_bind t oa ih =>
+        intro s
+        change
+          (do
+            let a ← (liftM (query t) : ProbComp (unifSpec.Range t))
+            (simulateQ idImpl (oa a)).run s) =
+            (do
+              let a ← liftM (query t)
+              (fun x => (x, s)) <$> oa a)
+        have hfun :
+            (fun a => (simulateQ idImpl (oa a)).run s) =
+              (fun a => (fun x => (x, s)) <$> oa a) := by
+          funext a
+          exact ih a s
+        simp [hfun]
+  rw [hrun c s]
   simpa using
-    (StateT_run'_simulateQ_eq_self (so := idImpl) (h := hid) (oa := c) (s := s))
+    (OracleComp.liftM_run_StateT (x := c) (s := s))
 
 section OW_PCVA
 
@@ -153,7 +176,7 @@ def OW_PCVA_Game {encAlg : AsymmEncAlg (OracleComp spec) M PK SK C}
     (adversary : OW_PCVA_Adversary encAlg) : ProbComp Bool :=
   encAlg.exec do
     let (pk, sk) ← encAlg.keygen
-    let msg ← encAlg.lift_probComp ($ᵗ M)
+    let msg ← encAlg.liftProbComp ($ᵗ M)
     let cStar ← encAlg.encrypt pk msg
     let msg' ← simulateQ (OW_PCVA_queryImpl encAlg sk) (adversary pk cStar)
     return decide (msg' = msg)

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
@@ -67,17 +67,26 @@ def TTransform (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     let r ← query (spec := TTransform.oracleSpec M R) (Sum.inr msg)
     return pke.encrypt pk msg r
   decrypt := fun (pk, sk) c => TTransform.decrypt pke pk sk c
+  SemState := QueryCache M R
+  execSem :=
+    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+      (StateT (QueryCache M R) ProbComp)
+    simulateQ' (idImpl + TTransform.queryImpl (M := M) (R := R))
+  initState := ∅
   exec := fun comp =>
     let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
       (StateT (QueryCache M R) ProbComp)
     StateT.run' (simulateQ (idImpl + TTransform.queryImpl (M := M) (R := R)) comp) ∅
-  lift_probComp := monadLift
-  exec_lift_probComp := by
-    intro α c
+  exec_eq_execSem := by
+    intro α comp
+    rfl
+  liftProbComp := MonadHom.ofLift ProbComp (OracleComp (TTransform.oracleSpec M R))
+  execSem_liftProbComp := by
+    ext α c s
     simpa using
-      (exec_lift_probComp_withHashOracle
-        (hashImpl := TTransform.queryImpl (M := M) (R := R))
-        (s := (∅ : QueryCache M R))
+      congrArg (fun st => st.run s) <|
+      (ExecutionMethod.execSem_liftProbComp_withStateOracle
+        (stateImpl := TTransform.queryImpl (M := M) (R := R))
         c)
 
 namespace TTransform

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
@@ -49,23 +49,22 @@ def implicitRejection {K C KPRF : Type} (prf : PRFScheme KPRF C K) : RejectionPo
   keygen := prf.keygen
   onReject := fun kPrf c => some (prf.eval kPrf c)
 
-/-- Execute an FO computation by combining public randomness with the
-variant-specific hash world. -/
-def exec {M PK C R K : Type} (variant : Variant M PK C R K)
-    {α : Type} (comp : OracleComp (unifSpec + variant.hashOracleSpec) α) : ProbComp α :=
+/-- Stateful FO semantics given by the public-randomness and hash-oracle world. -/
+def execSem {M PK C R K : Type} (variant : Variant M PK C R K) :
+    OracleComp (unifSpec + variant.hashOracleSpec) →ᵐ StateT variant.QueryCache ProbComp :=
   let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
     (StateT variant.QueryCache ProbComp)
-  StateT.run' (simulateQ (idImpl + variant.queryImpl) comp) variant.initCache
+  simulateQ' (idImpl + variant.queryImpl)
 
-/-- Lifted probabilistic computations ignore the FO hash world. -/
-theorem exec_lift_probComp {M PK C R K : Type} (variant : Variant M PK C R K)
+/-- Lifted probabilistic computations ignore the FO hash world at the stateful semantics level. -/
+theorem execSem_liftProbComp {M PK C R K : Type} (variant : Variant M PK C R K)
     {α : Type} (c : ProbComp α) :
-    FujisakiOkamoto.exec variant (monadLift c) = c := by
-  simpa [exec] using
-    (exec_lift_probComp_withHashOracle
-      (hashImpl := variant.queryImpl)
-      (s := variant.initCache)
-      c)
+    FujisakiOkamoto.execSem variant (monadLift c) =
+      (MonadHom.ofLift ProbComp (StateT variant.QueryCache ProbComp)) c := by
+  simpa using
+    (ExecutionMethod.execSem_liftProbComp_withStateOracle
+      (stateImpl := variant.queryImpl)
+      (c := c))
 
 /-- Generic FO construction parameterized by a hash world and a rejection policy. -/
 def scheme
@@ -99,11 +98,18 @@ def scheme
           return some k
         else
           return policy.onReject fb c
-  exec := FujisakiOkamoto.exec variant
-  lift_probComp := monadLift
-  exec_lift_probComp := by
-    intro α c
-    simpa using FujisakiOkamoto.exec_lift_probComp (variant := variant) (c := c)
+  SemState := variant.QueryCache
+  execSem := FujisakiOkamoto.execSem variant
+  initState := variant.initCache
+  exec := fun comp => StateT.run' (FujisakiOkamoto.execSem variant comp) variant.initCache
+  exec_eq_execSem := by
+    intro α comp
+    rfl
+  liftProbComp := MonadHom.ofLift ProbComp (OracleComp (unifSpec + variant.hashOracleSpec))
+  execSem_liftProbComp := by
+    ext α c s
+    simpa using congrArg (fun st => st.run s) <|
+      FujisakiOkamoto.execSem_liftProbComp (variant := variant) (c := c)
 
 end FujisakiOkamoto
 

--- a/VCVio/CryptoFoundations/GPVHashAndSign.lean
+++ b/VCVio/CryptoFoundations/GPVHashAndSign.lean
@@ -107,28 +107,33 @@ def GPVHashAndSign
   verify := fun pk m (r, s) => do
     let c ← query (spec := unifSpec + (Salt × M →ₒ Range)) (Sum.inr (r, m))
     return (decide (psf.eval pk s = c) && psf.isShort s)
-  exec comp :=
+  SemState := (Salt × M →ₒ Range).QueryCache
+  execSem :=
+    let ro : QueryImpl (Salt × M →ₒ Range)
+      (StateT ((Salt × M →ₒ Range).QueryCache) ProbComp) := randomOracle
+    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+      (StateT ((Salt × M →ₒ Range).QueryCache) ProbComp)
+    simulateQ' (idImpl + ro)
+  initState := ∅
+  exec := fun comp =>
     let ro : QueryImpl (Salt × M →ₒ Range)
       (StateT ((Salt × M →ₒ Range).QueryCache) ProbComp) := randomOracle
     let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
       (StateT ((Salt × M →ₒ Range).QueryCache) ProbComp)
     StateT.run' (simulateQ (idImpl + ro) comp) ∅
-  lift_probComp := monadLift
-  exec_lift_probComp c := by
+  exec_eq_execSem := by
+    intro α comp
+    rfl
+  liftProbComp := MonadHom.ofLift ProbComp (OracleComp (unifSpec + (Salt × M →ₒ Range)))
+  execSem_liftProbComp := by
+    ext α c s
     let ro : QueryImpl (Salt × M →ₒ Range)
       (StateT ((Salt × M →ₒ Range).QueryCache) ProbComp) := randomOracle
-    let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
-      (StateT ((Salt × M →ₒ Range).QueryCache) ProbComp)
-    change StateT.run' (simulateQ (idImpl + ro) (monadLift c)) ∅ = c
-    rw [show simulateQ (idImpl + ro) (monadLift c) = simulateQ idImpl c by
-      simpa [MonadLift.monadLift] using
-        (QueryImpl.simulateQ_add_liftComp_left (impl₁' := idImpl) (impl₂' := ro) c)]
-    have hid : ∀ t s, (idImpl t).run' s = query t := by
-      intro t s
-      rfl
     simpa using
-      (StateT_run'_simulateQ_eq_self (so := idImpl) (h := hid) (oa := c)
-        (s := (∅ : (Salt × M →ₒ Range).QueryCache)))
+      congrArg (fun st => st.run s) <|
+      (ExecutionMethod.execSem_liftProbComp_withStateOracle
+        (stateImpl := ro)
+        (c := c))
 
 namespace GPVHashAndSign
 

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -23,7 +23,7 @@ universe u v
 
 /-- A key encapsulation mechanism with shared-key space `K`, public/secret key spaces `PK` and
 `SK`, and ciphertext space `C`. -/
-structure KEMScheme (m : Type → Type u) (K PK SK C : Type)
+structure KEMScheme (m : Type → Type u) [Monad m] (K PK SK C : Type)
     extends ExecutionMethod m where
   keygen : m (PK × SK)
   encaps : PK → m (C × K)
@@ -31,12 +31,12 @@ structure KEMScheme (m : Type → Type u) (K PK SK C : Type)
 
 namespace KEMScheme
 
-variable {m : Type → Type v} {K PK SK C : Type}
+variable {m : Type → Type v} [Monad m] {K PK SK C : Type}
   (kem : KEMScheme m K PK SK C)
 
 section Correct
 
-variable [DecidableEq K] [Monad m]
+variable [DecidableEq K]
 
 /-- Correctness experiment: decapsulation of an honestly generated encapsulation should recover the
 shared key. -/
@@ -71,7 +71,7 @@ def IND_CPA_Exp {kem : KEMScheme (OracleComp spec) K PK SK C}
     let (pk, _sk) ← kem.keygen
     let st ← adversary.preChallenge pk
     let (cStar, kReal) ← kem.encaps pk
-    let kRand ← kem.lift_probComp ($ᵗ K)
+    let kRand ← kem.liftProbComp ($ᵗ K)
     adversary.postChallenge st cStar (if b then kReal else kRand)
 
 /-- Single-game IND-CPA experiment obtained by sampling the challenge bit uniformly and checking
@@ -81,9 +81,9 @@ def IND_CPA_Game {kem : KEMScheme (OracleComp spec) K PK SK C}
   kem.exec do
     let (pk, _sk) ← kem.keygen
     let st ← adversary.preChallenge pk
-    let b ← kem.lift_probComp ($ᵗ Bool)
+    let b ← kem.liftProbComp ($ᵗ Bool)
     let (cStar, kReal) ← kem.encaps pk
-    let kRand ← kem.lift_probComp ($ᵗ K)
+    let kRand ← kem.liftProbComp ($ᵗ K)
     let b' ← adversary.postChallenge st cStar (if b then kReal else kRand)
     return (b == b')
 
@@ -132,9 +132,9 @@ def IND_CCA_Game {kem : KEMScheme (OracleComp spec) K PK SK C}
   kem.exec do
     let (pk, sk) ← kem.keygen
     let st ← simulateQ (kem.IND_CCA_preChallengeImpl sk) (adversary.preChallenge pk)
-    let b ← kem.lift_probComp ($ᵗ Bool)
+    let b ← kem.liftProbComp ($ᵗ Bool)
     let (cStar, kReal) ← kem.encaps pk
-    let kRand ← kem.lift_probComp ($ᵗ K)
+    let kRand ← kem.liftProbComp ($ᵗ K)
     let b' ← simulateQ (kem.IND_CCA_postChallengeImpl sk cStar)
       (adversary.postChallenge st cStar (if b then kReal else kRand))
     return (b == b')

--- a/VCVio/CryptoFoundations/MacAlg.lean
+++ b/VCVio/CryptoFoundations/MacAlg.lean
@@ -22,7 +22,7 @@ open OracleSpec OracleComp ENNReal
 
 /-- MAC algorithm with computations in the monad `m`, where `M` is the message space, `K` the key
 space, and `T` the tag space. -/
-structure MacAlg (m : Type → Type v) (M K T : Type)
+structure MacAlg (m : Type → Type v) [Monad m] (M K T : Type)
     extends ExecutionMethod m where
   keygen : m K
   tag : K → M → m T

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -35,6 +35,98 @@ noncomputable def ProbComp.boolBiasAdvantage (p : ProbComp Bool) : ℝ :=
 noncomputable def ProbComp.boolDistAdvantage (p q : ProbComp Bool) : ℝ :=
   |(Pr[= true | p]).toReal - (Pr[= true | q]).toReal|
 
+lemma ProbComp.boolDistAdvantage_triangle (p q r : ProbComp Bool) :
+    p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by
+  unfold ProbComp.boolDistAdvantage
+  exact abs_sub_le _ _ _
+
+lemma ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half (p : ProbComp Bool) :
+    p.boolBiasAdvantage = 2 * |(Pr[= true | p]).toReal - 1 / 2| := by
+  have hfalse : Pr[= false | p] = 1 - Pr[= true | p] := by
+    have hsum : Pr[= true | p] + Pr[= false | p] = 1 := by simp
+    rw [← hsum, ENNReal.add_sub_cancel_left probOutput_ne_top]
+  unfold ProbComp.boolBiasAdvantage
+  rw [hfalse, ENNReal.toReal_sub_of_le probOutput_le_one ENNReal.one_ne_top]
+  rw [ENNReal.toReal_one]
+  rw [show (Pr[= true | p]).toReal - (1 - (Pr[= true | p]).toReal) =
+      2 * ((Pr[= true | p]).toReal - 1 / 2) by ring]
+  rw [abs_mul, abs_of_pos (by positivity : (0 : ℝ) < 2)]
+
+lemma ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch
+    (real rand : ProbComp Bool) :
+    (do
+      let b ← ($ᵗ Bool : ProbComp Bool)
+      let z ← if b then real else rand
+      pure (b == z)).boolBiasAdvantage =
+    real.boolDistAdvantage rand := by
+  rw [ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half]
+  rw [probOutput_uniformBool_branch_toReal_sub_half]
+  unfold ProbComp.boolDistAdvantage
+  calc
+    2 * |((Pr[= true | real]).toReal - (Pr[= true | rand]).toReal) / 2|
+        = |(2 : ℝ)| * |((Pr[= true | real]).toReal - (Pr[= true | rand]).toReal) / 2| := by
+            norm_num
+    _ = |(2 : ℝ) * (((Pr[= true | real]).toReal - (Pr[= true | rand]).toReal) / 2)| := by
+          rw [← abs_mul]
+    _ = |(Pr[= true | real]).toReal - (Pr[= true | rand]).toReal| := by
+          congr 1
+          ring
+
+lemma ProbComp.boolBiasAdvantage_bind_uniformBool_eq_boolDistAdvantage
+    {α : Type} (pref : ProbComp α) (real rand : α → ProbComp Bool) :
+    (do
+      let a ← pref
+      let b ← ($ᵗ Bool : ProbComp Bool)
+      let z ← if b then real a else rand a
+      pure (b == z)).boolBiasAdvantage =
+    (do
+      let a ← pref
+      real a).boolDistAdvantage
+      (do
+        let a ← pref
+        rand a) := by
+  let game : ProbComp Bool := do
+    let a ← pref
+    let b ← ($ᵗ Bool : ProbComp Bool)
+    let z ← if b then real a else rand a
+    pure (b == z)
+  let left : ProbComp Bool := do
+    let a ← pref
+    real a
+  let right : ProbComp Bool := do
+    let a ← pref
+    rand a
+  let branchGame : ProbComp Bool := do
+    let b ← ($ᵗ Bool : ProbComp Bool)
+    let z ← if b then left else right
+    pure (b == z)
+  have hbranch : evalDist game = evalDist branchGame := by
+    apply evalDist_ext
+    intro x
+    calc
+      Pr[= x | game] =
+          Pr[= x | do
+            let b ← ($ᵗ Bool : ProbComp Bool)
+            let a ← pref
+            let z ← if b then real a else rand a
+            pure (b == z)] := by
+              simpa [game, bind_assoc] using
+                (probOutput_bind_bind_swap pref ($ᵗ Bool : ProbComp Bool)
+                  (fun a b => do
+                    let z ← if b then real a else rand a
+                    pure (b == z))
+                  x)
+      _ = Pr[= x | branchGame] := by
+            refine probOutput_bind_congr' ($ᵗ Bool : ProbComp Bool) x ?_
+            intro b
+            cases b <;> simp [branchGame, left, right, bind_assoc]
+  have hprob := evalDist_ext_iff.mp hbranch
+  rw [show game.boolBiasAdvantage = branchGame.boolBiasAdvantage by
+    unfold ProbComp.boolBiasAdvantage
+    rw [hprob true, hprob false]]
+  simpa [branchGame, left, right] using
+    ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch left right
+
 /-- The **advantage** of a game `p`, assumed to be a probabilistic computation ending with a `guard`
   statement, is the absolute difference between the probability of success and 1/2. -/
 noncomputable def ProbComp.guessAdvantage (p : ProbComp Unit) : ℝ := |1 / 2 - (Pr[= () | p]).toReal|
@@ -130,7 +222,7 @@ end BoundedAdversary
 
 /-- Structure to represent a security experiment.
 The experiment is considered successful unless it terminates with `failure`. -/
-structure SecExp (m : Type → Type w)
+structure SecExp (m : Type → Type w) [Monad m]
     extends ExecutionMethod m where
   main : m Unit
 

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -23,7 +23,7 @@ open OracleSpec OracleComp ENNReal
 /-- Signature algorithm with computations in the monad `m`,
 where `M` is the space of messages, `PK`/`SK` are the spaces of the public/private keys,
 and `S` is the type of the final signature. -/
-structure SignatureAlg (m : Type → Type v) (M PK SK S : Type)
+structure SignatureAlg (m : Type → Type v) [Monad m] (M PK SK S : Type)
     extends ExecutionMethod m where
   keygen : m (PK × SK)
   sign (pk : PK) (sk : SK) (msg : M) : m S

--- a/VCVio/OracleComp/ExecutionMethod.lean
+++ b/VCVio/OracleComp/ExecutionMethod.lean
@@ -3,6 +3,8 @@ Copyright (c) 2024 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma
 -/
+import ToMathlib.Control.Monad.Hom
+import VCVio.OracleComp.SimSemantics.Append
 import VCVio.OracleComp.SimSemantics.Constructions
 
 /-!
@@ -18,22 +20,147 @@ This means that definitions like "IND-CPA secure" are always *relative* to the e
 "execution function" is just `id`.
 -/
 
+open OracleComp
+
 universe u v w
 
 /-- An `ExecutionMethod m` provides a way to map computations in the monad `m` into `ProbComp`.
 In particular it allows computations in `m` -/
-structure ExecutionMethod (m : Type → Type v) where
+structure ExecutionMethod (m : Type → Type v) [Monad m] where
+    SemState : Type
+    execSem : m →ᵐ StateT SemState ProbComp
+    initState : SemState
     exec {α : Type} : m α → ProbComp α
-    lift_probComp {α : Type} : ProbComp α → m α
-    exec_lift_probComp {α : Type} (px : ProbComp α) :
-      exec (lift_probComp px) = px
+    exec_eq_execSem {α : Type} (mx : m α) : exec mx = (execSem mx).run' initState
+    liftProbComp : ProbComp →ᵐ m
+    execSem_liftProbComp :
+      execSem ∘ₘ liftProbComp = MonadHom.ofLift ProbComp (StateT SemState ProbComp)
 
 namespace ExecutionMethod
 
+variable {m : Type → Type v} [Monad m]
+
+@[simp] theorem exec_liftProbComp_apply
+    (execMethod : _root_.ExecutionMethod m) {α : Type} (px : ProbComp α) :
+    execMethod.exec (execMethod.liftProbComp px) = px := by
+  rw [execMethod.exec_eq_execSem]
+  change ((execMethod.execSem ∘ₘ execMethod.liftProbComp) px).run' execMethod.initState = px
+  rw [execMethod.execSem_liftProbComp]
+  rw [MonadHom.ofLift_apply]
+  rw [StateT.run']
+  rw [map_eq_bind_pure_comp]
+  change (((liftM px : StateT execMethod.SemState ProbComp α).run execMethod.initState) >>=
+      pure ∘ fun x => x.1) = px
+  have h := congrArg (fun q => q >>= pure ∘ fun x => x.1)
+    (OracleComp.liftM_run_StateT (x := px) (s := execMethod.initState))
+  have h' :
+      (((liftM px : StateT execMethod.SemState ProbComp α).run execMethod.initState) >>=
+        pure ∘ fun x => x.1) =
+      ((px >>= fun a => pure (a, execMethod.initState)) >>= pure ∘ fun x => x.1) := by
+    simpa using h
+  rw [h']
+  simp
+
+@[simp] theorem exec_bind_liftProbComp_apply
+    (execMethod : _root_.ExecutionMethod m) {α β : Type}
+    (px : ProbComp α) (f : α → m β) :
+    execMethod.exec (do
+      let x ← execMethod.liftProbComp px
+      f x) =
+    (do
+      let x ← px
+      execMethod.exec (f x)) := by
+  rw [execMethod.exec_eq_execSem]
+  rw [MonadHom.mmap_bind]
+  have hlift :
+      execMethod.execSem (execMethod.liftProbComp px) =
+      (MonadHom.ofLift ProbComp (StateT execMethod.SemState ProbComp)) px := by
+    exact congrArg (fun H => H px) execMethod.execSem_liftProbComp
+  rw [hlift, MonadHom.ofLift_apply]
+  change Prod.fst <$> ((liftM px >>= fun x => execMethod.execSem (f x)).run execMethod.initState) =
+    (do
+      let x ← px
+      execMethod.exec (f x))
+  rw [StateT.run_bind]
+  have hrunLift :
+      ((liftM px : StateT execMethod.SemState ProbComp α).run execMethod.initState) =
+      px >>= fun x => pure (x, execMethod.initState) := by
+    simpa using OracleComp.liftM_run_StateT (x := px) (s := execMethod.initState)
+  rw [hrunLift]
+  simp [execMethod.exec_eq_execSem, map_bind]
+
+@[simp] theorem exec_map_apply
+    (execMethod : _root_.ExecutionMethod m) [LawfulMonad m]
+    {α β : Type} (f : α → β) (mx : m α) :
+    execMethod.exec (f <$> mx) = f <$> execMethod.exec mx := by
+  rw [execMethod.exec_eq_execSem, execMethod.exec_eq_execSem]
+  simp [MonadHom.mmap_map, StateT.run'_eq, map_eq_bind_pure_comp]
+
+/-- In a public-randomness plus state-oracle world, lifted `ProbComp` computations ignore the
+oracle state even before the initial state is chosen. -/
+theorem execSem_liftProbComp_withStateOracle
+    {ι : Type} {stateSpec : OracleSpec ι} {σ : Type}
+    (stateImpl : QueryImpl stateSpec (StateT σ ProbComp))
+    {α : Type} (c : ProbComp α) :
+    simulateQ
+      ((QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp) + stateImpl)
+      (monadLift c) =
+        (MonadHom.ofLift ProbComp (StateT σ ProbComp)) c := by
+  let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp)
+  funext s
+  rw [show simulateQ (idImpl + stateImpl) (monadLift c) = simulateQ idImpl c by
+    simpa [MonadLift.monadLift] using
+      (QueryImpl.simulateQ_add_liftComp_left (impl₁' := idImpl) (impl₂' := stateImpl) c)]
+  change (simulateQ idImpl c).run s = ((MonadHom.ofLift ProbComp (StateT σ ProbComp)) c).run s
+  have hrun :
+      ∀ {β : Type} (oa : ProbComp β) (s : σ),
+        (simulateQ idImpl oa).run s = (fun x => (x, s)) <$> oa := by
+    intro β oa
+    induction oa using OracleComp.inductionOn with
+    | pure x =>
+        intro s
+        simp
+    | query_bind t oa ih =>
+        intro s
+        change
+          (do
+            let a ← (liftM (query t) : ProbComp (unifSpec.Range t))
+            (simulateQ idImpl (oa a)).run s) =
+            (do
+              let a ← liftM (query t)
+              (fun x => (x, s)) <$> oa a)
+        have hfun :
+            (fun a => (simulateQ idImpl (oa a)).run s) =
+              (fun a => (fun x => (x, s)) <$> oa a) := by
+          funext a
+          exact ih a s
+        simp [hfun]
+  rw [hrun c s]
+  simpa using (OracleComp.liftM_run_StateT (x := c) (s := s))
+
 /-- Execute a computation in `ProbComp` via `ProbComp`, by using the identity function. -/
 @[simp] protected def default : ExecutionMethod ProbComp where
-  exec := id
-  lift_probComp := id
-  exec_lift_probComp _ := rfl
+  SemState := PUnit
+  execSem := MonadHom.ofLift ProbComp (StateT PUnit ProbComp)
+  initState := PUnit.unit
+  exec := fun mx => mx
+  exec_eq_execSem := by
+    intro α mx
+    rw [MonadHom.ofLift_apply]
+    rw [StateT.run']
+    rw [map_eq_bind_pure_comp]
+    change mx = (((liftM mx : StateT PUnit ProbComp α).run PUnit.unit) >>= pure ∘ fun x => x.1)
+    have h := congrArg (fun q => q >>= pure ∘ fun x => x.1)
+      (OracleComp.liftM_run_StateT (x := mx) (s := PUnit.unit))
+    have h' :
+        (((liftM mx : StateT PUnit ProbComp α).run PUnit.unit) >>= pure ∘ fun x => x.1) =
+          ((mx >>= fun a => pure (a, PUnit.unit)) >>= pure ∘ fun x => x.1) := by
+      simpa using h
+    rw [h']
+    simp
+  liftProbComp := MonadHom.id ProbComp
+  execSem_liftProbComp := by
+    ext α x
+    simp [MonadHom.ofLift]
 
 end ExecutionMethod


### PR DESCRIPTION
## Summary
This PR strengthens `ExecutionMethod` so execution is backed by a compositional stateful semantics instead of only a bare `exec : m α → ProbComp α` view.

It updates the core abstraction to carry:
- `SemState`
- `execSem : m →ᵐ StateT SemState ProbComp`
- `initState`
- compatibility laws relating `exec`, `execSem`, and `liftProbComp`

It then ports the affected crypto constructions and helper modules to the stronger interface.

## Why
The previous abstraction was too weak for semantic game-hopping because it did not say how `exec` interacts with `pure`, `bind`, or lifted probabilistic computations.

The strengthened form keeps the existing user-facing `exec` API while adding the structure needed for later proofs, especially the remaining KEM-DEM composition argument.

## Impact
This refactor updates the custom execution methods used by Fiat-Shamir, Fischlin, GPV hash-and-sign, and the Fujisaki-Okamoto transforms so they expose their hidden state semantics explicitly.

It also adds supporting execution/probability lemmas and fixes the small monad-assumption fallout in nearby asymmetric-encryption files.

## Validation
- `lake build`
- targeted module builds during the refactor for the touched crypto modules

## Notes
Existing `sorry`s in the repo remain, including the current `sorry` in `VCVio/CryptoFoundations/KEMDEM.lean`.

AI-authored by Codex on behalf of Quang Dao using GPT-5.