### PR TITLE
Add HasQuery capability for ROM constructions

### DIFF
--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
 import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.QueryTracking.LoggingOracle
 import VCVio.OracleComp.QueryTracking.RandomOracle
@@ -109,7 +110,7 @@ sampling, while the right component is a lazy random oracle on `Rand → M`. -/
 private def roQueryImpl :
     QueryImpl (RO_Spec Rand M) (StateT ((Rand →ₒ M).QueryCache) ProbComp) :=
   let ro : QueryImpl (Rand →ₒ M) (StateT ((Rand →ₒ M).QueryCache) ProbComp) := randomOracle
-  let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+  let idImpl := (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (StateT ((Rand →ₒ M).QueryCache) ProbComp)
   idImpl + ro
 

--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
 import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 import VCVio.OracleComp.HasQuery

--- a/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
+++ b/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.Constructions.SampleableType
 import VCVio.OracleComp.QueryTracking.RandomOracle
@@ -136,7 +137,7 @@ noncomputable def experiment
   let params ← problem.sampleParams
   let ro : QueryImpl (HashInput →ₒ HashOutput)
     (StateT ((HashInput →ₒ HashOutput).QueryCache) ProbComp) := randomOracle
-  let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+  let idImpl := (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (StateT ((HashInput →ₒ HashOutput).QueryCache) ProbComp)
   let ((hashInput, response), cache) ←
     StateT.run (simulateQ (idImpl + ro) (adv.run params)) ∅

--- a/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
+++ b/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.CryptoFoundations.SecExp
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbComp

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -59,7 +59,7 @@ import VCVio.OracleComp.Constructions.Replicate
 import VCVio.OracleComp.Constructions.SampleableType
 import VCVio.OracleComp.EvalDist
 import VCVio.OracleComp.FinRatPMF
-import VCVio.OracleComp.MonadQuery
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.OracleComp
 import VCVio.OracleComp.OracleContext
 import VCVio.OracleComp.OracleQuery

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -58,6 +58,7 @@ import VCVio.OracleComp.Constructions.GenerateSeed
 import VCVio.OracleComp.Constructions.Replicate
 import VCVio.OracleComp.Constructions.SampleableType
 import VCVio.OracleComp.EvalDist
+import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.FinRatPMF
 import VCVio.OracleComp.OracleComp
 import VCVio.OracleComp.OracleContext

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -58,8 +58,8 @@ import VCVio.OracleComp.Constructions.GenerateSeed
 import VCVio.OracleComp.Constructions.Replicate
 import VCVio.OracleComp.Constructions.SampleableType
 import VCVio.OracleComp.EvalDist
-import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.FinRatPMF
+import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.OracleComp
 import VCVio.OracleComp.OracleContext
 import VCVio.OracleComp.OracleQuery

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCCA.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCCA.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.SimSemantics.Append
@@ -52,14 +53,14 @@ structure IND_CCA_Adversary (encAlg : AsymmEncAlg (OracleComp spec) M PK SK C) w
 /-- Pre-challenge decryption oracle for the IND-CCA game. -/
 def IND_CCA_preChallengeImpl (encAlg : AsymmEncAlg (OracleComp spec) M PK SK C)
     (sk : SK) : QueryImpl (IND_CCA_oracleSpec encAlg) (OracleComp spec) :=
-  (QueryImpl.ofLift spec (OracleComp spec)) + fun c => encAlg.decrypt sk c
+  (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)) + fun c => encAlg.decrypt sk c
 
 /-- Post-challenge decryption oracle for the IND-CCA game.
 The challenge ciphertext itself is answered with `none`, while all other ciphertexts are
 decrypted normally. -/
 def IND_CCA_postChallengeImpl (encAlg : AsymmEncAlg (OracleComp spec) M PK SK C)
     (sk : SK) (cStar : C) : QueryImpl (IND_CCA_oracleSpec encAlg) (OracleComp spec) :=
-  (QueryImpl.ofLift spec (OracleComp spec)) + fun c =>
+  (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)) + fun c =>
     if c = cStar then return none else encAlg.decrypt sk c
 
 /-- IND-CCA security game in the standard two-phase form.

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCCA.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCCA.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
+
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.Coercions.SubSpec

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -6,6 +6,7 @@ Authors: Devon Tuma, Quang Dao
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
+import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -29,19 +30,22 @@ variable {X W PC SC Ω P : Type}
 /-- Given a Σ-protocol and a generable relation, the Fiat-Shamir transform produces a
 signature scheme. The signing algorithm commits, queries the random oracle on (message,
 commitment), and then responds to the challenge. -/
-def FiatShamir (sigmaAlg : SigmaProtocol X W PC SC Ω P p)
-    (hr : GenerableRelation X W p) (M : Type) [DecidableEq M] :
-    SignatureAlg (OracleComp (unifSpec + (M × PC →ₒ Ω)))
+def FiatShamir
+    {m : Type → Type v} [Monad m]
+    (sigmaAlg : SigmaProtocol X W PC SC Ω P p)
+    (hr : GenerableRelation X W p) (M : Type) [DecidableEq M]
+    [MonadLiftT ProbComp m] [MonadQuery (M × PC →ₒ Ω) m] :
+    SignatureAlg m
       (M := M) (PK := X) (SK := W) (S := PC × P) where
-  keygen := hr.gen
-  sign := fun pk sk m => do
-    let (c, e) ← sigmaAlg.commit pk sk
-    let r ← query (spec := unifSpec + (M × PC →ₒ Ω)) (Sum.inr (m, c))
-    let s ← sigmaAlg.respond pk sk e r
-    return (c, s)
-  verify := fun pk m (c, s) => do
-    let r' ← query (spec := unifSpec + (M × PC →ₒ Ω)) (Sum.inr (m, c))
-    return sigmaAlg.verify pk c r' s
+  keygen := monadLift hr.gen
+  sign := fun pk sk msg => do
+    let (c, e) ← (monadLift (sigmaAlg.commit pk sk) : m _)
+    let r ← MonadQuery.query (spec := (M × PC →ₒ Ω)) (msg, c)
+    let s ← (monadLift (sigmaAlg.respond pk sk e r) : m _)
+    pure (c, s)
+  verify := fun pk msg (c, s) => do
+    let r' ← MonadQuery.query (spec := (M × PC →ₒ Ω)) (msg, c)
+    pure (sigmaAlg.verify pk c r' s)
 
 namespace FiatShamir
 
@@ -82,7 +86,9 @@ omit [DecidableEq P] [DecidableEq Ω] in
 /-- Completeness of the Fiat-Shamir signature scheme follows from completeness of the
 underlying Σ-protocol. -/
 theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
-    SignatureAlg.PerfectlyComplete (FiatShamir σ hr M) (runtime M) := by
+    SignatureAlg.PerfectlyComplete
+      (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M)
+      (runtime M) := by
   intro msg
   classical
   let ro : QueryImpl (M × PC →ₒ Ω)
@@ -128,13 +134,13 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
     simpa using hrun oa s
   change
     Pr[= true | (runtime M).evalDist (do
-      let (pk, sk) ← (FiatShamir σ hr M).keygen
-      let sig ← (FiatShamir σ hr M).sign pk sk msg
-      (FiatShamir σ hr M).verify pk msg sig)] = 1
+      let (pk, sk) ← (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).keygen
+      let sig ← (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).sign pk sk msg
+      (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).verify pk msg sig)] = 1
   rw [show (runtime M).evalDist (do
-      let (pk, sk) ← (FiatShamir σ hr M).keygen
-      let sig ← (FiatShamir σ hr M).sign pk sk msg
-      (FiatShamir σ hr M).verify pk msg sig) =
+      let (pk, sk) ← (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).keygen
+      let sig ← (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).sign pk sk msg
+      (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).verify pk msg sig) =
         evalDist (do
           let (pk, sk) ← hr.gen
           let (c, e) ← σ.commit pk sk
@@ -142,10 +148,27 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
           let s ← σ.respond pk sk e r
           pure (σ.verify pk c r s)) by
     change evalDist (StateT.run' (simulateQ (idImpl + ro) (do
-        let (pk, sk) ← (FiatShamir σ hr M).keygen
-        let sig ← (FiatShamir σ hr M).sign pk sk msg
-        (FiatShamir σ hr M).verify pk msg sig)) ∅) = _
+        let (pk, sk) ← (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).keygen
+        let sig ← (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).sign pk sk msg
+        (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M).verify pk msg sig)) ∅) = _
     dsimp only [FiatShamir]
+    have hquery :
+        ∀ q : M × PC,
+          @MonadQuery.query (M × PC) (M × PC →ₒ Ω)
+              (OracleComp (unifSpec + (M × PC →ₒ Ω)))
+              (inferInstanceAs (Monad (OracleComp (unifSpec + (M × PC →ₒ Ω)))))
+              (MonadQuery.instOfMonadLift
+                (spec := (M × PC →ₒ Ω))
+                (m := OracleComp (unifSpec + (M × PC →ₒ Ω))))
+              q =
+            (query (spec := unifSpec + (M × PC →ₒ Ω)) (Sum.inr q) :
+              OracleComp (unifSpec + (M × PC →ₒ Ω)) Ω) := by
+      intro q
+      exact congrArg
+        (fun z => (liftM z : OracleComp (unifSpec + (M × PC →ₒ Ω)) Ω))
+        (OracleQuery.liftM_add_right_query
+          (spec₁ := unifSpec) (spec₂ := (M × PC →ₒ Ω)) q)
+    simp_rw [hquery]
     simp only [simulateQ_bind, simulateQ_pure, simulateQ_query,
       QueryImpl.add_apply_inr,
       OracleQuery.cont_query, OracleQuery.input_query, id_map]
@@ -188,8 +211,8 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
         MonadLift.monadLift, StateT.run_lift, hmod]
     simp only [bind_assoc, pure_bind]
     simp_rw [hpeel]
-    simp_rw [hro_miss]
-    simp_rw [hpeel]
+    try simp_rw [hro_miss]
+    try simp_rw [hpeel]
     have hro_hit : ∀ {β : Type} (q : M × PC) (r : Ω)
         (rest : Ω → StateT ((M × PC →ₒ Ω).QueryCache) ProbComp β),
         (ro q >>= rest).run' ((∅ : (M × PC →ₒ Ω).QueryCache).cacheQuery q r) =
@@ -202,13 +225,13 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
       rw [StateT.run_bind]
       simp only [ro, randomOracle, QueryImpl.withCaching_apply, StateT.run_bind,
         StateT.run_get, pure_bind, QueryCache.cacheQuery_self, StateT.run_pure]
-    simp_rw [hro_hit]
+    try simp_rw [hro_hit]
     have hpure_run' : ∀ {α : Type} (a : α) (s : (M × PC →ₒ Ω).QueryCache),
         (pure a : StateT _ ProbComp α).run' s = (pure a : ProbComp α) := by
       intro α a s
       change Prod.fst <$> (pure (a, s) : ProbComp _) = pure a
       simp [map_pure]
-    simp_rw [hpure_run']]
+    try simp_rw [hpure_run']]
   change
     Pr[= true | (do
       let (pk, sk) ← hr.gen
@@ -260,7 +283,8 @@ theorem euf_cma_bound
     [Fintype Ω]
     (simTranscript : X → ProbComp (PC × Ω × P))
     (_hhvzk : σ.PerfectHVZK simTranscript)
-    (adv : SignatureAlg.unforgeableAdv (FiatShamir σ hr M))
+    (adv : SignatureAlg.unforgeableAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) σ hr M))
     (qBound : ℕ)
     (_hQ : ∀ pk, hashQueryBound (M := M) (PC := PC) (Ω := Ω)
       (S' := PC × P) (oa := adv.main pk) qBound) :

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -6,7 +6,7 @@ Authors: Devon Tuma, Quang Dao
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
-import VCVio.OracleComp.MonadQuery
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -34,17 +34,17 @@ def FiatShamir
     {m : Type → Type v} [Monad m]
     (sigmaAlg : SigmaProtocol X W PC SC Ω P p)
     (hr : GenerableRelation X W p) (M : Type) [DecidableEq M]
-    [MonadLiftT ProbComp m] [MonadQuery (M × PC →ₒ Ω) m] :
+    [MonadLiftT ProbComp m] [HasQuery (M × PC →ₒ Ω) m] :
     SignatureAlg m
       (M := M) (PK := X) (SK := W) (S := PC × P) where
   keygen := monadLift hr.gen
   sign := fun pk sk msg => do
     let (c, e) ← (monadLift (sigmaAlg.commit pk sk) : m _)
-    let r ← MonadQuery.query (spec := (M × PC →ₒ Ω)) (msg, c)
+    let r ← HasQuery.query (spec := (M × PC →ₒ Ω)) (msg, c)
     let s ← (monadLift (sigmaAlg.respond pk sk e r) : m _)
     pure (c, s)
   verify := fun pk msg (c, s) => do
-    let r' ← MonadQuery.query (spec := (M × PC →ₒ Ω)) (msg, c)
+    let r' ← HasQuery.query (spec := (M × PC →ₒ Ω)) (msg, c)
     pure (sigmaAlg.verify pk c r' s)
 
 namespace FiatShamir
@@ -154,7 +154,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
     dsimp only [FiatShamir]
     have hquery :
         ∀ q : M × PC,
-          MonadQuery.query
+          HasQuery.query
               (spec := (M × PC →ₒ Ω))
               (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) q =
             (query (spec := unifSpec + (M × PC →ₒ Ω)) (Sum.inr q) :

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -154,13 +154,9 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
     dsimp only [FiatShamir]
     have hquery :
         ∀ q : M × PC,
-          @MonadQuery.query (M × PC) (M × PC →ₒ Ω)
-              (OracleComp (unifSpec + (M × PC →ₒ Ω)))
-              (inferInstanceAs (Monad (OracleComp (unifSpec + (M × PC →ₒ Ω)))))
-              (MonadQuery.instOfMonadLift
-                (spec := (M × PC →ₒ Ω))
-                (m := OracleComp (unifSpec + (M × PC →ₒ Ω))))
-              q =
+          MonadQuery.query
+              (spec := (M × PC →ₒ Ω))
+              (m := OracleComp (unifSpec + (M × PC →ₒ Ω))) q =
             (query (spec := unifSpec + (M × PC →ₒ Ω)) (Sum.inr q) :
               OracleComp (unifSpec + (M × PC →ₒ Ω)) Ω) := by
       intro q

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -93,7 +93,7 @@ theorem perfectlyCorrect (hc : σ.PerfectlyComplete) :
   classical
   let ro : QueryImpl (M × PC →ₒ Ω)
       (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp) := randomOracle
-  let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+  let idImpl := (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (StateT ((M × PC →ₒ Ω).QueryCache) ProbComp)
   have hleft :
       ∀ {α : Type} (oa : ProbComp α),

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
+
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 import VCVio.CryptoFoundations.IdenSchemeWithAbort
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
-import VCVio.OracleComp.MonadQuery
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -56,13 +56,13 @@ Tries up to `n` commit-hash-respond cycles:
 Returns `none` only when all `n` attempts abort. -/
 def fsAbortSignLoop (ids : IdenSchemeWithAbort S W W' St C Z p)
     {m : Type → Type v} [Monad m]
-    (M : Type) [DecidableEq M] [MonadLiftT ProbComp m] [MonadQuery (M × W' →ₒ C) m]
+    (M : Type) [DecidableEq M] [MonadLiftT ProbComp m] [HasQuery (M × W' →ₒ C) m]
     (pk : S) (sk : W) (msg : M) :
     ℕ → m (Option (W' × Z))
   | 0 => return none
   | n + 1 => do
     let (w', st) ← (monadLift (ids.commit pk sk : ProbComp _) : m _)
-    let c ← MonadQuery.query (spec := (M × W' →ₒ C)) (msg, w')
+    let c ← HasQuery.query (spec := (M × W' →ₒ C)) (msg, w')
     let oz ← (monadLift (ids.respond pk sk st c : ProbComp _) : m _)
     match oz with
     | some z => return some (w', z)
@@ -84,7 +84,7 @@ def FiatShamirWithAbort
     {m : Type → Type v} [Monad m]
     (ids : IdenSchemeWithAbort S W W' St C Z p)
     (hr : GenerableRelation S W p) (M : Type) [DecidableEq M]
-    [MonadLiftT ProbComp m] [MonadQuery (M × W' →ₒ C) m]
+    [MonadLiftT ProbComp m] [HasQuery (M × W' →ₒ C) m]
     (maxAttempts : ℕ) :
     SignatureAlg m
       (M := M) (PK := S) (SK := W) (S := Option (W' × Z)) where
@@ -94,7 +94,7 @@ def FiatShamirWithAbort
     match sig with
     | none => return false
     | some (w', z) =>
-      let c ← MonadQuery.query (spec := (M × W' →ₒ C)) (msg, w')
+      let c ← HasQuery.query (spec := (M × W' →ₒ C)) (msg, w')
       pure (ids.verify pk w' c z)
 
 namespace FiatShamirWithAbort

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.CryptoFoundations.IdenSchemeWithAbort
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 import VCVio.CryptoFoundations.IdenSchemeWithAbort
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
+import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -34,6 +35,8 @@ This is the transform used by ML-DSA (CRYSTALS-Dilithium, FIPS 204).
 - NIST FIPS 204, Algorithms 2 (ML-DSA.Sign) and 3 (ML-DSA.Verify)
 -/
 
+universe v
+
 
 open OracleComp OracleSpec
 
@@ -52,16 +55,18 @@ Tries up to `n` commit-hash-respond cycles:
 
 Returns `none` only when all `n` attempts abort. -/
 def fsAbortSignLoop (ids : IdenSchemeWithAbort S W W' St C Z p)
-    (M : Type) [DecidableEq M] (pk : S) (sk : W) (m : M) :
-    ℕ → OracleComp (unifSpec + (M × W' →ₒ C)) (Option (W' × Z))
+    {m : Type → Type v} [Monad m]
+    (M : Type) [DecidableEq M] [MonadLiftT ProbComp m] [MonadQuery (M × W' →ₒ C) m]
+    (pk : S) (sk : W) (msg : M) :
+    ℕ → m (Option (W' × Z))
   | 0 => return none
   | n + 1 => do
-    let (w', st) ← (ids.commit pk sk : ProbComp _)
-    let c ← query (spec := unifSpec + (M × W' →ₒ C)) (Sum.inr (m, w'))
-    let oz ← (ids.respond pk sk st c : ProbComp _)
+    let (w', st) ← (monadLift (ids.commit pk sk : ProbComp _) : m _)
+    let c ← MonadQuery.query (spec := (M × W' →ₒ C)) (msg, w')
+    let oz ← (monadLift (ids.respond pk sk st c : ProbComp _) : m _)
     match oz with
     | some z => return some (w', z)
-    | none => fsAbortSignLoop ids M pk sk m n
+    | none => fsAbortSignLoop ids M pk sk msg n
 
 /-- The Fiat-Shamir with aborts transform applied to an identification scheme with aborts.
 Produces a signature scheme in the random oracle model.
@@ -75,19 +80,22 @@ The type parameters are:
 - `C`: challenge space (range of the hash/random oracle)
 - `Z`: response space
 - `S` / `W`: statement / witness (= public key / secret key) -/
-def FiatShamirWithAbort (ids : IdenSchemeWithAbort S W W' St C Z p)
+def FiatShamirWithAbort
+    {m : Type → Type v} [Monad m]
+    (ids : IdenSchemeWithAbort S W W' St C Z p)
     (hr : GenerableRelation S W p) (M : Type) [DecidableEq M]
+    [MonadLiftT ProbComp m] [MonadQuery (M × W' →ₒ C) m]
     (maxAttempts : ℕ) :
-    SignatureAlg (OracleComp (unifSpec + (M × W' →ₒ C)))
+    SignatureAlg m
       (M := M) (PK := S) (SK := W) (S := Option (W' × Z)) where
-  keygen := hr.gen
-  sign := fun pk sk m => fsAbortSignLoop ids M pk sk m maxAttempts
-  verify := fun pk m sig => do
+  keygen := monadLift hr.gen
+  sign := fun pk sk msg => fsAbortSignLoop ids M pk sk msg maxAttempts
+  verify := fun pk msg sig => do
     match sig with
     | none => return false
     | some (w', z) =>
-      let c ← query (spec := unifSpec + (M × W' →ₒ C)) (Sum.inr (m, w'))
-      return ids.verify pk w' c z
+      let c ← MonadQuery.query (spec := (M × W' →ₒ C)) (msg, w')
+      pure (ids.verify pk w' c z)
 
 namespace FiatShamirWithAbort
 
@@ -180,7 +188,8 @@ theorem euf_cma_bound [DecidableEq Z]
     (recover : S → C → Z → W')
     (hcr : ids.CommitmentRecoverable recover)
     (adv : SignatureAlg.unforgeableAdv
-      (FiatShamirWithAbort ids hr M maxAttempts))
+      (FiatShamirWithAbort
+        (m := OracleComp (unifSpec + (M × W' →ₒ C))) ids hr M maxAttempts))
     (qS qH : ℕ) (ε p_abort δ : ℝ) (hp : p_abort < 1)
     (hQ : ∀ pk, signHashQueryBound M
       (S' := Option (W' × Z)) (oa := adv.main pk) qS qH) :
@@ -204,7 +213,8 @@ theorem euf_cma_bound_perfectHVZK [DecidableEq Z]
     (recover : S → C → Z → W')
     (hcr : ids.CommitmentRecoverable recover)
     (adv : SignatureAlg.unforgeableAdv
-      (FiatShamirWithAbort ids hr M maxAttempts))
+      (FiatShamirWithAbort
+        (m := OracleComp (unifSpec + (M × W' →ₒ C))) ids hr M maxAttempts))
     (qS qH : ℕ) (ε p_abort δ : ℝ) (hp : p_abort < 1)
     (hQ : ∀ pk, signHashQueryBound M
       (S' := Option (W' × Z)) (oa := adv.main pk) qS qH) :

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -286,11 +286,11 @@ noncomputable def knowledgeSoundnessExp
   let roSpec := fischlinROSpec X PC Ω P ρ b M
   let ro : QueryImpl roSpec (StateT roSpec.QueryCache ProbComp) := randomOracle
   let loggedRO := ro.withLogging
-  let idImpl := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+  let idImpl := (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (WriterT (QueryLog roSpec) (StateT roSpec.QueryCache ProbComp))
   do
     let ((π, roLog), cache) ← (simulateQ (idImpl + loggedRO) (prover x msg)).run |>.run ∅
-    let idImpl' := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
+    let idImpl' := (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
       (StateT roSpec.QueryCache ProbComp)
     let (verified, _) ←
       (simulateQ (idImpl' + ro)

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
-import VCVio.OracleComp.MonadQuery
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.QueryTracking.LoggingOracle
 import VCVio.OracleComp.Coercions.Add
@@ -80,13 +80,13 @@ the prover queries `H` on each input and keeps the best. -/
 private def fischlinSearchAux {X W PC SC Ω P M : Type} {p : X → W → Bool} {ρ b : ℕ}
     {m : Type → Type v} [Monad m]
     (σ : SigmaProtocol X W PC SC Ω P p)
-    [MonadLiftT ProbComp m] [MonadQuery (fischlinROSpec X PC Ω P ρ b M) m]
+    [MonadLiftT ProbComp m] [HasQuery (fischlinROSpec X PC Ω P ρ b M) m]
     (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ) :
     List Ω → Option (Ω × P × Fin (2 ^ b)) → m (Option (Ω × P))
   | [], best => return best.map fun (ω, resp, _) => (ω, resp)
   | ω :: rest, best => do
     let resp ← (monadLift (σ.respond pk sk sc ω) : m _)
-    let h ← MonadQuery.query (spec := (fischlinROSpec X PC Ω P ρ b M))
+    let h ← HasQuery.query (spec := (fischlinROSpec X PC Ω P ρ b M))
       ⟨pk, msg, comList, i, ω, resp⟩
     if h.val = 0 then return some (ω, resp)
     else
@@ -118,7 +118,7 @@ def Fischlin
     (σ : SigmaProtocol X W PC SC Ω P p)
     (hr : GenerableRelation X W p) (ρ b S : ℕ) (M : Type)
     [DecidableEq M] [MonadLiftT ProbComp m]
-    [MonadQuery (fischlinROSpec X PC Ω P ρ b M) m] :
+    [HasQuery (fischlinROSpec X PC Ω P ρ b M) m] :
     SignatureAlg m
       (M := M) (PK := X) (SK := W) (S := FischlinProof PC Ω P ρ) where
   keygen := monadLift hr.gen
@@ -142,7 +142,7 @@ def Fischlin
     let comList := List.ofFn comVec
     let results ← Fin.mOfFn ρ fun i => do
       let (_, ω_i, resp_i) := π i
-      let h_i ← MonadQuery.query (spec := (fischlinROSpec X PC Ω P ρ b M))
+      let h_i ← HasQuery.query (spec := (fischlinROSpec X PC Ω P ρ b M))
         ⟨pk, msg, comList, i, ω_i, resp_i⟩
       pure (σ.verify pk (comVec i) ω_i resp_i, h_i.val)
     let allVerified := (List.finRange ρ).all fun i => (results i).1

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
+import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.QueryTracking.LoggingOracle
 import VCVio.OracleComp.Coercions.Add
@@ -77,15 +78,16 @@ Otherwise, tracks the `(challenge, response)` pair with the minimal hash value.
 This models the sequential search in Construction 1 of the Fischlin paper:
 the prover queries `H` on each input and keeps the best. -/
 private def fischlinSearchAux {X W PC SC Ω P M : Type} {p : X → W → Bool} {ρ b : ℕ}
+    {m : Type → Type v} [Monad m]
     (σ : SigmaProtocol X W PC SC Ω P p)
+    [MonadLiftT ProbComp m] [MonadQuery (fischlinROSpec X PC Ω P ρ b M) m]
     (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ) :
-    List Ω → Option (Ω × P × Fin (2 ^ b)) →
-      OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M) (Option (Ω × P))
+    List Ω → Option (Ω × P × Fin (2 ^ b)) → m (Option (Ω × P))
   | [], best => return best.map fun (ω, resp, _) => (ω, resp)
   | ω :: rest, best => do
-    let resp ← σ.respond pk sk sc ω
-    let h ← query (spec := unifSpec + fischlinROSpec X PC Ω P ρ b M)
-      (Sum.inr ⟨pk, msg, comList, i, ω, resp⟩)
+    let resp ← (monadLift (σ.respond pk sk sc ω) : m _)
+    let h ← MonadQuery.query (spec := (fischlinROSpec X PC Ω P ρ b M))
+      ⟨pk, msg, comList, i, ω, resp⟩
     if h.val = 0 then return some (ω, resp)
     else
       let newBest := match best with
@@ -111,20 +113,27 @@ whose hash value is minimal, exiting early at hash `0`.
 **Verification**: re-hashes each `(commitment, challenge, response)` triple, checks
 sigma-protocol verification for each repetition, and verifies that the sum of hash
 values is at most `S`. -/
-def Fischlin (σ : SigmaProtocol X W PC SC Ω P p)
+def Fischlin
+    {m : Type → Type v} [Monad m]
+    (σ : SigmaProtocol X W PC SC Ω P p)
     (hr : GenerableRelation X W p) (ρ b S : ℕ) (M : Type)
-    [DecidableEq M] :
-    SignatureAlg (OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M))
+    [DecidableEq M] [MonadLiftT ProbComp m]
+    [MonadQuery (fischlinROSpec X PC Ω P ρ b M) m] :
+    SignatureAlg m
       (M := M) (PK := X) (SK := W) (S := FischlinProof PC Ω P ρ) where
-  keygen := hr.gen
+  keygen := monadLift hr.gen
   sign := fun pk sk msg => do
-    let commits ← Fin.mOfFn ρ fun _ => σ.commit pk sk
+    let commits : Fin ρ → PC × SC ←
+      Fin.mOfFn ρ fun _ => (monadLift (σ.commit pk sk) : m (PC × SC))
     let comVec : Fin ρ → PC := fun i => (commits i).1
     let comList := List.ofFn comVec
     Fin.mOfFn ρ fun i => do
       let sc_i := (commits i).2
-      let result ← fischlinSearchAux σ pk sk sc_i msg comList i
-        (FinEnum.toList Ω) none
+      let result ←
+        fischlinSearchAux
+          (X := X) (W := W) (PC := PC) (SC := SC) (Ω := Ω) (P := P) (M := M)
+          (p := p) (ρ := ρ) (b := b) (m := m)
+          σ pk sk sc_i msg comList i (FinEnum.toList Ω) none
       match result with
       | some (ω, resp) => return (comVec i, ω, resp)
       | none => return (comVec i, default, default)
@@ -133,12 +142,12 @@ def Fischlin (σ : SigmaProtocol X W PC SC Ω P p)
     let comList := List.ofFn comVec
     let results ← Fin.mOfFn ρ fun i => do
       let (_, ω_i, resp_i) := π i
-      let h_i ← query (spec := unifSpec + fischlinROSpec X PC Ω P ρ b M)
-        (Sum.inr ⟨pk, msg, comList, i, ω_i, resp_i⟩)
-      return (σ.verify pk (comVec i) ω_i resp_i, h_i.val)
+      let h_i ← MonadQuery.query (spec := (fischlinROSpec X PC Ω P ρ b M))
+        ⟨pk, msg, comList, i, ω_i, resp_i⟩
+      pure (σ.verify pk (comVec i) ω_i resp_i, h_i.val)
     let allVerified := (List.finRange ρ).all fun i => (results i).1
     let hashSum := (List.finRange ρ).foldl (fun acc i => acc + (results i).2) 0
-    return (allVerified && decide (hashSum ≤ S))
+    pure (allVerified && decide (hashSum ≤ S))
 
 namespace Fischlin
 
@@ -189,9 +198,14 @@ has a non-zero completeness error because the prover's proof-of-work search may 
 to find hash values whose sum is at most `S`. -/
 theorem almostComplete (hρ : 0 < ρ) (hc : σ.PerfectlyComplete) (msg : M) :
     Pr[= true | (runtime ρ b M).evalDist do
-      let (pk, sk) ← (Fischlin σ hr ρ b S M).keygen
-      let sig ← (Fischlin σ hr ρ b S M).sign pk sk msg
-      (Fischlin σ hr ρ b S M).verify pk msg sig]
+      let (pk, sk) ←
+        (Fischlin (m := OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M))
+          σ hr ρ b S M).keygen
+      let sig ←
+        (Fischlin (m := OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M))
+          σ hr ρ b S M).sign pk sk msg
+      (Fischlin (m := OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M))
+        σ hr ρ b S M).verify pk msg sig]
     ≥ 1 - completenessError ρ b S (FinEnum.card Ω) := by sorry
 
 /-! ### Online Extraction / Knowledge Soundness -/
@@ -279,7 +293,9 @@ noncomputable def knowledgeSoundnessExp
     let idImpl' := (QueryImpl.ofLift unifSpec ProbComp).liftTarget
       (StateT roSpec.QueryCache ProbComp)
     let (verified, _) ←
-      (simulateQ (idImpl' + ro) ((Fischlin σ hr ρ b S M).verify x msg π)).run cache
+      (simulateQ (idImpl' + ro)
+        ((Fischlin (m := OracleComp (unifSpec + fischlinROSpec X PC Ω P ρ b M))
+          σ hr ρ b S M).verify x msg π)).run cache
     let extracted ← onlineExtract σ ρ b M x π roLog
     return (verified && !(match extracted with | some w => p x w | none => false))
 

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/Defs.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/Defs.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -73,7 +74,7 @@ abbrev OW_CPA_Adversary := PK → C → OracleComp pke.OW_CPA_oracleSpec M
 
 /-- Implementation of the OW-CPA encryption oracle. -/
 def OW_CPA_queryImpl (pk : PK) : QueryImpl pke.OW_CPA_oracleSpec ProbComp :=
-  (QueryImpl.ofLift unifSpec ProbComp) + fun msg => do
+  (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)) + fun msg => do
     let r ← ($ᵗ R : ProbComp R)
     pure (pke.encrypt pk msg r)
 
@@ -129,7 +130,7 @@ def OW_PCVA_queryImpl (encAlg : AsymmEncAlg (OracleComp spec) M PK SK C)
   let validImpl : QueryImpl (C →ₒ Bool) (OracleComp spec) := fun c => do
     let msg' ← encAlg.decrypt sk c
     return msg'.isSome
-  (QueryImpl.ofLift spec (OracleComp spec)) + (checkImpl + validImpl)
+  (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)) + (checkImpl + validImpl)
 
 /-- Main one-way under plaintext-checking and validity attacks (OW-PCVA) experiment.
 

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/Defs.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/Defs.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.Coercions.Add

--- a/VCVio/CryptoFoundations/GPVHashAndSign.lean
+++ b/VCVio/CryptoFoundations/GPVHashAndSign.lean
@@ -5,7 +5,7 @@ Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
-import VCVio.OracleComp.MonadQuery
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -101,17 +101,17 @@ def GPVHashAndSign
     (hr : GenerableRelation PK SK p)
     (M Salt : Type) [DecidableEq M] [DecidableEq Salt] [SampleableType Salt]
     [DecidableEq Range] [SampleableType Range]
-    [MonadLiftT ProbComp m] [MonadQuery (Salt × M →ₒ Range) m] :
+    [MonadLiftT ProbComp m] [HasQuery (Salt × M →ₒ Range) m] :
     SignatureAlg m
       (M := M) (PK := PK) (SK := SK) (S := Salt × Domain) where
   keygen := monadLift hr.gen
   sign := fun pk sk msg => do
     let r ← (monadLift ($ᵗ Salt : ProbComp Salt) : m Salt)
-    let c ← MonadQuery.query (spec := (Salt × M →ₒ Range)) (r, msg)
+    let c ← HasQuery.query (spec := (Salt × M →ₒ Range)) (r, msg)
     let s ← (monadLift (psf.trapdoorSample pk sk c) : m _)
     pure (r, s)
   verify := fun pk msg (r, s) => do
-    let c ← MonadQuery.query (spec := (Salt × M →ₒ Range)) (r, msg)
+    let c ← HasQuery.query (spec := (Salt × M →ₒ Range)) (r, msg)
     pure (decide (psf.eval pk s = c) && psf.isShort s)
 
 namespace GPVHashAndSign

--- a/VCVio/CryptoFoundations/GPVHashAndSign.lean
+++ b/VCVio/CryptoFoundations/GPVHashAndSign.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 import VCVio.OracleComp.HasQuery

--- a/VCVio/CryptoFoundations/GPVHashAndSign.lean
+++ b/VCVio/CryptoFoundations/GPVHashAndSign.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
+import VCVio.OracleComp.MonadQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
@@ -42,6 +43,8 @@ The GPV framework is the hash-and-sign analogue of the Fiat-Shamir transform:
 - Boneh, Dagdelen, Fischlin, Lehmann, Schaffner, Zhandry. "Random Oracles in a Quantum
   World." ASIACRYPT 2011.
 -/
+
+universe v
 
 
 open OracleComp OracleSpec ENNReal
@@ -91,23 +94,25 @@ Given a preimage sampleable function `psf`, a generable key relation `hr`, and a
 The signature type is `Salt × Domain` (salt paired with the short preimage).
 The oracle spec is `unifSpec + (Salt × M →ₒ Range)` (uniform sampling + random oracle). -/
 def GPVHashAndSign
+    {m : Type → Type v} [Monad m]
     {PK SK Domain Range : Type}
     (psf : PreimageSampleableFunction PK SK Domain Range)
     {p : PK → SK → Bool} [SampleableType PK] [SampleableType SK]
     (hr : GenerableRelation PK SK p)
     (M Salt : Type) [DecidableEq M] [DecidableEq Salt] [SampleableType Salt]
-    [DecidableEq Range] [SampleableType Range] :
-    SignatureAlg (OracleComp (unifSpec + (Salt × M →ₒ Range)))
+    [DecidableEq Range] [SampleableType Range]
+    [MonadLiftT ProbComp m] [MonadQuery (Salt × M →ₒ Range) m] :
+    SignatureAlg m
       (M := M) (PK := PK) (SK := SK) (S := Salt × Domain) where
-  keygen := hr.gen
-  sign := fun pk sk m => do
-    let r ← $ᵗ Salt
-    let c ← query (spec := unifSpec + (Salt × M →ₒ Range)) (Sum.inr (r, m))
-    let s ← psf.trapdoorSample pk sk c
-    return (r, s)
-  verify := fun pk m (r, s) => do
-    let c ← query (spec := unifSpec + (Salt × M →ₒ Range)) (Sum.inr (r, m))
-    return (decide (psf.eval pk s = c) && psf.isShort s)
+  keygen := monadLift hr.gen
+  sign := fun pk sk msg => do
+    let r ← (monadLift ($ᵗ Salt : ProbComp Salt) : m Salt)
+    let c ← MonadQuery.query (spec := (Salt × M →ₒ Range)) (r, msg)
+    let s ← (monadLift (psf.trapdoorSample pk sk c) : m _)
+    pure (r, s)
+  verify := fun pk msg (r, s) => do
+    let c ← MonadQuery.query (spec := (Salt × M →ₒ Range)) (r, msg)
+    pure (decide (psf.eval pk s = c) && psf.isShort s)
 
 namespace GPVHashAndSign
 
@@ -177,7 +182,8 @@ The proof is a standard GPV argument:
 
 Reference: GPV08, Theorem 6.1; see also BDF+11 for the QROM extension. -/
 theorem euf_cma_bound [DecidableEq Domain] [SampleableType Domain]
-    (adv : SignatureAlg.unforgeableAdv (GPVHashAndSign psf hr M Salt)) :
+    (adv : SignatureAlg.unforgeableAdv
+      (GPVHashAndSign (m := OracleComp (unifSpec + (Salt × M →ₒ Range))) psf hr M Salt)) :
     ∃ (reduction : PreimageAdversary (PK := PK) (Domain := Domain) (Range := Range))
       (collisionBound : ENNReal),
       adv.advantage (runtime M Salt) ≤

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
+
 import VCVio.CryptoFoundations.SecExp
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbCompLift

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbCompLift
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.Coercions.Add
@@ -123,12 +124,12 @@ structure IND_CCA_Adversary (kem : KEMScheme (OracleComp spec) K PK SK C) where
 /-- Pre-challenge decapsulation oracle. -/
 def IND_CCA_preChallengeImpl (kem : KEMScheme (OracleComp spec) K PK SK C)
     (sk : SK) : QueryImpl (IND_CCA_oracleSpec kem) (OracleComp spec) :=
-  (QueryImpl.ofLift spec (OracleComp spec)) + fun c => kem.decaps sk c
+  (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)) + fun c => kem.decaps sk c
 
 /-- Post-challenge decapsulation oracle: the challenge ciphertext itself maps to `none`. -/
 def IND_CCA_postChallengeImpl (kem : KEMScheme (OracleComp spec) K PK SK C)
     (sk : SK) (cStar : C) : QueryImpl (IND_CCA_oracleSpec kem) (OracleComp spec) :=
-  (QueryImpl.ofLift spec (OracleComp spec)) + fun c =>
+  (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)) + fun c =>
     if c = cStar then return none else kem.decaps sk c
 
 /-- IND-CCA real-or-random experiment for a KEM. -/
@@ -158,12 +159,10 @@ def IND_CPA_Adversary.toIND_CCA {kem : KEMScheme (OracleComp spec) K PK SK C}
     (adversary : kem.IND_CPA_Adversary) : kem.IND_CCA_Adversary where
   State := adversary.State
   preChallenge pk := simulateQ
-    (show QueryImpl spec (OracleComp (spec + (C →ₒ Option K))) from
-      fun t => liftM (query (spec := spec) t))
+    (HasQuery.toQueryImpl (spec := spec) (m := OracleComp (spec + (C →ₒ Option K))))
     (adversary.preChallenge pk)
   postChallenge st cStar kStar := simulateQ
-    (show QueryImpl spec (OracleComp (spec + (C →ₒ Option K))) from
-      fun t => liftM (query (spec := spec) t))
+    (HasQuery.toQueryImpl (spec := spec) (m := OracleComp (spec + (C →ₒ Option K))))
     (adversary.postChallenge st cStar kStar)
 
 /-- The one-stage IND-CPA game is exactly the IND-CCA game instantiated with the trivial
@@ -178,9 +177,8 @@ theorem IND_CPA_Game_eq_IND_CCA_Game_toIND_CCA
   congr 1
   simp only [← QueryImpl.simulateQ_compose]
   have h : ∀ (impl₂ : QueryImpl (C →ₒ Option K) (OracleComp spec)),
-      (QueryImpl.ofLift spec (OracleComp spec) + impl₂) ∘ₛ
-        (fun t => liftM (query (spec := spec) t) :
-          QueryImpl spec (OracleComp (spec + (C →ₒ Option K)))) =
+      ((HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)) + impl₂) ∘ₛ
+        (HasQuery.toQueryImpl (spec := spec) (m := OracleComp (spec + (C →ₒ Option K)))) =
       QueryImpl.id' spec := by
     intro impl₂
     ext t

--- a/VCVio/CryptoFoundations/MacAlg.lean
+++ b/VCVio/CryptoFoundations/MacAlg.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbCompLift
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.LoggingOracle
@@ -72,7 +73,7 @@ def UF_CMA_Exp {macAlg : MacAlg (OracleComp spec) M K T}
     let k ← macAlg.keygen
     let impl : QueryImpl (spec + (M →ₒ T))
         (WriterT (QueryLog (M →ₒ T)) (OracleComp spec)) :=
-      (QueryImpl.ofLift spec (OracleComp spec)).liftTarget
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
         (WriterT (QueryLog (M →ₒ T)) (OracleComp spec)) +
         macAlg.taggingOracle k
     let sim_adv : WriterT (QueryLog (M →ₒ T)) (OracleComp spec) (M × T) :=

--- a/VCVio/CryptoFoundations/PRF.lean
+++ b/VCVio/CryptoFoundations/PRF.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.EvalDist
 import VCVio.OracleComp.HasQuery

--- a/VCVio/CryptoFoundations/PRF.lean
+++ b/VCVio/CryptoFoundations/PRF.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.EvalDist
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.SimSemantics.Append
@@ -26,7 +27,6 @@ distinguish the real function `PRF.eval k` (for a random key `k`) from a truly r
 - `prfIdealExp` — the ideal experiment (adversary queries a random oracle).
 - `prfAdvantage` — distinguishing advantage.
 -/
-
 
 open OracleComp OracleSpec ENNReal
 
@@ -57,13 +57,14 @@ by the ambient `unifSpec`; function queries are answered by `prf.eval k`. -/
 def prfRealQueryImpl (prf : PRFScheme K D R) (k : K) :
     QueryImpl (PRFOracleSpec D R) ProbComp :=
   let so : QueryImpl (D →ₒ R) ProbComp := fun d => pure (prf.eval k d)
-  (QueryImpl.ofLift unifSpec ProbComp) + so
+  (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)) + so
 
 /-- Query implementation for the ideal PRF experiment. Uniform-sampling queries are handled
 by the ambient `unifSpec`; function queries are answered by a lazy random oracle. -/
 def prfIdealQueryImpl [DecidableEq D] [SampleableType R] :
     QueryImpl (PRFOracleSpec D R) (StateT ((D →ₒ R).QueryCache) ProbComp) :=
-  (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT ((D →ₒ R).QueryCache) ProbComp) +
+  (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
+    (StateT ((D →ₒ R).QueryCache) ProbComp) +
     randomOracle (spec := (D →ₒ R))
 
 /-- Real PRF experiment: sample a key, let the adversary query `prf.eval k`. -/

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.SecExp
+import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbCompLift
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.LoggingOracle
@@ -68,7 +69,7 @@ the adversary successfully forged a signature.
 
 API changes from old version:
 - `spec ++ₒ` → `spec +`
-- `idOracle ++ₛₒ sigAlg.signingOracle pk sk` → explicit `QueryImpl.ofLift` + `liftTarget` + `+`
+- `idOracle ++ₛₒ sigAlg.signingOracle pk sk` → explicit `HasQuery.toQueryImpl` + `liftTarget` + `+`
 - `log.wasQueried () m` → `log.wasQueried msg` (Domain of `M →ₒ S` is `M`, not `Unit × M`) -/
 def unforgeableExp {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
@@ -77,7 +78,7 @@ def unforgeableExp {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     let (pk, sk) ← sigAlg.keygen
     let impl : QueryImpl (spec + (M →ₒ S))
         (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) :=
-      (QueryImpl.ofLift spec (OracleComp spec)).liftTarget
+      (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget
         (WriterT (QueryLog (M →ₒ S)) (OracleComp spec)) +
         sigAlg.signingOracle pk sk
     let sim_adv : WriterT (QueryLog (M →ₒ S)) (OracleComp spec) (M × S) :=

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -3,6 +3,7 @@ Copyright (c) 2024 Devon Tuma. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
+
 import VCVio.CryptoFoundations.SecExp
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.ProbCompLift
@@ -65,12 +66,9 @@ structure unforgeableAdv (_sigAlg : SignatureAlg (OracleComp spec) M PK SK S) wh
   main (pk : PK) : OracleComp (spec + (M →ₒ S)) (M × S)
 
 /-- Unforgeability experiment for a signature algorithm: runs the adversary and checks whether
-the adversary successfully forged a signature.
-
-API changes from old version:
-- `spec ++ₒ` → `spec +`
-- `idOracle ++ₛₒ sigAlg.signingOracle pk sk` → explicit `HasQuery.toQueryImpl` + `liftTarget` + `+`
-- `log.wasQueried () m` → `log.wasQueried msg` (Domain of `M →ₒ S` is `M`, not `Unit × M`) -/
+the adversary successfully forged a signature. The ambient oracle family is forwarded unchanged,
+the signing oracle is logged, and the final check requires both signature validity and that the
+forged message was never submitted to the signing oracle. -/
 def unforgeableExp {sigAlg : SignatureAlg (OracleComp spec) M PK SK S}
     (runtime : ProbCompRuntime (OracleComp spec))
     (adv : unforgeableAdv sigAlg) : SPMF Bool :=

--- a/VCVio/OracleComp/HasQuery.lean
+++ b/VCVio/OracleComp/HasQuery.lean
@@ -17,9 +17,10 @@ induction, and query-bound reasoning. `HasQuery` is the lighter interface used w
 construction only needs to *ask* oracle queries, without reifying or analyzing the query syntax.
 
 The key design choice is that `HasQuery` is just a facade over the existing lifting story:
+the primitive single-query syntax `OracleQuery spec` is itself a `HasQuery spec` instance, and
 any monad that supports `MonadLiftT (OracleQuery spec) m` automatically gets a `HasQuery spec m`
-instance. As a result, the capability composes with the existing `SubSpec` coercions and with
-standard transformer lifts such as `StateT`, `ReaderT`, `ExceptT`, and `WriterT`.
+instance as well. As a result, the capability composes with the existing `SubSpec` coercions
+and with standard transformer lifts such as `StateT`, `ReaderT`, `ExceptT`, and `WriterT`.
 -/
 
 open OracleSpec
@@ -34,6 +35,15 @@ class HasQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) (m : Type v → Type 
 namespace HasQuery
 
 variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {m : Type v → Type w}
+
+/-- The primitive single-query syntax `OracleQuery spec` has the obvious query capability. -/
+instance instOracleQuery : HasQuery spec (OracleQuery spec) where
+  query := OracleQuery.query
+
+@[simp]
+lemma instOracleQuery_query (t : spec.Domain) :
+    (instOracleQuery (spec := spec)).query t = OracleQuery.query (spec := spec) t :=
+  rfl
 
 /-- Repackage `HasQuery` as a `QueryImpl`, for APIs that still consume explicit oracle
 implementations. -/

--- a/VCVio/OracleComp/HasQuery.lean
+++ b/VCVio/OracleComp/HasQuery.lean
@@ -42,7 +42,8 @@ instance instOracleQuery : HasQuery spec (OracleQuery spec) where
 
 @[simp]
 lemma instOracleQuery_query (t : spec.Domain) :
-    (instOracleQuery (spec := spec)).query t = OracleQuery.query (spec := spec) t :=
+    HasQuery.query (spec := spec) (m := OracleQuery spec) t =
+      OracleQuery.query (spec := spec) t :=
   rfl
 
 /-- Repackage `HasQuery` as a `QueryImpl`, for APIs that still consume explicit oracle
@@ -62,7 +63,7 @@ instance (priority := low) instOfMonadLift [MonadLiftT (OracleQuery spec) m] :
 
 @[simp]
 lemma instOfMonadLift_query [MonadLiftT (OracleQuery spec) m] (t : spec.Domain) :
-    (instOfMonadLift (spec := spec) (m := m)).query t =
+    HasQuery.query (spec := spec) (m := m) t =
       liftM (OracleQuery.query (spec := spec) t) :=
   rfl
 

--- a/VCVio/OracleComp/HasQuery.lean
+++ b/VCVio/OracleComp/HasQuery.lean
@@ -9,15 +9,15 @@ import VCVio.OracleComp.SimSemantics.QueryImpl
 /-!
 # Generic Oracle Query Capability
 
-This file defines `MonadQuery spec m`, a thin capability interface for monads that can issue
+This file defines `HasQuery spec m`, a thin capability interface for monads that can issue
 queries to an oracle family `spec`.
 
 `OracleComp spec` remains the canonical free syntax for explicit oracle computations, structural
-induction, and query-bound reasoning. `MonadQuery` is the lighter interface used when a
+induction, and query-bound reasoning. `HasQuery` is the lighter interface used when a
 construction only needs to *ask* oracle queries, without reifying or analyzing the query syntax.
 
-The key design choice is that `MonadQuery` is just a facade over the existing lifting story:
-any monad that supports `MonadLiftT (OracleQuery spec) m` automatically gets a `MonadQuery spec m`
+The key design choice is that `HasQuery` is just a facade over the existing lifting story:
+any monad that supports `MonadLiftT (OracleQuery spec) m` automatically gets a `HasQuery spec m`
 instance. As a result, the capability composes with the existing `SubSpec` coercions and with
 standard transformer lifts such as `StateT`, `ReaderT`, `ExceptT`, and `WriterT`.
 -/
@@ -27,27 +27,27 @@ open OracleSpec
 universe u v w
 
 /-- Capability to issue queries to the oracle family `spec` inside the ambient monad `m`. -/
-class MonadQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) (m : Type v → Type w) where
+class HasQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) (m : Type v → Type w) where
   /-- Issue a single oracle query. -/
   query : (t : spec.Domain) → m (spec.Range t)
 
-namespace MonadQuery
+namespace HasQuery
 
 variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {m : Type v → Type w}
 
-/-- Repackage `MonadQuery` as a `QueryImpl`, for APIs that still consume explicit oracle
+/-- Repackage `HasQuery` as a `QueryImpl`, for APIs that still consume explicit oracle
 implementations. -/
-def toQueryImpl [MonadQuery spec m] : QueryImpl spec m :=
-  fun t => MonadQuery.query t
+def toQueryImpl [HasQuery spec m] : QueryImpl spec m :=
+  fun t => HasQuery.query t
 
 @[simp]
-lemma toQueryImpl_apply [MonadQuery spec m] (t : spec.Domain) :
-    toQueryImpl (spec := spec) (m := m) t = MonadQuery.query (spec := spec) (m := m) t := rfl
+lemma toQueryImpl_apply [HasQuery spec m] (t : spec.Domain) :
+    toQueryImpl (spec := spec) (m := m) t = HasQuery.query (spec := spec) (m := m) t := rfl
 
 /-- Any lawful lift of `OracleQuery spec` into `m` gives query capability in `m`. This is the
-main bridge that makes `MonadQuery` compose with `SubSpec` lifts and standard transformer lifts. -/
+main bridge that makes `HasQuery` compose with `SubSpec` lifts and standard transformer lifts. -/
 instance (priority := low) instOfMonadLift [MonadLiftT (OracleQuery spec) m] :
-    MonadQuery spec m where
+    HasQuery spec m where
   query t := liftM (OracleQuery.query (spec := spec) t)
 
 @[simp]
@@ -56,4 +56,4 @@ lemma instOfMonadLift_query [MonadLiftT (OracleQuery spec) m] (t : spec.Domain) 
       liftM (OracleQuery.query (spec := spec) t) :=
   rfl
 
-end MonadQuery
+end HasQuery

--- a/VCVio/OracleComp/MonadQuery.lean
+++ b/VCVio/OracleComp/MonadQuery.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.OracleComp.SimSemantics.QueryImpl
+
+/-!
+# Generic Oracle Query Capability
+
+This file defines `MonadQuery spec m`, a thin capability interface for monads that can issue
+queries to an oracle family `spec`.
+
+`OracleComp spec` remains the canonical free syntax for explicit oracle computations, structural
+induction, and query-bound reasoning. `MonadQuery` is the lighter interface used when a
+construction only needs to *ask* oracle queries, without reifying or analyzing the query syntax.
+
+The key design choice is that `MonadQuery` is just a facade over the existing lifting story:
+any monad that supports `MonadLiftT (OracleQuery spec) m` automatically gets a `MonadQuery spec m`
+instance. As a result, the capability composes with the existing `SubSpec` coercions and with
+standard transformer lifts such as `StateT`, `ReaderT`, `ExceptT`, and `WriterT`.
+-/
+
+open OracleSpec
+
+universe u v w
+
+/-- Capability to issue queries to the oracle family `spec` inside the ambient monad `m`. -/
+class MonadQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) (m : Type v → Type w) [Monad m] where
+  /-- Issue a single oracle query. -/
+  query : (t : spec.Domain) → m (spec.Range t)
+
+namespace MonadQuery
+
+variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {m : Type v → Type w} [Monad m]
+
+/-- Repackage `MonadQuery` as a `QueryImpl`, for APIs that still consume explicit oracle
+implementations. -/
+def toQueryImpl [MonadQuery spec m] : QueryImpl spec m :=
+  fun t => MonadQuery.query t
+
+@[simp]
+lemma toQueryImpl_apply [MonadQuery spec m] (t : spec.Domain) :
+    toQueryImpl (spec := spec) (m := m) t = MonadQuery.query (spec := spec) (m := m) t := rfl
+
+/-- Any lawful lift of `OracleQuery spec` into `m` gives query capability in `m`. This is the
+main bridge that makes `MonadQuery` compose with `SubSpec` lifts and standard transformer lifts. -/
+instance (priority := low) instOfMonadLift [MonadLiftT (OracleQuery spec) m] :
+    MonadQuery spec m where
+  query t := liftM (OracleQuery.query (spec := spec) t)
+
+@[simp]
+lemma instOfMonadLift_query [MonadLiftT (OracleQuery spec) m] (t : spec.Domain) :
+    (instOfMonadLift (spec := spec) (m := m)).query t =
+      liftM (OracleQuery.query (spec := spec) t) :=
+  rfl
+
+@[simp]
+lemma query_eq_liftM_query [MonadLiftT (OracleQuery spec) m] (t : spec.Domain) :
+    @MonadQuery.query ι spec m ‹Monad m› (instOfMonadLift (spec := spec) (m := m)) t =
+      liftM (OracleQuery.query (spec := spec) t) :=
+  rfl
+
+end MonadQuery

--- a/VCVio/OracleComp/MonadQuery.lean
+++ b/VCVio/OracleComp/MonadQuery.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+
 import VCVio.OracleComp.SimSemantics.QueryImpl
 
 /-!
@@ -26,13 +27,13 @@ open OracleSpec
 universe u v w
 
 /-- Capability to issue queries to the oracle family `spec` inside the ambient monad `m`. -/
-class MonadQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) (m : Type v → Type w) [Monad m] where
+class MonadQuery {ι : Type u} (spec : OracleSpec.{u, v} ι) (m : Type v → Type w) where
   /-- Issue a single oracle query. -/
   query : (t : spec.Domain) → m (spec.Range t)
 
 namespace MonadQuery
 
-variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {m : Type v → Type w} [Monad m]
+variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {m : Type v → Type w}
 
 /-- Repackage `MonadQuery` as a `QueryImpl`, for APIs that still consume explicit oracle
 implementations. -/
@@ -52,12 +53,6 @@ instance (priority := low) instOfMonadLift [MonadLiftT (OracleQuery spec) m] :
 @[simp]
 lemma instOfMonadLift_query [MonadLiftT (OracleQuery spec) m] (t : spec.Domain) :
     (instOfMonadLift (spec := spec) (m := m)).query t =
-      liftM (OracleQuery.query (spec := spec) t) :=
-  rfl
-
-@[simp]
-lemma query_eq_liftM_query [MonadLiftT (OracleQuery spec) m] (t : spec.Domain) :
-    @MonadQuery.query ι spec m ‹Monad m› (instOfMonadLift (spec := spec) (m := m)) t =
       liftM (OracleQuery.query (spec := spec) t) :=
   rfl
 


### PR DESCRIPTION
## Summary
- add `MonadQuery` as a thin capability interface for oracle access, with automatic instances from `MonadLiftT (OracleQuery spec) m`
- generalize the ROM construction layer in `FiatShamir`, `FiatShamirWithAbort`, `Fischlin`, and `GPVHashAndSign` to any monad with `MonadLiftT ProbComp` and `MonadQuery`
- keep the proof and runtime-facing code on concrete `OracleComp` worlds by instantiating `m := OracleComp ...` explicitly where needed

## Verification
- `lake build`

Posted by Codex on behalf of Quang Dao using GPT-5.