### PR TITLE
Salvage ML-DSA norm and NTT lemmas

### DIFF
--- a/LatticeCrypto/MLDSA/Concrete/NTT.lean
+++ b/LatticeCrypto/MLDSA/Concrete/NTT.lean
@@ -197,14 +197,22 @@ private theorem hzero_rq (i : Fin polyBackend.degree) :
   LatticeCrypto.vectorRing_zero_get i
 
 /-- The concrete NTT is additive. -/
+theorem ntt_add_toRq (f g : Rq) : (ntt (f + g) : Rq) = (ntt f : Rq) + (ntt g : Rq) :=
+  LatticeCrypto.NTTCert.applyMatrix_add (backend := polyBackend) nttMatrix hadd_rq f g
+
+/-- The concrete NTT is additive. -/
 theorem ntt_add (f g : Rq) : ntt (f + g) = ntt f + ntt g := by
   apply LatticeCrypto.TransformPoly.ext
-  exact LatticeCrypto.NTTCert.applyMatrix_add (backend := polyBackend) nttMatrix hadd_rq f g
+  simpa using ntt_add_toRq f g
+
+/-- The concrete NTT preserves subtraction. -/
+theorem ntt_sub_toRq (f g : Rq) : (ntt (f - g) : Rq) = (ntt f : Rq) - (ntt g : Rq) :=
+  LatticeCrypto.NTTCert.applyMatrix_sub (backend := polyBackend) nttMatrix hsub_rq f g
 
 /-- The concrete NTT preserves subtraction. -/
 theorem ntt_sub (f g : Rq) : ntt (f - g) = ntt f - ntt g := by
   apply LatticeCrypto.TransformPoly.ext
-  exact LatticeCrypto.NTTCert.applyMatrix_sub (backend := polyBackend) nttMatrix hsub_rq f g
+  simpa using ntt_sub_toRq f g
 
 /-- Concrete `NTTRingOps` instance for ML-DSA. -/
 def concreteNTTRingOps : NTTRingOps where

--- a/LatticeCrypto/Ring/Norms.lean
+++ b/LatticeCrypto/Ring/Norms.lean
@@ -260,6 +260,17 @@ variable {Coeff : Type*} {backend : PolyBackend Coeff} (ops : NormOps backend) {
 def cInfNorm (v : PolyVec backend.Poly k) : ℕ :=
   Finset.sup Finset.univ fun j : Fin k => ops.cInfNorm (v.get j)
 
+/-- A polynomial vector has centered infinity norm at most `b` exactly when each component
+polynomial does. -/
+theorem cInfNorm_le_iff {v : PolyVec backend.Poly k} {b : ℕ} :
+    PolyVec.cInfNorm ops v ≤ b ↔ ∀ j : Fin k, ops.cInfNorm (v.get j) ≤ b := by
+  simp [PolyVec.cInfNorm, Finset.sup_le_iff]
+
+/-- Each component polynomial is bounded by the centered infinity norm of the whole vector. -/
+theorem component_cInfNorm_le (v : PolyVec backend.Poly k) (j : Fin k) :
+    ops.cInfNorm (v.get j) ≤ PolyVec.cInfNorm ops v :=
+  Finset.le_sup (f := fun j => ops.cInfNorm (v.get j)) (Finset.mem_univ j)
+
 /-- The `ℓ₁` norm of a polynomial vector. -/
 def l1Norm (v : PolyVec backend.Poly k) : ℕ :=
   Finset.sup Finset.univ fun j : Fin k => ops.l1Norm (v.get j)


### PR DESCRIPTION
## Summary
- salvage the two missing generic `PolyVec` centered-infinity-norm lemmas into `LatticeCrypto/Ring/Norms`
- restore the ML-DSA coefficient-carrier `ntt_add_toRq` / `ntt_sub_toRq` lemmas for parity with the ML-KEM concrete NTT API
- derive the existing typed `ntt_add` / `ntt_sub` theorems from those coefficient-view lemmas to avoid duplicated proofs

## Verification
- `git diff --check`
- `lake build LatticeCrypto.Ring.Norms LatticeCrypto.MLDSA.Concrete.NTT LatticeCrypto.MLDSA.Signature LatticeCrypto.MLDSA.Security`

AI-authored by Codex GPT-5.4 on behalf of Quang Dao.