### PR TITLE
Move security experiments onto bundled SPMF semantics

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -37,6 +37,7 @@ import VCVio.EvalDist.Defs.AlternativeMonad
 import VCVio.EvalDist.Defs.Basic
 import VCVio.EvalDist.Defs.Instances
 import VCVio.EvalDist.Defs.NeverFails
+import VCVio.EvalDist.Defs.Semantics
 import VCVio.EvalDist.Defs.Support
 import VCVio.EvalDist.Fintype
 import VCVio.EvalDist.Instances.ErrorT

--- a/VCVio/CryptoFoundations/AsymmEncAlg/Defs.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.ExecutionMethod
 
 /-!
 # Asymmetric Encryption Schemes

--- a/VCVio/CryptoFoundations/Asymptotics/Security.lean
+++ b/VCVio/CryptoFoundations/Asymptotics/Security.lean
@@ -53,7 +53,7 @@ theorem secure_of_pointwise_bound
 
 /-- Build from a family of failure-based `SecExp`. -/
 noncomputable def ofSecExp {m : ℕ → Type → Type*}
-    [∀ n, Monad (m n)] [∀ n, HasEvalSPMF (m n)]
+    [∀ n, Monad (m n)]
     (exp : (n : ℕ) → SecExp (m n)) : SecurityExp where
   advantage n := (exp n).advantage
 
@@ -106,7 +106,7 @@ theorem toSecurityExp_advantage (g : SecurityGame Adv) (A : Adv) :
 
 /-- Build from a family of failure-based `SecExp`. -/
 noncomputable def ofSecExp {m : ℕ → Type → Type*}
-    [∀ n, Monad (m n)] [∀ n, HasEvalSPMF (m n)]
+    [∀ n, Monad (m n)]
     (game : Adv → (n : ℕ) → SecExp (m n)) : SecurityGame Adv where
   advantage A n := (game A n).advantage
 

--- a/VCVio/CryptoFoundations/DataEncapMech.lean
+++ b/VCVio/CryptoFoundations/DataEncapMech.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.ExecutionMethod
 import VCVio.OracleComp.ProbComp
 
 /-!

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.ExecutionMethod
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.Coercions.SubSpec

--- a/VCVio/CryptoFoundations/MacAlg.lean
+++ b/VCVio/CryptoFoundations/MacAlg.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.ExecutionMethod
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.LoggingOracle
 import VCVio.OracleComp.SimSemantics.Append

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -247,12 +247,12 @@ section advantage
 
 /-- Advantage of a failure-based security experiment: one minus its failure probability. -/
 noncomputable def advantage (exp : SecExp m) : ℝ≥0∞ :=
-  1 - exp.toSPMFSemantics.probFailure exp.main
+  1 - Pr[⊥ | exp.toSPMFSemantics.evalDist exp.main]
 
 /-- A failure-based experiment has zero advantage exactly when it fails with probability `1`. -/
 @[simp]
 lemma advantage_eq_zero_iff (exp : SecExp m) :
-    exp.advantage = 0 ↔ exp.toSPMFSemantics.probFailure exp.main = 1 := by
+    exp.advantage = 0 ↔ Pr[⊥ | exp.toSPMFSemantics.evalDist exp.main] = 1 := by
   rw [advantage, tsub_eq_zero_iff_le]
   exact ⟨fun h => le_antisymm (exp.toSPMFSemantics.probFailure_le_one _) h,
     fun h => h ▸ le_refl _⟩
@@ -260,7 +260,7 @@ lemma advantage_eq_zero_iff (exp : SecExp m) :
 /-- A failure-based experiment has advantage `1` exactly when it never fails. -/
 @[simp]
 lemma advantage_eq_one_iff (exp : SecExp m) :
-    exp.advantage = 1 ↔ exp.toSPMFSemantics.probFailure exp.main = 0 := by
+    exp.advantage = 1 ↔ Pr[⊥ | exp.toSPMFSemantics.evalDist exp.main] = 0 := by
   constructor
   · intro h; by_contra hne
     have : exp.advantage < 1 := by

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -29,6 +29,98 @@ noncomputable def ProbComp.boolBiasAdvantage (p : ProbComp Bool) : ℝ :=
 noncomputable def ProbComp.boolDistAdvantage (p q : ProbComp Bool) : ℝ :=
   |(Pr[= true | p]).toReal - (Pr[= true | q]).toReal|
 
+lemma ProbComp.boolDistAdvantage_triangle (p q r : ProbComp Bool) :
+    p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by
+  unfold ProbComp.boolDistAdvantage
+  exact abs_sub_le _ _ _
+
+lemma ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half (p : ProbComp Bool) :
+    p.boolBiasAdvantage = 2 * |(Pr[= true | p]).toReal - 1 / 2| := by
+  have hfalse : Pr[= false | p] = 1 - Pr[= true | p] := by
+    have hsum : Pr[= true | p] + Pr[= false | p] = 1 := by simp
+    rw [← hsum, ENNReal.add_sub_cancel_left probOutput_ne_top]
+  unfold ProbComp.boolBiasAdvantage
+  rw [hfalse, ENNReal.toReal_sub_of_le probOutput_le_one ENNReal.one_ne_top]
+  rw [ENNReal.toReal_one]
+  rw [show (Pr[= true | p]).toReal - (1 - (Pr[= true | p]).toReal) =
+      2 * ((Pr[= true | p]).toReal - 1 / 2) by ring]
+  rw [abs_mul, abs_of_pos (by positivity : (0 : ℝ) < 2)]
+
+lemma ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch
+    (real rand : ProbComp Bool) :
+    (do
+      let b ← ($ᵗ Bool : ProbComp Bool)
+      let z ← if b then real else rand
+      pure (b == z)).boolBiasAdvantage =
+    real.boolDistAdvantage rand := by
+  rw [ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half]
+  rw [probOutput_uniformBool_branch_toReal_sub_half]
+  unfold ProbComp.boolDistAdvantage
+  calc
+    2 * |((Pr[= true | real]).toReal - (Pr[= true | rand]).toReal) / 2|
+        = |(2 : ℝ)| * |((Pr[= true | real]).toReal - (Pr[= true | rand]).toReal) / 2| := by
+            norm_num
+    _ = |(2 : ℝ) * (((Pr[= true | real]).toReal - (Pr[= true | rand]).toReal) / 2)| := by
+          rw [← abs_mul]
+    _ = |(Pr[= true | real]).toReal - (Pr[= true | rand]).toReal| := by
+          congr 1
+          ring
+
+lemma ProbComp.boolBiasAdvantage_bind_uniformBool_eq_boolDistAdvantage
+    {α : Type} (pref : ProbComp α) (real rand : α → ProbComp Bool) :
+    (do
+      let a ← pref
+      let b ← ($ᵗ Bool : ProbComp Bool)
+      let z ← if b then real a else rand a
+      pure (b == z)).boolBiasAdvantage =
+    (do
+      let a ← pref
+      real a).boolDistAdvantage
+      (do
+        let a ← pref
+        rand a) := by
+  let game : ProbComp Bool := do
+    let a ← pref
+    let b ← ($ᵗ Bool : ProbComp Bool)
+    let z ← if b then real a else rand a
+    pure (b == z)
+  let left : ProbComp Bool := do
+    let a ← pref
+    real a
+  let right : ProbComp Bool := do
+    let a ← pref
+    rand a
+  let branchGame : ProbComp Bool := do
+    let b ← ($ᵗ Bool : ProbComp Bool)
+    let z ← if b then left else right
+    pure (b == z)
+  have hbranch : evalDist game = evalDist branchGame := by
+    apply evalDist_ext
+    intro x
+    calc
+      Pr[= x | game] =
+          Pr[= x | do
+            let b ← ($ᵗ Bool : ProbComp Bool)
+            let a ← pref
+            let z ← if b then real a else rand a
+            pure (b == z)] := by
+              simpa [game, bind_assoc] using
+                (probOutput_bind_bind_swap pref ($ᵗ Bool : ProbComp Bool)
+                  (fun a b => do
+                    let z ← if b then real a else rand a
+                    pure (b == z))
+                  x)
+      _ = Pr[= x | branchGame] := by
+            refine probOutput_bind_congr' ($ᵗ Bool : ProbComp Bool) x ?_
+            intro b
+            cases b <;> simp [left, right]
+  have hprob := evalDist_ext_iff.mp hbranch
+  rw [show game.boolBiasAdvantage = branchGame.boolBiasAdvantage by
+    unfold ProbComp.boolBiasAdvantage
+    rw [hprob true, hprob false]]
+  simpa [branchGame, left, right] using
+    ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch left right
+
 /-- The **advantage** of a game `p`, assumed to be a probabilistic computation ending with a `guard`
   statement, is the absolute difference between the probability of success and 1/2. -/
 noncomputable def ProbComp.guessAdvantage (p : ProbComp Unit) : ℝ := |1 / 2 - (Pr[= () | p]).toReal|

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -230,10 +230,10 @@ end BoundedAdversary
 /-- Structure to represent a security experiment.
 The experiment is considered successful unless it terminates with failure.
 
-Unlike the older `ExecutionMethod`-based design, a `SecExp` carries bundled
-`SPMFSemantics` directly. This keeps the semantic assumptions attached to the experiment itself:
-the surface monad can be interpreted through some internal semantic monad, and only then observed
-as a subdistribution for measuring success and failure probabilities. -/
+A `SecExp` carries bundled `SPMFSemantics` directly. This keeps the semantic assumptions attached
+to the experiment itself: the surface monad can be interpreted through some internal semantic
+monad, and only then observed as a subdistribution for measuring success and failure
+probabilities. -/
 structure SecExp (m : Type → Type w) [Monad m]
     extends SPMFSemantics m where
   /-- Main experiment body. Success is interpreted as terminating without failure. -/

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -23,17 +23,26 @@ universe u v w
 
 open OracleComp OracleSpec ENNReal Polynomial Prod
 
+/-- Bias advantage of a Boolean-valued game: the gap between the probabilities of the two outputs.
+
+This is the canonical single-game formulation for hidden-bit guessing experiments. -/
 noncomputable def ProbComp.boolBiasAdvantage (p : ProbComp Bool) : ℝ :=
   |(Pr[= true | p]).toReal - (Pr[= false | p]).toReal|
 
+/-- Distinguishing advantage between two Boolean-valued games, measured on the `true` branch.
+
+For Boolean outputs this is equivalent to measuring the gap on `false`; choosing `true` is just a
+conventional presentation. -/
 noncomputable def ProbComp.boolDistAdvantage (p q : ProbComp Bool) : ℝ :=
   |(Pr[= true | p]).toReal - (Pr[= true | q]).toReal|
 
+/-- Triangle inequality for Boolean distinguishing advantage. -/
 lemma ProbComp.boolDistAdvantage_triangle (p q r : ProbComp Bool) :
     p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by
   unfold ProbComp.boolDistAdvantage
   exact abs_sub_le _ _ _
 
+/-- Re-express Boolean bias as twice the absolute deviation of `Pr[true]` from `1/2`. -/
 lemma ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half (p : ProbComp Bool) :
     p.boolBiasAdvantage = 2 * |(Pr[= true | p]).toReal - 1 / 2| := by
   have hfalse : Pr[= false | p] = 1 - Pr[= true | p] := by
@@ -46,6 +55,8 @@ lemma ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half (p : ProbComp Bool) :
       2 * ((Pr[= true | p]).toReal - 1 / 2) by ring]
   rw [abs_mul, abs_of_pos (by positivity : (0 : ℝ) < 2)]
 
+/-- A hidden-bit guessing game over two Boolean branches has bias exactly equal to the
+distinguishing advantage between those two branches. -/
 lemma ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch
     (real rand : ProbComp Bool) :
     (do
@@ -66,6 +77,8 @@ lemma ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch
           congr 1
           ring
 
+/-- Version of `boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch` with a shared sampled
+prefix before the real/random branch is chosen. -/
 lemma ProbComp.boolBiasAdvantage_bind_uniformBool_eq_boolDistAdvantage
     {α : Type} (pref : ProbComp α) (real rand : α → ProbComp Bool) :
     (do
@@ -215,9 +228,15 @@ variable {ι : Type u} {spec : OracleSpec ι} {α β : Type u}
 end BoundedAdversary
 
 /-- Structure to represent a security experiment.
-The experiment is considered successful unless it terminates with failure. -/
+The experiment is considered successful unless it terminates with failure.
+
+Unlike the older `ExecutionMethod`-based design, a `SecExp` carries bundled
+`SPMFSemantics` directly. This keeps the semantic assumptions attached to the experiment itself:
+the surface monad can be interpreted through some internal semantic monad, and only then observed
+as a subdistribution for measuring success and failure probabilities. -/
 structure SecExp (m : Type → Type w) [Monad m]
     extends SPMFSemantics m where
+  /-- Main experiment body. Success is interpreted as terminating without failure. -/
   main : m Unit
 
 namespace SecExp
@@ -226,9 +245,11 @@ variable {m : Type → Type w} [Monad m]
 
 section advantage
 
+/-- Advantage of a failure-based security experiment: one minus its failure probability. -/
 noncomputable def advantage (exp : SecExp m) : ℝ≥0∞ :=
   1 - exp.toSPMFSemantics.probFailure exp.main
 
+/-- A failure-based experiment has zero advantage exactly when it fails with probability `1`. -/
 @[simp]
 lemma advantage_eq_zero_iff (exp : SecExp m) :
     exp.advantage = 0 ↔ exp.toSPMFSemantics.probFailure exp.main = 1 := by
@@ -236,6 +257,7 @@ lemma advantage_eq_zero_iff (exp : SecExp m) :
   exact ⟨fun h => le_antisymm (exp.toSPMFSemantics.probFailure_le_one _) h,
     fun h => h ▸ le_refl _⟩
 
+/-- A failure-based experiment has advantage `1` exactly when it never fails. -/
 @[simp]
 lemma advantage_eq_one_iff (exp : SecExp m) :
     exp.advantage = 1 ↔ exp.toSPMFSemantics.probFailure exp.main = 0 := by

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -3,26 +3,20 @@ Copyright (c) 2024 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
-import VCVio.OracleComp.ExecutionMethod
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.EvalDist.TVDist
+import VCVio.EvalDist.Defs.Semantics
 
 /-!
 # Security Experiments
 
-This file gives a basic way to represent security experiments, as an extension of `OracleAlg`.
-The definition is meant to be simple enough to give useful lemmas while still being
-able to represent most common use cases.
+This file defines simple security experiments that succeed unless they terminate with failure.
+Each experiment carries bundled subprobabilistic semantics, so the experiment can be interpreted
+through an internal semantic monad instead of requiring a global `HasEvalSPMF` instance on the
+ambient monad.
 
-We also give a definition `BoundedAdversary α β` of a security adversary with input
-`α` and output `β`, as just a computation bundled with a bound on the number of queries
-it makes.
-
-The main definition is `SecExp spec α β`, which extends `OracleAlg` with three functions:
-* `inp_gen` that chooses an input for the experiment of type `α`
-* `main` that takes an input and computes a result of type `β`
-* `isValid` that decides whether the experiment succeeded
+We also define `BoundedAdversary α β` as an oracle computation bundled with a query bound.
 -/
 
 universe u v w
@@ -129,29 +123,30 @@ variable {ι : Type u} {spec : OracleSpec ι} {α β : Type u}
 end BoundedAdversary
 
 /-- Structure to represent a security experiment.
-The experiment is considered successful unless it terminates with `failure`. -/
-structure SecExp (m : Type → Type w)
-    extends ExecutionMethod m where
+The experiment is considered successful unless it terminates with failure. -/
+structure SecExp (m : Type → Type w) [Monad m]
+    extends SPMFSemantics m where
   main : m Unit
 
 namespace SecExp
 
-variable {m : Type → Type w}
+variable {m : Type → Type w} [Monad m]
 
 section advantage
 
-noncomputable def advantage [Monad m] [HasEvalSPMF m] (exp : SecExp m) : ℝ≥0∞ :=
-  1 - Pr[⊥ | exp.main]
+noncomputable def advantage (exp : SecExp m) : ℝ≥0∞ :=
+  1 - exp.toSPMFSemantics.probFailure exp.main
 
 @[simp]
-lemma advantage_eq_zero_iff [Monad m] [HasEvalSPMF m] (exp : SecExp m) :
-    exp.advantage = 0 ↔ Pr[⊥ | exp.main] = 1 := by
+lemma advantage_eq_zero_iff (exp : SecExp m) :
+    exp.advantage = 0 ↔ exp.toSPMFSemantics.probFailure exp.main = 1 := by
   rw [advantage, tsub_eq_zero_iff_le]
-  exact ⟨fun h => le_antisymm probFailure_le_one h, fun h => h ▸ le_refl _⟩
+  exact ⟨fun h => le_antisymm (exp.toSPMFSemantics.probFailure_le_one _) h,
+    fun h => h ▸ le_refl _⟩
 
 @[simp]
-lemma advantage_eq_one_iff [Monad m] [HasEvalSPMF m] (exp : SecExp m) :
-    exp.advantage = 1 ↔ Pr[⊥ | exp.main] = 0 := by
+lemma advantage_eq_one_iff (exp : SecExp m) :
+    exp.advantage = 1 ↔ exp.toSPMFSemantics.probFailure exp.main = 0 := by
   constructor
   · intro h; by_contra hne
     have : exp.advantage < 1 := by

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.ExecutionMethod
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.LoggingOracle
 import VCVio.OracleComp.SimSemantics.Append

--- a/VCVio/EvalDist/Defs/Semantics.lean
+++ b/VCVio/EvalDist/Defs/Semantics.lean
@@ -8,7 +8,8 @@ import VCVio.EvalDist.Defs.Basic
 /-!
 # Bundled Probability Semantics
 
-This file defines bundled subprobabilistic and probabilistic semantics for monads.
+This file defines bundled semantics for monads that factor through an internal semantic monad
+before being externally observed.
 
 The existing classes `HasEvalSPMF` and `HasEvalPMF` say that a monad already *has* an
 `SPMF` or `PMF` denotation. That is convenient when the monad itself is the semantic object,
@@ -26,10 +27,13 @@ not be visible at the final security-game interface. Typical examples include:
 - auxiliary logs or bookkeeping used only for the semantics
 - semantic monads that are more structured than the surface monad being specified
 
-`SPMFSemantics` is the general bundled notion for subprobabilistic semantics, while
-`PMFSemantics` is the total-probability specialization. They are deliberately *bundled*
-rather than typeclasses so that a construction can carry its intended semantics locally
-without forcing a single global instance on the ambient monad.
+The generic factoring pattern is captured by `SemanticsVia`. The probability-specific notions
+`SPMFSemantics` and `PMFSemantics` are then specializations where the observation target is
+respectively `SPMF` or `PMF`.
+
+These semantics are deliberately *bundled* rather than typeclasses so that a construction can
+carry its intended semantics locally without forcing a single global instance on the ambient
+monad.
 -/
 
 /-!
@@ -39,49 +43,79 @@ The fields are intentionally minimal:
 
 - `Sem` is the internal semantic monad
 - `interpret` embeds the surface computation into that internal semantics
-- `observeSPMF` / `observePMF` discard the internal structure and return the external
-  distribution seen by the security definitions
+- `observe` discards the internal structure and returns the external semantic object
 
 Notably, observation is not required to be a monad morphism. That is important: running a
 stateful semantics from a fixed initial state is a perfectly reasonable observation, but it is
 not itself a monad homomorphism. The bundling here leaves room for that style of semantics.
 -/
 
-universe u v w
+universe u v w x
 
-/-- Bundled subprobabilistic semantics for a monad `m`.
+/-- Bundled semantics for `m` obtained by factoring through an internal semantic monad.
 
-An `SPMFSemantics m` says that computations in `m` can be understood denotationally by:
+`SemanticsVia m Obs` packages the very general pattern:
 
-1. interpreting them into some internal semantic monad `Sem`, and then
-2. observing the resulting computation as a subprobability mass function
+1. interpret a computation in the surface monad `m` into some internal semantic monad `Sem`
+2. observe the resulting internal computation as an external semantic object `Obs α`
 
-The key point is that `Sem` need not be the same as `m`. This lets us model surface monads whose
-meaning naturally passes through hidden semantic structure, such as caches, internal state, or
-other bookkeeping that should be invisible once we talk about probabilities of externally visible
-outcomes. -/
-structure SPMFSemantics (m : Type u → Type v) [Monad m] where
+The observation target `Obs` is intentionally generic. In this file we mainly care about the
+cases `Obs = SPMF` and `Obs = PMF`, but the same factoring pattern could later be reused for
+other kinds of denotational semantics such as sets of outcomes, traces, or quantum objects.
+
+The important asymmetry is that `interpret` is required to be a monad morphism, while `observe`
+is not. This lets us model semantics where running the internal computation requires fixing hidden
+state or discarding auxiliary structure before exposing the final denotation. -/
+structure SemanticsVia
+    (m : Type u → Type v) [Monad m] (Obs : Type u → Type x) where
   /-- Internal monad used to give denotational meaning to computations in `m`. -/
   Sem : Type u → Type w
   /-- Monad structure on the internal semantic monad. -/
   instMonadSem : Monad Sem
   /-- Interpret a surface computation into the internal semantic monad. -/
   interpret : m →ᵐ Sem
-  /-- Observe the internal semantic computation as an `SPMF`, forgetting any hidden structure. -/
-  observeSPMF : {α : Type u} → Sem α → SPMF α
+  /-- Observe the internal semantic computation as an external semantic object, forgetting any
+  hidden internal structure. -/
+  observe : {α : Type u} → Sem α → Obs α
 
-attribute [instance] SPMFSemantics.instMonadSem
+attribute [instance] SemanticsVia.instMonadSem
+
+namespace SemanticsVia
+
+variable {m : Type u → Type v} [Monad m] {Obs : Type u → Type x} {α : Type u}
+
+/-- The external denotation of `mx` under a bundled semantics factorization. -/
+def denote (sem : SemanticsVia m Obs) (mx : m α) : Obs α :=
+  sem.observe (sem.interpret mx)
+
+end SemanticsVia
+
+/-- Bundled subprobabilistic semantics for a monad `m`.
+
+This is the specialization of `SemanticsVia` where the external observation target is `SPMF`.
+Computations in `m` are therefore interpreted as subprobability distributions on outputs, possibly
+with failure mass. -/
+structure SPMFSemantics (m : Type u → Type v) [Monad m]
+    extends SemanticsVia m SPMF
+
+/-- The internal semantic monad of an `SPMFSemantics` carries the inherited monad structure. -/
+instance {m : Type u → Type v} [Monad m] (sem : SPMFSemantics m) : Monad sem.Sem :=
+  sem.toSemanticsVia.instMonadSem
 
 namespace SPMFSemantics
 
 variable {m : Type u → Type v} [Monad m] {α : Type u}
+
+/-- The observation map of an `SPMFSemantics`, specialized to `SPMF`. -/
+def observeSPMF (sem : SPMFSemantics m) : {α : Type u} → sem.Sem α → SPMF α :=
+  sem.observe
 
 /-- The subdistribution denoted by `mx` under the bundled semantics `sem`.
 
 This first moves `mx` into the internal semantic monad via `interpret`, and then collapses the
 internal structure to the externally visible `SPMF` via `observeSPMF`. -/
 def evalDist (sem : SPMFSemantics m) (mx : m α) : SPMF α :=
-  sem.observeSPMF (sem.interpret mx)
+  sem.toSemanticsVia.denote mx
 
 /-- The probability that `mx` fails to return a value under `sem`.
 
@@ -106,33 +140,32 @@ protected def ofHasEvalSPMF (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
   Sem := m
   instMonadSem := inferInstance
   interpret := MonadHom.id m
-  observeSPMF := fun mx => HasEvalSPMF.toSPMF mx
+  observe := fun mx => HasEvalSPMF.toSPMF mx
 
 end SPMFSemantics
 
 /-- Bundled total probabilistic semantics for a monad `m`.
 
-This is the total analogue of `SPMFSemantics`. The interpretation still factors through an
-internal semantic monad, but observation produces a `PMF`, so there is no failure mass. -/
-structure PMFSemantics (m : Type u → Type v) [Monad m] where
-  /-- Internal monad used to give denotational meaning to computations in `m`. -/
-  Sem : Type u → Type w
-  /-- Monad structure on the internal semantic monad. -/
-  instMonadSem : Monad Sem
-  /-- Interpret a surface computation into the internal semantic monad. -/
-  interpret : m →ᵐ Sem
-  /-- Observe the internal semantic computation as a total probability mass function. -/
-  observePMF : {α : Type u} → Sem α → PMF α
+This is the specialization of `SemanticsVia` where the external observation target is `PMF`.
+There is therefore no failure mass in the resulting denotation. -/
+structure PMFSemantics (m : Type u → Type v) [Monad m]
+    extends SemanticsVia m PMF
 
-attribute [instance] PMFSemantics.instMonadSem
+/-- The internal semantic monad of a `PMFSemantics` carries the inherited monad structure. -/
+instance {m : Type u → Type v} [Monad m] (sem : PMFSemantics m) : Monad sem.Sem :=
+  sem.toSemanticsVia.instMonadSem
 
 namespace PMFSemantics
 
 variable {m : Type u → Type v} [Monad m] {α : Type u}
 
+/-- The observation map of a `PMFSemantics`, specialized to `PMF`. -/
+def observePMF (sem : PMFSemantics m) : {α : Type u} → sem.Sem α → PMF α :=
+  sem.observe
+
 /-- The total distribution denoted by `mx` under the bundled semantics `sem`. -/
 def evalDist (sem : PMFSemantics m) (mx : m α) : PMF α :=
-  sem.observePMF (sem.interpret mx)
+  sem.toSemanticsVia.denote mx
 
 /-- Forget that a total semantics is total, yielding the underlying subprobabilistic semantics.
 
@@ -143,7 +176,7 @@ noncomputable def toSPMFSemantics (sem : PMFSemantics m) : SPMFSemantics m where
   Sem := sem.Sem
   instMonadSem := sem.instMonadSem
   interpret := sem.interpret
-  observeSPMF := fun mx => liftM (sem.observePMF mx)
+  observe := fun mx => liftM (sem.observePMF mx)
 
 /-- Package an ordinary `HasEvalPMF` instance as a bundled `PMFSemantics`.
 
@@ -154,6 +187,6 @@ protected def ofHasEvalPMF (m : Type u → Type v) [Monad m] [HasEvalPMF m] :
   Sem := m
   instMonadSem := inferInstance
   interpret := MonadHom.id m
-  observePMF := fun mx => HasEvalPMF.toPMF mx
+  observe := fun mx => HasEvalPMF.toPMF mx
 
 end PMFSemantics

--- a/VCVio/EvalDist/Defs/Semantics.lean
+++ b/VCVio/EvalDist/Defs/Semantics.lean
@@ -9,16 +9,65 @@ import VCVio.EvalDist.Defs.Basic
 # Bundled Probability Semantics
 
 This file defines bundled subprobabilistic and probabilistic semantics for monads.
-Unlike `HasEvalSPMF` and `HasEvalPMF`, these structures allow the denotational semantics
-to factor through an internal semantic monad before being observed as an `SPMF` or `PMF`.
+
+The existing classes `HasEvalSPMF` and `HasEvalPMF` say that a monad already *has* an
+`SPMF` or `PMF` denotation. That is convenient when the monad itself is the semantic object,
+but it is too rigid for constructions whose natural semantics has hidden internal structure.
+
+The main new idea here is to split semantics into two stages:
+
+1. `interpret`: map computations in the user-facing monad into an internal semantic monad
+2. `observe`: forget the internal bookkeeping and expose only the probabilistic behavior
+
+This is useful when the internal semantics carries extra state or other information that should
+not be visible at the final security-game interface. Typical examples include:
+
+- oracle caches modeled by hidden state
+- auxiliary logs or bookkeeping used only for the semantics
+- semantic monads that are more structured than the surface monad being specified
+
+`SPMFSemantics` is the general bundled notion for subprobabilistic semantics, while
+`PMFSemantics` is the total-probability specialization. They are deliberately *bundled*
+rather than typeclasses so that a construction can carry its intended semantics locally
+without forcing a single global instance on the ambient monad.
+-/
+
+/-!
+## Design Note
+
+The fields are intentionally minimal:
+
+- `Sem` is the internal semantic monad
+- `interpret` embeds the surface computation into that internal semantics
+- `observeSPMF` / `observePMF` discard the internal structure and return the external
+  distribution seen by the security definitions
+
+Notably, observation is not required to be a monad morphism. That is important: running a
+stateful semantics from a fixed initial state is a perfectly reasonable observation, but it is
+not itself a monad homomorphism. The bundling here leaves room for that style of semantics.
 -/
 
 universe u v w
 
+/-- Bundled subprobabilistic semantics for a monad `m`.
+
+An `SPMFSemantics m` says that computations in `m` can be understood denotationally by:
+
+1. interpreting them into some internal semantic monad `Sem`, and then
+2. observing the resulting computation as a subprobability mass function
+
+The key point is that `Sem` need not be the same as `m`. This lets us model surface monads whose
+meaning naturally passes through hidden semantic structure, such as caches, internal state, or
+other bookkeeping that should be invisible once we talk about probabilities of externally visible
+outcomes. -/
 structure SPMFSemantics (m : Type u → Type v) [Monad m] where
+  /-- Internal monad used to give denotational meaning to computations in `m`. -/
   Sem : Type u → Type w
+  /-- Monad structure on the internal semantic monad. -/
   instMonadSem : Monad Sem
+  /-- Interpret a surface computation into the internal semantic monad. -/
   interpret : m →ᵐ Sem
+  /-- Observe the internal semantic computation as an `SPMF`, forgetting any hidden structure. -/
   observeSPMF : {α : Type u} → Sem α → SPMF α
 
 attribute [instance] SPMFSemantics.instMonadSem
@@ -27,21 +76,31 @@ namespace SPMFSemantics
 
 variable {m : Type u → Type v} [Monad m] {α : Type u}
 
-/-- Evaluate a computation by first interpreting it into the internal semantic monad and then
-observing it as an `SPMF`. -/
+/-- The subdistribution denoted by `mx` under the bundled semantics `sem`.
+
+This first moves `mx` into the internal semantic monad via `interpret`, and then collapses the
+internal structure to the externally visible `SPMF` via `observeSPMF`. -/
 def evalDist (sem : SPMFSemantics m) (mx : m α) : SPMF α :=
   sem.observeSPMF (sem.interpret mx)
 
-/-- Failure probability of a computation under a bundled `SPMFSemantics`. -/
+/-- The probability that `mx` fails to return a value under `sem`.
+
+Since `SPMFSemantics` is subprobabilistic, failure is represented by the missing mass of the
+resulting `SPMF`, equivalently the probability of `none` in the underlying `Option`-valued PMF. -/
 def probFailure (sem : SPMFSemantics m) (mx : m α) : ENNReal :=
   (sem.evalDist mx).run none
 
+/-- Failure probability under an `SPMFSemantics` is always at most `1`. -/
 @[simp]
 lemma probFailure_le_one (sem : SPMFSemantics m) (mx : m α) :
     sem.probFailure mx ≤ 1 :=
   PMF.coe_le_one (sem.evalDist mx) none
 
-/-- Bundle an existing `HasEvalSPMF` instance as an `SPMFSemantics`. -/
+/-- Package an ordinary `HasEvalSPMF` instance as a bundled `SPMFSemantics`.
+
+This is the bridge back to the old style where the surface monad itself already carries its
+subprobabilistic denotation. In that case the internal semantic monad is just `m` itself, the
+interpreter is the identity monad morphism, and observation is `HasEvalSPMF.toSPMF`. -/
 protected def ofHasEvalSPMF (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
     SPMFSemantics m where
   Sem := m
@@ -51,10 +110,18 @@ protected def ofHasEvalSPMF (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
 
 end SPMFSemantics
 
+/-- Bundled total probabilistic semantics for a monad `m`.
+
+This is the total analogue of `SPMFSemantics`. The interpretation still factors through an
+internal semantic monad, but observation produces a `PMF`, so there is no failure mass. -/
 structure PMFSemantics (m : Type u → Type v) [Monad m] where
+  /-- Internal monad used to give denotational meaning to computations in `m`. -/
   Sem : Type u → Type w
+  /-- Monad structure on the internal semantic monad. -/
   instMonadSem : Monad Sem
+  /-- Interpret a surface computation into the internal semantic monad. -/
   interpret : m →ᵐ Sem
+  /-- Observe the internal semantic computation as a total probability mass function. -/
   observePMF : {α : Type u} → Sem α → PMF α
 
 attribute [instance] PMFSemantics.instMonadSem
@@ -63,20 +130,25 @@ namespace PMFSemantics
 
 variable {m : Type u → Type v} [Monad m] {α : Type u}
 
-/-- Evaluate a computation by first interpreting it into the internal semantic monad and then
-observing it as a `PMF`. -/
+/-- The total distribution denoted by `mx` under the bundled semantics `sem`. -/
 def evalDist (sem : PMFSemantics m) (mx : m α) : PMF α :=
   sem.observePMF (sem.interpret mx)
 
-/-- Every probabilistic semantics induces a subprobabilistic semantics by forgetting that failure
-never occurs. -/
+/-- Forget that a total semantics is total, yielding the underlying subprobabilistic semantics.
+
+This simply postcomposes observation with the canonical embedding `PMF α → SPMF α`. The resulting
+`SPMFSemantics` has zero failure probability, but it can now be consumed by APIs that are stated in
+terms of subprobabilistic semantics. -/
 noncomputable def toSPMFSemantics (sem : PMFSemantics m) : SPMFSemantics m where
   Sem := sem.Sem
   instMonadSem := sem.instMonadSem
   interpret := sem.interpret
   observeSPMF := fun mx => liftM (sem.observePMF mx)
 
-/-- Bundle an existing `HasEvalPMF` instance as a `PMFSemantics`. -/
+/-- Package an ordinary `HasEvalPMF` instance as a bundled `PMFSemantics`.
+
+As with `SPMFSemantics.ofHasEvalSPMF`, this recovers the familiar case where the surface monad
+already comes with a total probabilistic denotation. -/
 protected def ofHasEvalPMF (m : Type u → Type v) [Monad m] [HasEvalPMF m] :
     PMFSemantics m where
   Sem := m

--- a/VCVio/EvalDist/Defs/Semantics.lean
+++ b/VCVio/EvalDist/Defs/Semantics.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.EvalDist.Defs.Basic
+
+/-!
+# Bundled Probability Semantics
+
+This file defines bundled subprobabilistic and probabilistic semantics for monads.
+Unlike `HasEvalSPMF` and `HasEvalPMF`, these structures allow the denotational semantics
+to factor through an internal semantic monad before being observed as an `SPMF` or `PMF`.
+-/
+
+universe u v w
+
+structure SPMFSemantics (m : Type u → Type v) [Monad m] where
+  Sem : Type u → Type w
+  instMonadSem : Monad Sem
+  interpret : m →ᵐ Sem
+  observeSPMF : {α : Type u} → Sem α → SPMF α
+
+attribute [instance] SPMFSemantics.instMonadSem
+
+namespace SPMFSemantics
+
+variable {m : Type u → Type v} [Monad m] {α : Type u}
+
+/-- Evaluate a computation by first interpreting it into the internal semantic monad and then
+observing it as an `SPMF`. -/
+def evalDist (sem : SPMFSemantics m) (mx : m α) : SPMF α :=
+  sem.observeSPMF (sem.interpret mx)
+
+/-- Failure probability of a computation under a bundled `SPMFSemantics`. -/
+def probFailure (sem : SPMFSemantics m) (mx : m α) : ENNReal :=
+  (sem.evalDist mx).run none
+
+@[simp]
+lemma probFailure_le_one (sem : SPMFSemantics m) (mx : m α) :
+    sem.probFailure mx ≤ 1 :=
+  PMF.coe_le_one (sem.evalDist mx) none
+
+/-- Bundle an existing `HasEvalSPMF` instance as an `SPMFSemantics`. -/
+protected def ofHasEvalSPMF (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
+    SPMFSemantics m where
+  Sem := m
+  instMonadSem := inferInstance
+  interpret := MonadHom.id m
+  observeSPMF := fun mx => HasEvalSPMF.toSPMF mx
+
+end SPMFSemantics
+
+structure PMFSemantics (m : Type u → Type v) [Monad m] where
+  Sem : Type u → Type w
+  instMonadSem : Monad Sem
+  interpret : m →ᵐ Sem
+  observePMF : {α : Type u} → Sem α → PMF α
+
+attribute [instance] PMFSemantics.instMonadSem
+
+namespace PMFSemantics
+
+variable {m : Type u → Type v} [Monad m] {α : Type u}
+
+/-- Evaluate a computation by first interpreting it into the internal semantic monad and then
+observing it as a `PMF`. -/
+def evalDist (sem : PMFSemantics m) (mx : m α) : PMF α :=
+  sem.observePMF (sem.interpret mx)
+
+/-- Every probabilistic semantics induces a subprobabilistic semantics by forgetting that failure
+never occurs. -/
+noncomputable def toSPMFSemantics (sem : PMFSemantics m) : SPMFSemantics m where
+  Sem := sem.Sem
+  instMonadSem := sem.instMonadSem
+  interpret := sem.interpret
+  observeSPMF := fun mx => liftM (sem.observePMF mx)
+
+/-- Bundle an existing `HasEvalPMF` instance as a `PMFSemantics`. -/
+protected def ofHasEvalPMF (m : Type u → Type v) [Monad m] [HasEvalPMF m] :
+    PMFSemantics m where
+  Sem := m
+  instMonadSem := inferInstance
+  interpret := MonadHom.id m
+  observePMF := fun mx => HasEvalPMF.toPMF mx
+
+end PMFSemantics

--- a/VCVio/EvalDist/Defs/Semantics.lean
+++ b/VCVio/EvalDist/Defs/Semantics.lean
@@ -71,14 +71,12 @@ structure SemanticsVia
   /-- Internal monad used to give denotational meaning to computations in `m`. -/
   Sem : Type u → Type w
   /-- Monad structure on the internal semantic monad. -/
-  instMonadSem : Monad Sem
+  [instMonadSem : Monad Sem]
   /-- Interpret a surface computation into the internal semantic monad. -/
   interpret : m →ᵐ Sem
   /-- Observe the internal semantic computation as an external semantic object, forgetting any
   hidden internal structure. -/
   observe : {α : Type u} → Sem α → Obs α
-
-attribute [instance] SemanticsVia.instMonadSem
 
 namespace SemanticsVia
 


### PR DESCRIPTION
AI-authored by Codex on behalf of Quang Dao using GPT-5.

## Summary
- add bundled `SPMFSemantics` and `PMFSemantics` for monads interpreted through an internal semantic monad
- move `SecExp` from `ExecutionMethod` onto bundled `SPMFSemantics`
- update asymptotic security constructors so `ofSecExp` no longer requires a global `HasEvalSPMF`
- make the remaining direct `ExecutionMethod` dependencies explicit in scheme definition files

## Why
This is the first cut in the semantics refactor. It removes `ExecutionMethod` from the security-experiment critical path without yet rewriting the broader scheme APIs or tactic layer.

## Validation
- `lake build`
