### PR TITLE
Add query runtimes and Fiat-Shamir cost pilot

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -72,6 +72,7 @@ import VCVio.OracleComp.QueryTracking.CountingOracle
 import VCVio.OracleComp.QueryTracking.Enforcement
 import VCVio.OracleComp.QueryTracking.LoggingOracle
 import VCVio.OracleComp.QueryTracking.QueryBound
+import VCVio.OracleComp.QueryTracking.QueryRuntime
 import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.QueryTracking.SeededOracle
 import VCVio.OracleComp.QueryTracking.Structures

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -9,6 +9,7 @@ import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
+import VCVio.OracleComp.QueryTracking.QueryRuntime
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
 import VCVio.ProgramLogic.Tactics.Unary
@@ -107,6 +108,142 @@ theorem map_construction
     simp [FiatShamir]
 
 end naturality
+
+section costAccounting
+
+variable {m : Type → Type u} [Monad m] [LawfulMonad m]
+  [MonadLiftT ProbComp m]
+
+@[simp]
+private lemma run_monadLift_addWriterT {α : Type} (x : m α) :
+    WriterT.run (monadLift x : AddWriterT ℕ m α) =
+      (fun y => (y, Multiplicative.ofAdd 0)) <$> x := by
+  simp
+
+private lemma fst_map_run_monadLift_query_monadLift
+    {α β γ : Type} (x : m α) (q : α → m β) (f : α → β → m γ) :
+    (do
+      let a ← WriterT.run (monadLift x : AddWriterT ℕ m α)
+      let b ← q a.1
+      (fun c ↦ (a.1, c.1)) <$> WriterT.run (monadLift (f a.1 b) : AddWriterT ℕ m γ)) =
+      (do
+        let a ← x
+        let b ← q a
+        Prod.mk a <$> f a b) := by
+  simp [bind_map_left]
+
+private lemma snd_map_run_monadLift_query_monadLift
+    {α β γ : Type} (x : m α) (q : α → m β) (f : α → β → m γ) :
+    (do
+      let a ← WriterT.run (monadLift x : AddWriterT ℕ m α)
+      let b ← q a.1
+      (fun c ↦ a.2 * (Multiplicative.ofAdd 1 * c.2)) <$>
+        WriterT.run (monadLift (f a.1 b) : AddWriterT ℕ m γ)) =
+      (do
+        let a ← x
+        let b ← q a
+        (fun _ ↦ Multiplicative.ofAdd 1) <$> f a b) := by
+  simp [bind_map_left]
+
+private lemma fst_map_sign_core
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
+    (do
+      let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ℕ m (PC × SC))
+      let r ← runtime.impl (msg, a.1.1)
+      (fun z : P × Multiplicative ℕ => (a.1.1, z.1)) <$>
+        WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ℕ m P)) =
+    (do
+      let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+      let r ← runtime.impl (msg, a.1)
+      Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P)) := by
+  change (do
+      let a ← WriterT.run (monadLift ((monadLift (σ.commit pk sk) : m (PC × SC))) :
+        AddWriterT ℕ m (PC × SC))
+      let r ← runtime.impl (msg, a.1.1)
+      (fun z : P × Multiplicative ℕ => (a.1.1, z.1)) <$>
+        WriterT.run (monadLift ((monadLift (σ.respond pk sk a.1.2 r) : m P)) : AddWriterT ℕ m P)) =
+    (do
+      let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+      let r ← runtime.impl (msg, a.1)
+      Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P))
+  simp [bind_map_left]
+
+private lemma snd_map_sign_core
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
+    (do
+      let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ℕ m (PC × SC))
+      let r ← runtime.impl (msg, a.1.1)
+      (fun z : P × Multiplicative ℕ => a.2 * (Multiplicative.ofAdd 1 * z.2)) <$>
+        WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ℕ m P)) =
+    (do
+      let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+      let r ← runtime.impl (msg, a.1)
+      (fun _ ↦ Multiplicative.ofAdd 1) <$> (monadLift (σ.respond pk sk a.2 r) : m P)) := by
+  change (do
+      let a ← WriterT.run (monadLift ((monadLift (σ.commit pk sk) : m (PC × SC))) :
+        AddWriterT ℕ m (PC × SC))
+      let r ← runtime.impl (msg, a.1.1)
+      (fun z : P × Multiplicative ℕ => a.2 * (Multiplicative.ofAdd 1 * z.2)) <$>
+        WriterT.run (monadLift ((monadLift (σ.respond pk sk a.1.2 r) : m P)) : AddWriterT ℕ m P)) =
+    (do
+      let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+      let r ← runtime.impl (msg, a.1)
+      (fun _ ↦ Multiplicative.ofAdd 1) <$> (monadLift (σ.respond pk sk a.2 r) : m P))
+  simp [bind_map_left]
+
+/-- Output projection of unit-cost-instrumented Fiat-Shamir signing. -/
+@[simp]
+theorem fst_map_sign_run_withAddCost
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
+    let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+    let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+    Prod.fst <$> ((FiatShamir (m := AddWriterT ℕ m) σ hr M).sign pk sk msg).run =
+      (FiatShamir (m := m) σ hr M).sign pk sk msg := by
+  let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+  let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+  simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+  exact fst_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+
+/-- Cost projection of unit-cost-instrumented Fiat-Shamir signing. -/
+@[simp]
+theorem snd_map_sign_run_withAddCost
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
+    let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+    let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+    Prod.snd <$> ((FiatShamir (m := AddWriterT ℕ m) σ hr M).sign pk sk msg).run =
+      (fun _ => Multiplicative.ofAdd 1) <$> (FiatShamir (m := m) σ hr M).sign pk sk msg := by
+  let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+  let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+  simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+  exact snd_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+
+/-- Output projection of unit-cost-instrumented Fiat-Shamir verification. -/
+@[simp]
+theorem fst_map_verify_run_withAddCost
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
+    let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+    let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+    Prod.fst <$> ((FiatShamir (m := AddWriterT ℕ m) σ hr M).verify pk msg sig).run =
+      (FiatShamir (m := m) σ hr M).verify pk msg sig := by
+  let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+  let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+  rcases sig with ⟨c, s⟩
+  simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+
+/-- Cost projection of unit-cost-instrumented Fiat-Shamir verification. -/
+@[simp]
+theorem snd_map_verify_run_withAddCost
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
+    let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+    let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+    Prod.snd <$> ((FiatShamir (m := AddWriterT ℕ m) σ hr M).verify pk msg sig).run =
+      (fun _ => Multiplicative.ofAdd 1) <$> (FiatShamir (m := m) σ hr M).verify pk msg sig := by
+  let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
+  let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
+  rcases sig with ⟨c, s⟩
+  simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+
+end costAccounting
 
 /-- Structural bound that counts only random-oracle queries in a Fiat-Shamir
 EUF-CMA adversary. Uniform-sampling and signing-oracle queries are unrestricted. -/

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -114,12 +114,13 @@ section costAccounting
 variable {m : Type → Type u} [Monad m] [LawfulMonad m]
   [MonadLiftT ProbComp m]
 
-@[simp]
+omit [LawfulMonad m] [MonadLiftT ProbComp m] in
 private lemma run_monadLift_addWriterT {α : Type} (x : m α) :
     WriterT.run (monadLift x : AddWriterT ℕ m α) =
       (fun y => (y, Multiplicative.ofAdd 0)) <$> x := by
   simp
 
+omit [MonadLiftT ProbComp m] in
 private lemma fst_map_run_monadLift_query_monadLift
     {α β γ : Type} (x : m α) (q : α → m β) (f : α → β → m γ) :
     (do
@@ -132,6 +133,7 @@ private lemma fst_map_run_monadLift_query_monadLift
         Prod.mk a <$> f a b) := by
   simp [bind_map_left]
 
+omit [MonadLiftT ProbComp m] in
 private lemma snd_map_run_monadLift_query_monadLift
     {α β γ : Type} (x : m α) (q : α → m β) (f : α → β → m γ) :
     (do
@@ -145,6 +147,8 @@ private lemma snd_map_run_monadLift_query_monadLift
         (fun _ ↦ Multiplicative.ofAdd 1) <$> f a b) := by
   simp [bind_map_left]
 
+omit [SampleableType X] [SampleableType W] [DecidableEq PC] [DecidableEq P]
+  [DecidableEq Ω] [SampleableType Ω] [DecidableEq M] in
 private lemma fst_map_sign_core
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
     (do
@@ -168,6 +172,8 @@ private lemma fst_map_sign_core
       Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P))
   simp [bind_map_left]
 
+omit [SampleableType X] [SampleableType W] [DecidableEq PC] [DecidableEq P]
+  [DecidableEq Ω] [SampleableType Ω] [DecidableEq M] in
 private lemma snd_map_sign_core
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
     (do
@@ -191,8 +197,8 @@ private lemma snd_map_sign_core
       (fun _ ↦ Multiplicative.ofAdd 1) <$> (monadLift (σ.respond pk sk a.2 r) : m P))
   simp [bind_map_left]
 
+omit [DecidableEq PC] [DecidableEq P] [DecidableEq Ω] [SampleableType Ω] in
 /-- Output projection of unit-cost-instrumented Fiat-Shamir signing. -/
-@[simp]
 theorem fst_map_sign_run_withAddCost
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
     let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
@@ -201,11 +207,21 @@ theorem fst_map_sign_run_withAddCost
       (FiatShamir (m := m) σ hr M).sign pk sk msg := by
   let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
   let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
-  simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ℕ m (PC × SC))
+        let r ← runtime.impl (msg, a.1.1)
+        (fun z : P × Multiplicative ℕ => (a.1.1, z.1)) <$>
+          WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ℕ m P)) =
+      (do
+        let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+        let r ← runtime.impl (msg, a.1)
+        Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P)) by
+    simpa [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell] using h
   exact fst_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
 
+omit [DecidableEq PC] [DecidableEq P] [DecidableEq Ω] [SampleableType Ω] in
 /-- Cost projection of unit-cost-instrumented Fiat-Shamir signing. -/
-@[simp]
 theorem snd_map_sign_run_withAddCost
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
     let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
@@ -214,11 +230,21 @@ theorem snd_map_sign_run_withAddCost
       (fun _ => Multiplicative.ofAdd 1) <$> (FiatShamir (m := m) σ hr M).sign pk sk msg := by
   let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
   let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
-  simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ℕ m (PC × SC))
+        let r ← runtime.impl (msg, a.1.1)
+        (fun z : P × Multiplicative ℕ => a.2 * (Multiplicative.ofAdd 1 * z.2)) <$>
+          WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ℕ m P)) =
+      (do
+        let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+        let r ← runtime.impl (msg, a.1)
+        (fun _ ↦ Multiplicative.ofAdd 1) <$> (monadLift (σ.respond pk sk a.2 r) : m P)) by
+    simpa [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell] using h
   exact snd_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
 
+omit [DecidableEq PC] [DecidableEq P] [DecidableEq Ω] [SampleableType Ω] in
 /-- Output projection of unit-cost-instrumented Fiat-Shamir verification. -/
-@[simp]
 theorem fst_map_verify_run_withAddCost
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
     let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
@@ -230,8 +256,8 @@ theorem fst_map_verify_run_withAddCost
   rcases sig with ⟨c, s⟩
   simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
 
+omit [DecidableEq PC] [DecidableEq P] [DecidableEq Ω] [SampleableType Ω] in
 /-- Cost projection of unit-cost-instrumented Fiat-Shamir verification. -/
-@[simp]
 theorem snd_map_verify_run_withAddCost
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
     let _ : HasQuery (M × PC →ₒ Ω) m := runtime.toHasQuery
@@ -242,6 +268,9 @@ theorem snd_map_verify_run_withAddCost
   let _ : HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m) := (runtime.withAddCost fun _ => 1).toHasQuery
   rcases sig with ⟨c, s⟩
   simp [FiatShamir, QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+
+attribute [simp] fst_map_sign_run_withAddCost snd_map_sign_run_withAddCost
+  fst_map_verify_run_withAddCost snd_map_verify_run_withAddCost
 
 end costAccounting
 

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -1,0 +1,87 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import VCVio.OracleComp.HasQuery
+import VCVio.OracleComp.QueryTracking.CountingOracle
+
+/-!
+# Bundled Query Runtimes
+
+This file packages concrete query implementations as explicit runtime objects.
+
+`HasQuery spec m` is the right *capability* interface for constructions that only need to issue
+queries. When we want to instrument, transport, or otherwise analyze that capability, we also need
+an explicit `QueryImpl spec m` to work with. `QueryRuntime spec m` is the thin bundle that stores
+that implementation without changing the capability layer.
+
+The main use cases are:
+
+- reifying an existing `HasQuery` capability as a `QueryRuntime`;
+- adding cost, counting, or logging layers to a runtime;
+- instantiating a generic `HasQuery` construction directly in an analysis monad.
+-/
+
+open OracleSpec
+
+/-- Bundled implementation of the oracle family `spec` in the ambient monad `m`. -/
+structure QueryRuntime {ι : Type} (spec : OracleSpec ι) (m : Type → Type*) where
+  /-- Concrete implementation of each query in the family `spec`. -/
+  impl : QueryImpl spec m
+
+namespace QueryRuntime
+
+variable {ι : Type} {spec : OracleSpec ι} {m : Type → Type*}
+
+/-- View a bundled query runtime as the corresponding `HasQuery` capability. -/
+def toHasQuery (runtime : QueryRuntime spec m) : HasQuery spec m :=
+  runtime.impl.toHasQuery
+
+lemma toHasQuery_query (runtime : QueryRuntime spec m) (t : spec.Domain) :
+    (runtime.toHasQuery).query t = runtime.impl t := rfl
+
+/-- Repackage an existing `HasQuery` capability as an explicit query runtime. -/
+def ofHasQuery [HasQuery spec m] : QueryRuntime spec m where
+  impl := HasQuery.toQueryImpl
+
+@[simp]
+lemma ofHasQuery_impl [HasQuery spec m] (t : spec.Domain) :
+    (ofHasQuery (spec := spec) (m := m)).impl t =
+      HasQuery.query (spec := spec) (m := m) t := rfl
+
+section instrumentation
+
+variable [Monad m]
+
+/-- Instrument a query runtime with multiplicative/monoidal cost accumulation in a `WriterT`
+layer. -/
+def withCost {ω : Type} [Monoid ω]
+    (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) :
+    QueryRuntime spec (WriterT ω m) where
+  impl := QueryImpl.withCost (spec := spec) (m := m) runtime.impl costFn
+
+@[simp]
+lemma withCost_impl {ω : Type} [Monoid ω]
+    (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) (t : spec.Domain) :
+    (runtime.withCost costFn).impl t = (do tell (costFn t); liftM (runtime.impl t)) := by
+  simp [withCost]
+
+/-- Instrument a query runtime with additive cost accumulation in an `AddWriterT` layer. -/
+def withAddCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) :
+    QueryRuntime spec (AddWriterT ω m) where
+  impl := QueryImpl.withCost (spec := spec) (m := m) runtime.impl
+    (fun t => Multiplicative.ofAdd (costFn t))
+
+@[simp]
+lemma withAddCost_impl {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) (t : spec.Domain) :
+    (runtime.withAddCost costFn).impl t =
+      (do AddWriterT.addTell (M := m) (costFn t); liftM (runtime.impl t)) := by
+  simp [withAddCost, AddWriterT.addTell, QueryImpl.withCost]
+
+end instrumentation
+
+end QueryRuntime


### PR DESCRIPTION
This PR introduces a first query-accounting slice for the new generic query infrastructure.

What is included:
- add `QueryRuntime`, a thin bundle around `QueryImpl` for explicit query runtimes
- add runtime instrumentation helpers for monoidal and additive cost accumulation
- wire the new module into `VCVio.lean`
- add a Fiat-Shamir pilot showing that, for any instrumented query runtime, signing and verification each incur exactly one unit of additive query cost

Verification:
- `git diff --check`
- `lake exe mk_all --lib VCVio --check`
- `lake build VCVio.OracleComp.QueryTracking.QueryRuntime VCVio.CryptoFoundations.FiatShamir`
- `lake build VCVio`

Notes:
- the Fiat-Shamir pilot currently leaves some local linter noise from inherited section variables and proof presentation; the theorems themselves build and the architectural slice is complete

AI-authored by Codex (GPT-5) on behalf of Quang Dao.