### PR TITLE
Generalize query tracking to weighted expected cost and abort tail bounds

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -89,6 +89,7 @@ Structures use UpperCamelCase: `SecExp`, `SymmEncAlg`, `RelTriple`.
 - SubSpec / coercions: `VCVio/OracleComp/Coercions/SubSpec.lean`
 - DLog / CDH / DDH via HHS: `VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean`
 - Cost model / polynomial time: `VCVio/OracleComp/QueryTracking/CostModel.lean`
+- Query runtime / weighted expected cost: `VCVio/OracleComp/QueryTracking/QueryRuntime.lean`
 - Asymptotic security games: `VCVio/CryptoFoundations/Asymptotics/Security.lean`
 - Negligible function algebra: `VCVio/CryptoFoundations/Asymptotics/Negligible.lean`
 - Query enforcement: `VCVio/OracleComp/QueryTracking/Enforcement.lean`
@@ -129,6 +130,7 @@ Before working in a specific area, read the relevant guide in `docs/agents/`:
 
 - **LatticeCrypto layout and workflows**: [`docs/agents/lattice.md`](docs/agents/lattice.md)
 - **OracleComp / SubSpec / SimSemantics**: [`docs/agents/oracle-comp.md`](docs/agents/oracle-comp.md)
+- **Query tracking / weighted cost / expected runtime**: [`docs/agents/query-tracking.md`](docs/agents/query-tracking.md)
 - **Probability reasoning (EvalDist, ProbComp)**: [`docs/agents/probability.md`](docs/agents/probability.md)
 - **Crypto primitives and reductions**: [`docs/agents/crypto.md`](docs/agents/crypto.md)
 - **Program logic tactics**: [`docs/agents/program-logic.md`](docs/agents/program-logic.md)

--- a/LatticeCrypto/MLKEM/Security.lean
+++ b/LatticeCrypto/MLKEM/Security.lean
@@ -174,9 +174,7 @@ theorem ind_cca_security
           (prfAdv : PRFScheme.PRFAdversary (KPKE.Ciphertext params encoding) SharedSecret),
           (foKEMScheme params ring encoding prims).IND_CCA_Advantage
               (FujisakiOkamoto.twoRORuntime
-                (PK := EncapsulationKey params encoding) (R := Coins)
-                (C := KPKE.Ciphertext params encoding) (KD := Message) (K := SharedSecret)
-                (fun (m : Message) (_c : KPKE.Ciphertext params encoding) => m))
+                (M := Message) (R := Coins) (KD := Message) (K := SharedSecret))
               adv ≤
             2 * |LearningWithErrors.advantage mlwe mlweAdv₁| +
             2 * |LearningWithErrors.advantage mlwe mlweAdv₂| +

--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -34,6 +34,7 @@ import ToMathlib.PFunctor.Cofree
 import ToMathlib.PFunctor.Equiv.Basic
 import ToMathlib.PFunctor.Free
 import ToMathlib.PFunctor.Lens.Basic
+import ToMathlib.Probability.ProbabilityMassFunction.TailSums
 import ToMathlib.Probability.ProbabilityMassFunction.TotalVariation
 import ToMathlib.ProbabilityTheory.Coupling
 import ToMathlib.ProbabilityTheory.FinRatPMF

--- a/ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean
+++ b/ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean
@@ -1,0 +1,80 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import Mathlib.Probability.ProbabilityMassFunction.Basic
+public import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
+
+/-!
+# Tail-Sum Identities for `PMF`
+
+This file records discrete tail-sum formulas for nonnegative `ℕ`-valued random variables.
+
+The core identity is the standard discrete expectation formula
+
+`E[X] = ∑ i, Pr[i < X]`
+
+for `ℕ`-valued random variables with values in `ℝ≥0∞`.
+
+We first prove the corresponding summation identity for arbitrary nonnegative sequences, and then
+specialize it to probability mass functions.
+-/
+
+@[expose] public section
+
+open scoped ENNReal
+
+namespace ENNReal
+
+/-- Tail-sum identity for a nonnegative sequence on `ℕ`:
+
+`∑' n, f n * n = ∑' i, ∑' n, if i < n then f n else 0`.
+
+This is the discrete nonnegative analogue of writing `n = ∑_{i < n} 1` and exchanging the order of
+summation. -/
+theorem tsum_mul_nat_eq_tsum_tail (f : ℕ → ℝ≥0∞) :
+    (∑' n : ℕ, f n * (n : ℝ≥0∞)) = ∑' i : ℕ, ∑' n : ℕ, if i < n then f n else 0 := by
+  calc
+    ∑' n : ℕ, f n * (n : ℝ≥0∞) = ∑' n : ℕ, (n : ℝ≥0∞) * f n := by
+      refine tsum_congr fun n => ?_
+      rw [mul_comm]
+    _ = ∑' n : ℕ, ∑' i : ℕ, if i < n then f n else 0 := by
+      refine tsum_congr fun n => ?_
+      rw [tsum_eq_sum (s := Finset.range n)]
+      · have hsum :
+            ∑ b ∈ Finset.range n, (if b < n then f n else 0) =
+              ∑ _b ∈ Finset.range n, f n := by
+              refine Finset.sum_congr rfl ?_
+              intro b hb
+              simp [Finset.mem_range.mp hb]
+        rw [hsum, Finset.sum_const, Finset.card_range, nsmul_eq_mul, mul_comm]
+      · intro i hi
+        simp only [Finset.mem_range] at hi
+        simp [if_neg hi]
+    _ = ∑' i : ℕ, ∑' n : ℕ, if i < n then f n else 0 := ENNReal.tsum_comm
+
+end ENNReal
+
+namespace PMF
+
+/-- Tail-sum identity for the `ℝ≥0∞`-valued expectation of a `PMF ℕ`:
+
+`∑' n, p n * n = ∑' i, p.toMeasure {n | i < n}`.
+
+This is the discrete formula `E[X] = ∑ i, Pr[i < X]` for `ℕ`-valued random variables. -/
+theorem tsum_coe_mul_nat_eq_tsum_measure_Ioi (p : PMF ℕ) :
+    (∑' n : ℕ, p n * (n : ℝ≥0∞)) = ∑' i : ℕ, p.toMeasure (Set.Ioi i) := by
+  calc
+    ∑' n : ℕ, p n * (n : ℝ≥0∞) = ∑' i : ℕ, ∑' n : ℕ, if i < n then p n else 0 :=
+      ENNReal.tsum_mul_nat_eq_tsum_tail p
+    _ = ∑' i : ℕ, p.toMeasure (Set.Ioi i) := by
+      refine tsum_congr fun i => ?_
+      rw [p.toMeasure_apply_eq_tsum]
+      refine tsum_congr fun n => ?_
+      by_cases h : i < n <;> simp [Set.Ioi, Set.indicator, h]
+
+end PMF

--- a/ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean
+++ b/ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean
@@ -77,4 +77,15 @@ theorem tsum_coe_mul_nat_eq_tsum_measure_Ioi (p : PMF ℕ) :
       refine tsum_congr fun n => ?_
       by_cases h : i < n <;> simp [Set.Ioi, Set.indicator, h]
 
+/-- Tail domination bounds the `ℝ≥0∞`-valued expectation of a `PMF ℕ`.
+
+If each tail probability `Pr[i < X]` is bounded above by `a i`, then
+`E[X] ≤ ∑ i, a i`. This is the generic discrete upper-bound principle used to turn
+tail estimates into expectation bounds. -/
+theorem tsum_coe_mul_nat_le_tsum_of_measure_Ioi_le (p : PMF ℕ) {a : ℕ → ℝ≥0∞}
+    (h : ∀ i : ℕ, p.toMeasure (Set.Ioi i) ≤ a i) :
+    (∑' n : ℕ, p n * (n : ℝ≥0∞)) ≤ ∑' i : ℕ, a i := by
+  rw [tsum_coe_mul_nat_eq_tsum_measure_Ioi]
+  exact ENNReal.tsum_le_tsum h
+
 end PMF

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -247,55 +247,47 @@ theorem sign_usesExactlyOneQuery
   exact sign_costs_formula_withUnitCost (σ := σ) (hr := hr) (M := M)
     (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
 
-private lemma verify_outputs_formula_withUnitCost
-    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
-    AddWriterT.outputs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m)] =>
-            (FiatShamir (m := AddWriterT ℕ m) σ hr M).verify pk msg sig)
-          runtime) =
-      HasQuery.inRuntime
-        (fun [HasQuery (M × PC →ₒ Ω) m] =>
-          (FiatShamir (m := m) σ hr M).verify pk msg sig)
-        runtime := by
+/-- Fiat-Shamir verification incurs exactly the weighted cost assigned to the single
+random-oracle query on `(msg, sig.1)`. -/
+theorem verify_usesExactQueryCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P)
+    (costFn : M × PC → ω) :
+    QueryCost[ (FiatShamir σ hr M).verify pk msg sig in runtime by costFn ] =
+      costFn (msg, sig.1) := by
   rcases sig with ⟨c, s⟩
-  simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.outputs, FiatShamir,
-    QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
+  change Cost[
+    HasQuery.withAddCost
+      (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
+        (FiatShamir (m := AddWriterT ω m) σ hr M).verify pk msg (c, s))
+      runtime costFn
+  ] = costFn (msg, c)
+  rw [AddWriterT.hasCost_iff]
+  simp [HasQuery.withAddCost, FiatShamir, QueryRuntime.withAddCost_impl,
+    AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
 
-/-- Running Fiat-Shamir verification in a unit-cost query runtime records exactly one query
-cost. -/
-private lemma verify_costs_formula_withUnitCost
-    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
-    AddWriterT.costs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m)] =>
-            (FiatShamir (m := AddWriterT ℕ m) σ hr M).verify pk msg sig)
-          runtime) =
-      (fun _ ↦ 1) <$>
-        HasQuery.inRuntime
-          (fun [HasQuery (M × PC →ₒ Ω) m] =>
-            (FiatShamir (m := m) σ hr M).verify pk msg sig)
-          runtime := by
-  rcases sig with ⟨c, s⟩
-  simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.costs, FiatShamir,
-    QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
+/-- Fiat-Shamir verification has expected weighted query cost equal to the weight of its single
+random-oracle query. -/
+theorem verify_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P)
+    (costFn : M × PC → ω) (val : ω → ENNReal) (hval : Monotone val) :
+    ExpectedQueryCost[
+      (FiatShamir σ hr M).verify pk msg sig in runtime by costFn via val
+    ] = val (costFn (msg, sig.1)) := by
+  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    (verify_usesExactQueryCost
+      (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (msg := msg)
+      (sig := sig) (costFn := costFn))
+    hval
 
 /-- Fiat-Shamir verification makes exactly one random-oracle query under unit-cost
 instrumentation. -/
 theorem verify_usesExactlyOneQuery
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (msg : M) (sig : PC × P) :
     Queries[ (FiatShamir σ hr M).verify pk msg sig in runtime ] = 1 := by
-  change Cost[
-    HasQuery.withUnitCost
-      (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ℕ m)] =>
-        (FiatShamir (m := AddWriterT ℕ m) σ hr M).verify pk msg sig)
-      runtime
-  ] = 1
-  rw [AddWriterT.HasCost, AddWriterT.CostsAs]
-  rw [verify_outputs_formula_withUnitCost (σ := σ) (hr := hr) (M := M)
-    (runtime := runtime) (pk := pk) (msg := msg) (sig := sig)]
-  exact verify_costs_formula_withUnitCost (σ := σ) (hr := hr) (M := M)
-    (runtime := runtime) (pk := pk) (msg := msg) (sig := sig)
+  simpa [HasQuery.UsesExactlyQueries] using
+    (verify_usesExactQueryCost
+      (ω := ℕ) (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk)
+      (msg := msg) (sig := sig) (costFn := fun _ ↦ 1))
 
 attribute [simp] sign_usesExactlyOneQuery verify_usesExactlyOneQuery
 

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -120,51 +120,57 @@ variable (σ : SigmaProtocol X W PC SC Ω P p) (M : Type)
 
 variable {m : Type → Type u} [Monad m] [LawfulMonad m]
   [MonadLiftT ProbComp m]
+variable {ω : Type} [AddMonoid ω]
 
 private lemma fst_map_sign_core
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
     (do
-      let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ℕ m (PC × SC))
+      let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ω m (PC × SC))
       let r ← runtime.impl (msg, a.1.1)
-      (fun z : P × Multiplicative ℕ => (a.1.1, z.1)) <$>
-        WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ℕ m P)) =
+      (fun z : P × Multiplicative ω => (a.1.1, z.1)) <$>
+        WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ω m P)) =
     (do
       let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
       let r ← runtime.impl (msg, a.1)
       Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P)) := by
   change (do
       let a ← WriterT.run (monadLift ((monadLift (σ.commit pk sk) : m (PC × SC))) :
-        AddWriterT ℕ m (PC × SC))
+        AddWriterT ω m (PC × SC))
       let r ← runtime.impl (msg, a.1.1)
-      (fun z : P × Multiplicative ℕ => (a.1.1, z.1)) <$>
-        WriterT.run (monadLift ((monadLift (σ.respond pk sk a.1.2 r) : m P)) : AddWriterT ℕ m P)) =
+      (fun z : P × Multiplicative ω => (a.1.1, z.1)) <$>
+        WriterT.run (monadLift ((monadLift (σ.respond pk sk a.1.2 r) : m P)) : AddWriterT ω m P)) =
     (do
       let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
       let r ← runtime.impl (msg, a.1)
       Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P))
   simp [bind_map_left]
 
-private lemma snd_map_sign_core
-    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
+private lemma snd_map_sign_core_withAddCost
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (costFn : M × PC → ω)
+    (pk : X) (sk : W) (msg : M) :
     (do
-      let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ℕ m (PC × SC))
+      let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ω m (PC × SC))
       let r ← runtime.impl (msg, a.1.1)
-      (fun z : P × Multiplicative ℕ => a.2 * (Multiplicative.ofAdd 1 * z.2)) <$>
-        WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ℕ m P)) =
+      (fun z : P × Multiplicative ω =>
+        a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2)) <$>
+        WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ω m P)) =
     (do
       let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
       let r ← runtime.impl (msg, a.1)
-      (fun _ ↦ Multiplicative.ofAdd 1) <$> (monadLift (σ.respond pk sk a.2 r) : m P)) := by
+      (fun _ ↦ Multiplicative.ofAdd (costFn (msg, a.1))) <$>
+        (monadLift (σ.respond pk sk a.2 r) : m P)) := by
   change (do
       let a ← WriterT.run (monadLift ((monadLift (σ.commit pk sk) : m (PC × SC))) :
-        AddWriterT ℕ m (PC × SC))
+        AddWriterT ω m (PC × SC))
       let r ← runtime.impl (msg, a.1.1)
-      (fun z : P × Multiplicative ℕ => a.2 * (Multiplicative.ofAdd 1 * z.2)) <$>
-        WriterT.run (monadLift ((monadLift (σ.respond pk sk a.1.2 r) : m P)) : AddWriterT ℕ m P)) =
+      (fun z : P × Multiplicative ω =>
+        a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2)) <$>
+        WriterT.run (monadLift ((monadLift (σ.respond pk sk a.1.2 r) : m P)) : AddWriterT ω m P)) =
     (do
       let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
       let r ← runtime.impl (msg, a.1)
-      (fun _ ↦ Multiplicative.ofAdd 1) <$> (monadLift (σ.respond pk sk a.2 r) : m P))
+      (fun _ ↦ Multiplicative.ofAdd (costFn (msg, a.1))) <$>
+        (monadLift (σ.respond pk sk a.2 r) : m P))
   simp [bind_map_left]
 
 end signCore
@@ -204,6 +210,33 @@ private lemma sign_outputs_formula_withUnitCost
       using h
   exact fst_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
 
+private lemma sign_outputs_formula_withAddCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M)
+    (costFn : M × PC → ω) :
+    AddWriterT.outputs
+        (HasQuery.withAddCost
+          (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
+            (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
+          runtime costFn) =
+      HasQuery.inRuntime
+        (fun [HasQuery (M × PC →ₒ Ω) m] =>
+          (FiatShamir (m := m) σ hr M).sign pk sk msg)
+        runtime := by
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ω m (PC × SC))
+        let r ← runtime.impl (msg, a.1.1)
+        (fun z : P × Multiplicative ω => (a.1.1, z.1)) <$>
+          WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ω m P)) =
+      (do
+        let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+        let r ← runtime.impl (msg, a.1)
+        Prod.mk a.1 <$> (monadLift (σ.respond pk sk a.2 r) : m P)) by
+    simpa [HasQuery.inRuntime, HasQuery.withAddCost, AddWriterT.outputs, FiatShamir,
+      QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+      using h
+  exact fst_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+
 private lemma sign_costs_formula_withUnitCost
     (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M) :
     AddWriterT.costs
@@ -229,7 +262,99 @@ private lemma sign_costs_formula_withUnitCost
     simpa [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.costs, FiatShamir,
       QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
       using h
-  exact snd_map_sign_core (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+  exact snd_map_sign_core_withAddCost
+    (σ := σ) (runtime := runtime) (costFn := fun _ ↦ (1 : ℕ))
+    (pk := pk) (sk := sk) (msg := msg)
+
+private lemma sign_costs_formula_withAddCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M)
+    (costFn : M × PC → ω) :
+    AddWriterT.costs
+        (HasQuery.withAddCost
+          (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
+            (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
+          runtime costFn) =
+      (fun sig ↦ costFn (msg, sig.1)) <$>
+        HasQuery.inRuntime
+          (fun [HasQuery (M × PC →ₒ Ω) m] =>
+            (FiatShamir (m := m) σ hr M).sign pk sk msg)
+          runtime := by
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (σ.commit pk sk) : AddWriterT ω m (PC × SC))
+        let r ← runtime.impl (msg, a.1.1)
+        (fun z : P × Multiplicative ω =>
+          a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2)) <$>
+          WriterT.run (monadLift (σ.respond pk sk a.1.2 r) : AddWriterT ω m P)) =
+      (do
+        let a ← (monadLift (σ.commit pk sk) : m (PC × SC))
+        let r ← runtime.impl (msg, a.1)
+        (fun _ ↦ Multiplicative.ofAdd (costFn (msg, a.1))) <$>
+          (monadLift (σ.respond pk sk a.2 r) : m P)) by
+    simpa [HasQuery.inRuntime, HasQuery.withAddCost, AddWriterT.costs, FiatShamir,
+      QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+      using h
+  exact snd_map_sign_core_withAddCost
+    (σ := σ) (runtime := runtime) (costFn := costFn)
+    (pk := pk) (sk := sk) (msg := msg)
+
+/-- Fiat-Shamir signing has query cost determined by its output: the signature `(c, s)` records
+the unique queried commitment `c`, so the total weighted query cost is exactly
+`costFn (msg, c)`. -/
+theorem sign_usesCostAsQueryCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M)
+    (costFn : M × PC → ω) :
+    HasQuery.UsesCostAs
+      (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
+        (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
+      runtime costFn (fun sig ↦ costFn (msg, sig.1)) := by
+  rw [HasQuery.UsesCostAs, AddWriterT.costsAs_iff]
+  rw [sign_outputs_formula_withAddCost
+    (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+    (msg := msg) (costFn := costFn)]
+  exact sign_costs_formula_withAddCost
+    (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+    (msg := msg) (costFn := costFn)
+
+/-- Fiat-Shamir signing has expected weighted query cost equal to the expectation of the queried
+commitment cost over the output signature distribution. -/
+theorem sign_expectedQueryCost_eq_outputExpectation {ω : Type} [AddMonoid ω] [HasEvalSPMF m]
+    (runtime : QueryRuntime (M × PC →ₒ Ω) m) (pk : X) (sk : W) (msg : M)
+    (costFn : M × PC → ω) (val : ω → ENNReal) :
+    ExpectedQueryCost[
+      (FiatShamir σ hr M).sign pk sk msg in runtime by costFn via val
+    ] =
+      ∑' sig : PC × P,
+        Pr[= sig | HasQuery.inRuntime
+          (fun [HasQuery (M × PC →ₒ Ω) m] =>
+            (FiatShamir (m := m) σ hr M).sign pk sk msg)
+          runtime] * val (costFn (msg, sig.1)) := by
+  calc
+    ExpectedQueryCost[
+      (FiatShamir σ hr M).sign pk sk msg in runtime by costFn via val
+    ] =
+      ∑' sig : PC × P,
+        Pr[= sig | AddWriterT.outputs
+          (HasQuery.withAddCost
+            (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
+              (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
+            runtime costFn)] * val (costFn (msg, sig.1)) := by
+          exact HasQuery.expectedQueryCost_eq_tsum_outputs_of_usesCostAs
+            (oa := fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
+              (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
+            (runtime := runtime) (costFn := costFn) (f := fun sig ↦ costFn (msg, sig.1))
+            (val := val)
+            (sign_usesCostAsQueryCost
+              (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+              (msg := msg) (costFn := costFn))
+    _ = ∑' sig : PC × P,
+          Pr[= sig | HasQuery.inRuntime
+            (fun [HasQuery (M × PC →ₒ Ω) m] =>
+              (FiatShamir (m := m) σ hr M).sign pk sk msg)
+            runtime] * val (costFn (msg, sig.1)) := by
+          rw [sign_outputs_formula_withAddCost
+            (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+            (msg := msg) (costFn := costFn)]
 
 /-- Fiat-Shamir signing makes exactly one random-oracle query under unit-cost instrumentation. -/
 theorem sign_usesExactlyOneQuery

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -593,11 +593,14 @@ end schemeCost
 
 end expectedCost
 
+end costAccounting
+
 section expectedCostPMF
 
-variable [HasEvalPMF m]
+variable (ids : IdenSchemeWithAbort S W W' St C Z p) (M : Type)
 
-omit [LawfulMonad m] [HasEvalPMF m] in
+variable {m : Type → Type u} [Monad m] [MonadLiftT ProbComp m]
+
 private lemma signLoop_inRuntime_succ
     (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
     HasQuery.inRuntime
@@ -619,16 +622,8 @@ private lemma signLoop_inRuntime_succ
               runtime) := by
   rfl
 
-/-- The probability that a single Fiat-Shamir-with-aborts signing attempt aborts. -/
-noncomputable abbrev signAttemptAbortProbability
-    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) : ENNReal :=
-  Pr[ fun attempt ↦ attempt.2 = none |
-    HasQuery.inRuntime
-      (fun [HasQuery (M × W' →ₒ C) m] =>
-        fsAbortSignAttempt (m := m) ids M pk sk msg)
-      runtime]
+variable [LawfulMonad m]
 
-omit [HasEvalPMF m] in
 private lemma signLoop_queryCountDist_succ
     (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
     HasQuery.queryCountDist
@@ -676,7 +671,17 @@ private lemma signLoop_queryCountDist_succ
       simp [HasQuery.queryCountDist, HasQuery.queryCostDist, HasQuery.withUnitCost,
         HasQuery.withAddCost, AddWriterT.costs, add_comm]
 
-omit [LawfulMonad m] in
+variable [HasEvalPMF m]
+
+/-- The probability that a single Fiat-Shamir-with-aborts signing attempt aborts. -/
+noncomputable abbrev signAttemptAbortProbability
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) : ENNReal :=
+  Pr[ fun attempt ↦ attempt.2 = none |
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignAttempt (m := m) ids M pk sk msg)
+      runtime]
+
 private lemma signLoop_probNone_succ
     (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
     Pr[= none |
@@ -948,7 +953,6 @@ private theorem signLoop_queryTailProbability_eq_probNonePrefix
                       (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
                       (msg := msg) (n := i)
 
-omit [LawfulMonad m] in
 private theorem signLoop_probNone_eq_signAttemptAbortProbability_pow
     (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) :
     ∀ i,
@@ -987,8 +991,6 @@ private theorem signLoop_probNone_eq_signAttemptAbortProbability_pow
               simp [pow_succ']
 
 section
-
-omit [LawfulMonad m]
 
 /-- The probability that the first `i` signing attempts all abort is the `i`-th power of the
 single-attempt abort probability. -/
@@ -1265,8 +1267,6 @@ theorem verify_expectedQueryCost_eq
 end schemeCost
 
 end expectedCostPMF
-
-end costAccounting
 
 section EUF_CMA
 

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -12,6 +12,7 @@ import VCVio.OracleComp.QueryTracking.RandomOracle
 import VCVio.OracleComp.QueryTracking.QueryRuntime
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
+import Mathlib.Analysis.SpecificLimits.Basic
 /-!
 # Fiat-Shamir with Aborts Transform
 
@@ -618,6 +619,15 @@ private lemma signLoop_inRuntime_succ
               runtime) := by
   rfl
 
+/-- The probability that a single Fiat-Shamir-with-aborts signing attempt aborts. -/
+noncomputable abbrev signAttemptAbortProbability
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) : ENNReal :=
+  Pr[ fun attempt ↦ attempt.2 = none |
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignAttempt (m := m) ids M pk sk msg)
+      runtime]
+
 omit [HasEvalPMF m] in
 private lemma signLoop_queryCountDist_succ
     (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
@@ -938,6 +948,63 @@ private theorem signLoop_queryTailProbability_eq_probNonePrefix
                       (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
                       (msg := msg) (n := i)
 
+omit [LawfulMonad m] in
+private theorem signLoop_probNone_eq_signAttemptAbortProbability_pow
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) :
+    ∀ i,
+      Pr[= none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignLoop (m := m) ids M pk sk msg i)
+          runtime] =
+        (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i
+  | 0 => by
+      simp [signAttemptAbortProbability, HasQuery.inRuntime, fsAbortSignLoop]
+  | i + 1 => by
+      calc
+        Pr[= none |
+          HasQuery.inRuntime
+            (fun [HasQuery (M × W' →ₒ C) m] =>
+              fsAbortSignLoop (m := m) ids M pk sk msg (i + 1))
+            runtime] =
+          signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg *
+            Pr[= none |
+              HasQuery.inRuntime
+                (fun [HasQuery (M × W' →ₒ C) m] =>
+                  fsAbortSignLoop (m := m) ids M pk sk msg i)
+                runtime] := by
+                  simpa [signAttemptAbortProbability] using
+                    signLoop_probNone_succ
+                      (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+                      (msg := msg) (n := i)
+        _ =
+          signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg *
+            (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+              rw [signLoop_probNone_eq_signAttemptAbortProbability_pow
+                (runtime := runtime) (pk := pk) (sk := sk) (msg := msg) i]
+        _ =
+          (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ (i + 1) := by
+              simp [pow_succ']
+
+section
+
+omit [LawfulMonad m]
+
+/-- The probability that the first `i` signing attempts all abort is the `i`-th power of the
+single-attempt abort probability. -/
+theorem sign_abortPrefixProbability_eq_signAttemptAbortProbability_pow
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (i : ℕ) :
+    Pr[= none |
+      HasQuery.inRuntime
+        (fun [HasQuery (M × W' →ₒ C) m] =>
+          fsAbortSignLoop (m := m) ids M pk sk msg i)
+        runtime] =
+      (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+  exact signLoop_probNone_eq_signAttemptAbortProbability_pow
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg) i
+
+end
+
 section schemeCost
 
 variable [SampleableType S] [SampleableType W]
@@ -975,6 +1042,23 @@ length `i` returns `none`, meaning that the `(i + 1)`-st attempt is reached. -/
   exact signLoop_queryTailProbability_eq_probNonePrefix
     (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
     (i := i) (extra := extra)
+
+/-- The probability that signing makes more than `i` oracle queries is the `i`-th power of the
+single-attempt abort probability, as long as `i < maxAttempts`. -/
+theorem sign_queryTailProbability_eq_signAttemptAbortProbability_pow
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    {i maxAttempts : ℕ} (hi : i < maxAttempts) :
+    Pr[ fun q ↦ i < q |
+      HasQuery.queryCountDist
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+          (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+        runtime] =
+      (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+  rw [sign_queryTailProbability_eq_probAllFirstAttemptsAbort
+    (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+    (msg := msg) (hi := hi)]
+  exact sign_abortPrefixProbability_eq_signAttemptAbortProbability_pow
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg) i
 
 /-- The expected number of signing queries is the sum, over prefixes of the retry loop, of the
 probability that every attempt in the prefix aborts. -/
@@ -1014,6 +1098,136 @@ theorem sign_expectedQueries_eq_sum_abortPrefixProbabilities
             exact sign_queryTailProbability_eq_probAllFirstAttemptsAbort
               (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
               (msg := msg) (hi := by exact Finset.mem_range.mp hi)
+
+/-- The expected number of signing queries is the finite geometric sum of the one-step abort
+probability. -/
+theorem sign_expectedQueries_eq_sum_signAttemptAbortProbability_powers
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] =
+      ∑ i ∈ Finset.range maxAttempts,
+        (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+  calc
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] =
+      ∑ i ∈ Finset.range maxAttempts,
+        Pr[= none |
+          HasQuery.inRuntime
+            (fun [HasQuery (M × W' →ₒ C) m] =>
+              fsAbortSignLoop (m := m) ids M pk sk msg i)
+            runtime] := by
+              exact sign_expectedQueries_eq_sum_abortPrefixProbabilities
+                (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+                (msg := msg) (maxAttempts := maxAttempts)
+    _ = ∑ i ∈ Finset.range maxAttempts,
+          (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+            refine Finset.sum_congr rfl ?_
+            intro i _
+            exact sign_abortPrefixProbability_eq_signAttemptAbortProbability_pow
+              (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg) i
+
+/-- Tail probabilities for the signer query count are bounded by the corresponding power of the
+single-attempt abort probability. -/
+theorem sign_queryTailProbability_le_signAttemptAbortProbability_pow
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (i maxAttempts : ℕ) :
+    Pr[ fun q ↦ i < q |
+      HasQuery.queryCountDist
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+          (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+        runtime] ≤
+      (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+  letI : HasEvalSPMF m := HasEvalPMF.toHasEvalSPMF
+  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  by_cases hi : i < maxAttempts
+  · rw [sign_queryTailProbability_eq_signAttemptAbortProbability_pow
+      (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+      (msg := msg) (hi := hi)]
+  · have hzero :
+        Pr[ fun q ↦ i < q |
+          HasQuery.queryCountDist
+            (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+              (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+            runtime] = 0 := by
+        refine probEvent_eq_zero ?_
+        intro c hc
+        have hc' : c ∈ support
+            (AddWriterT.costs
+              (HasQuery.withUnitCost
+                (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                  (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+                runtime)) := by
+          simpa [HasQuery.queryCountDist, HasQuery.queryCostDist, HasQuery.withUnitCost,
+            HasQuery.withAddCost] using hc
+        rw [AddWriterT.costs_def, support_map] at hc'
+        rcases hc' with ⟨z, hz, rfl⟩
+        exact not_lt_of_ge <|
+          le_trans
+            (sign_usesAtMostMaxAttemptsQueries
+              (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+              (msg := msg) (maxAttempts := maxAttempts) z hz)
+            (Nat.le_of_not_lt hi)
+    rw [hzero]
+    exact zero_le _
+
+/-- The expected number of signing queries is bounded by the infinite geometric series generated by
+the single-attempt abort probability. -/
+theorem sign_expectedQueries_le_tsum_signAttemptAbortProbability_powers
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] ≤
+      ∑' i : ℕ, (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+  letI : HasEvalSPMF m := HasEvalPMF.toHasEvalSPMF
+  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  exact HasQuery.expectedQueries_le_tsum_of_tail_probs_le
+    (oa := fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+    (runtime := runtime)
+    (a := fun i ↦ (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i)
+    (fun i ↦ sign_queryTailProbability_le_signAttemptAbortProbability_pow
+      (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+      (msg := msg) (i := i) (maxAttempts := maxAttempts))
+
+/-- If the single-attempt abort probability is bounded by `q`, then the expected number of signing
+queries is bounded by the corresponding geometric series. -/
+theorem sign_expectedQueries_le_geometric_of_signAttemptAbortProbability_le
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) {q : ENNReal}
+    (hq : signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg ≤ q) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] ≤
+      (1 - q)⁻¹ := by
+  calc
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] ≤
+      ∑' i : ℕ, (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
+          exact sign_expectedQueries_le_tsum_signAttemptAbortProbability_powers
+            (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+            (msg := msg) (maxAttempts := maxAttempts)
+    _ ≤ ∑' i : ℕ, q ^ i := by
+          refine ENNReal.tsum_le_tsum fun i ↦ ?_
+          exact ENNReal.pow_le_pow_left hq
+    _ = (1 - q)⁻¹ := ENNReal.tsum_geometric q
+
+/-- Specializing the geometric upper bound to the actual one-step abort probability yields the
+canonical infinite geometric upper bound on expected query count. -/
+theorem sign_expectedQueries_le_geometric
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] ≤
+      (1 - signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg)⁻¹ := by
+  exact sign_expectedQueries_le_geometric_of_signAttemptAbortProbability_le
+    (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+    (msg := msg) (maxAttempts := maxAttempts) le_rfl
 
 /-- Verification has expected weighted query cost equal to the cost of the single verification
 query when a signature is present, and `0` when the signature is `none`. -/

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -1015,7 +1015,7 @@ probability that the first `i` signing attempts all abort.
 
 Equivalently, the event `i < q` for the signer query count is the event that the retry loop of
 length `i` returns `none`, meaning that the `(i + 1)`-st attempt is reached. -/
-  theorem sign_queryTailProbability_eq_probAllFirstAttemptsAbort
+theorem sign_queryTailProbability_eq_probAllFirstAttemptsAbort
     (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
     {i maxAttempts : ℕ} (hi : i < maxAttempts) :
     Pr[ fun q ↦ i < q |

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -9,6 +9,7 @@ import VCVio.CryptoFoundations.SignatureAlg
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.RandomOracle
+import VCVio.OracleComp.QueryTracking.QueryRuntime
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.BundledSemantics
 /-!
@@ -36,13 +37,28 @@ This is the transform used by ML-DSA (CRYSTALS-Dilithium, FIPS 204).
 - NIST FIPS 204, Algorithms 2 (ML-DSA.Sign) and 3 (ML-DSA.Verify)
 -/
 
-universe v
+universe u v
 
 
 open OracleComp OracleSpec
+open scoped BigOperators
 
 variable {S W W' St C Z : Type}
   {p : S → W → Bool}
+
+/-- One signing attempt for the Fiat-Shamir-with-aborts transform.
+
+This performs a single commit-hash-respond cycle and returns the public commitment together with
+either a response or an abort marker. Unlike [`fsAbortSignLoop`], it never retries internally. -/
+def fsAbortSignAttempt (ids : IdenSchemeWithAbort S W W' St C Z p)
+    {m : Type → Type v} [Monad m]
+    (M : Type) [MonadLiftT ProbComp m] [HasQuery (M × W' →ₒ C) m]
+    (pk : S) (sk : W) (msg : M) :
+    m (W' × Option Z) := do
+  let (w', st) ← (monadLift (ids.commit pk sk : ProbComp _) : m _)
+  let c ← HasQuery.query (spec := (M × W' →ₒ C)) (msg, w')
+  let oz ← (monadLift (ids.respond pk sk st c : ProbComp _) : m _)
+  pure (w', oz)
 
 /-- Signing retry loop with early return for the Fiat-Shamir with aborts transform.
 
@@ -55,14 +71,12 @@ Tries up to `n` commit-hash-respond cycles:
 Returns `none` only when all `n` attempts abort. -/
 def fsAbortSignLoop (ids : IdenSchemeWithAbort S W W' St C Z p)
     {m : Type → Type v} [Monad m]
-    (M : Type) [DecidableEq M] [MonadLiftT ProbComp m] [HasQuery (M × W' →ₒ C) m]
+    (M : Type) [MonadLiftT ProbComp m] [HasQuery (M × W' →ₒ C) m]
     (pk : S) (sk : W) (msg : M) :
     ℕ → m (Option (W' × Z))
   | 0 => return none
   | n + 1 => do
-    let (w', st) ← (monadLift (ids.commit pk sk : ProbComp _) : m _)
-    let c ← HasQuery.query (spec := (M × W' →ₒ C)) (msg, w')
-    let oz ← (monadLift (ids.respond pk sk st c : ProbComp _) : m _)
+    let (w', oz) ← fsAbortSignAttempt ids M pk sk msg
     match oz with
     | some z => return some (w', z)
     | none => fsAbortSignLoop ids M pk sk msg n
@@ -83,7 +97,7 @@ def FiatShamirWithAbort
     {m : Type → Type v} [Monad m]
     (ids : IdenSchemeWithAbort S W W' St C Z p)
     [SampleableType S] [SampleableType W]
-    (hr : GenerableRelation S W p) (M : Type) [DecidableEq M]
+    (hr : GenerableRelation S W p) (M : Type)
     [MonadLiftT ProbComp m] [HasQuery (M × W' →ₒ C) m]
     (maxAttempts : ℕ) :
     SignatureAlg m
@@ -113,6 +127,459 @@ noncomputable def runtime :
   toProbCompLift := ProbCompLift.ofMonadLift _
 
 end runtime
+
+section signAttemptCore
+
+variable (ids : IdenSchemeWithAbort S W W' St C Z p) (M : Type)
+
+variable {m : Type → Type u} [Monad m] [LawfulMonad m]
+  [MonadLiftT ProbComp m]
+variable {ω : Type} [AddMonoid ω]
+
+private lemma fst_map_signAttempt_core
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) :
+    (do
+      let a ← WriterT.run (monadLift (ids.commit pk sk) : AddWriterT ω m (W' × St))
+      let c ← runtime.impl (msg, a.1.1)
+      (fun z : Option Z × Multiplicative ω => (a.1.1, z.1)) <$>
+        WriterT.run (monadLift (ids.respond pk sk a.1.2 c) : AddWriterT ω m (Option Z))) =
+    (do
+      let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+      let c ← runtime.impl (msg, a.1)
+      Prod.mk a.1 <$> (monadLift (ids.respond pk sk a.2 c) : m (Option Z))) := by
+  change (do
+      let a ← WriterT.run (monadLift ((monadLift (ids.commit pk sk) : m (W' × St))) :
+        AddWriterT ω m (W' × St))
+      let c ← runtime.impl (msg, a.1.1)
+      (fun z : Option Z × Multiplicative ω => (a.1.1, z.1)) <$>
+        WriterT.run
+          (monadLift ((monadLift (ids.respond pk sk a.1.2 c) : m (Option Z))) :
+            AddWriterT ω m (Option Z))) =
+    (do
+      let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+      let c ← runtime.impl (msg, a.1)
+      Prod.mk a.1 <$> (monadLift (ids.respond pk sk a.2 c) : m (Option Z)))
+  simp [bind_map_left]
+
+private lemma snd_map_signAttempt_core_withAddCost
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (costFn : M × W' → ω)
+    (pk : S) (sk : W) (msg : M) :
+    (do
+      let a ← WriterT.run (monadLift (ids.commit pk sk) : AddWriterT ω m (W' × St))
+      let c ← runtime.impl (msg, a.1.1)
+      (fun z : Option Z × Multiplicative ω =>
+        a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2)) <$>
+        WriterT.run (monadLift (ids.respond pk sk a.1.2 c) : AddWriterT ω m (Option Z))) =
+    (do
+      let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+      let c ← runtime.impl (msg, a.1)
+      (fun _ ↦ Multiplicative.ofAdd (costFn (msg, a.1))) <$>
+        (monadLift (ids.respond pk sk a.2 c) : m (Option Z))) := by
+  change (do
+      let a ← WriterT.run (monadLift ((monadLift (ids.commit pk sk) : m (W' × St))) :
+        AddWriterT ω m (W' × St))
+      let c ← runtime.impl (msg, a.1.1)
+      (fun z : Option Z × Multiplicative ω =>
+        a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2)) <$>
+        WriterT.run
+          (monadLift ((monadLift (ids.respond pk sk a.1.2 c) : m (Option Z))) :
+            AddWriterT ω m (Option Z))) =
+    (do
+      let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+      let c ← runtime.impl (msg, a.1)
+      (fun _ ↦ Multiplicative.ofAdd (costFn (msg, a.1))) <$>
+        (monadLift (ids.respond pk sk a.2 c) : m (Option Z)))
+  simp [bind_map_left]
+
+end signAttemptCore
+
+section costAccounting
+
+variable (ids : IdenSchemeWithAbort S W W' St C Z p) (M : Type)
+
+variable {m : Type → Type u} [Monad m] [LawfulMonad m]
+  [MonadLiftT ProbComp m]
+
+private lemma signAttempt_outputs_formula_withAddCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → ω) :
+    AddWriterT.outputs
+        (HasQuery.withAddCost
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+            fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
+          runtime costFn) =
+      HasQuery.inRuntime
+        (fun [HasQuery (M × W' →ₒ C) m] =>
+          fsAbortSignAttempt (m := m) ids M pk sk msg)
+        runtime := by
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (ids.commit pk sk) : AddWriterT ω m (W' × St))
+        let c ← runtime.impl (msg, a.1.1)
+        (fun z : Option Z × Multiplicative ω => (a.1.1, z.1)) <$>
+          WriterT.run (monadLift (ids.respond pk sk a.1.2 c) : AddWriterT ω m (Option Z))) =
+      (do
+        let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+        let c ← runtime.impl (msg, a.1)
+        Prod.mk a.1 <$> (monadLift (ids.respond pk sk a.2 c) : m (Option Z))) by
+    simpa [HasQuery.inRuntime, HasQuery.withAddCost, fsAbortSignAttempt, AddWriterT.outputs,
+      QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+      using h
+  exact fst_map_signAttempt_core
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+
+private lemma signAttempt_costs_formula_withAddCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → ω) :
+    AddWriterT.costs
+        (HasQuery.withAddCost
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+            fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
+          runtime costFn) =
+      (fun attempt ↦ costFn (msg, attempt.1)) <$>
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime := by
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (ids.commit pk sk) : AddWriterT ω m (W' × St))
+        let c ← runtime.impl (msg, a.1.1)
+        (fun z : Option Z × Multiplicative ω =>
+          a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2)) <$>
+          WriterT.run (monadLift (ids.respond pk sk a.1.2 c) : AddWriterT ω m (Option Z))) =
+      (do
+        let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+        let c ← runtime.impl (msg, a.1)
+        (fun _ ↦ Multiplicative.ofAdd (costFn (msg, a.1))) <$>
+          (monadLift (ids.respond pk sk a.2 c) : m (Option Z))) by
+    simpa [HasQuery.inRuntime, HasQuery.withAddCost, fsAbortSignAttempt, AddWriterT.costs,
+      QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+      using h
+  exact snd_map_signAttempt_core_withAddCost
+    (ids := ids) (M := M) (runtime := runtime) (costFn := costFn)
+    (pk := pk) (sk := sk) (msg := msg)
+
+/-- A single signing attempt has query cost determined by its output: the returned commitment
+`w'` is exactly the random-oracle query point. -/
+theorem signAttempt_usesCostAsQueryCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → ω) :
+    HasQuery.UsesCostAs
+      (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+        fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
+      runtime costFn (fun attempt ↦ costFn (msg, attempt.1)) := by
+  rw [HasQuery.UsesCostAs, AddWriterT.costsAs_iff]
+  rw [signAttempt_outputs_formula_withAddCost
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+    (costFn := costFn)]
+  exact signAttempt_costs_formula_withAddCost
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+    (costFn := costFn)
+
+/-- The expected weighted query cost of one signing attempt is the expectation of the queried
+commitment cost over the attempt output distribution. -/
+theorem signAttempt_expectedQueryCost_eq_outputExpectation
+    {ω : Type} [AddMonoid ω] [HasEvalSPMF m]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → ω) (val : ω → ENNReal) :
+    ExpectedQueryCost[
+      fsAbortSignAttempt ids M pk sk msg in runtime by costFn via val
+    ] =
+      ∑' attempt : W' × Option Z,
+        Pr[= attempt | HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime] * val (costFn (msg, attempt.1)) := by
+  calc
+    ExpectedQueryCost[
+      fsAbortSignAttempt ids M pk sk msg in runtime by costFn via val
+    ] =
+      ∑' attempt : W' × Option Z,
+        Pr[= attempt | AddWriterT.outputs
+          (HasQuery.withAddCost
+            (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+              fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
+            runtime costFn)] * val (costFn (msg, attempt.1)) := by
+          exact HasQuery.expectedQueryCost_eq_tsum_outputs_of_usesCostAs
+            (oa := fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+              fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
+            (runtime := runtime) (costFn := costFn) (f := fun attempt ↦ costFn (msg, attempt.1))
+            (val := val)
+            (signAttempt_usesCostAsQueryCost
+              (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+              (msg := msg) (costFn := costFn))
+    _ = ∑' attempt : W' × Option Z,
+          Pr[= attempt | HasQuery.inRuntime
+            (fun [HasQuery (M × W' →ₒ C) m] =>
+              fsAbortSignAttempt (m := m) ids M pk sk msg)
+            runtime] * val (costFn (msg, attempt.1)) := by
+          rw [signAttempt_outputs_formula_withAddCost
+            (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+            (msg := msg) (costFn := costFn)]
+
+section queryBounds
+
+variable [HasEvalSet m]
+
+private lemma signAttempt_usesWeightedQueryCostAtMost
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → κ) (w : κ) (hcost : ∀ t, costFn t ≤ w) :
+    HasQuery.UsesCostAtMost
+      (fun [HasQuery (M × W' →ₒ C) (AddWriterT κ m)] =>
+        fsAbortSignAttempt (m := AddWriterT κ m) ids M pk sk msg)
+      runtime costFn w := by
+  change AddWriterT.PathwiseCostAtMost
+    (do
+      let a ← (monadLift (ids.commit pk sk : ProbComp (W' × St)) : AddWriterT κ m (W' × St))
+      let c ← (runtime.withAddCost costFn).impl (msg, a.1)
+      let oz ← (monadLift (ids.respond pk sk a.2 c : ProbComp (Option Z)) :
+        AddWriterT κ m (Option Z))
+      pure (a.1, oz))
+    w
+  have hCommit :
+      AddWriterT.PathwiseCostAtMost
+        (monadLift (ids.commit pk sk : ProbComp (W' × St)) : AddWriterT κ m (W' × St))
+        0 :=
+    AddWriterT.pathwiseCostAtMost_probCompLift (m := m) (ω := κ) (ids.commit pk sk)
+  have hQuery :
+      ∀ a : W' × St,
+        AddWriterT.PathwiseCostAtMost ((runtime.withAddCost costFn).impl (msg, a.1)) w := by
+    intro a
+    exact AddWriterT.pathwiseCostAtMost_of_hasCost
+      (HasQuery.hasCost_withAddCost_query
+        (runtime := runtime) (costFn := costFn) (t := (msg, a.1)))
+      (hcost (msg, a.1))
+  have hRespond :
+      ∀ a : W' × St, ∀ c : C,
+        AddWriterT.PathwiseCostAtMost
+          (monadLift (ids.respond pk sk a.2 c : ProbComp (Option Z)) :
+            AddWriterT κ m (Option Z))
+          0 := by
+    intro a c
+    exact AddWriterT.pathwiseCostAtMost_probCompLift
+      (m := m) (ω := κ) (ids.respond pk sk a.2 c)
+  have hPure :
+      ∀ a : W' × St, ∀ oz : Option Z,
+        AddWriterT.PathwiseCostAtMost (pure (a.1, oz) : AddWriterT κ m (W' × Option Z)) 0 := by
+    intro a oz
+    exact AddWriterT.pathwiseCostAtMost_pure (m := m) (ω := κ) (x := (a.1, oz))
+  simpa [zero_add, add_comm] using
+    (AddWriterT.pathwiseCostAtMost_bind (w₁ := 0) (w₂ := w) hCommit
+      (fun a ↦ by
+        simpa [zero_add, add_comm] using
+          (AddWriterT.pathwiseCostAtMost_bind (w₁ := w) (w₂ := 0) (hQuery a)
+            (fun c ↦ by
+              simpa [zero_add] using
+                (AddWriterT.pathwiseCostAtMost_bind (w₁ := 0) (w₂ := 0) (hRespond a c)
+                  (fun oz ↦ hPure a oz))))))
+
+/-- The retry loop makes weighted query cost at most `n • w` when each query costs at most `w`.
+-/
+theorem fsAbortSignLoop_usesWeightedQueryCostAtMost
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → κ) (w : κ) (hcost : ∀ t, costFn t ≤ w) :
+    ∀ n,
+      HasQuery.UsesCostAtMost
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT κ m)] =>
+          fsAbortSignLoop (m := AddWriterT κ m) ids M pk sk msg n)
+        runtime costFn (n • w)
+  | 0 => by
+      simpa [HasQuery.UsesCostAtMost, HasQuery.withAddCost, fsAbortSignLoop] using
+        (AddWriterT.pathwiseCostAtMost_pure
+          (m := m) (ω := κ) (x := (none : Option (W' × Z))))
+  | n + 1 => by
+      have hStep := signAttempt_usesWeightedQueryCostAtMost
+        (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+        (msg := msg) (costFn := costFn) (w := w) hcost
+      have hRec := fsAbortSignLoop_usesWeightedQueryCostAtMost
+        (runtime := runtime) (pk := pk) (sk := sk)
+        (msg := msg) (costFn := costFn) (w := w) hcost n
+      let cont : W' × Option Z → AddWriterT κ m (Option (W' × Z)) := fun attempt =>
+        match attempt.2 with
+        | some z => pure (some (attempt.1, z))
+        | none =>
+            HasQuery.withAddCost
+              (fun [HasQuery (M × W' →ₒ C) (AddWriterT κ m)] =>
+                fsAbortSignLoop (m := AddWriterT κ m) ids M pk sk msg n)
+              runtime costFn
+      have hCont : ∀ attempt, AddWriterT.PathwiseCostAtMost (cont attempt) (n • w) := by
+        intro attempt
+        cases hAttempt : attempt.2 with
+        | some z =>
+            simpa only [cont, hAttempt] using
+              (AddWriterT.pathwiseCostAtMost_mono
+                (AddWriterT.pathwiseCostAtMost_pure
+                  (m := m) (ω := κ) (x := (some (attempt.1, z) : Option (W' × Z))))
+                (zero_le _))
+        | none =>
+            simpa [cont, hAttempt, HasQuery.UsesCostAtMost] using hRec
+      simpa [HasQuery.UsesCostAtMost, HasQuery.withAddCost, fsAbortSignLoop, succ_nsmul',
+        fsAbortSignAttempt, cont] using
+        (AddWriterT.pathwiseCostAtMost_bind (w₁ := w) (w₂ := n • w) hStep hCont)
+
+section schemeCost
+
+variable [SampleableType S] [SampleableType W]
+variable (hr : GenerableRelation S W p)
+
+/-- Signing makes weighted query cost at most `maxAttempts • w` when each query costs at most
+`w`. -/
+theorem sign_usesWeightedQueryCostAtMost
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → κ) (w : κ) (hcost : ∀ t, costFn t ≤ w) (maxAttempts : ℕ) :
+    QueryCost[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime by costFn
+    ] ≤ maxAttempts • w := by
+  change HasQuery.UsesCostAtMost
+    (fun [HasQuery (M × W' →ₒ C) (AddWriterT κ m)] =>
+      fsAbortSignLoop (m := AddWriterT κ m) ids M pk sk msg maxAttempts)
+    runtime costFn (maxAttempts • w)
+  exact fsAbortSignLoop_usesWeightedQueryCostAtMost
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+    (costFn := costFn) (w := w) hcost maxAttempts
+
+/-- Unit-cost specialization: signing makes at most `maxAttempts` random-oracle queries. -/
+theorem sign_usesAtMostMaxAttemptsQueries
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    QueryCost[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] ≤ maxAttempts := by
+  simpa [nsmul_eq_mul] using
+    (sign_usesWeightedQueryCostAtMost
+      (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+      (msg := msg) (costFn := fun _ ↦ (1 : ℕ)) (w := 1) (hcost := fun _ ↦ le_rfl)
+      (maxAttempts := maxAttempts))
+
+end schemeCost
+
+end queryBounds
+
+section expectedCost
+
+variable [HasEvalSPMF m]
+
+section schemeCost
+
+variable [SampleableType S] [SampleableType W]
+variable (hr : GenerableRelation S W p)
+
+/-- Tail-sum formula for the expected number of signing queries in Fiat-Shamir with aborts.
+
+The random variable on the right is the unit-cost query count of the signer. The event `i < q`
+means that the signer performed at least `i + 1` random-oracle queries, equivalently that the
+`(i + 1)`-st signing attempt was reached. Since the signer performs at most `maxAttempts`
+iterations, the infinite tail sum truncates to `Finset.range maxAttempts`. -/
+theorem sign_expectedQueries_eq_sum_reachedAttemptProbabilities
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] =
+      ∑ i ∈ Finset.range maxAttempts,
+        Pr[ fun q ↦ i < q |
+          HasQuery.queryCountDist
+            (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+              (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+            runtime] := by
+  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  exact HasQuery.expectedQueries_eq_sum_tail_probs_of_usesAtMostQueries
+    (oa := fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+    (runtime := runtime) (n := maxAttempts)
+    (sign_usesAtMostMaxAttemptsQueries
+      (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+      (msg := msg) (maxAttempts := maxAttempts))
+
+/-- Expected weighted query cost of signing is bounded by the worst-case `maxAttempts • w`
+budget whenever every query costs at most `w`. -/
+theorem sign_expectedQueryCost_le
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → κ) (w : κ) (val : κ → ENNReal)
+    (hcost : ∀ t, costFn t ≤ w) (hval : Monotone val) (maxAttempts : ℕ) :
+    ExpectedQueryCost[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime by costFn via val
+    ] ≤ val (maxAttempts • w) := by
+  let _ : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
+    (sign_usesWeightedQueryCostAtMost
+      (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+      (msg := msg) (costFn := costFn) (w := w) hcost (maxAttempts := maxAttempts))
+    hval
+
+/-- Unit-cost specialization: the expected number of signing queries is at most `maxAttempts`. -/
+theorem sign_expectedQueries_le
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] ≤ maxAttempts := by
+  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  exact HasQuery.expectedQueries_le_of_usesAtMostQueries
+    (sign_usesAtMostMaxAttemptsQueries
+      (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+      (msg := msg) (maxAttempts := maxAttempts))
+
+end schemeCost
+
+end expectedCost
+
+section expectedCostPMF
+
+variable [HasEvalPMF m]
+
+section schemeCost
+
+variable [SampleableType S] [SampleableType W]
+variable (hr : GenerableRelation S W p)
+
+/-- Verification has expected weighted query cost equal to the cost of the single verification
+query when a signature is present, and `0` when the signature is `none`. -/
+theorem verify_expectedQueryCost_eq
+    {ω : Type} [AddMonoid ω] [Preorder ω]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (msg : M) (sig : Option (W' × Z))
+    (costFn : M × W' → ω) (val : ω → ENNReal) (hval : Monotone val) (maxAttempts : ℕ) :
+    ExpectedQueryCost[
+      (FiatShamirWithAbort ids hr M maxAttempts).verify pk msg sig in runtime by costFn via val
+    ] =
+      match sig with
+      | none => val 0
+      | some (w', _) => val (costFn (msg, w')) := by
+  cases sig with
+  | none =>
+      letI : DecidableEq ω := Classical.decEq ω
+      simp [FiatShamirWithAbort, HasQuery.expectedQueryCost, AddWriterT.expectedCost,
+        HasQuery.withAddCost]
+  | some pair =>
+      rcases pair with ⟨w', z⟩
+      exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+        (by
+          change Cost[
+            HasQuery.withAddCost
+              (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+                (FiatShamirWithAbort (m := AddWriterT ω m) ids hr M maxAttempts).verify pk msg
+                  (some (w', z)))
+              runtime costFn
+          ] = costFn (msg, w')
+          rw [AddWriterT.hasCost_iff]
+          simp [FiatShamirWithAbort, HasQuery.withAddCost, QueryRuntime.withAddCost_impl,
+            AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell])
+        hval
+
+end schemeCost
+
+end expectedCostPMF
+
+end costAccounting
 
 section EUF_CMA
 

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -260,6 +260,65 @@ private lemma signAttempt_costs_formula_withAddCost {ω : Type} [AddMonoid ω]
     (ids := ids) (M := M) (runtime := runtime) (costFn := costFn)
     (pk := pk) (sk := sk) (msg := msg)
 
+private lemma signAttempt_run_formula_withAddCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (costFn : M × W' → ω) :
+    WriterT.run
+        (HasQuery.withAddCost
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
+            fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
+          runtime costFn) =
+      (fun attempt : W' × Option Z =>
+        (attempt, Multiplicative.ofAdd (costFn (msg, attempt.1)))) <$>
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime := by
+  suffices h :
+      (do
+        let a ← WriterT.run (monadLift (ids.commit pk sk) : AddWriterT ω m (W' × St))
+        let c ← runtime.impl (msg, a.1.1)
+        let z ← WriterT.run (monadLift (ids.respond pk sk a.1.2 c) : AddWriterT ω m (Option Z))
+        pure ((a.1.1, z.1), a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2))) =
+      (do
+        let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+        let c ← runtime.impl (msg, a.1)
+        let z ← (monadLift (ids.respond pk sk a.2 c) : m (Option Z))
+        pure ((a.1, z), Multiplicative.ofAdd (costFn (msg, a.1)))) by
+    simpa [HasQuery.inRuntime, HasQuery.withAddCost, fsAbortSignAttempt,
+      QueryRuntime.withAddCost_impl, AddWriterT.addTell]
+      using h
+  change (do
+      let a ← WriterT.run (monadLift ((monadLift (ids.commit pk sk) : m (W' × St))) :
+        AddWriterT ω m (W' × St))
+      let c ← runtime.impl (msg, a.1.1)
+      let z ← WriterT.run (monadLift ((monadLift (ids.respond pk sk a.1.2 c) : m (Option Z))) :
+        AddWriterT ω m (Option Z))
+      pure ((a.1.1, z.1), a.2 * (Multiplicative.ofAdd (costFn (msg, a.1.1)) * z.2))) =
+    (do
+      let a ← (monadLift (ids.commit pk sk) : m (W' × St))
+      let c ← runtime.impl (msg, a.1)
+      let z ← (monadLift (ids.respond pk sk a.2 c) : m (Option Z))
+      pure ((a.1, z), Multiplicative.ofAdd (costFn (msg, a.1))))
+  simp [bind_map_left]
+
+private lemma signAttempt_run_formula_withUnitCost
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) :
+    WriterT.run
+        (HasQuery.withUnitCost
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+            fsAbortSignAttempt (m := AddWriterT ℕ m) ids M pk sk msg)
+          runtime) =
+      (fun attempt : W' × Option Z => (attempt, Multiplicative.ofAdd 1)) <$>
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime := by
+  simpa [HasQuery.withUnitCost] using
+    signAttempt_run_formula_withAddCost
+      (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+      (costFn := fun _ ↦ (1 : ℕ))
+
 /-- A single signing attempt has query cost determined by its output: the returned commitment
 `w'` is exactly the random-oracle query point. -/
 theorem signAttempt_usesCostAsQueryCost {ω : Type} [AddMonoid ω]
@@ -537,10 +596,424 @@ section expectedCostPMF
 
 variable [HasEvalPMF m]
 
+omit [LawfulMonad m] [HasEvalPMF m] in
+private lemma signLoop_inRuntime_succ
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignLoop (m := m) ids M pk sk msg (n + 1))
+      runtime
+    =
+      (do
+        let attempt ← HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime
+        match attempt.2 with
+        | some z => pure (some (attempt.1, z))
+        | none =>
+            HasQuery.inRuntime
+              (fun [HasQuery (M × W' →ₒ C) m] =>
+                fsAbortSignLoop (m := m) ids M pk sk msg n)
+              runtime) := by
+  rfl
+
+omit [HasEvalPMF m] in
+private lemma signLoop_queryCountDist_succ
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
+    HasQuery.queryCountDist
+      (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+        fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (n + 1))
+      runtime
+    =
+      (do
+        let attempt ← HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime
+        match attempt.2 with
+        | some _ => pure 1
+        | none =>
+            let recCosts :=
+              HasQuery.queryCountDist
+                (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                  fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg n)
+                runtime
+            Nat.succ <$> recCosts) := by
+  change AddWriterT.costs
+      (do
+        let attempt ← HasQuery.withUnitCost
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+            fsAbortSignAttempt (m := AddWriterT ℕ m) ids M pk sk msg)
+          runtime
+        match attempt.2 with
+        | some z => pure (some (attempt.1, z))
+        | none =>
+            HasQuery.withUnitCost
+              (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg n)
+              runtime) = _
+  rw [AddWriterT.costs_def, WriterT.run_bind]
+  rw [signAttempt_run_formula_withUnitCost
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)]
+  simp only [bind_map_left, map_bind, Functor.map_map, Prod.map_snd, toAdd_mul, toAdd_ofAdd]
+  refine bind_congr (m := m) ?_
+  intro attempt
+  cases attempt.2 with
+  | some z =>
+      simp
+  | none =>
+      simp [HasQuery.queryCountDist, HasQuery.queryCostDist, HasQuery.withUnitCost,
+        HasQuery.withAddCost, AddWriterT.costs, add_comm]
+
+omit [LawfulMonad m] in
+private lemma signLoop_probNone_succ
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
+    Pr[= none |
+      HasQuery.inRuntime
+        (fun [HasQuery (M × W' →ₒ C) m] =>
+          fsAbortSignLoop (m := m) ids M pk sk msg (n + 1))
+        runtime] =
+      Pr[ fun attempt ↦ attempt.2 = none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime] *
+      Pr[= none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignLoop (m := m) ids M pk sk msg n)
+          runtime] := by
+  set attemptComp : m (W' × Option Z) :=
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignAttempt (m := m) ids M pk sk msg)
+      runtime
+  set recLoop : m (Option (W' × Z)) :=
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignLoop (m := m) ids M pk sk msg n)
+      runtime
+  rw [signLoop_inRuntime_succ (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+    (msg := msg) (n := n)]
+  change Pr[= none |
+      attemptComp >>= fun attempt =>
+        match attempt.2 with
+        | some z => pure (some (attempt.1, z))
+        | none => recLoop] =
+    Pr[ fun attempt ↦ attempt.2 = none | attemptComp] * Pr[= none | recLoop]
+  rw [probOutput_bind_eq_tsum]
+  calc
+    ∑' attempt : W' × Option Z,
+        Pr[= attempt | attemptComp] *
+          Pr[= none |
+            match attempt.2 with
+            | some z => pure (some (attempt.1, z))
+            | none => recLoop]
+      = ∑' attempt : W' × Option Z,
+          Pr[= attempt | attemptComp] *
+            (if attempt.2 = none then Pr[= none | recLoop] else 0) := by
+              refine tsum_congr fun attempt => ?_
+              cases hAttempt : attempt.2 with
+              | some z =>
+                  simp
+              | none =>
+                  simp
+    _ = ∑' attempt : W' × Option Z,
+          (if attempt.2 = none then Pr[= attempt | attemptComp] else 0) * Pr[= none | recLoop] := by
+            refine tsum_congr fun attempt => ?_
+            by_cases hAttempt : attempt.2 = none <;> simp [hAttempt, mul_comm]
+    _ = (∑' attempt : W' × Option Z, if attempt.2 = none then Pr[= attempt | attemptComp] else 0)
+          * Pr[= none | recLoop] := by
+            rw [ENNReal.tsum_mul_right]
+    _ = Pr[ fun attempt ↦ attempt.2 = none | attemptComp] * Pr[= none | recLoop] := by
+            simp [probEvent_eq_tsum_indicator, Set.indicator, Set.mem_setOf_eq]
+
+private lemma signLoop_queryTailProbability_zero
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (n : ℕ) :
+    Pr[ fun q ↦ 0 < q |
+      HasQuery.queryCountDist
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+          fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (n + 1))
+        runtime] = 1 := by
+  set attemptComp : m (W' × Option Z) :=
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignAttempt (m := m) ids M pk sk msg)
+      runtime
+  set recCosts : m ℕ :=
+    HasQuery.queryCountDist (m := m)
+      (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+        fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg n)
+      runtime
+  rw [signLoop_queryCountDist_succ (ids := ids) (M := M) (runtime := runtime) (pk := pk)
+    (sk := sk) (msg := msg) (n := n)]
+  change Pr[ fun q ↦ 0 < q |
+      attemptComp >>= fun attempt =>
+        match attempt.2 with
+        | some _ => pure 1
+        | none => Nat.succ <$> recCosts] = 1
+  rw [probEvent_bind_of_const (r := 1)]
+  · simp
+  · intro attempt _
+    cases hAttempt : attempt.2 with
+    | some z =>
+        simp
+    | none =>
+        simp [probEvent_map]
+
+private lemma signLoop_queryTailProbability_succ
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) (i n : ℕ) :
+    Pr[ fun q ↦ i + 1 < q |
+      HasQuery.queryCountDist
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+          fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (n + 1))
+        runtime] =
+      Pr[ fun attempt ↦ attempt.2 = none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignAttempt (m := m) ids M pk sk msg)
+          runtime] *
+      Pr[ fun q ↦ i < q |
+        HasQuery.queryCountDist
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+            fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg n)
+          runtime] := by
+  set attemptComp : m (W' × Option Z) :=
+    HasQuery.inRuntime
+      (fun [HasQuery (M × W' →ₒ C) m] =>
+        fsAbortSignAttempt (m := m) ids M pk sk msg)
+      runtime
+  set recCosts : m ℕ :=
+    HasQuery.queryCountDist (m := m)
+      (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+        fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg n)
+      runtime
+  let cont : W' × Option Z → m ℕ := fun attempt =>
+    match attempt.2 with
+    | some _ => pure 1
+    | none => Nat.succ <$> recCosts
+  rw [signLoop_queryCountDist_succ (ids := ids) (M := M) (runtime := runtime) (pk := pk)
+    (sk := sk) (msg := msg) (n := n)]
+  change Pr[ fun q ↦ i + 1 < q |
+      attemptComp >>= cont] =
+    Pr[ fun attempt ↦ attempt.2 = none | attemptComp] *
+      Pr[ fun q ↦ i < q | recCosts]
+  rw [probEvent_bind_eq_tsum]
+  calc
+    ∑' attempt : W' × Option Z,
+        Pr[= attempt | attemptComp] * Pr[ fun q ↦ i + 1 < q | cont attempt]
+      = ∑' attempt : W' × Option Z,
+          Pr[= attempt | attemptComp] *
+            (if attempt.2 = none then Pr[ fun q ↦ i < q | recCosts] else 0) := by
+              refine tsum_congr fun attempt => ?_
+              cases hAttempt : attempt.2 with
+              | some z =>
+                  simp [cont, hAttempt]
+              | none =>
+                  have hs :
+                      Pr[ fun q ↦ i + 1 < q | Nat.succ <$> recCosts] =
+                        Pr[ fun q ↦ i < q | recCosts] := by
+                    have hpred : ((fun q ↦ i + 1 < q) ∘ Nat.succ) = fun q ↦ i < q := by
+                      funext q
+                      exact propext (show Nat.succ i < Nat.succ q ↔ i < q from
+                        Nat.succ_lt_succ_iff)
+                    calc
+                      Pr[ fun q ↦ i + 1 < q | Nat.succ <$> recCosts]
+                        = Pr[ ((fun q ↦ i + 1 < q) ∘ Nat.succ) | recCosts] := by
+                            rw [probEvent_map]
+                      _ = Pr[ fun q ↦ i < q | recCosts] := by
+                            rw [hpred]
+                  rw [show cont attempt = Nat.succ <$> recCosts by simp [cont, hAttempt]]
+                  rw [hs]
+                  simp
+    _ = ∑' attempt : W' × Option Z,
+          (if attempt.2 = none then Pr[= attempt | attemptComp] else 0) *
+            Pr[ fun q ↦ i < q | recCosts] := by
+              refine tsum_congr fun attempt => ?_
+              by_cases hAttempt : attempt.2 = none <;> simp [hAttempt, mul_comm]
+    _ = (∑' attempt : W' × Option Z, if attempt.2 = none then Pr[= attempt | attemptComp] else 0)
+          * Pr[ fun q ↦ i < q | recCosts] := by
+            rw [ENNReal.tsum_mul_right]
+    _ = Pr[ fun attempt ↦ attempt.2 = none | attemptComp] *
+          Pr[ fun q ↦ i < q | recCosts] := by
+            simp [probEvent_eq_tsum_indicator, Set.indicator, Set.mem_setOf_eq]
+
+private theorem signLoop_queryTailProbability_eq_probNonePrefix
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M) :
+    ∀ i extra,
+      Pr[ fun q ↦ i < q |
+        HasQuery.queryCountDist
+          (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+            fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (i + extra + 1))
+          runtime] =
+      Pr[= none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignLoop (m := m) ids M pk sk msg i)
+          runtime]
+  | 0, extra => by
+      have hzero :
+          Pr[ fun q ↦ 0 < q |
+            HasQuery.queryCountDist
+              (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (0 + extra + 1))
+              runtime] = 1 := by
+        simpa [Nat.zero_add] using
+          signLoop_queryTailProbability_zero
+            (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+            (msg := msg) (n := extra)
+      calc
+        Pr[ fun q ↦ 0 < q |
+          HasQuery.queryCountDist
+            (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+              fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (0 + extra + 1))
+            runtime] = 1 := hzero
+      _ = Pr[= none |
+            HasQuery.inRuntime
+              (fun [HasQuery (M × W' →ₒ C) m] =>
+                fsAbortSignLoop (m := m) ids M pk sk msg 0)
+              runtime] := by
+            simp [HasQuery.inRuntime, fsAbortSignLoop]
+  | i + 1, extra => by
+      have hstep :
+          Pr[ fun q ↦ i + 1 < q |
+            HasQuery.queryCountDist
+              (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (i + 1 + extra + 1))
+              runtime] =
+            Pr[ fun attempt ↦ attempt.2 = none |
+              HasQuery.inRuntime
+                (fun [HasQuery (M × W' →ₒ C) m] =>
+                  fsAbortSignAttempt (m := m) ids M pk sk msg)
+                runtime] *
+            Pr[ fun q ↦ i < q |
+              HasQuery.queryCountDist
+                (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                  fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (i + extra + 1))
+                runtime] := by
+        simpa [Nat.add_assoc, Nat.add_left_comm, Nat.add_comm] using
+          signLoop_queryTailProbability_succ
+            (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+            (msg := msg) (i := i) (n := i + extra + 1)
+      calc
+        Pr[ fun q ↦ i + 1 < q |
+          HasQuery.queryCountDist
+            (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+              fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (i + 1 + extra + 1))
+            runtime]
+          =
+            Pr[ fun attempt ↦ attempt.2 = none |
+              HasQuery.inRuntime
+                (fun [HasQuery (M × W' →ₒ C) m] =>
+                  fsAbortSignAttempt (m := m) ids M pk sk msg)
+                runtime] *
+            Pr[ fun q ↦ i < q |
+              HasQuery.queryCountDist
+                (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+                  fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (i + extra + 1))
+                runtime] := hstep
+        _ =
+            Pr[ fun attempt ↦ attempt.2 = none |
+              HasQuery.inRuntime
+                (fun [HasQuery (M × W' →ₒ C) m] =>
+                  fsAbortSignAttempt (m := m) ids M pk sk msg)
+                runtime] *
+            Pr[= none |
+              HasQuery.inRuntime
+                (fun [HasQuery (M × W' →ₒ C) m] =>
+                  fsAbortSignLoop (m := m) ids M pk sk msg i)
+                runtime] := by
+                  rw [signLoop_queryTailProbability_eq_probNonePrefix
+                    (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+                    (i := i) (extra := extra)]
+        _ = Pr[= none |
+              HasQuery.inRuntime
+                (fun [HasQuery (M × W' →ₒ C) m] =>
+                  fsAbortSignLoop (m := m) ids M pk sk msg (i + 1))
+                runtime] := by
+                  symm
+                  simpa using
+                    signLoop_probNone_succ
+                      (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+                      (msg := msg) (n := i)
+
 section schemeCost
 
 variable [SampleableType S] [SampleableType W]
 variable (hr : GenerableRelation S W p)
+
+/-- The probability that signing makes more than `i` random-oracle queries is exactly the
+probability that the first `i` signing attempts all abort.
+
+Equivalently, the event `i < q` for the signer query count is the event that the retry loop of
+length `i` returns `none`, meaning that the `(i + 1)`-st attempt is reached. -/
+  theorem sign_queryTailProbability_eq_probAllFirstAttemptsAbort
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    {i maxAttempts : ℕ} (hi : i < maxAttempts) :
+    Pr[ fun q ↦ i < q |
+      HasQuery.queryCountDist
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+          (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+        runtime] =
+      Pr[= none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignLoop (m := m) ids M pk sk msg i)
+          runtime] := by
+  obtain ⟨extra, rfl⟩ := Nat.exists_eq_add_of_lt hi
+  change Pr[ fun q ↦ i < q |
+      HasQuery.queryCountDist
+        (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+          fsAbortSignLoop (m := AddWriterT ℕ m) ids M pk sk msg (i + extra + 1))
+        runtime] =
+      Pr[= none |
+        HasQuery.inRuntime
+          (fun [HasQuery (M × W' →ₒ C) m] =>
+            fsAbortSignLoop (m := m) ids M pk sk msg i)
+          runtime]
+  exact signLoop_queryTailProbability_eq_probNonePrefix
+    (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+    (i := i) (extra := extra)
+
+/-- The expected number of signing queries is the sum, over prefixes of the retry loop, of the
+probability that every attempt in the prefix aborts. -/
+theorem sign_expectedQueries_eq_sum_abortPrefixProbabilities
+    (runtime : QueryRuntime (M × W' →ₒ C) m) (pk : S) (sk : W) (msg : M)
+    (maxAttempts : ℕ) :
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] =
+      ∑ i ∈ Finset.range maxAttempts,
+        Pr[= none |
+          HasQuery.inRuntime
+            (fun [HasQuery (M × W' →ₒ C) m] =>
+              fsAbortSignLoop (m := m) ids M pk sk msg i)
+            runtime] := by
+  calc
+    ExpectedQueries[
+      (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
+    ] =
+      ∑ i ∈ Finset.range maxAttempts,
+        Pr[ fun q ↦ i < q |
+          HasQuery.queryCountDist
+            (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
+              (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
+            runtime] := by
+              exact sign_expectedQueries_eq_sum_reachedAttemptProbabilities
+                (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+                (msg := msg) (maxAttempts := maxAttempts)
+    _ = ∑ i ∈ Finset.range maxAttempts,
+          Pr[= none |
+            HasQuery.inRuntime
+              (fun [HasQuery (M × W' →ₒ C) m] =>
+                fsAbortSignLoop (m := m) ids M pk sk msg i)
+              runtime] := by
+            refine Finset.sum_congr rfl ?_
+            intro i hi
+            exact sign_queryTailProbability_eq_probAllFirstAttemptsAbort
+              (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
+              (msg := msg) (hi := by exact Finset.mem_range.mp hi)
 
 /-- Verification has expected weighted query cost equal to the cost of the single verification
 query when a signature is present, and `0` when the signature is `none`. -/

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -286,15 +286,15 @@ private lemma fischlinSearchAuxWithUnitCost_queryBoundedAboveBy
 
 /-- Fischlin's inner search, instantiated in a weighted additive-cost runtime. -/
 private def fischlinSearchAuxWithAddCost
-    {ω : Type} [AddMonoid ω]
+    {κ : Type} [AddMonoid κ]
     {X W PC SC Ω P M : Type} {p : X → W → Bool} {ρ b : ℕ}
     {m : Type → Type v} [Monad m] [MonadLiftT ProbComp m]
     (σ : SigmaProtocol X W PC SC Ω P p)
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
     (challenges : List Ω) (best : Option (Ω × P × Fin (2 ^ b)))
-    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → ω) :
-    AddWriterT ω m (Option (Ω × P)) :=
+    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → κ) :
+    AddWriterT κ m (Option (Ω × P)) :=
   match challenges with
   | [] => pure (best.map fun (ω, resp, _) => (ω, resp))
   | ω :: rest => do

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -331,7 +331,8 @@ private lemma fischlinSearchAux_eq_withAddCost
   | nil =>
       simp [fischlinSearchAux, fischlinSearchAuxWithAddCost]
   | cons ω rest ih =>
-      simp [fischlinSearchAux, fischlinSearchAuxWithAddCost, ih]
+      simp [fischlinSearchAux, fischlinSearchAuxWithAddCost,
+        QueryRuntime.withAddCost_impl, liftM, MonadLiftT.monadLift, ih]
 
 omit [SampleableType X] [SampleableType W]
   [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -284,6 +284,141 @@ private lemma fischlinSearchAuxWithUnitCost_queryBoundedAboveBy
               if h.val < h'.val then some (ω, resp, h) else some (ω', resp', h')
         simpa [hashStep, hh, newBest] using ih (best := newBest)
 
+/-- Fischlin's inner search, instantiated in a weighted additive-cost runtime. -/
+private def fischlinSearchAuxWithAddCost
+    {ω : Type} [AddMonoid ω]
+    {X W PC SC Ω P M : Type} {p : X → W → Bool} {ρ b : ℕ}
+    {m : Type → Type v} [Monad m] [MonadLiftT ProbComp m]
+    (σ : SigmaProtocol X W PC SC Ω P p)
+    (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
+    (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
+    (challenges : List Ω) (best : Option (Ω × P × Fin (2 ^ b)))
+    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → ω) :
+    AddWriterT ω m (Option (Ω × P)) :=
+  match challenges with
+  | [] => pure (best.map fun (ω, resp, _) => (ω, resp))
+  | ω :: rest => do
+      let resp ← monadLift (σ.respond pk sk sc ω)
+      AddWriterT.addTell (M := m) (costFn ⟨pk, msg, comList, i, ω, resp⟩)
+      let h ← monadLift (runtime.impl ⟨pk, msg, comList, i, ω, resp⟩)
+      if h.val = 0 then
+        pure (some (ω, resp))
+      else
+        let newBest := match best with
+          | none => some (ω, resp, h)
+          | some (ω', resp', h') =>
+            if h.val < h'.val then some (ω, resp, h) else some (ω', resp', h')
+        fischlinSearchAuxWithAddCost σ runtime pk sk sc msg comList i rest newBest costFn
+
+omit [SampleableType X] [SampleableType W]
+  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
+  [DecidableEq M] [HasEvalSet m] in
+private lemma fischlinSearchAux_eq_withAddCost
+    {κ : Type} [AddMonoid κ]
+    (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
+    (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
+    (challenges : List Ω) (best : Option (Ω × P × Fin (2 ^ b)))
+    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → κ) :
+    let _ : HasQuery (fischlinROSpec X PC Ω P ρ b M) (AddWriterT κ m) :=
+      runtime.withAddCost costFn |>.toHasQuery
+    fischlinSearchAux
+      (m := AddWriterT κ m) σ pk sk sc msg comList i challenges best =
+      fischlinSearchAuxWithAddCost
+        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
+        (comList := comList) (i := i) challenges best costFn := by
+  induction challenges generalizing best with
+  | nil =>
+      simp [fischlinSearchAux, fischlinSearchAuxWithAddCost]
+  | cons ω rest ih =>
+      simp [fischlinSearchAux, fischlinSearchAuxWithAddCost, ih]
+
+omit [SampleableType X] [SampleableType W]
+  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
+  [DecidableEq M] in
+private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
+    (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
+    (challenges : List Ω) (best : Option (Ω × P × Fin (2 ^ b)))
+    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → κ) {w : κ}
+    (hcost : ∀ t, costFn t ≤ w) :
+    AddWriterT.PathwiseCostAtMost
+      (fischlinSearchAuxWithAddCost
+        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
+        (comList := comList) (i := i) challenges best costFn)
+      (challenges.length • w) := by
+  induction challenges generalizing best with
+  | nil =>
+      simpa using
+        (AddWriterT.pathwiseCostAtMost_pure
+          (m := m) ((best.map fun (ω, resp, _) => (ω, resp)) : Option (Ω × P)))
+  | cons chal rest ih =>
+      let hashStep : P → AddWriterT κ m (Option (Ω × P)) := fun resp =>
+        (AddWriterT.addTell (M := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩) :
+          AddWriterT κ m PUnit) >>= fun _ =>
+          (monadLift (runtime.impl ⟨pk, msg, comList, i, chal, resp⟩) :
+            AddWriterT κ m (Fin (2 ^ b))) >>= fun h =>
+              if h.val = 0 then
+                pure (some (chal, resp))
+              else
+                fischlinSearchAuxWithAddCost σ runtime pk sk sc msg comList i rest
+                  (match best with
+                  | none => some (chal, resp, h)
+                  | some (ω', resp', h') =>
+                      if h.val < h'.val then some (chal, resp, h) else some (ω', resp', h'))
+                  costFn
+      change AddWriterT.PathwiseCostAtMost
+        ((monadLift (σ.respond pk sk sc chal) : AddWriterT κ m P) >>= hashStep)
+        ((rest.length + 1) • w)
+      have hstep : ∀ resp, AddWriterT.PathwiseCostAtMost (hashStep resp) (w + rest.length • w) := by
+        intro resp
+        have htell :
+            AddWriterT.PathwiseCostAtMost
+              (AddWriterT.addTell (M := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
+              w := by
+          exact AddWriterT.pathwiseCostAtMost_mono
+            (AddWriterT.pathwiseCostAtMost_addTell
+              (m := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
+            (hcost _)
+        refine AddWriterT.pathwiseCostAtMost_bind (w₁ := w) (w₂ := rest.length • w) htell ?_
+        intro _
+        have hhash :
+            AddWriterT.PathwiseCostAtMost
+              (((monadLift (runtime.impl ⟨pk, msg, comList, i, chal, resp⟩) :
+                    AddWriterT κ m (Fin (2 ^ b))) >>= fun h =>
+                  if h.val = 0 then
+                    pure (some (chal, resp))
+                  else
+                    fischlinSearchAuxWithAddCost σ runtime pk sk sc msg comList i rest
+                      (match best with
+                      | none => some (chal, resp, h)
+                      | some (ω', resp', h') =>
+                          if h.val < h'.val then some (chal, resp, h) else some (ω', resp', h'))
+                      costFn))
+              (0 + rest.length • w) := by
+          refine AddWriterT.pathwiseCostAtMost_bind (w₁ := 0) (w₂ := rest.length • w)
+            (AddWriterT.pathwiseCostAtMost_monadLift
+              (m := m) (runtime.impl ⟨pk, msg, comList, i, chal, resp⟩)) ?_
+          intro h
+          by_cases hh : h.val = 0
+          · simpa [hh] using
+              AddWriterT.pathwiseCostAtMost_mono
+                (AddWriterT.pathwiseCostAtMost_pure ((some (chal, resp)) : Option (Ω × P)))
+                (zero_le _)
+          · let newBest : Option (Ω × P × Fin (2 ^ b)) := match best with
+              | none => some (chal, resp, h)
+              | some (ω', resp', h') =>
+                  if h.val < h'.val then some (chal, resp, h) else some (ω', resp', h')
+            simpa [hh, newBest] using ih (best := newBest)
+        exact AddWriterT.pathwiseCostAtMost_mono hhash (by simp [zero_add])
+      simpa [succ_nsmul'] using
+        (AddWriterT.pathwiseCostAtMost_bind (w₁ := 0) (w₂ := w + rest.length • w)
+          (AddWriterT.pathwiseCostAtMost_monadLift (m := m) (σ.respond pk sk sc chal))
+          hstep)
+
 section
 
 omit [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
@@ -487,6 +622,144 @@ theorem sign_usesAtMostRhoCardOmegaQueries
       (fun commits =>
         AddWriterT.queryBoundedAboveBy_fin_mOfFn (n := ρ) (k := FinEnum.card Ω)
           (fun i => hrep commits i)))
+
+/-- Fischlin signing has weighted query cost at most `ρ • (|Ω| • w)` whenever every random-oracle
+query carries cost at most `w`. -/
+theorem sign_usesWeightedQueryCostAtMost
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
+    (pk : X) (sk : W) (msg : M)
+    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → κ) (w : κ)
+    (hcost : ∀ t, costFn t ≤ w) :
+    QueryCost[ (Fischlin σ hr ρ b S M).sign pk sk msg in runtime by costFn ] ≤
+      ρ • (FinEnum.card Ω • w) := by
+  have hlen : (FinEnum.toList Ω).length = FinEnum.card Ω := by
+    simp [FinEnum.toList]
+  let repStep : (Fin ρ → PC × SC) → Fin ρ → AddWriterT κ m (PC × Ω × P) := fun commits i => do
+    let comVec : Fin ρ → PC := fun j => (commits j).1
+    let comList := List.ofFn comVec
+    let sc_i := (commits i).2
+    let result ←
+      fischlinSearchAuxWithAddCost
+        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc_i) (msg := msg)
+        (comList := comList) (i := i)
+        (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b))) costFn
+    match result with
+    | some (ω, resp) => pure (comVec i, ω, resp)
+    | none => pure (comVec i, default, default)
+  have hrep : ∀ commits i,
+      AddWriterT.PathwiseCostAtMost (repStep commits i) (FinEnum.card Ω • w) := by
+    intro commits i
+    let comVec : Fin ρ → PC := fun j => (commits j).1
+    let comList := List.ofFn comVec
+    have hsearch :
+        AddWriterT.PathwiseCostAtMost
+          (fischlinSearchAuxWithAddCost
+            (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+            (msg := msg) (comList := comList) (i := i)
+            (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b))) costFn)
+          ((FinEnum.toList Ω).length • w) := by
+      exact fischlinSearchAuxWithAddCost_pathwiseCostAtMost
+        (κ := κ)
+        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+        (msg := msg) (comList := comList) (i := i)
+        (challenges := FinEnum.toList Ω) (best := none) (costFn := costFn) (w := w)
+        (hcost := hcost)
+    let finish : Option (Ω × P) → AddWriterT κ m (PC × Ω × P)
+      | some (ω, resp) => pure (comVec i, ω, resp)
+      | none => pure (comVec i, default, default)
+    have hcont :
+        ∀ result : Option (Ω × P), AddWriterT.PathwiseCostAtMost (finish result) 0 := by
+      intro result
+      cases result with
+      | none =>
+          simpa [finish] using AddWriterT.pathwiseCostAtMost_pure
+            (m := m) ((comVec i, default, default) : PC × Ω × P)
+      | some pair =>
+          rcases pair with ⟨ω, resp⟩
+          simpa [finish] using AddWriterT.pathwiseCostAtMost_pure
+            (m := m) ((comVec i, ω, resp) : PC × Ω × P)
+    refine AddWriterT.pathwiseCostAtMost_mono
+      (AddWriterT.pathwiseCostAtMost_bind (w₁ := (FinEnum.toList Ω).length • w) (w₂ := 0)
+        hsearch hcont) ?_
+    simp [hlen]
+  let commitComp : AddWriterT κ m (Fin ρ → PC × SC) :=
+    Fin.mOfFn ρ fun _ => (liftM (σ.commit pk sk) : AddWriterT κ m (PC × SC))
+  have hcommit :
+      AddWriterT.PathwiseCostAtMost commitComp 0 := by
+    have hstep :
+        AddWriterT.PathwiseCostAtMost
+          (liftM (σ.commit pk sk) : AddWriterT κ m (PC × SC)) 0 := by
+      simpa [WriterT.liftM_def] using
+        (AddWriterT.pathwiseCostAtMost_monadLift
+          (m := m) (monadLift (σ.commit pk sk) : m (PC × SC)))
+    simpa [commitComp] using
+      (AddWriterT.pathwiseCostAtMost_fin_mOfFn (n := ρ) (k := 0)
+        (f := fun _ => (liftM (σ.commit pk sk) : AddWriterT κ m (PC × SC)))
+        (fun _ => hstep))
+  suffices
+      AddWriterT.PathwiseCostAtMost
+        (commitComp >>= fun commits => Fin.mOfFn ρ (repStep commits))
+        (ρ • (FinEnum.card Ω • w)) by
+    have hsign :
+        HasQuery.withAddCost
+          (fun [HasQuery (fischlinROSpec X PC Ω P ρ b M) (AddWriterT κ m)] =>
+            (Fischlin (m := AddWriterT κ m) σ hr ρ b S M).sign pk sk msg)
+          runtime costFn =
+          (commitComp >>= fun commits => Fin.mOfFn ρ (repStep commits)) := by
+      simp only [Fischlin, HasQuery.withAddCost, repStep, commitComp]
+      refine congrArg
+        (fun k => commitComp >>= k) ?_
+      funext commits
+      refine congrArg
+        (fun f : Fin ρ → AddWriterT κ m (PC × Ω × P) => Fin.mOfFn ρ f) ?_
+      funext i
+      let comVec : Fin ρ → PC := fun j => (commits j).1
+      let comList := List.ofFn comVec
+      let finish : AddWriterT κ m (Option (Ω × P)) → AddWriterT κ m (PC × Ω × P) := fun oa => do
+        let result ← oa
+        match result with
+        | some (ω, resp) => pure (comVec i, ω, resp)
+        | none => pure (comVec i, default, default)
+      simpa [finish] using congrArg finish
+        (fischlinSearchAux_eq_withAddCost
+          (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+          (msg := msg) (comList := comList) (i := i)
+          (challenges := FinEnum.toList Ω) (best := none) (costFn := costFn))
+    simpa [HasQuery.UsesCostAtMost, hsign] using this
+  simpa [zero_add] using
+    (AddWriterT.pathwiseCostAtMost_bind (w₁ := 0) (w₂ := ρ • (FinEnum.card Ω • w)) hcommit
+      (fun commits =>
+        AddWriterT.pathwiseCostAtMost_fin_mOfFn (n := ρ) (k := FinEnum.card Ω • w)
+          (fun i => hrep commits i)))
+
+section expectedWeightedQueryCost
+
+variable [HasEvalSPMF m]
+
+omit [HasEvalSet m] in
+/-- Fischlin signing has expected weighted query cost at most `ρ • (|Ω| • w)` whenever every
+random-oracle query is weighted by at most `w`. -/
+theorem sign_expectedQueryCost_le
+    {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
+    [CanonicallyOrderedAdd κ]
+    (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
+    (pk : X) (sk : W) (msg : M)
+    (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → κ) (w : κ)
+    (val : κ → ENNReal) (hcost : ∀ t, costFn t ≤ w) (hval : Monotone val) :
+    ExpectedQueryCost[
+      (Fischlin σ hr ρ b S M).sign pk sk msg in runtime by costFn via val
+    ] ≤ val (ρ • (FinEnum.card Ω • w)) := by
+  let _ : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
+    (sign_usesWeightedQueryCostAtMost
+      (σ := σ) (hr := hr) (ρ := ρ) (b := b) (S := S) (M := M)
+      (runtime := runtime) (pk := pk) (sk := sk) (msg := msg)
+      (costFn := costFn) (w := w) hcost)
+    hval
+
+end expectedWeightedQueryCost
 
 section expectedQueries
 

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -101,9 +101,13 @@ private def fischlinSearchAux {X W PC SC Ω P M : Type} {p : X → W → Bool} {
 /-! ## Main Definition -/
 
 variable {X W PC SC Ω P : Type}
-    {p : X → W → Bool} [SampleableType X] [SampleableType W]
-    [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-    [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
+    {p : X → W → Bool}
+
+section mainDefinition
+
+variable [SampleableType X] [SampleableType W]
+  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
 
 /-- The Fischlin transform applied to a Σ-protocol and a generable relation produces
 a signature scheme in the random oracle model.
@@ -150,17 +154,17 @@ def Fischlin
     let hashSum := (List.finRange ρ).foldl (fun acc i => acc + (results i).2) 0
     pure (allVerified && decide (hashSum ≤ S))
 
+end mainDefinition
+
 namespace Fischlin
 
 variable {X W PC SC Ω P : Type} {p : X → W → Bool}
-  [SampleableType X] [SampleableType W]
-  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
-
-variable (σ : SigmaProtocol X W PC SC Ω P p) (hr : GenerableRelation X W p)
-  (ρ b S : ℕ) (M : Type) [DecidableEq M]
 
 open ENNReal
+
+section runtime
+
+variable [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P] [SampleableType Ω]
 
 /-- Runtime bundle for the Fischlin random-oracle world. -/
 noncomputable def runtime
@@ -173,9 +177,13 @@ noncomputable def runtime
     ∅
   toProbCompLift := ProbCompLift.ofMonadLift _
 
+end runtime
+
 section costAccounting
 
-variable {m : Type → Type v} [Monad m] [LawfulMonad m] [HasEvalSet m]
+variable (σ : SigmaProtocol X W PC SC Ω P p) (ρ b : ℕ) (M : Type)
+
+variable {m : Type → Type v} [Monad m] [LawfulMonad m]
   [MonadLiftT ProbComp m]
 
 /-- Fischlin's inner search, instantiated in a concrete unit-cost runtime. -/
@@ -202,10 +210,6 @@ private def fischlinSearchAuxWithUnitCost
             if h.val < h'.val then some (ω, resp, h) else some (ω', resp', h')
         fischlinSearchAuxWithUnitCost σ runtime pk sk sc msg comList i rest newBest
 
-omit [SampleableType X] [SampleableType W]
-  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
-  [DecidableEq M] [HasEvalSet m] in
 private lemma fischlinSearchAux_eq_withUnitCost
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
@@ -214,8 +218,8 @@ private lemma fischlinSearchAux_eq_withUnitCost
       runtime.withUnitCost.toHasQuery
     fischlinSearchAux
       (m := AddWriterT ℕ m) σ pk sk sc msg comList i challenges best =
-      fischlinSearchAuxWithUnitCost
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
+      fischlinSearchAuxWithUnitCost σ
+        (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
         (comList := comList) (i := i) challenges best := by
   induction challenges generalizing best with
   | nil =>
@@ -224,17 +228,14 @@ private lemma fischlinSearchAux_eq_withUnitCost
       simp [fischlinSearchAux, fischlinSearchAuxWithUnitCost,
         QueryRuntime.withUnitCost_impl, liftM, MonadLiftT.monadLift, ih]
 
-omit [SampleableType X] [SampleableType W]
-  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
-  [DecidableEq M] in
 private lemma fischlinSearchAuxWithUnitCost_queryBoundedAboveBy
+    [HasEvalSet m]
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
     (challenges : List Ω) (best : Option (Ω × P × Fin (2 ^ b))) :
     AddWriterT.QueryBoundedAboveBy
-      (fischlinSearchAuxWithUnitCost
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
+      (fischlinSearchAuxWithUnitCost σ
+        (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
         (comList := comList) (i := i) challenges best)
       challenges.length := by
   induction challenges generalizing best with
@@ -310,10 +311,6 @@ private def fischlinSearchAuxWithAddCost
             if h.val < h'.val then some (ω, resp, h) else some (ω', resp', h')
         fischlinSearchAuxWithAddCost σ runtime pk sk sc msg comList i rest newBest costFn
 
-omit [SampleableType X] [SampleableType W]
-  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
-  [DecidableEq M] [HasEvalSet m] in
 private lemma fischlinSearchAux_eq_withAddCost
     {κ : Type} [AddMonoid κ]
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
@@ -324,8 +321,8 @@ private lemma fischlinSearchAux_eq_withAddCost
       runtime.withAddCost costFn |>.toHasQuery
     fischlinSearchAux
       (m := AddWriterT κ m) σ pk sk sc msg comList i challenges best =
-      fischlinSearchAuxWithAddCost
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
+      fischlinSearchAuxWithAddCost σ
+        (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
         (comList := comList) (i := i) challenges best costFn := by
   induction challenges generalizing best with
   | nil =>
@@ -334,21 +331,18 @@ private lemma fischlinSearchAux_eq_withAddCost
       simp [fischlinSearchAux, fischlinSearchAuxWithAddCost,
         QueryRuntime.withAddCost_impl, liftM, MonadLiftT.monadLift, ih]
 
-omit [SampleableType X] [SampleableType W]
-  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
-  [DecidableEq M] in
 private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
     {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
     [CanonicallyOrderedAdd κ]
+    [HasEvalSet m]
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (sk : W) (sc : SC) (msg : M) (comList : List PC) (i : Fin ρ)
     (challenges : List Ω) (best : Option (Ω × P × Fin (2 ^ b)))
     (costFn : (fischlinROSpec X PC Ω P ρ b M).Domain → κ) {w : κ}
     (hcost : ∀ t, costFn t ≤ w) :
     AddWriterT.PathwiseCostAtMost
-      (fischlinSearchAuxWithAddCost
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
+      (fischlinSearchAuxWithAddCost σ
+        (runtime := runtime) (pk := pk) (sk := sk) (sc := sc) (msg := msg)
         (comList := comList) (i := i) challenges best costFn)
       (challenges.length • w) := by
   induction challenges generalizing best with
@@ -420,10 +414,12 @@ private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
           (AddWriterT.pathwiseCostAtMost_monadLift (m := m) (σ.respond pk sk sc chal))
           hstep)
 
-section
+section verifyCostAccounting
 
-omit [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
-  [SampleableType Ω]
+variable (σ : SigmaProtocol X W PC SC Ω P p)
+variable [SampleableType X] [SampleableType W]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P] (hr : GenerableRelation X W p) (S : ℕ)
+  [DecidableEq M] [HasEvalSet m]
 
 /-- Fischlin verification makes at most `ρ` random-oracle queries under unit-cost
 instrumentation. -/
@@ -431,6 +427,8 @@ theorem verify_usesAtMostRhoQueries
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (msg : M) (π : FischlinProof PC Ω P ρ) :
     Queries[ (Fischlin σ hr ρ b S M).verify pk msg π in runtime ] ≤ ρ := by
+  classical
+  let _ : SampleableType Ω := inferInstance
   let step : Fin ρ → AddWriterT ℕ m (Bool × ℕ) := fun i => do
     let (_, ω_i, resp_i) := π i
     AddWriterT.addTell (M := m) 1
@@ -478,6 +476,8 @@ theorem verify_usesAtLeastRhoQueries
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (msg : M) (π : FischlinProof PC Ω P ρ) :
     Queries[ (Fischlin σ hr ρ b S M).verify pk msg π in runtime ] ≥ ρ := by
+  classical
+  let _ : SampleableType Ω := inferInstance
   let step : Fin ρ → AddWriterT ℕ m (Bool × ℕ) := fun i => do
     let (_, ω_i, resp_i) := π i
     AddWriterT.addTell (M := m) 1
@@ -519,19 +519,30 @@ theorem verify_usesAtLeastRhoQueries
             (AddWriterT.queryBoundedBelowBy_fin_mOfFn (n := ρ) (k := 1) hstep))
         (fun _ => AddWriterT.queryBoundedBelowBy_pure _))
 
+end verifyCostAccounting
+
+section signCostAccounting
+
+variable (σ : SigmaProtocol X W PC SC Ω P p)
+variable [SampleableType X] [SampleableType W]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P] (hr : GenerableRelation X W p) (S : ℕ)
+  [DecidableEq M] [HasEvalSet m]
+
 /-- Fischlin signing makes at most `ρ * |Ω|` random-oracle queries under unit-cost
 instrumentation. -/
 theorem sign_usesAtMostRhoCardOmegaQueries
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
     (pk : X) (sk : W) (msg : M) :
     Queries[ (Fischlin σ hr ρ b S M).sign pk sk msg in runtime ] ≤ ρ * FinEnum.card Ω := by
+  classical
+  let _ : SampleableType Ω := inferInstance
   let repStep : (Fin ρ → PC × SC) → Fin ρ → AddWriterT ℕ m (PC × Ω × P) := fun commits i => do
     let comVec : Fin ρ → PC := fun j => (commits j).1
     let comList := List.ofFn comVec
     let sc_i := (commits i).2
     let result ←
-      fischlinSearchAuxWithUnitCost
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc_i) (msg := msg)
+      fischlinSearchAuxWithUnitCost σ
+        (runtime := runtime) (pk := pk) (sk := sk) (sc := sc_i) (msg := msg)
         (comList := comList) (i := i)
         (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b)))
     match result with
@@ -546,14 +557,14 @@ theorem sign_usesAtMostRhoCardOmegaQueries
     let comList := List.ofFn comVec
     have hsearch :
         AddWriterT.QueryBoundedAboveBy
-          (fischlinSearchAuxWithUnitCost
-            (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+          (fischlinSearchAuxWithUnitCost σ
+            (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
             (msg := msg) (comList := comList) (i := i)
             (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b))))
           (FinEnum.toList Ω).length := by
       simpa using
         (fischlinSearchAuxWithUnitCost_queryBoundedAboveBy
-          (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+          σ (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
           (msg := msg) (comList := comList) (i := i)
           (challenges := FinEnum.toList Ω) (best := none))
     let finish : Option (Ω × P) → AddWriterT ℕ m (PC × Ω × P)
@@ -614,7 +625,7 @@ theorem sign_usesAtMostRhoCardOmegaQueries
         | none => pure (comVec i, default, default)
       simpa [finish] using congrArg finish
         (fischlinSearchAux_eq_withUnitCost
-          (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+          σ (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
           (msg := msg) (comList := comList) (i := i)
           (challenges := FinEnum.toList Ω) (best := none))
     simpa [HasQuery.UsesAtMostQueries, hsign] using this
@@ -635,6 +646,8 @@ theorem sign_usesWeightedQueryCostAtMost
     (hcost : ∀ t, costFn t ≤ w) :
     QueryCost[ (Fischlin σ hr ρ b S M).sign pk sk msg in runtime by costFn ] ≤
       ρ • (FinEnum.card Ω • w) := by
+  classical
+  let _ : SampleableType Ω := inferInstance
   have hlen : (FinEnum.toList Ω).length = FinEnum.card Ω := by
     simp [FinEnum.toList]
   let repStep : (Fin ρ → PC × SC) → Fin ρ → AddWriterT κ m (PC × Ω × P) := fun commits i => do
@@ -642,8 +655,8 @@ theorem sign_usesWeightedQueryCostAtMost
     let comList := List.ofFn comVec
     let sc_i := (commits i).2
     let result ←
-      fischlinSearchAuxWithAddCost
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := sc_i) (msg := msg)
+      fischlinSearchAuxWithAddCost σ
+        (runtime := runtime) (pk := pk) (sk := sk) (sc := sc_i) (msg := msg)
         (comList := comList) (i := i)
         (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b))) costFn
     match result with
@@ -656,14 +669,13 @@ theorem sign_usesWeightedQueryCostAtMost
     let comList := List.ofFn comVec
     have hsearch :
         AddWriterT.PathwiseCostAtMost
-          (fischlinSearchAuxWithAddCost
-            (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+          (fischlinSearchAuxWithAddCost σ
+            (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
             (msg := msg) (comList := comList) (i := i)
             (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b))) costFn)
           ((FinEnum.toList Ω).length • w) := by
       exact fischlinSearchAuxWithAddCost_pathwiseCostAtMost
-        (κ := κ)
-        (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+        σ (κ := κ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
         (msg := msg) (comList := comList) (i := i)
         (challenges := FinEnum.toList Ω) (best := none) (costFn := costFn) (w := w)
         (hcost := hcost)
@@ -725,7 +737,7 @@ theorem sign_usesWeightedQueryCostAtMost
         | none => pure (comVec i, default, default)
       simpa [finish] using congrArg finish
         (fischlinSearchAux_eq_withAddCost
-          (σ := σ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
+          σ (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
           (msg := msg) (comList := comList) (i := i)
           (challenges := FinEnum.toList Ω) (best := none) (costFn := costFn))
     simpa [HasQuery.UsesCostAtMost, hsign] using this
@@ -735,11 +747,16 @@ theorem sign_usesWeightedQueryCostAtMost
         AddWriterT.pathwiseCostAtMost_fin_mOfFn (n := ρ) (k := FinEnum.card Ω • w)
           (fun i => hrep commits i)))
 
+end signCostAccounting
+
 section expectedWeightedQueryCost
 
-variable [HasEvalSPMF m]
+variable (σ : SigmaProtocol X W PC SC Ω P p)
+variable [SampleableType X] [SampleableType W]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P]
+  (hr : GenerableRelation X W p) (S : ℕ)
+  [DecidableEq M] [HasEvalSPMF m]
 
-omit [HasEvalSet m] in
 /-- Fischlin signing has expected weighted query cost at most `ρ • (|Ω| • w)` whenever every
 random-oracle query is weighted by at most `w`. -/
 theorem sign_expectedQueryCost_le
@@ -764,9 +781,12 @@ end expectedWeightedQueryCost
 
 section expectedQueries
 
-variable [HasEvalSPMF m]
+variable (σ : SigmaProtocol X W PC SC Ω P p)
+variable [SampleableType X] [SampleableType W]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P]
+  (hr : GenerableRelation X W p) (S : ℕ)
+  [DecidableEq M] [HasEvalSPMF m]
 
-omit [HasEvalSet m] in
 /-- Fischlin signing has expected query count at most `ρ * |Ω|` in the unit-cost runtime model.
 
 This is the expectation-level counterpart of
@@ -786,9 +806,12 @@ end expectedQueries
 
 section expectedQueriesPMF
 
-variable [HasEvalPMF m]
+variable (σ : SigmaProtocol X W PC SC Ω P p)
+variable [SampleableType X] [SampleableType W]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P]
+  (hr : GenerableRelation X W p) (S : ℕ)
+  [DecidableEq M] [HasEvalPMF m]
 
-omit [HasEvalSet m] in
 /-- Fischlin verification has expected query count exactly `ρ` in the unit-cost runtime model. -/
 theorem verify_expectedQueries_eq_rho
     (runtime : QueryRuntime (fischlinROSpec X PC Ω P ρ b M) m)
@@ -806,11 +829,18 @@ theorem verify_expectedQueries_eq_rho
 
 end expectedQueriesPMF
 
-end
-
 end costAccounting
 
 /-! ### Completeness -/
+
+section security
+
+variable [SampleableType X] [SampleableType W]
+  [DecidableEq X] [DecidableEq PC] [DecidableEq Ω] [DecidableEq P]
+  [FinEnum Ω] [Inhabited Ω] [Inhabited P] [SampleableType Ω]
+
+variable (σ : SigmaProtocol X W PC SC Ω P p) (hr : GenerableRelation X W p)
+  (ρ b S : ℕ) (M : Type) [DecidableEq M]
 
 /-- Completeness error bound for the Fischlin transform (Fischlin 2005, Lemma 1).
 
@@ -963,5 +993,7 @@ simulation of signing queries inside a hard-relation experiment. The previous
 placeholder theorem overclaimed by bounding forgery probability solely by the
 knowledge-soundness error, so we intentionally leave that corollary unstated
 until the signing-simulation reduction is formalized. -/
+
+end security
 
 end Fischlin

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -752,7 +752,7 @@ theorem sign_expectedQueryCost_le
     ExpectedQueryCost[
       (Fischlin σ hr ρ b S M).sign pk sk msg in runtime by costFn via val
     ] ≤ val (ρ • (FinEnum.card Ω • w)) := by
-  let _ : HasEvalSet m := HasEvalSPMF.toHasEvalSet
+  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
     (sign_usesWeightedQueryCostAtMost
       (σ := σ) (hr := hr) (ρ := ρ) (b := b) (S := S) (M := M)

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean
@@ -95,8 +95,8 @@ def singleRO
 
 /-- Runtime bundle for the canonical two-RO Fujisaki-Okamoto oracle world. -/
 noncomputable def twoRORuntime
-    [DecidableEq M] [DecidableEq C] [DecidableEq KD]
-    [SampleableType M] [SampleableType R] [SampleableType K] :
+    [DecidableEq M] [DecidableEq KD]
+    [SampleableType R] [SampleableType K] :
     ProbCompRuntime (OracleComp (UTransform.oracleSpec M R KD K)) :=
   UTransform.runtime (R := R) (KD := KD) (K := K)
 
@@ -125,7 +125,7 @@ theorem IND_CCA_bound
     ∃ cpaAdv₁ cpaAdv₂ : (pke.toAsymmEncAlg ProbCompRuntime.probComp).IND_CPA_adversary,
       ∃ prfAdv : PRFScheme.PRFAdversary C K,
         (FujisakiOkamoto pke kdInput (implicitRejection prf)).IND_CCA_Advantage
-            (twoRORuntime (M := M) (R := R) (C := C) (KD := KD) (K := K))
+            (twoRORuntime (M := M) (R := R) (KD := KD) (K := K))
             adversary ≤
           2 * ((pke.toAsymmEncAlg ProbCompRuntime.probComp).IND_CPA_advantage cpaAdv₁).toReal +
           2 * ((pke.toAsymmEncAlg ProbCompRuntime.probComp).IND_CPA_advantage cpaAdv₂).toReal +

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean
@@ -27,7 +27,7 @@ def FujisakiOkamoto
     [SampleableType M] [SampleableType R] [SampleableType K] :
     KEMScheme (OracleComp (UTransform.oracleSpec M R KD K))
       K PK ((PK × SK) × policy.FallbackState) C :=
-  UTransform pke kdInput policy
+  UTransform (m := OracleComp (UTransform.oracleSpec M R KD K)) pke kdInput policy
 
 namespace FujisakiOkamoto
 
@@ -66,17 +66,17 @@ def singleROVariant
     {PKHash : Type}
     (pkh : PK → PKHash)
     [DecidableEq PKHash] [DecidableEq M] [SampleableType R] [SampleableType K] :
-    Variant M PK C R K where
-  ι := _
-  hashOracleSpec := singleROHashOracleSpec PKHash M R K
+    Variant (singleROHashOracleSpec PKHash M R K) M PK C R K where
   QueryCache := SingleROQueryCache PKHash M R K
   initCache := ∅
   queryImpl := singleROOracleImpl (PKHash := PKHash) (M := M) (R := R) (K := K)
-  deriveCoins := fun pk msg => do
-    let out ← query (spec := singleROOracleSpec PKHash M R K) (Sum.inr (pkh pk, msg))
+  deriveCoins := fun {m} [Monad m] [MonadLiftT ProbComp m]
+      [HasQuery (singleROHashOracleSpec PKHash M R K) m] pk msg => do
+    let out ← HasQuery.query (spec := singleROHashOracleSpec PKHash M R K) (m := m) (pkh pk, msg)
     return out.1
-  deriveKey := fun pk msg _c => do
-    let out ← query (spec := singleROOracleSpec PKHash M R K) (Sum.inr (pkh pk, msg))
+  deriveKey := fun {m} [Monad m] [MonadLiftT ProbComp m]
+      [HasQuery (singleROHashOracleSpec PKHash M R K) m] pk msg _c => do
+    let out ← HasQuery.query (spec := singleROHashOracleSpec PKHash M R K) (m := m) (pkh pk, msg)
     return out.2
 
 /-- Single-RO specialization for the `H(m)` branch. The oracle input is `(pkh pk, m)` and the
@@ -90,23 +90,25 @@ def singleRO
     [SampleableType M] [SampleableType R] [SampleableType K] :
     KEMScheme (OracleComp (singleROOracleSpec PKHash M R K))
       K PK ((PK × SK) × policy.FallbackState) C :=
-  scheme pke (singleROVariant (PK := PK) (C := C) (R := R) (K := K) pkh) policy
+  scheme (m := OracleComp (singleROOracleSpec PKHash M R K))
+    pke (singleROVariant (PK := PK) (C := C) (R := R) (K := K) pkh) policy
 
 /-- Runtime bundle for the canonical two-RO Fujisaki-Okamoto oracle world. -/
 noncomputable def twoRORuntime
-    (kdInput : M → C → KD)
     [DecidableEq M] [DecidableEq C] [DecidableEq KD]
     [SampleableType M] [SampleableType R] [SampleableType K] :
     ProbCompRuntime (OracleComp (UTransform.oracleSpec M R KD K)) :=
-  UTransform.runtime (PK := PK) (C := C) (R := R) (KD := KD) (K := K) kdInput
+  UTransform.runtime (R := R) (KD := KD) (K := K)
 
 /-- Runtime bundle for the single-RO Fujisaki-Okamoto oracle world. -/
 noncomputable def singleRORuntime
     {PKHash : Type}
-    (pkh : PK → PKHash)
     [DecidableEq PKHash] [DecidableEq M] [SampleableType R] [SampleableType K] :
-    ProbCompRuntime (OracleComp (singleROOracleSpec PKHash M R K)) :=
-  FujisakiOkamoto.runtime (singleROVariant (PK := PK) (C := C) (R := R) (K := K) pkh)
+    ProbCompRuntime (OracleComp (singleROOracleSpec PKHash M R K)) where
+  toSPMFSemantics := SPMFSemantics.withStateOracle
+    (hashImpl := singleROOracleImpl (PKHash := PKHash) (M := M) (R := R) (K := K))
+    (∅ : SingleROQueryCache PKHash M R K)
+  toProbCompLift := ProbCompLift.ofMonadLift _
 
 /-- Main composed Fujisaki-Okamoto theorem statement. The proof is intentionally deferred, but the
 reduction artifacts are now existentially quantified rather than passed in as unrelated inputs. -/
@@ -123,7 +125,7 @@ theorem IND_CCA_bound
     ∃ cpaAdv₁ cpaAdv₂ : (pke.toAsymmEncAlg ProbCompRuntime.probComp).IND_CPA_adversary,
       ∃ prfAdv : PRFScheme.PRFAdversary C K,
         (FujisakiOkamoto pke kdInput (implicitRejection prf)).IND_CCA_Advantage
-            (twoRORuntime (PK := PK) (R := R) (C := C) (KD := KD) (K := K) kdInput)
+            (twoRORuntime (M := M) (R := R) (C := C) (KD := KD) (K := K))
             adversary ≤
           2 * ((pke.toAsymmEncAlg ProbCompRuntime.probComp).IND_CPA_advantage cpaAdv₁).toReal +
           2 * ((pke.toAsymmEncAlg ProbCompRuntime.probComp).IND_CPA_advantage cpaAdv₂).toReal +

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
@@ -263,22 +263,23 @@ theorem decrypt_usesAtMostOneQuery [HasEvalSet m]
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (pk : PK) (sk : SK) (c : C) :
     Queries[ (TTransform pke).decrypt (pk, sk) c in runtime ] ≤ 1 := by
-  by_cases hdec : pke.decrypt sk c = none
-  · exact HasQuery.usesAtMostQueries_of_usesExactlyQueries
-      (oa := fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-        (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-      (runtime := runtime)
-      (decrypt_usesNoQueries_of_decrypt_eq_none
-        (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c) hdec)
-      (Nat.zero_le 1)
-  · rcases Option.ne_none_iff_exists'.mp hdec with ⟨msg, hsome⟩
-    exact HasQuery.usesAtMostQueries_of_usesExactlyQueries
-      (oa := fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-        (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-      (runtime := runtime)
-      (decrypt_usesExactlyOneQuery_of_decrypt_eq_some
-        (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c) hsome)
-      le_rfl
+  cases hdec : pke.decrypt sk c with
+  | none =>
+      exact HasQuery.usesAtMostQueries_of_usesExactlyQueries
+        (oa := fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
+          (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
+        (runtime := runtime)
+        (decrypt_usesNoQueries_of_decrypt_eq_none
+          (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c) hdec)
+        (Nat.zero_le 1)
+  | some msg =>
+      exact HasQuery.usesAtMostQueries_of_usesExactlyQueries
+        (oa := fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
+          (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
+        (runtime := runtime)
+        (decrypt_usesExactlyOneQuery_of_decrypt_eq_some
+          (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c) hdec)
+        le_rfl
 
 end costAccounting
 

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
@@ -116,39 +116,37 @@ variable [DecidableEq C]
 variable {m : Type → Type u} [Monad m] [LawfulMonad m]
   [MonadLiftT ProbComp m]
 
-/-- Running unit-cost-instrumented T-transform encryption preserves the ciphertext output. -/
-private lemma encrypt_outputs_formula_withUnitCost
+/-- T-transform encryption incurs exactly the weighted cost assigned to the single coins-oracle
+query on `msg`. -/
+theorem encrypt_usesExactQueryCost {ω : Type} [AddMonoid ω]
     (runtime : QueryRuntime (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
-    (pk : PK) (msg : M) :
-    AddWriterT.outputs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-            (TTransform (m := AddWriterT ℕ m) pke).encrypt pk msg)
-          runtime) =
-      HasQuery.inRuntime
-        (fun [HasQuery (M →ₒ R) m] =>
-          (TTransform (m := m) pke).encrypt pk msg)
-        runtime := by
-  simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.outputs, TTransform,
-    QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
+    (pk : PK) (msg : M) (costFn : M → ω) :
+    QueryCost[ (TTransform pke).encrypt pk msg in runtime by costFn ] = costFn msg := by
+  change Cost[
+    HasQuery.withAddCost
+      (fun [HasQuery (M →ₒ R) (AddWriterT ω m)] =>
+        (TTransform (m := AddWriterT ω m) pke).encrypt pk msg)
+      runtime costFn
+  ] = costFn msg
+  rw [AddWriterT.hasCost_iff]
+  simp [HasQuery.withAddCost, TTransform, QueryRuntime.withAddCost_impl,
+    AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
 
-private lemma encrypt_costs_formula_withUnitCost
+/-- T-transform encryption has expected weighted query cost equal to the weight of querying
+`msg`. -/
+theorem encrypt_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω]
+    [HasEvalPMF m]
     (runtime : QueryRuntime (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
-    (pk : PK) (msg : M) :
-    AddWriterT.costs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-            (TTransform (m := AddWriterT ℕ m) pke).encrypt pk msg)
-          runtime) =
-      (fun _ ↦ 1) <$>
-        HasQuery.inRuntime
-          (fun [HasQuery (M →ₒ R) m] =>
-            (TTransform (m := m) pke).encrypt pk msg)
-          runtime := by
-  simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.costs, TTransform,
-    QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
+    (pk : PK) (msg : M) (costFn : M → ω) (val : ω → ENNReal) (hval : Monotone val) :
+    ExpectedQueryCost[
+      (TTransform pke).encrypt pk msg in runtime by costFn via val
+    ] = val (costFn msg) := by
+  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    (encrypt_usesExactQueryCost
+      (runtime := runtime) (pke := pke) (pk := pk) (msg := msg) (costFn := costFn))
+    hval
 
 /-- T-transform encryption makes exactly one hash-oracle query under unit-cost instrumentation. -/
 theorem encrypt_usesExactlyOneQuery
@@ -156,65 +154,82 @@ theorem encrypt_usesExactlyOneQuery
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (pk : PK) (msg : M) :
     Queries[ (TTransform pke).encrypt pk msg in runtime ] = 1 := by
+  simpa [HasQuery.UsesExactlyQueries] using
+    (encrypt_usesExactQueryCost
+      (ω := ℕ) (runtime := runtime) (pke := pke) (pk := pk) (msg := msg)
+      (costFn := fun _ ↦ 1))
+
+/-- If deterministic decryption fails immediately, the T-transform incurs zero weighted
+query cost. -/
+theorem decrypt_usesZeroQueryCost_of_decrypt_eq_none {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (M →ₒ R) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (pk : PK) (sk : SK) (c : C) (costFn : M → ω)
+    (hdec : pke.decrypt sk c = none) :
+    QueryCost[ (TTransform pke).decrypt (pk, sk) c in runtime by costFn ] = 0 := by
   change Cost[
-    HasQuery.withUnitCost
-      (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-        (TTransform (m := AddWriterT ℕ m) pke).encrypt pk msg)
-      runtime
-  ] = 1
+    HasQuery.withAddCost
+      (fun [HasQuery (M →ₒ R) (AddWriterT ω m)] =>
+        (TTransform (m := AddWriterT ω m) pke).decrypt (pk, sk) c)
+      runtime costFn
+  ] = 0
   rw [AddWriterT.hasCost_iff]
-  rw [encrypt_outputs_formula_withUnitCost
-    (runtime := runtime) (pke := pke) (pk := pk) (msg := msg)]
-  exact encrypt_costs_formula_withUnitCost
-    (runtime := runtime) (pke := pke) (pk := pk) (msg := msg)
+  simp [HasQuery.withAddCost, TTransform, TTransform.decrypt, hdec,
+    QueryRuntime.withAddCost_impl, AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
 
-/-- Running unit-cost-instrumented T-transform decryption preserves the decryption result. -/
-private lemma decrypt_outputs_formula_withUnitCost
+/-- If deterministic decryption fails immediately, the T-transform has expected weighted query
+cost `0`. -/
+theorem decrypt_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
+    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
     (runtime : QueryRuntime (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
-    (pk : PK) (sk : SK) (c : C) :
-    AddWriterT.outputs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-            (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-          runtime) =
-      HasQuery.inRuntime
-        (fun [HasQuery (M →ₒ R) m] =>
-          (TTransform (m := m) pke).decrypt (pk, sk) c)
-        runtime := by
-  cases hdec : pke.decrypt sk c with
-  | none =>
-      simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.outputs, TTransform,
-        TTransform.decrypt, hdec]
-  | some msg =>
-      simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.outputs, TTransform,
-        TTransform.decrypt, hdec,
-        QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
+    (pk : PK) (sk : SK) (c : C) (costFn : M → ω)
+    (val : ω → ENNReal) (hval : Monotone val)
+    (hdec : pke.decrypt sk c = none) :
+    ExpectedQueryCost[
+      (TTransform pke).decrypt (pk, sk) c in runtime by costFn via val
+    ] = val 0 := by
+  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    (decrypt_usesZeroQueryCost_of_decrypt_eq_none
+      (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
+      (costFn := costFn) hdec)
+    hval
 
-private lemma decrypt_costs_formula_withUnitCost
+/-- If deterministic decryption returns a message, the T-transform incurs exactly the weighted
+cost of querying that message to re-derive the coins. -/
+theorem decrypt_usesExactQueryCost_of_decrypt_eq_some {ω : Type} [AddMonoid ω]
     (runtime : QueryRuntime (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
-    (pk : PK) (sk : SK) (c : C) :
-    AddWriterT.costs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-            (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-          runtime) =
-      match pke.decrypt sk c with
-      | none => pure 0
-      | some _ => (fun _ ↦ 1) <$>
-          HasQuery.inRuntime
-            (fun [HasQuery (M →ₒ R) m] =>
-              (TTransform (m := m) pke).decrypt (pk, sk) c)
-            runtime := by
-  cases hdec : pke.decrypt sk c with
-  | none =>
-      simp [HasQuery.withUnitCost, AddWriterT.costs, TTransform,
-        TTransform.decrypt, hdec]
-  | some msg =>
-      simp [HasQuery.inRuntime, HasQuery.withUnitCost, AddWriterT.costs, TTransform,
-        TTransform.decrypt, hdec,
-        QueryRuntime.withUnitCost_impl, AddWriterT.addTell]
+    (pk : PK) (sk : SK) (c : C) (costFn : M → ω) {msg : M}
+    (hdec : pke.decrypt sk c = some msg) :
+    QueryCost[ (TTransform pke).decrypt (pk, sk) c in runtime by costFn ] = costFn msg := by
+  change Cost[
+    HasQuery.withAddCost
+      (fun [HasQuery (M →ₒ R) (AddWriterT ω m)] =>
+        (TTransform (m := AddWriterT ω m) pke).decrypt (pk, sk) c)
+      runtime costFn
+  ] = costFn msg
+  rw [AddWriterT.hasCost_iff]
+  simp [HasQuery.withAddCost, TTransform, TTransform.decrypt, hdec,
+    QueryRuntime.withAddCost_impl, AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
+
+/-- If deterministic decryption returns a message, the T-transform has expected weighted query
+cost equal to the weight of querying that message. -/
+theorem decrypt_expectedQueryCost_eq_of_decrypt_eq_some {ω : Type}
+    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    (runtime : QueryRuntime (M →ₒ R) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (pk : PK) (sk : SK) (c : C) (costFn : M → ω)
+    (val : ω → ENNReal) (hval : Monotone val) {msg : M}
+    (hdec : pke.decrypt sk c = some msg) :
+    ExpectedQueryCost[
+      (TTransform pke).decrypt (pk, sk) c in runtime by costFn via val
+    ] = val (costFn msg) := by
+  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    (decrypt_usesExactQueryCost_of_decrypt_eq_some
+      (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
+      (costFn := costFn) hdec)
+    hval
 
 /-- If deterministic decryption fails immediately, the T-transform makes no hash-oracle
 queries. -/
@@ -224,28 +239,10 @@ theorem decrypt_usesNoQueries_of_decrypt_eq_none
     (pk : PK) (sk : SK) (c : C)
     (hdec : pke.decrypt sk c = none) :
     Queries[ (TTransform pke).decrypt (pk, sk) c in runtime ] = 0 := by
-  change AddWriterT.costs
-      (HasQuery.withUnitCost
-        (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-          (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-        runtime) =
-    (fun _ ↦ 0) <$>
-      AddWriterT.outputs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-            (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-          runtime)
-  have h_outputs := decrypt_outputs_formula_withUnitCost
-    (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
-  have h_decrypt :
-      HasQuery.inRuntime
-        (fun [HasQuery (M →ₒ R) m] =>
-          (TTransform (m := m) pke).decrypt (pk, sk) c)
-        runtime = pure none := by
-    simp [HasQuery.inRuntime, TTransform, TTransform.decrypt, hdec]
-  rw [h_outputs, h_decrypt]
-  simpa [hdec] using decrypt_costs_formula_withUnitCost
-    (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
+  simpa [HasQuery.UsesExactlyQueries] using
+    (decrypt_usesZeroQueryCost_of_decrypt_eq_none
+      (ω := ℕ) (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
+      (costFn := fun _ ↦ 1) hdec)
 
 /-- If deterministic decryption returns a message, the T-transform makes exactly one
 hash-oracle query to re-derive the coins. -/
@@ -255,22 +252,10 @@ theorem decrypt_usesExactlyOneQuery_of_decrypt_eq_some
     (pk : PK) (sk : SK) (c : C) {msg : M}
     (hdec : pke.decrypt sk c = some msg) :
     Queries[ (TTransform pke).decrypt (pk, sk) c in runtime ] = 1 := by
-  change AddWriterT.costs
-      (HasQuery.withUnitCost
-        (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-          (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-        runtime) =
-    (fun _ ↦ 1) <$>
-      AddWriterT.outputs
-        (HasQuery.withUnitCost
-          (fun [HasQuery (M →ₒ R) (AddWriterT ℕ m)] =>
-            (TTransform (m := AddWriterT ℕ m) pke).decrypt (pk, sk) c)
-          runtime)
-  have h_outputs := decrypt_outputs_formula_withUnitCost
-    (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
-  rw [h_outputs]
-  simpa [hdec] using decrypt_costs_formula_withUnitCost
-    (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
+  simpa [HasQuery.UsesExactlyQueries] using
+    (decrypt_usesExactQueryCost_of_decrypt_eq_some
+      (ω := ℕ) (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
+      (costFn := fun _ ↦ 1) hdec)
 
 /-- T-transform decryption makes at most one hash-oracle query under unit-cost instrumentation. -/
 theorem decrypt_usesAtMostOneQuery [HasEvalSet m]

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
@@ -16,20 +16,22 @@ This file defines the U-transform family on top of the T-transform oracle world.
 -/
 
 
+universe u v
+
 open OracleComp OracleSpec ENNReal
 
 namespace FujisakiOkamoto
 
 /-- A reusable FO hash world packages the public hash-oracle interface together with the
 variant-specific ways of deriving encryption coins and shared keys. -/
-structure Variant (M PK C R K : Type) where
-  ι : Type
-  hashOracleSpec : OracleSpec ι
+structure Variant {ι : Type} (hashOracleSpec : OracleSpec ι) (M PK C R K : Type) where
   QueryCache : Type
   initCache : QueryCache
   queryImpl : QueryImpl hashOracleSpec (StateT QueryCache ProbComp)
-  deriveCoins : PK → M → OracleComp (unifSpec + hashOracleSpec) R
-  deriveKey : PK → M → C → OracleComp (unifSpec + hashOracleSpec) K
+  deriveCoins : {m : Type → Type v} → [Monad m] → [MonadLiftT ProbComp m] →
+    [HasQuery hashOracleSpec m] → PK → M → m R
+  deriveKey : {m : Type → Type v} → [Monad m] → [MonadLiftT ProbComp m] →
+    [HasQuery hashOracleSpec m] → PK → M → C → m K
 
 /-- Rejection behavior is factored out from the FO hash world so explicit and implicit rejection
 share the same core construction. -/
@@ -52,34 +54,34 @@ def implicitRejection {K C KPRF : Type} (prf : PRFScheme KPRF C K) : RejectionPo
 
 /-- Bundled subprobabilistic semantics for an FO hash world, obtained by hiding the
 variant-specific cache after running the public-randomness-plus-hash simulation. -/
-noncomputable def spmfSemantics {M PK C R K : Type} (variant : Variant M PK C R K) :
-    SPMFSemantics (OracleComp (unifSpec + variant.hashOracleSpec)) :=
+noncomputable def spmfSemantics {ι : Type} {hashOracleSpec : OracleSpec ι}
+    {M PK C R K : Type} (variant : Variant hashOracleSpec M PK C R K) :
+    SPMFSemantics (OracleComp (unifSpec + hashOracleSpec)) :=
   SPMFSemantics.withStateOracle variant.queryImpl variant.initCache
 
 /-- Full public-randomness runtime for an FO hash world. -/
-noncomputable def runtime {M PK C R K : Type} (variant : Variant M PK C R K) :
-    ProbCompRuntime (OracleComp (unifSpec + variant.hashOracleSpec)) where
+noncomputable def runtime {ι : Type} {hashOracleSpec : OracleSpec ι}
+    {M PK C R K : Type} (variant : Variant hashOracleSpec M PK C R K) :
+    ProbCompRuntime (OracleComp (unifSpec + hashOracleSpec)) where
   toSPMFSemantics := spmfSemantics variant
   toProbCompLift := ProbCompLift.ofMonadLift _
 
 /-- Generic FO construction parameterized by a hash world and a rejection policy. -/
 def scheme
-    {M PK SK R C K : Type}
+    {ι : Type} {hashOracleSpec : OracleSpec ι} {M PK SK R C K : Type}
+    {m : Type → Type v} [Monad m] [MonadLiftT ProbComp m]
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
-    (variant : Variant M PK C R K)
+    (variant : Variant hashOracleSpec M PK C R K)
     (policy : RejectionPolicy K C)
-    [SampleableType M] [DecidableEq C] :
-    KEMScheme (OracleComp (unifSpec + variant.hashOracleSpec))
+    [SampleableType M] [DecidableEq C] [HasQuery hashOracleSpec m] :
+    KEMScheme m
       K PK ((PK × SK) × policy.FallbackState) C where
   keygen := do
-    let (pk, sk) ← (monadLift pke.keygen :
-      OracleComp (unifSpec + variant.hashOracleSpec) (PK × SK))
-    let fb ← (monadLift policy.keygen :
-      OracleComp (unifSpec + variant.hashOracleSpec) policy.FallbackState)
+    let (pk, sk) ← monadLift pke.keygen
+    let fb ← monadLift policy.keygen
     return (pk, ((pk, sk), fb))
   encaps := fun pk => do
-    let msg ← (monadLift ($ᵗ M : ProbComp M) :
-      OracleComp (unifSpec + variant.hashOracleSpec) M)
+    let msg ← monadLift ($ᵗ M : ProbComp M)
     let r ← variant.deriveCoins pk msg
     let c := pke.encrypt pk msg r
     let k ← variant.deriveKey pk msg c
@@ -148,16 +150,16 @@ def variant
     {M PK C R KD K : Type}
     (kdInput : M → C → KD)
     [DecidableEq M] [DecidableEq KD] [SampleableType R] [SampleableType K] :
-    FujisakiOkamoto.Variant M PK C R K where
-  ι := _
-  hashOracleSpec := hashOracleSpec M R KD K
+    FujisakiOkamoto.Variant (hashOracleSpec M R KD K) M PK C R K where
   QueryCache := QueryCache M R KD K
   initCache := (∅, ∅)
   queryImpl := queryImpl (M := M) (R := R) (KD := KD) (K := K)
-  deriveCoins := fun _pk msg =>
-    query (spec := oracleSpec M R KD K) (Sum.inr (Sum.inl msg))
-  deriveKey := fun _pk msg c =>
-    query (spec := oracleSpec M R KD K) (Sum.inr (Sum.inr (kdInput msg c)))
+  deriveCoins := fun {m} [Monad m] [MonadLiftT ProbComp m]
+      [HasQuery (hashOracleSpec M R KD K) m] _pk msg =>
+    HasQuery.query (spec := hashOracleSpec M R KD K) (m := m) (Sum.inl msg)
+  deriveKey := fun {m} [Monad m] [MonadLiftT ProbComp m]
+      [HasQuery (hashOracleSpec M R KD K) m] _pk msg c =>
+    HasQuery.query (spec := hashOracleSpec M R KD K) (m := m) (Sum.inr (kdInput msg c))
 
 end UTransform
 
@@ -168,28 +170,350 @@ variable {M PK SK R C KD K KPRF : Type}
 /-- The generic two-RO U-transform family. The argument `kdInput` chooses whether the shared key
 is derived from `m`, `(m, c)`, or some other encoding of the recovered plaintext and ciphertext. -/
 def UTransform
+    {m : Type → Type v} [Monad m] [MonadLiftT ProbComp m]
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
     (policy : FujisakiOkamoto.RejectionPolicy K C)
     [DecidableEq M] [DecidableEq C] [DecidableEq KD]
-    [SampleableType M] [SampleableType R] [SampleableType K] :
-    KEMScheme (OracleComp (UTransform.oracleSpec M R KD K))
+    [SampleableType M] [SampleableType R] [SampleableType K]
+    [HasQuery (UTransform.hashOracleSpec M R KD K) m] :
+    KEMScheme m
       K PK ((PK × SK) × policy.FallbackState) C :=
-  FujisakiOkamoto.scheme pke
+  FujisakiOkamoto.scheme (m := m) pke
     (UTransform.variant (PK := PK) (kdInput := kdInput) (M := M) (C := C) (R := R) (KD := KD)
       (K := K))
     policy
 
 namespace UTransform
 
+section costAccounting
+
+variable [DecidableEq M] [DecidableEq C] [DecidableEq KD]
+  [SampleableType M] [SampleableType R] [SampleableType K]
+
+variable {m : Type → Type v} [Monad m] [LawfulMonad m] [MonadLiftT ProbComp m]
+
+/-- If each of the two U-transform oracle families is assigned a constant weight, encapsulation
+incurs exactly the sum of those family weights. -/
+theorem encaps_usesExactFamilyWeightedCost {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (wCoins wKey : ω)
+    (hCoins : ∀ msg, costFn (Sum.inl msg) = wCoins)
+    (hKeys : ∀ kd, costFn (Sum.inr kd) = wKey) :
+    QueryCost[
+      (UTransform pke kdInput policy).encaps pk in runtime by costFn
+    ] = wCoins + wKey := by
+  rw [HasQuery.UsesCostExactly]
+  change Cost[
+    ((monadLift ((monadLift ($ᵗ M : ProbComp M) : m M)) : AddWriterT ω m M) >>= fun msg => do
+      let r ← (runtime.withAddCost costFn).impl (Sum.inl msg)
+      let c := pke.encrypt pk msg r
+      let k ← (runtime.withAddCost costFn).impl (Sum.inr (kdInput msg c))
+      pure (c, k))
+  ] = wCoins + wKey
+  rw [AddWriterT.hasCost_iff]
+  simp [QueryRuntime.withAddCost_impl, AddWriterT.outputs, AddWriterT.costs, hCoins, hKeys]
+
+/-- Under per-family upper bounds on the two U-transform oracle families, encapsulation incurs
+weighted query cost at most the sum of those bounds. -/
+theorem encaps_usesWeightedQueryCostAtMost {ω : Type}
+    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [HasEvalSet m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (wCoins wKey : ω)
+    (hCoins : ∀ msg, costFn (Sum.inl msg) ≤ wCoins)
+    (hKeys : ∀ kd, costFn (Sum.inr kd) ≤ wKey) :
+    QueryCost[ (UTransform pke kdInput policy).encaps pk in runtime by costFn ] ≤
+      wCoins + wKey := by
+  rw [HasQuery.UsesCostAtMost]
+  let f : M → AddWriterT ω m (C × K) := fun msg =>
+    ((runtime.withAddCost costFn).impl (Sum.inl msg)) >>= fun r =>
+      ((runtime.withAddCost costFn).impl (Sum.inr (kdInput msg (pke.encrypt pk msg r)))) >>=
+        fun k => pure (pke.encrypt pk msg r, k)
+  change AddWriterT.PathwiseCostAtMost
+    (((monadLift ((monadLift ($ᵗ M : ProbComp M) : m M)) : AddWriterT ω m M) >>= f))
+    (wCoins + wKey)
+  have hbind :
+      AddWriterT.PathwiseCostAtMost
+        (((monadLift ((monadLift ($ᵗ M : ProbComp M) : m M)) : AddWriterT ω m M) >>= f))
+        (0 + (wCoins + wKey)) := by
+    refine AddWriterT.pathwiseCostAtMost_bind (f := f) (w₁ := 0) (w₂ := wCoins + wKey)
+      (AddWriterT.pathwiseCostAtMost_monadLift (m := m) ((monadLift ($ᵗ M : ProbComp M)) : m M))
+      ?_
+    intro msg
+    refine AddWriterT.pathwiseCostAtMost_bind (w₁ := wCoins) (w₂ := wKey) ?_ ?_
+    · change AddWriterT.PathwiseCostAtMost
+          ((runtime.withAddCost costFn).impl (Sum.inl msg)) wCoins
+      exact HasQuery.usesCostAtMost_query_of_le
+        (runtime := runtime) (costFn := costFn) (t := Sum.inl msg) (b := wCoins) (hCoins msg)
+    · intro r
+      let c := pke.encrypt pk msg r
+      have hk :
+          AddWriterT.PathwiseCostAtMost
+            ((((runtime.withAddCost costFn).impl (Sum.inr (kdInput msg c))) >>= fun k =>
+              pure (c, k)))
+            (wKey + 0) := by
+        refine AddWriterT.pathwiseCostAtMost_bind (w₁ := wKey) (w₂ := 0) ?_ ?_
+        · exact HasQuery.usesCostAtMost_query_of_le
+            (runtime := runtime) (costFn := costFn)
+            (t := Sum.inr (kdInput msg c)) (b := wKey) (hKeys (kdInput msg c))
+        · intro k
+          simpa [c] using AddWriterT.pathwiseCostAtMost_pure (m := m) ((c, k) : C × K)
+      simpa [add_zero] using hk
+  simpa [zero_add] using hbind
+
+/-- Unit-cost specialization: U-transform encapsulation always makes exactly two oracle queries,
+one to derive coins and one to derive the shared key. -/
+theorem encaps_usesExactlyTwoQueries
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) :
+    Queries[ (UTransform pke kdInput policy).encaps pk in runtime ] = 2 := by
+  simpa [HasQuery.UsesExactlyQueries] using
+    (encaps_usesExactFamilyWeightedCost
+      (ω := ℕ) (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
+      (pk := pk) (costFn := fun _ ↦ 1) (wCoins := 1) (wKey := 1)
+      (hCoins := fun _ ↦ rfl) (hKeys := fun _ ↦ rfl))
+
+/-- Expected weighted query cost of U-transform encapsulation under constant per-family weights. -/
+theorem encaps_expectedQueryCost_eq_of_constantOracleWeights {ω : Type}
+    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (wCoins wKey : ω) (val : ω → ENNReal) (hval : Monotone val)
+    (hCoins : ∀ msg, costFn (Sum.inl msg) = wCoins)
+    (hKeys : ∀ kd, costFn (Sum.inr kd) = wKey) :
+    ExpectedQueryCost[
+      (UTransform pke kdInput policy).encaps pk in runtime by costFn via val
+    ] = val (wCoins + wKey) := by
+  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    (encaps_usesExactFamilyWeightedCost
+      (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy) (pk := pk)
+      (costFn := costFn) (wCoins := wCoins) (wKey := wKey) hCoins hKeys)
+    hval
+
+/-- Expected weighted query cost of U-transform encapsulation is bounded by the sum of the
+per-family bounds. -/
+theorem encaps_expectedQueryCost_le {ω : Type}
+    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [HasEvalPMF m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (wCoins wKey : ω) (val : ω → ENNReal) (hval : Monotone val)
+    (hCoins : ∀ msg, costFn (Sum.inl msg) ≤ wCoins)
+    (hKeys : ∀ kd, costFn (Sum.inr kd) ≤ wKey) :
+    ExpectedQueryCost[
+      (UTransform pke kdInput policy).encaps pk in runtime by costFn via val
+    ] ≤ val (wCoins + wKey) := by
+  exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
+    (encaps_usesWeightedQueryCostAtMost
+      (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy) (pk := pk)
+      (costFn := costFn) (wCoins := wCoins) (wKey := wKey) hCoins hKeys)
+    hval
+
+/-- Expected query count of U-transform encapsulation is exactly `2`. -/
+theorem encaps_expectedQueries_eq_two [HasEvalPMF m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) :
+    ExpectedQueries[ (UTransform pke kdInput policy).encaps pk in runtime ] = 2 := by
+  exact HasQuery.expectedQueries_eq_of_usesExactlyQueries
+    (encaps_usesExactlyTwoQueries
+      (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy) (pk := pk))
+
+/-- If deterministic decryption fails immediately, U-transform decapsulation incurs zero weighted
+query cost. -/
+theorem decaps_usesZeroQueryCost_of_decrypt_eq_none {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C)
+    (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (hdec : pke.decrypt sk c = none) :
+    QueryCost[
+      (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime by costFn
+    ] = 0 := by
+  rw [HasQuery.UsesCostExactly]
+  change Cost[
+    (match pke.decrypt sk c with
+    | none => pure (policy.onReject fb c)
+    | some msg => do
+        let r ← (runtime.withAddCost costFn).impl (Sum.inl msg)
+        if pke.encrypt pk msg r = c then
+          let k ← (runtime.withAddCost costFn).impl (Sum.inr (kdInput msg c))
+          pure (some k)
+        else
+          pure (policy.onReject fb c) : AddWriterT ω m (Option K))
+  ] = 0
+  rw [AddWriterT.hasCost_iff]
+  simp [hdec, AddWriterT.outputs, AddWriterT.costs]
+
+/-- Under per-family upper bounds on the two U-transform oracle families, decapsulation incurs
+weighted query cost at most the sum of those bounds. -/
+theorem decaps_usesWeightedQueryCostAtMost {ω : Type}
+    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [CanonicallyOrderedAdd ω]
+    [HasEvalSet m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C)
+    (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (wCoins wKey : ω)
+    (hCoins : ∀ msg, costFn (Sum.inl msg) ≤ wCoins)
+    (hKeys : ∀ kd, costFn (Sum.inr kd) ≤ wKey) :
+    QueryCost[
+      (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime by costFn
+    ] ≤ wCoins + wKey := by
+  rw [HasQuery.UsesCostAtMost]
+  cases hdec : pke.decrypt sk c with
+  | none =>
+      exact HasQuery.usesCostAtMost_of_usesCostExactly
+        (decaps_usesZeroQueryCost_of_decrypt_eq_none
+          (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
+          (pk := pk) (sk := sk) (fb := fb) (c := c) (costFn := costFn) hdec)
+        (by simp)
+  | some msg =>
+    let variant : FujisakiOkamoto.Variant (UTransform.hashOracleSpec M R KD K) M PK C R K :=
+      UTransform.variant (PK := PK) (M := M) (C := C) (R := R) (KD := KD) (K := K) kdInput
+    letI := (runtime.withAddCost costFn).toHasQuery
+    suffices hbranch :
+        AddWriterT.PathwiseCostAtMost
+          (((variant.deriveCoins (m := AddWriterT ω m) pk msg) >>= fun r =>
+            if pke.encrypt pk msg r = c then
+              some <$> (variant.deriveKey (m := AddWriterT ω m) pk msg c)
+            else pure (policy.onReject fb c)))
+          (wCoins + wKey) by
+      simpa [HasQuery.withAddCost, UTransform, FujisakiOkamoto.scheme, hdec] using hbranch
+    refine AddWriterT.pathwiseCostAtMost_bind (w₁ := wCoins) (w₂ := wKey) ?_ ?_
+    · change AddWriterT.PathwiseCostAtMost
+          (HasQuery.query
+            (spec := UTransform.hashOracleSpec M R KD K) (m := AddWriterT ω m) (Sum.inl msg))
+          wCoins
+      exact HasQuery.usesCostAtMost_query_of_le
+        (runtime := runtime) (costFn := costFn) (t := Sum.inl msg) (b := wCoins) (hCoins msg)
+    · intro r
+      by_cases henc : pke.encrypt pk msg r = c
+      · suffices hsucc :
+            AddWriterT.PathwiseCostAtMost
+              (some <$> (variant.deriveKey (m := AddWriterT ω m) pk msg c))
+              wKey by
+          simpa [henc] using hsucc
+        change AddWriterT.PathwiseCostAtMost
+          (some <$>
+            (HasQuery.query
+              (spec := UTransform.hashOracleSpec M R KD K) (m := AddWriterT ω m)
+              (Sum.inr (kdInput msg c))))
+          wKey
+        exact AddWriterT.pathwiseCostAtMost_map some
+          (HasQuery.usesCostAtMost_query_of_le
+            (runtime := runtime) (costFn := costFn)
+            (t := Sum.inr (kdInput msg c)) (b := wKey) (hKeys (kdInput msg c)))
+      · simpa [henc] using
+          AddWriterT.pathwiseCostAtMost_mono
+            (AddWriterT.pathwiseCostAtMost_pure (m := m) (policy.onReject fb c : Option K))
+            (by exact zero_le wKey)
+
+/-- If deterministic decryption fails immediately, decapsulation has expected weighted query cost
+`0`. -/
+theorem decaps_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
+    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C)
+    (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (val : ω → ENNReal) (hval : Monotone val)
+    (hdec : pke.decrypt sk c = none) :
+    ExpectedQueryCost[
+      (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime by costFn via val
+    ] = val 0 := by
+  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    (decaps_usesZeroQueryCost_of_decrypt_eq_none
+      (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
+      (pk := pk) (sk := sk) (fb := fb) (c := c) (costFn := costFn) hdec)
+    hval
+
+/-- Expected weighted query cost of U-transform decapsulation is bounded by the sum of the
+per-family bounds. -/
+theorem decaps_expectedQueryCost_le {ω : Type}
+    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [CanonicallyOrderedAdd ω]
+    [HasEvalPMF m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C)
+    (costFn : (UTransform.hashOracleSpec M R KD K).Domain → ω)
+    (wCoins wKey : ω) (val : ω → ENNReal) (hval : Monotone val)
+    (hCoins : ∀ msg, costFn (Sum.inl msg) ≤ wCoins)
+    (hKeys : ∀ kd, costFn (Sum.inr kd) ≤ wKey) :
+    ExpectedQueryCost[
+      (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime by costFn via val
+    ] ≤ val (wCoins + wKey) := by
+  exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
+    (decaps_usesWeightedQueryCostAtMost
+      (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
+      (pk := pk) (sk := sk) (fb := fb) (c := c) (costFn := costFn)
+      (wCoins := wCoins) (wKey := wKey) hCoins hKeys)
+    hval
+
+/-- Unit-cost specialization: U-transform decapsulation makes at most two oracle queries. -/
+theorem decaps_usesAtMostTwoQueries [HasEvalSet m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C) :
+    Queries[ (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime ] ≤ 2 := by
+  simpa [HasQuery.UsesAtMostQueries] using
+    (decaps_usesWeightedQueryCostAtMost
+      (ω := ℕ) (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
+      (pk := pk) (sk := sk) (fb := fb) (c := c) (costFn := fun _ ↦ 1) (wCoins := 1) (wKey := 1)
+      (hCoins := fun _ ↦ le_rfl) (hKeys := fun _ ↦ le_rfl))
+
+/-- Expected query count of U-transform decapsulation is at most `2`. -/
+theorem decaps_expectedQueries_le_two [HasEvalPMF m]
+    (runtime : QueryRuntime (UTransform.hashOracleSpec M R KD K) m)
+    (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
+    (kdInput : M → C → KD)
+    (policy : FujisakiOkamoto.RejectionPolicy K C)
+    (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C) :
+    ExpectedQueries[ (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime ] ≤ 2 := by
+  exact HasQuery.expectedQueries_le_of_usesAtMostQueries
+    (decaps_usesAtMostTwoQueries
+      (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
+      (pk := pk) (sk := sk) (fb := fb) (c := c))
+
+end costAccounting
+
 /-- Runtime bundle for the two-RO U-transform oracle world. -/
 noncomputable def runtime
-    {M PK C R KD K : Type}
-    [DecidableEq M] [DecidableEq KD] [SampleableType R] [SampleableType K]
-    (kdInput : M → C → KD) :
-    ProbCompRuntime (OracleComp (oracleSpec M R KD K)) :=
-  FujisakiOkamoto.runtime
-    (variant (PK := PK) (C := C) (R := R) (KD := KD) (K := K) kdInput)
+    {M R KD K : Type}
+    [DecidableEq M] [DecidableEq KD] [SampleableType R] [SampleableType K] :
+    ProbCompRuntime (OracleComp (oracleSpec M R KD K)) where
+  toSPMFSemantics := SPMFSemantics.withStateOracle
+    (hashImpl := queryImpl (M := M) (R := R) (KD := KD) (K := K))
+    ((∅, ∅) : QueryCache M R KD K)
+  toProbCompLift := ProbCompLift.ofMonadLift _
 
 /-- The generic U-transform CCA bound. The proof is intentionally deferred, but the reduction
 artifacts are now existentially quantified rather than passed in as unrelated inputs. -/
@@ -200,12 +524,14 @@ theorem IND_CCA_bound
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (prf : PRFScheme KPRF C K)
     (kdInput : M → C → KD)
-    (adversary : (UTransform pke kdInput (FujisakiOkamoto.implicitRejection prf)).IND_CCA_Adversary)
+    (adversary : (UTransform (m := OracleComp (UTransform.oracleSpec M R KD K))
+      pke kdInput (FujisakiOkamoto.implicitRejection prf)).IND_CCA_Adversary)
     (correctnessBound₁ correctnessBound₂ : ℝ) :
     ∃ prfAdv : PRFScheme.PRFAdversary C K,
       ∃ owAdv : OW_PCVA_Adversary (TTransform pke),
-        (UTransform pke kdInput (FujisakiOkamoto.implicitRejection prf)).IND_CCA_Advantage
-            (runtime (PK := PK) (C := C) (R := R) (KD := KD) (K := K) kdInput) adversary ≤
+        (UTransform (m := OracleComp (UTransform.oracleSpec M R KD K))
+          pke kdInput (FujisakiOkamoto.implicitRejection prf)).IND_CCA_Advantage
+            (runtime (M := M) (R := R) (KD := KD) (K := K)) adversary ≤
           PRFScheme.prfAdvantage prf prfAdv +
           correctnessBound₁ +
           correctnessBound₂ +

--- a/VCVio/OracleComp/QueryTracking/CostModel.lean
+++ b/VCVio/OracleComp/QueryTracking/CostModel.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import Mathlib.Algebra.Polynomial.Eval.Defs
-import VCVio.OracleComp.QueryTracking.CountingOracle
+import VCVio.OracleComp.QueryTracking.QueryRuntime
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.ProgramLogic.Unary.HoareTriple
 
@@ -19,7 +19,9 @@ Uses `AddWriterT` (defined in `ToMathlib.Control.WriterT`) for additive cost acc
 
 ## Main Definitions
 
-- `addCostOracle costFn`: Oracle that tracks additive cost via `AddWriterT`.
+- `instrumentedRun oa cm`: `oa` interpreted in the canonical free runtime with additive cost
+  tracking.
+- `addCostOracle costFn`: the corresponding one-query instrumented oracle implementation.
 - `CostModel spec ω`: Assigns cost `queryCost t : ω` to each oracle query `t`.
 - `costDist oa cm`: Joint distribution of `(output, totalCost)`.
 - `expectedCost oa cm val`: Expected total cost `E[val(cost)]`, computed via `wp`.
@@ -43,21 +45,20 @@ All definitions below operate at `Type` (= `Type 0`), matching `wp`, `support`, 
 which are defined for `{α : Type}` in the program logic.
 -/
 
-variable {ι : Type} {spec : OracleSpec ι} {α : Type}
-variable {ω : Type} [AddCommMonoid ω]
+variable {ι : Type} {spec : OracleSpec ι} {α : Type} {ω : Type}
 
 /-- Oracle that tracks additive cost. Wraps `costOracle` with `Multiplicative`
 to get additive accumulation through the existing `WriterT` infrastructure. -/
-def addCostOracle (costFn : spec.Domain → ω) :
+def addCostOracle [AddCommMonoid ω] (costFn : spec.Domain → ω) :
     QueryImpl spec (AddWriterT ω (OracleComp spec)) :=
-  costOracle (fun t => Multiplicative.ofAdd (costFn t))
+  ((QueryRuntime.oracleCompRuntime (spec := spec)).withAddCost costFn).impl
 
 @[simp]
-lemma fst_map_run_simulateQ_addCostOracle (costFn : spec.Domain → ω)
+lemma fst_map_run_simulateQ_addCostOracle [AddCommMonoid ω] (costFn : spec.Domain → ω)
     (oa : OracleComp spec α) :
     Prod.fst <$> (simulateQ (addCostOracle costFn) oa).run = oa := by
-  unfold addCostOracle costOracle
-  rw [QueryImpl.fst_map_run_withCost, simulateQ_ofLift_eq_self]
+  simp [addCostOracle, QueryRuntime.withAddCost, QueryImpl.fst_map_run_withCost,
+    QueryRuntime.oracleCompRuntime_impl_eq_ofLift]
 
 /-- A cost model assigns a cost in `ω` to each oracle query.
 The cost type `ω` can be `ℕ`, `ℝ≥0∞`, `ι → ℕ` (per-oracle), or any `AddCommMonoid`. -/
@@ -67,29 +68,53 @@ structure CostModel (spec : OracleSpec ι) (ω : Type) [AddCommMonoid ω] where
 namespace CostModel
 
 /-- The zero cost model: every query is free. -/
-def zero : CostModel spec ω where
+def zero [AddCommMonoid ω] : CostModel spec ω where
   queryCost _ := 0
 
 end CostModel
+
+/-- Run `oa` in the canonical free `OracleComp` runtime instrumented by `cm`'s additive
+query-cost function. This is the semantic core of `CostModel`. -/
+abbrev instrumentedRun [AddCommMonoid ω] (oa : OracleComp spec α) (cm : CostModel spec ω) :
+    AddWriterT ω (OracleComp spec) α :=
+  simulateQ ((QueryRuntime.oracleCompRuntime (spec := spec)).withAddCost cm.queryCost).impl oa
 
 /-- The joint distribution of `(output, totalCost)` obtained by running `oa` with
 additive cost tracking. Cost accumulates via `+` through `AddWriterT`.
 
 Since `Multiplicative ω` and `ω` are definitionally equal, the second component
 of the product can be used directly as `ω`. -/
-def costDist (oa : OracleComp spec α) (cm : CostModel spec ω) :=
-  (simulateQ (addCostOracle cm.queryCost) oa).run
+def costDist [AddCommMonoid ω] (oa : OracleComp spec α) (cm : CostModel spec ω) :=
+  (instrumentedRun oa cm).run
 
 /-- Cost instrumentation does not change the output distribution. -/
 @[simp]
-theorem fst_map_costDist (oa : OracleComp spec α) (cm : CostModel spec ω) :
+theorem fst_map_costDist [AddCommMonoid ω] (oa : OracleComp spec α) (cm : CostModel spec ω) :
     Prod.fst <$> costDist oa cm = oa :=
   fst_map_run_simulateQ_addCostOracle cm.queryCost oa
+
+namespace AddWriterT
+
+variable [spec.Fintype] [spec.Inhabited]
+
+/-- For `OracleComp`, `AddWriterT.expectedCost` is the weakest-precondition expectation of the
+run semantics projected to the additive cost component. -/
+lemma expectedCost_eq_wp_run
+    [AddMonoid ω]
+    (oa : AddWriterT ω (OracleComp spec) α) (val : ω → ENNReal) :
+    AddWriterT.expectedCost oa val =
+      wp oa.run (fun z => val (Multiplicative.toAdd z.2)) := by
+  unfold AddWriterT.expectedCost
+  rw [← wp_eq_tsum, AddWriterT.costs_def, wp_map]
+  rfl
+
+end AddWriterT
 
 /-! ## Expected Cost -/
 
 section ExpectedCost
 
+variable [AddCommMonoid ω]
 variable [spec.Fintype] [spec.Inhabited]
 
 /-- The expected total cost of `oa` under cost model `cm`, valued by `val : ω → ℝ≥0∞`.
@@ -100,21 +125,33 @@ For `ω = ℕ`, use `(↑·)`. For `ω = ℝ≥0∞`, use `id`. For multi-dimens
 choose which dimension to analyze. -/
 noncomputable def expectedCost (oa : OracleComp spec α) (cm : CostModel spec ω)
     (val : ω → ℝ≥0∞) : ℝ≥0∞ :=
-  wp (costDist oa cm) (fun z => val z.2)
+  AddWriterT.expectedCost (instrumentedRun oa cm) val
 
 /-- Convenience: expected cost for `ℕ`-valued cost models. -/
 noncomputable abbrev expectedCostNat (oa : OracleComp spec α)
     (cm : CostModel spec ℕ) : ℝ≥0∞ :=
   expectedCost oa cm (fun n => ↑n)
 
+/-- The `CostModel.expectedCost` facade agrees definitionally with the weakest-precondition
+expectation of the instrumented `costDist`. -/
+theorem expectedCost_eq_wp_costDist (oa : OracleComp spec α) (cm : CostModel spec ω)
+    (val : ω → ℝ≥0∞) :
+    expectedCost oa cm val = wp (costDist oa cm) (fun z => val z.2) := by
+  unfold expectedCost costDist instrumentedRun
+  simpa using
+    (AddWriterT.expectedCost_eq_wp_run
+      (spec := spec)
+      (oa := simulateQ
+        ((QueryRuntime.oracleCompRuntime (spec := spec)).withAddCost cm.queryCost).impl oa)
+      (val := val))
+
 @[simp]
 theorem expectedCost_pure (x : α) (cm : CostModel spec ω)
     (val : ω → ℝ≥0∞) (hval : val 0 = 0) :
     expectedCost (spec := spec) (pure x) cm val = 0 := by
-  simp only [expectedCost, costDist, addCostOracle, costOracle, simulateQ_pure,
-    WriterT.run_pure, wp_pure]
-  -- `1 : Multiplicative ω` is definitionally `Multiplicative.ofAdd 0 = 0 : ω`
-  exact hval
+  rw [expectedCost_eq_wp_costDist]
+  simp [costDist, instrumentedRun]
+  simpa using hval
 
 /-- If `val z.2 ≤ c` for all `z` in the support of `costDist`, then `expectedCost ≤ c`.
 This is the key bridge from worst-case (support) bounds to expected bounds. -/
@@ -122,7 +159,7 @@ theorem expectedCost_le_of_support_bound (oa : OracleComp spec α) (cm : CostMod
     (val : ω → ℝ≥0∞) (c : ℝ≥0∞)
     (h : ∀ z ∈ support (costDist oa cm), val z.2 ≤ c) :
     expectedCost oa cm val ≤ c := by
-  rw [expectedCost, wp_eq_tsum]
+  rw [expectedCost_eq_wp_costDist, wp_eq_tsum]
   calc ∑' z, Pr[= z | costDist oa cm] * val z.2
       ≤ ∑' z, Pr[= z | costDist oa cm] * c := by
         apply ENNReal.tsum_le_tsum fun z => ?_
@@ -134,16 +171,27 @@ theorem expectedCost_le_of_support_bound (oa : OracleComp spec α) (cm : CostMod
 
 end ExpectedCost
 
+/-! ## Worst-Case Cost Bounds -/
+
+/-- Every execution path of `oa` under `cm` has total cost at most `bound`. -/
+def WorstCaseCostBound [AddCommMonoid ω] [Preorder ω]
+    (oa : OracleComp spec α) (cm : CostModel spec ω) (bound : ω) : Prop :=
+  AddWriterT.PathwiseCostAtMost (instrumentedRun oa cm) bound
+
+/-- `WorstCaseCostBound` is equivalently a support bound over the old `costDist` view. -/
+theorem worstCaseCostBound_iff_support_bound [AddCommMonoid ω] [Preorder ω]
+    (oa : OracleComp spec α) (cm : CostModel spec ω) (bound : ω) :
+    WorstCaseCostBound oa cm bound ↔
+      ∀ z ∈ support (costDist oa cm), z.2 ≤ bound := by
+  unfold WorstCaseCostBound costDist instrumentedRun AddWriterT.PathwiseCostAtMost
+  constructor <;> intro h z hz <;> simpa using h z hz
+
 /-! ## Cost Bounds -/
 
 section CostBounds
 
+variable [AddCommMonoid ω]
 variable [spec.Fintype] [spec.Inhabited]
-
-/-- Every execution path of `oa` under `cm` has total cost at most `bound`. -/
-def WorstCaseCostBound [LE ω] (oa : OracleComp spec α) (cm : CostModel spec ω)
-    (bound : ω) : Prop :=
-  ∀ z ∈ support (costDist oa cm), z.2 ≤ bound
 
 /-- The expected cost of `oa` under `cm` (valued by `val`) is at most `bound`. -/
 def ExpectedCostBound (oa : OracleComp spec α) (cm : CostModel spec ω)
@@ -156,15 +204,17 @@ theorem WorstCaseCostBound.toExpectedCostBound [Preorder ω]
     {oa : OracleComp spec α} {cm : CostModel spec ω} {bound : ω}
     (hstrict : WorstCaseCostBound oa cm bound)
     {val : ω → ℝ≥0∞} (hval_mono : Monotone val) :
-    ExpectedCostBound oa cm val (val bound) :=
-  expectedCost_le_of_support_bound oa cm val (val bound)
-    (fun z hz => hval_mono (hstrict z hz))
+    ExpectedCostBound oa cm val (val bound) := by
+  simpa [ExpectedCostBound, expectedCost] using
+    (AddWriterT.expectedCost_le_of_pathwiseCostAtMost
+      (oa := instrumentedRun oa cm) (w := bound) (val := val) hstrict hval_mono)
 
 /-- **Markov's inequality for cost distributions** (multiplication form).
 The probability that the valued cost exceeds `t`, times `t`, is at most `expectedCost`. -/
 theorem probEvent_cost_gt_mul_le_expectedCost
     (oa : OracleComp spec α) (cm : CostModel spec ω) (val : ω → ℝ≥0∞) (t : ℝ≥0∞) :
     Pr[ fun z => t < val z.2 | costDist oa cm] * t ≤ expectedCost oa cm val := by
+  rw [expectedCost_eq_wp_costDist]
   rw [probEvent_eq_wp_indicator]
   change wp (costDist oa cm) (fun z => if t < val z.2 then 1 else 0) * t ≤
     wp (costDist oa cm) (fun z => val z.2)
@@ -204,7 +254,8 @@ private lemma addCostOracle_unit_run_apply (t : spec.Domain) :
     (addCostOracle CostModel.unit.queryCost t).run =
       (fun u => (u, Multiplicative.ofAdd 1)) <$>
         (liftM (query t) : OracleComp spec (spec.Range t)) := by
-  simp [CostModel.unit, addCostOracle, costOracle, QueryImpl.withCost]
+  simp [CostModel.unit, addCostOracle, QueryRuntime.withAddCost,
+    QueryRuntime.oracleCompRuntime_impl_eq_ofLift, QueryImpl.withCost]
 
 section UnitCostBridge
 
@@ -224,7 +275,7 @@ private lemma exists_mem_support (oa : OracleComp spec α) :
 
 omit [DecidableEq ι] [spec.Fintype] [spec.Inhabited] in
 private lemma exists_mem_support_costDist_of_mem_support
-    (oa : OracleComp spec α) (cm : CostModel spec ω) {x : α}
+    [AddCommMonoid ω] (oa : OracleComp spec α) (cm : CostModel spec ω) {x : α}
     (hx : x ∈ support oa) :
     ∃ c, (x, c) ∈ support (costDist oa cm) := by
   have hx' : x ∈ support (Prod.fst <$> costDist oa cm) := by
@@ -241,24 +292,21 @@ private lemma mem_support_costDist_unit_query_bind_of_mem_support
     {z : α × Multiplicative ℕ} (hz : z ∈ support (costDist (mx u) CostModel.unit)) :
     (z.1, Multiplicative.ofAdd (Multiplicative.toAdd z.2 + 1)) ∈ support
       (costDist ((liftM (query t) : OracleComp spec (spec.Range t)) >>= mx) CostModel.unit) := by
-  rw [costDist, simulateQ_bind, simulateQ_query, WriterT.run_bind]
+  rw [costDist, instrumentedRun, simulateQ_bind, simulateQ_query, WriterT.run_bind]
   refine (mem_support_bind_iff _ _ _).2 ?_
   refine ⟨(u, (Multiplicative.ofAdd 1 : Multiplicative ℕ)), ?_, ?_⟩
   · have hq : (u, Multiplicative.ofAdd 1) ∈
       support ((addCostOracle CostModel.unit.queryCost t).run) := by
       rw [addCostOracle_unit_run_apply, support_map]
       exact ⟨u, mem_support_query t u, by simp⟩
-    simp [OracleQuery.cont_query]
+    simp [OracleQuery.cont_query, CostModel.unit]
   · rw [support_map]
     exact ⟨z, hz, by ext <;> simp [Prod.map, Nat.add_comm]⟩
 
 omit [spec.Fintype] in
-/-- A strict bound under the unit cost model yields a uniform per-index query bound:
-if every execution uses at most `bound` total unit-cost steps, then each oracle index
-is queried at most `bound` times. -/
-theorem WorstCaseCostBound.toIsPerIndexQueryBound_unit
+private theorem isPerIndexQueryBound_of_unit_support_bound
     {oa : OracleComp spec α} {bound : ℕ}
-    (h : WorstCaseCostBound oa CostModel.unit bound) :
+    (hSupport : ∀ z ∈ support (costDist oa CostModel.unit), z.2 ≤ bound) :
     IsPerIndexQueryBound oa (fun _ => bound) := by
   induction oa using OracleComp.inductionOn generalizing bound with
   | pure x =>
@@ -272,23 +320,35 @@ theorem WorstCaseCostBound.toIsPerIndexQueryBound_unit
         have hparent :=
           mem_support_costDist_unit_query_bind_of_mem_support t mx default hc
         have hle : Multiplicative.toAdd c + 1 ≤ bound := by
-          simpa using (h _ hparent)
+          simpa using (hSupport _ hparent)
         omega
-      · have hcont : WorstCaseCostBound (mx u) CostModel.unit (bound - 1) := by
+      · have hcontSupport : ∀ z ∈ support (costDist (mx u) CostModel.unit), z.2 ≤ bound - 1 := by
           intro z hz
           have hparent :=
             mem_support_costDist_unit_query_bind_of_mem_support t mx u hz
           have hle : Multiplicative.toAdd z.2 + 1 ≤ bound := by
-            simpa using (h _ hparent)
+            simpa using (hSupport _ hparent)
           change Multiplicative.toAdd z.2 ≤ bound - 1
           omega
-        have hu : IsPerIndexQueryBound (mx u) (fun _ => bound - 1) := ih u hcont
+        have hu : IsPerIndexQueryBound (mx u) (fun _ => bound - 1) := ih u hcontSupport
         refine hu.mono ?_
         intro i
         by_cases hi : i = t
         · subst hi
           simp
         · simp [Function.update, hi]
+
+omit [spec.Fintype] in
+/-- A strict bound under the unit cost model yields a uniform per-index query bound:
+if every execution uses at most `bound` total unit-cost steps, then each oracle index
+is queried at most `bound` times. -/
+theorem WorstCaseCostBound.toIsPerIndexQueryBound_unit
+    {oa : OracleComp spec α} {bound : ℕ}
+    (h : WorstCaseCostBound oa CostModel.unit bound) :
+    IsPerIndexQueryBound oa (fun _ => bound) := by
+  refine isPerIndexQueryBound_of_unit_support_bound ?_
+  intro z hz
+  simpa [WorstCaseCostBound, costDist, instrumentedRun] using h z hz
 
 end UnitCostBridge
 
@@ -299,6 +359,7 @@ security parameter `n : ℕ`. These connect the cost model to asymptotic complex
 
 section PolyTime
 
+variable [AddCommMonoid ω]
 variable [spec.Fintype] [spec.Inhabited]
 
 /-- All execution paths of `family n` have valued cost at most `p(n)` for some polynomial `p`. -/
@@ -335,7 +396,12 @@ noncomputable def WorstCasePolyTime.toPolyQueries_unit [DecidableEq ι]
   have hp := Classical.choose_spec h
   refine ⟨fun _ => p, ?_⟩
   intro n _
+  have hbound : WorstCaseCostBound (family n) CostModel.unit (p.eval n) := by
+    intro z hz
+    change Multiplicative.toAdd z.2 ≤ p.eval n
+    simpa [p] using hp n (z.1, Multiplicative.toAdd z.2)
+      (by simpa [costDist, instrumentedRun] using hz)
   exact WorstCaseCostBound.toIsPerIndexQueryBound_unit
-    (oa := family n) (bound := p.eval n) (fun z hz => hp n z hz)
+    (oa := family n) (bound := p.eval n) hbound
 
 end PolyTime

--- a/VCVio/OracleComp/QueryTracking/CostModel.lean
+++ b/VCVio/OracleComp/QueryTracking/CostModel.lean
@@ -259,10 +259,7 @@ private lemma addCostOracle_unit_run_apply (t : spec.Domain) :
 
 section UnitCostBridge
 
-variable [DecidableEq ι] [spec.Fintype] [spec.Inhabited]
-
-omit [DecidableEq ι] [spec.Fintype] in
-private lemma exists_mem_support (oa : OracleComp spec α) :
+private lemma exists_mem_support [spec.Inhabited] (oa : OracleComp spec α) :
     ∃ x, x ∈ support oa := by
   induction oa using OracleComp.inductionOn with
   | pure x =>
@@ -273,7 +270,6 @@ private lemma exists_mem_support (oa : OracleComp spec α) :
       refine ⟨x, (mem_support_bind_iff _ _ _).2 ?_⟩
       exact ⟨u, mem_support_query t u, hx⟩
 
-omit [DecidableEq ι] [spec.Fintype] [spec.Inhabited] in
 private lemma exists_mem_support_costDist_of_mem_support
     [AddCommMonoid ω] (oa : OracleComp spec α) (cm : CostModel spec ω) {x : α}
     (hx : x ∈ support oa) :
@@ -286,7 +282,6 @@ private lemma exists_mem_support_costDist_of_mem_support
   subst x'
   exact ⟨c, hz⟩
 
-omit [DecidableEq ι] [spec.Fintype] [spec.Inhabited] in
 private lemma mem_support_costDist_unit_query_bind_of_mem_support
     (t : spec.Domain) (mx : spec.Range t → OracleComp spec α) (u : spec.Range t)
     {z : α × Multiplicative ℕ} (hz : z ∈ support (costDist (mx u) CostModel.unit)) :
@@ -303,8 +298,8 @@ private lemma mem_support_costDist_unit_query_bind_of_mem_support
   · rw [support_map]
     exact ⟨z, hz, by ext <;> simp [Prod.map, Nat.add_comm]⟩
 
-omit [spec.Fintype] in
 private theorem isPerIndexQueryBound_of_unit_support_bound
+    [DecidableEq ι] [spec.Inhabited]
     {oa : OracleComp spec α} {bound : ℕ}
     (hSupport : ∀ z ∈ support (costDist oa CostModel.unit), z.2 ≤ bound) :
     IsPerIndexQueryBound oa (fun _ => bound) := by
@@ -338,11 +333,11 @@ private theorem isPerIndexQueryBound_of_unit_support_bound
           simp
         · simp [Function.update, hi]
 
-omit [spec.Fintype] in
 /-- A strict bound under the unit cost model yields a uniform per-index query bound:
 if every execution uses at most `bound` total unit-cost steps, then each oracle index
 is queried at most `bound` times. -/
 theorem WorstCaseCostBound.toIsPerIndexQueryBound_unit
+    [DecidableEq ι] [spec.Inhabited]
     {oa : OracleComp spec α} {bound : ℕ}
     (h : WorstCaseCostBound oa CostModel.unit bound) :
     IsPerIndexQueryBound oa (fun _ => bound) := by

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -8,6 +8,7 @@ import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.CountingOracle
 import VCVio.EvalDist.Monad.Map
 import ToMathlib.General
+import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
 
 /-!
@@ -235,6 +236,147 @@ lemma expectedCost_ge_of_pathwiseCostAtLeast [LawfulMonad m] [Preorder ω] [HasE
             simp
 
 end expectedCost
+
+section weightedPathwiseBounds
+
+variable [HasEvalSet m]
+variable {ω : Type} [AddCommMonoid ω] [PartialOrder ω]
+
+lemma pathwiseCostAtMost_pure [LawfulMonad m] (x : α) :
+    PathwiseCostAtMost (pure x : AddWriterT ω m α) 0 := by
+  intro z hz
+  rw [WriterT.run_pure, support_pure] at hz
+  rcases hz with rfl
+  simp
+
+lemma pathwiseCostAtLeast_pure [LawfulMonad m] (x : α) :
+    PathwiseCostAtLeast (pure x : AddWriterT ω m α) 0 := by
+  intro z hz
+  rw [WriterT.run_pure, support_pure] at hz
+  rcases hz with rfl
+  simp
+
+lemma pathwiseCostAtMost_monadLift [LawfulMonad m] (x : m α) :
+    PathwiseCostAtMost (monadLift x : AddWriterT ω m α) 0 := by
+  intro z hz
+  rw [WriterT.run_monadLift, support_map] at hz
+  rcases hz with ⟨a, _, rfl⟩
+  simp
+
+lemma pathwiseCostAtLeast_monadLift [LawfulMonad m] (x : m α) :
+    PathwiseCostAtLeast (monadLift x : AddWriterT ω m α) 0 := by
+  intro z hz
+  rw [WriterT.run_monadLift, support_map] at hz
+  rcases hz with ⟨a, _, rfl⟩
+  simp
+
+lemma pathwiseCostAtMost_mono {oa : AddWriterT ω m α} {w₁ w₂ : ω}
+    (h : PathwiseCostAtMost oa w₁) (hw : w₁ ≤ w₂) :
+    PathwiseCostAtMost oa w₂ := by
+  intro z hz
+  exact le_trans (h z hz) hw
+
+lemma pathwiseCostAtLeast_mono {oa : AddWriterT ω m α} {w₁ w₂ : ω}
+    (h : PathwiseCostAtLeast oa w₂) (hw : w₁ ≤ w₂) :
+    PathwiseCostAtLeast oa w₁ := by
+  intro z hz
+  exact le_trans hw (h z hz)
+
+lemma pathwiseCostAtMost_addTell [LawfulMonad m] (w : ω) :
+    PathwiseCostAtMost (AddWriterT.addTell (M := m) w) w := by
+  intro z hz
+  rw [AddWriterT.run_addTell, support_pure] at hz
+  rcases hz with rfl
+  simp
+
+lemma pathwiseCostAtLeast_addTell [LawfulMonad m] (w : ω) :
+    PathwiseCostAtLeast (AddWriterT.addTell (M := m) w) w := by
+  intro z hz
+  rw [AddWriterT.run_addTell, support_pure] at hz
+  rcases hz with rfl
+  simp
+
+lemma pathwiseCostAtMost_map [LawfulMonad m] {oa : AddWriterT ω m α} {w : ω}
+    (f : α → β) (h : PathwiseCostAtMost oa w) :
+    PathwiseCostAtMost (f <$> oa) w := by
+  intro z hz
+  rw [WriterT.run_map, support_map] at hz
+  rcases hz with ⟨z', hz', rfl⟩
+  exact h z' hz'
+
+lemma pathwiseCostAtLeast_map [LawfulMonad m] {oa : AddWriterT ω m α} {w : ω}
+    (f : α → β) (h : PathwiseCostAtLeast oa w) :
+    PathwiseCostAtLeast (f <$> oa) w := by
+  intro z hz
+  rw [WriterT.run_map, support_map] at hz
+  rcases hz with ⟨z', hz', rfl⟩
+  exact h z' hz'
+
+lemma pathwiseCostAtMost_bind [LawfulMonad m] [IsOrderedAddMonoid ω]
+    {oa : AddWriterT ω m α} {f : α → AddWriterT ω m β} {w₁ w₂ : ω}
+    (h₁ : PathwiseCostAtMost oa w₁) (h₂ : ∀ a, PathwiseCostAtMost (f a) w₂) :
+    PathwiseCostAtMost (oa >>= f) (w₁ + w₂) := by
+  intro z hz
+  rw [WriterT.run_bind] at hz
+  rcases (mem_support_bind_iff
+    (mx := oa.run)
+    (my := fun aw ↦ Prod.map id (aw.2 * ·) <$> (f aw.1).run)
+    (y := z)).1 hz with ⟨aw, haw, hz⟩
+  rcases aw with ⟨a, wa⟩
+  rw [support_map] at hz
+  rcases hz with ⟨bw, hbw, rfl⟩
+  rcases bw with ⟨b, wb⟩
+  simpa using add_le_add (h₁ (a, wa) haw) (h₂ a (b, wb) hbw)
+
+lemma pathwiseCostAtLeast_bind [LawfulMonad m] [IsOrderedAddMonoid ω]
+    {oa : AddWriterT ω m α} {f : α → AddWriterT ω m β} {w₁ w₂ : ω}
+    (h₁ : PathwiseCostAtLeast oa w₁) (h₂ : ∀ a, PathwiseCostAtLeast (f a) w₂) :
+    PathwiseCostAtLeast (oa >>= f) (w₁ + w₂) := by
+  intro z hz
+  rw [WriterT.run_bind] at hz
+  rcases (mem_support_bind_iff
+    (mx := oa.run)
+    (my := fun aw ↦ Prod.map id (aw.2 * ·) <$> (f aw.1).run)
+    (y := z)).1 hz with ⟨aw, haw, hz⟩
+  rcases aw with ⟨a, wa⟩
+  rw [support_map] at hz
+  rcases hz with ⟨bw, hbw, rfl⟩
+  rcases bw with ⟨b, wb⟩
+  simpa using add_le_add (h₁ (a, wa) haw) (h₂ a (b, wb) hbw)
+
+lemma pathwiseCostAtMost_fin_mOfFn [LawfulMonad m] [IsOrderedAddMonoid ω] {n : ℕ} {k : ω}
+    {f : Fin n → AddWriterT ω m α} (h : ∀ i, PathwiseCostAtMost (f i) k) :
+    PathwiseCostAtMost (Fin.mOfFn n f) (n • k) := by
+  induction n with
+  | zero =>
+      simpa [zero_nsmul] using
+        (pathwiseCostAtMost_pure (m := m) (ω := ω) (x := (Fin.elim0 : Fin 0 → α)))
+  | succ n ih =>
+      simp only [Fin.mOfFn, succ_nsmul']
+      simpa [add_comm] using
+        (pathwiseCostAtMost_bind (w₁ := k) (w₂ := n • k)
+          (by simpa using h 0)
+          (fun a ↦
+            pathwiseCostAtMost_map (fun rest ↦ Fin.cons a rest)
+              (ih (fun i ↦ h i.succ))))
+
+lemma pathwiseCostAtLeast_fin_mOfFn [LawfulMonad m] [IsOrderedAddMonoid ω] {n : ℕ} {k : ω}
+    {f : Fin n → AddWriterT ω m α} (h : ∀ i, PathwiseCostAtLeast (f i) k) :
+    PathwiseCostAtLeast (Fin.mOfFn n f) (n • k) := by
+  induction n with
+  | zero =>
+      simpa [zero_nsmul] using
+        (pathwiseCostAtLeast_pure (m := m) (ω := ω) (x := (Fin.elim0 : Fin 0 → α)))
+  | succ n ih =>
+      simp only [Fin.mOfFn, succ_nsmul']
+      simpa [add_comm] using
+        (pathwiseCostAtLeast_bind (w₁ := k) (w₂ := n • k)
+          (by simpa using h 0)
+          (fun a ↦
+            pathwiseCostAtLeast_map (fun rest ↦ Fin.cons a rest)
+              (ih (fun i ↦ h i.succ))))
+
+end weightedPathwiseBounds
 
 section unitCostBounds
 

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -454,6 +454,19 @@ section queryBounds
 variable {ι : Type} {spec : OracleSpec ι} {m : Type → Type*}
 variable [Monad m] [LawfulMonad m] [HasEvalSet m]
 
+omit [HasEvalSet m] in
+lemma hasCost_withAddCost_query {ω : Type} [AddMonoid ω]
+    (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) (t : spec.Domain) :
+    Cost[
+      HasQuery.withAddCost
+        (fun [HasQuery spec (AddWriterT ω m)] =>
+          HasQuery.query (spec := spec) (m := AddWriterT ω m) t)
+        runtime costFn
+    ] = costFn t := by
+  change Cost[(runtime.withAddCost costFn).impl t] = costFn t
+  rw [QueryRuntime.withAddCost_impl, AddWriterT.hasCost_iff]
+  simp [AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
+
 lemma queryBoundedAboveBy_withUnitCost_query
     (runtime : QueryRuntime spec m) (t : spec.Domain) :
     AddWriterT.QueryBoundedAboveBy

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -56,6 +56,22 @@ lemma ofHasQuery_impl [HasQuery spec m] (t : spec.Domain) :
     (ofHasQuery (spec := spec) (m := m)).impl t =
       HasQuery.query (spec := spec) (m := m) t := rfl
 
+section OracleComp
+
+variable {ι : Type} {spec : OracleSpec ι}
+
+/-- The canonical bundled runtime for the free oracle monad `OracleComp spec`. -/
+abbrev oracleCompRuntime (spec : OracleSpec ι) : QueryRuntime spec (OracleComp spec) :=
+  QueryRuntime.ofHasQuery (spec := spec) (m := OracleComp spec)
+
+@[simp]
+lemma oracleCompRuntime_impl_eq_ofLift :
+    (oracleCompRuntime (spec := spec)).impl = QueryImpl.ofLift spec (OracleComp spec) := by
+  ext t
+  rfl
+
+end OracleComp
+
 section instrumentation
 
 variable [Monad m]

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -205,6 +205,17 @@ lemma expectedCostNat_eq_tsum_tail_probs [HasEvalSPMF m] (oa : AddWriterT ℕ m 
           refine tsum_congr fun n ↦ ?_
           by_cases h : i < n <;> simp [Set.indicator, h]
 
+/-- Tail domination bounds the expected natural-valued writer cost.
+
+If the tail probability `Pr[i < cost]` is bounded by `a i` for every `i`, then
+`E[cost] ≤ ∑ i, a i`. -/
+lemma expectedCostNat_le_tsum_of_tail_probs_le [HasEvalSPMF m]
+    (oa : AddWriterT ℕ m α) {a : ℕ → ENNReal}
+    (h : ∀ i : ℕ, Pr[ fun c ↦ i < c | oa.costs ] ≤ a i) :
+    expectedCostNat oa ≤ ∑' i : ℕ, a i := by
+  rw [expectedCostNat_eq_tsum_tail_probs]
+  exact ENNReal.tsum_le_tsum h
+
 /-- Finite tail-sum formula for natural-valued writer cost under a pathwise upper bound.
 
 If every execution path of `oa` incurs cost at most `n`, then the tail probabilities vanish above
@@ -884,6 +895,18 @@ lemma expectedQueries_eq_tsum_tail_probs
       ∑' i : ℕ, Pr[ fun c ↦ i < c | HasQuery.queryCountDist oa runtime ] := by
   simpa [HasQuery.expectedQueries, HasQuery.expectedQueryCost] using
     AddWriterT.expectedCostNat_eq_tsum_tail_probs (oa := HasQuery.withUnitCost oa runtime)
+
+/-- Tail domination bounds expected query count.
+
+If `Pr[i < number of queries] ≤ a i` for every `i`, then
+`ExpectedQueries[ oa in runtime ] ≤ ∑ i, a i`. -/
+lemma expectedQueries_le_tsum_of_tail_probs_le
+    (oa : Computation spec (AddWriterT ℕ m) α) (runtime : QueryRuntime spec m)
+    {a : ℕ → ENNReal}
+    (h : ∀ i : ℕ, Pr[ fun c ↦ i < c | HasQuery.queryCountDist oa runtime ] ≤ a i) :
+    HasQuery.expectedQueries oa runtime ≤ ∑' i : ℕ, a i := by
+  rw [HasQuery.expectedQueries_eq_tsum_tail_probs]
+  exact ENNReal.tsum_le_tsum h
 
 /-- Finite tail-sum formula for expected query count under a pathwise upper bound.
 

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -171,7 +171,7 @@ end pathwiseCost
 
 section expectedCost
 
-variable {ω : Type} [AddMonoid ω]
+variable {ω : Type}
 
 /-- The expected additive cost of an `AddWriterT` computation, obtained by taking the expectation
 of its cost marginal.
@@ -234,7 +234,6 @@ lemma expectedCostNat_eq_sum_tail_probs_of_pathwiseCostAtMost
     rcases hc with ⟨z, hz, rfl⟩
     exact not_lt_of_ge (le_trans (h z hz) hnb)
 
-omit [AddMonoid ω] in
 lemma expectedCost_le_of_support_bound [HasEvalSPMF m]
     (oa : AddWriterT ω m α) (val : ω → ENNReal) (c : ENNReal)
     (h : ∀ w ∈ support oa.costs, val w ≤ c) :
@@ -262,7 +261,8 @@ lemma expectedCost_le_of_support_bound [HasEvalSPMF m]
           simpa [mul_comm] using (mul_le_mul_right hmass c)
     _ = c := by simp
 
-lemma expectedCost_le_of_pathwiseCostAtMost [HasEvalSPMF m] [LawfulMonad m] [Preorder ω]
+lemma expectedCost_le_of_pathwiseCostAtMost [AddMonoid ω] [HasEvalSPMF m] [LawfulMonad m]
+    [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} {val : ω → ENNReal}
     (h : PathwiseCostAtMost oa w) (hval : Monotone val) :
     expectedCost oa val ≤ val w := by
@@ -272,7 +272,8 @@ lemma expectedCost_le_of_pathwiseCostAtMost [HasEvalSPMF m] [LawfulMonad m] [Pre
   rcases hc with ⟨z, hz, rfl⟩
   exact hval (h z hz)
 
-lemma expectedCost_ge_of_pathwiseCostAtLeast [LawfulMonad m] [Preorder ω] [HasEvalPMF m]
+lemma expectedCost_ge_of_pathwiseCostAtLeast [AddMonoid ω] [LawfulMonad m] [Preorder ω]
+    [HasEvalPMF m]
     {oa : AddWriterT ω m α} {w : ω} {val : ω → ENNReal}
     (h : PathwiseCostAtLeast oa w) (hval : Monotone val) :
     val w ≤ expectedCost oa val := by
@@ -300,7 +301,6 @@ lemma expectedCost_ge_of_pathwiseCostAtLeast [LawfulMonad m] [Preorder ω] [HasE
             rw [hp]
             simp
 
-omit [AddMonoid ω] in
 lemma expectedCost_eq_tsum_outputs_of_costsAs [HasEvalSPMF m] [LawfulMonad m]
     {oa : AddWriterT ω m α} {f : α → ω} {val : ω → ENNReal}
     (h : oa.CostsAs f) :
@@ -701,9 +701,8 @@ end runtimeInstantiation
 section queryBounds
 
 variable {ι : Type} {spec : OracleSpec ι} {m : Type → Type*}
-variable [Monad m] [LawfulMonad m] [HasEvalSet m]
+variable [Monad m] [LawfulMonad m]
 
-omit [HasEvalSet m] in
 lemma hasCost_withAddCost_query {ω : Type} [AddMonoid ω]
     (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) (t : spec.Domain) :
     Cost[
@@ -717,6 +716,7 @@ lemma hasCost_withAddCost_query {ω : Type} [AddMonoid ω]
   simp [AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
 
 lemma queryBoundedAboveBy_withUnitCost_query
+    [HasEvalSet m]
     (runtime : QueryRuntime spec m) (t : spec.Domain) :
     AddWriterT.QueryBoundedAboveBy
       (HasQuery.withUnitCost
@@ -732,6 +732,7 @@ lemma queryBoundedAboveBy_withUnitCost_query
     exact AddWriterT.queryBoundedAboveBy_monadLift (runtime.impl t)
 
 lemma queryBoundedBelowBy_withUnitCost_query
+    [HasEvalSet m]
     (runtime : QueryRuntime spec m) (t : spec.Domain) :
     AddWriterT.QueryBoundedBelowBy
       (HasQuery.withUnitCost

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -8,6 +8,7 @@ import VCVio.OracleComp.HasQuery
 import VCVio.OracleComp.QueryTracking.CountingOracle
 import VCVio.EvalDist.Monad.Map
 import ToMathlib.General
+import ToMathlib.Probability.ProbabilityMassFunction.TailSums
 import Mathlib.Algebra.Order.Monoid.Defs
 import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
 
@@ -29,6 +30,7 @@ The main use cases are:
 -/
 
 open OracleSpec
+open scoped BigOperators
 
 /-- Bundled implementation of the oracle family `spec` in the ambient monad `m`. -/
 structure QueryRuntime {ι : Type} (spec : OracleSpec ι) (m : Type → Type*) where
@@ -185,6 +187,42 @@ noncomputable def expectedCost [HasEvalSPMF m]
 noncomputable abbrev expectedCostNat [HasEvalSPMF m] (oa : AddWriterT ℕ m α) : ENNReal :=
   expectedCost oa (fun n ↦ ↑n)
 
+/-- Tail-sum formula for the natural-valued expected cost of an `AddWriterT` computation:
+
+`E[cost] = ∑ i, Pr[i < cost]`.
+
+This is the standard discrete expectation identity specialized to the writer-cost marginal. -/
+lemma expectedCostNat_eq_tsum_tail_probs [HasEvalSPMF m] (oa : AddWriterT ℕ m α) :
+    expectedCostNat oa = ∑' i : ℕ, Pr[ fun c ↦ i < c | oa.costs ] := by
+  unfold expectedCostNat expectedCost
+  calc
+    ∑' n : ℕ, Pr[= n | oa.costs] * (n : ENNReal)
+        = ∑' i : ℕ, ∑' n : ℕ, if i < n then Pr[= n | oa.costs] else 0 :=
+          ENNReal.tsum_mul_nat_eq_tsum_tail (fun n ↦ Pr[= n | oa.costs])
+    _ = ∑' i : ℕ, Pr[ fun c ↦ i < c | oa.costs ] := by
+          refine tsum_congr fun i ↦ ?_
+          rw [probEvent_eq_tsum_indicator]
+          refine tsum_congr fun n ↦ ?_
+          by_cases h : i < n <;> simp [Set.indicator, h]
+
+/-- Finite tail-sum formula for natural-valued writer cost under a pathwise upper bound.
+
+If every execution path of `oa` incurs cost at most `n`, then the tail probabilities vanish above
+`n`, so the infinite tail sum truncates to `Finset.range n`. -/
+lemma expectedCostNat_eq_sum_tail_probs_of_pathwiseCostAtMost
+    [HasEvalSPMF m] [LawfulMonad m] {oa : AddWriterT ℕ m α} {n : ℕ}
+    (h : PathwiseCostAtMost oa n) :
+    expectedCostNat oa = ∑ i ∈ Finset.range n, Pr[ fun c ↦ i < c | oa.costs ] := by
+  rw [expectedCostNat_eq_tsum_tail_probs]
+  symm
+  rw [tsum_eq_sum (s := Finset.range n) (fun b hb => ?_)]
+  · have hnb : n ≤ b := Nat.le_of_not_lt (by simpa [Finset.mem_range] using hb)
+    refine probEvent_eq_zero ?_
+    intro c hc
+    rw [AddWriterT.costs_def, support_map] at hc
+    rcases hc with ⟨z, hz, rfl⟩
+    exact not_lt_of_ge (le_trans (h z hz) hnb)
+
 omit [AddMonoid ω] in
 lemma expectedCost_le_of_support_bound [HasEvalSPMF m]
     (oa : AddWriterT ω m α) (val : ω → ENNReal) (c : ENNReal)
@@ -250,6 +288,38 @@ lemma expectedCost_ge_of_pathwiseCostAtLeast [LawfulMonad m] [Preorder ω] [HasE
                 (by simpa [AddWriterT.costs_def] using hc)
             rw [hp]
             simp
+
+omit [AddMonoid ω] in
+lemma expectedCost_eq_tsum_outputs_of_costsAs [HasEvalSPMF m] [LawfulMonad m]
+    {oa : AddWriterT ω m α} {f : α → ω} {val : ω → ENNReal}
+    (h : oa.CostsAs f) :
+    expectedCost oa val = ∑' a : α, Pr[= a | oa.outputs] * val (f a) := by
+  classical
+  letI : DecidableEq ω := Classical.decEq ω
+  unfold expectedCost
+  rw [h]
+  simp_rw [probOutput_map_eq_tsum]
+  calc
+    ∑' w : ω, (∑' a : α, Pr[= a | oa.outputs] * Pr[= w | (pure (f a) : m ω)]) * val w
+      = ∑' w : ω, ∑' a : α, Pr[= a | oa.outputs] *
+          (Pr[= w | (pure (f a) : m ω)] * val w) := by
+            refine tsum_congr fun w => ?_
+            simpa [mul_assoc] using
+              (ENNReal.tsum_mul_right
+                (f := fun a : α =>
+                  Pr[= a | oa.outputs] * Pr[= w | (pure (f a) : m ω)])
+                (a := val w)).symm
+    _ = ∑' a : α, ∑' w : ω, Pr[= a | oa.outputs] *
+          (Pr[= w | (pure (f a) : m ω)] * val w) := by
+            rw [ENNReal.tsum_comm]
+    _ = ∑' a : α, Pr[= a | oa.outputs] *
+          ∑' w : ω, Pr[= w | (pure (f a) : m ω)] * val w := by
+            refine tsum_congr fun a => by
+              rw [← ENNReal.tsum_mul_left]
+    _ = ∑' a : α, Pr[= a | oa.outputs] * val (f a) := by
+            refine tsum_congr fun a => by
+              letI : DecidableEq ω := Classical.decEq ω
+              simp
 
 end expectedCost
 
@@ -785,11 +855,49 @@ noncomputable def expectedQueryCost {ω : Type} [AddMonoid ω]
     (costFn : spec.Domain → ω) (val : ω → ENNReal) : ENNReal :=
   AddWriterT.expectedCost (HasQuery.withAddCost oa runtime costFn) val
 
+/-- The marginal distribution of weighted query costs induced by running `oa` in `runtime` with
+query-cost function `costFn`. -/
+def queryCostDist {ω : Type} [AddMonoid ω]
+    (oa : Computation spec (AddWriterT ω m) α) (runtime : QueryRuntime spec m)
+    (costFn : spec.Domain → ω) : m ω :=
+  AddWriterT.costs (HasQuery.withAddCost oa runtime costFn)
+
+/-- The marginal distribution of the unit-cost query count induced by running `oa` in `runtime`. -/
+abbrev queryCountDist
+    (oa : Computation spec (AddWriterT ℕ m) α) (runtime : QueryRuntime spec m) : m ℕ :=
+  HasQuery.queryCostDist oa runtime (fun _ ↦ 1)
+
 /-- Expected number of oracle queries made by `oa` when run in `runtime`, counting each query
 with unit additive cost. -/
 noncomputable abbrev expectedQueries
     (oa : Computation spec (AddWriterT ℕ m) α) (runtime : QueryRuntime spec m) : ENNReal :=
   HasQuery.expectedQueryCost oa runtime (fun _ ↦ 1) (fun n ↦ (n : ENNReal))
+
+/-- Tail-sum formula for the expected number of oracle queries made by `oa` in `runtime`:
+
+`E[number of queries] = ∑ i, Pr[i < number of queries]`.
+
+This is the generic `HasQuery` version of [`AddWriterT.expectedCostNat_eq_tsum_tail_probs`]. -/
+lemma expectedQueries_eq_tsum_tail_probs
+    (oa : Computation spec (AddWriterT ℕ m) α) (runtime : QueryRuntime spec m) :
+    HasQuery.expectedQueries oa runtime =
+      ∑' i : ℕ, Pr[ fun c ↦ i < c | HasQuery.queryCountDist oa runtime ] := by
+  simpa [HasQuery.expectedQueries, HasQuery.expectedQueryCost] using
+    AddWriterT.expectedCostNat_eq_tsum_tail_probs (oa := HasQuery.withUnitCost oa runtime)
+
+/-- Finite tail-sum formula for expected query count under a pathwise upper bound.
+
+If `oa` uses at most `n` oracle queries in every execution, then its expected query count is the
+finite sum of the probabilities that the query count exceeds `i`, for `i < n`. -/
+lemma expectedQueries_eq_sum_tail_probs_of_usesAtMostQueries [LawfulMonad m]
+    {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryRuntime spec m} {n : ℕ}
+    (h : HasQuery.UsesAtMostQueries oa runtime n) :
+    HasQuery.expectedQueries oa runtime =
+      ∑ i ∈ Finset.range n, Pr[ fun c ↦ i < c | HasQuery.queryCountDist oa runtime ] := by
+  simpa [HasQuery.expectedQueries, HasQuery.expectedQueryCost, HasQuery.queryCountDist,
+    HasQuery.withUnitCost, HasQuery.queryCostDist] using
+    (AddWriterT.expectedCostNat_eq_sum_tail_probs_of_pathwiseCostAtMost
+      (oa := HasQuery.withUnitCost oa runtime) h)
 
 lemma expectedQueryCost_le_of_usesCostAtMost
     {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
@@ -798,6 +906,18 @@ lemma expectedQueryCost_le_of_usesCostAtMost
     (h : HasQuery.UsesCostAtMost oa runtime costFn w) (hval : Monotone val) :
     HasQuery.expectedQueryCost oa runtime costFn val ≤ val w :=
   AddWriterT.expectedCost_le_of_pathwiseCostAtMost h hval
+
+lemma expectedQueryCost_eq_tsum_outputs_of_usesCostAs
+    {ω : Type} [AddMonoid ω] [LawfulMonad m]
+    {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryRuntime spec m}
+    {costFn : spec.Domain → ω} {f : α → ω} {val : ω → ENNReal}
+    (h : HasQuery.UsesCostAs oa runtime costFn f) :
+    HasQuery.expectedQueryCost oa runtime costFn val =
+      ∑' a : α,
+        Pr[= a | AddWriterT.outputs (HasQuery.withAddCost oa runtime costFn)] * val (f a) := by
+  simpa [HasQuery.expectedQueryCost, HasQuery.UsesCostAs] using
+    (AddWriterT.expectedCost_eq_tsum_outputs_of_costsAs
+      (oa := HasQuery.withAddCost oa runtime costFn) (f := f) (val := val) h)
 
 lemma expectedQueries_le_of_usesAtMostQueries [LawfulMonad m]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryRuntime spec m} {n : ℕ}

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -1160,9 +1160,9 @@ syntax:max "ExpectedQueries[ " term " in " term " ]" : term
 
 macro_rules
   | `(ExpectedQueries[ $oa in $runtime ]) =>
-      `(HasQuery.expectedQueryCost
+      `(HasQuery.expectedQueries
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
-          $runtime (fun _ ↦ 1) (fun n ↦ (n : ENNReal)))
+          $runtime)
 
 end costAccounting
 

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -270,6 +270,16 @@ lemma pathwiseCostAtLeast_monadLift [LawfulMonad m] (x : m α) :
   rcases hz with ⟨a, _, rfl⟩
   simp
 
+lemma pathwiseCostAtMost_probCompLift [LawfulMonad m] [MonadLiftT ProbComp m] (x : ProbComp α) :
+    PathwiseCostAtMost (monadLift x : AddWriterT ω m α) 0 := by
+  change PathwiseCostAtMost (monadLift ((liftM x : m α)) : AddWriterT ω m α) 0
+  exact pathwiseCostAtMost_monadLift (m := m) (x := (liftM x : m α))
+
+lemma pathwiseCostAtLeast_probCompLift [LawfulMonad m] [MonadLiftT ProbComp m] (x : ProbComp α) :
+    PathwiseCostAtLeast (monadLift x : AddWriterT ω m α) 0 := by
+  change PathwiseCostAtLeast (monadLift ((liftM x : m α)) : AddWriterT ω m α) 0
+  exact pathwiseCostAtLeast_monadLift (m := m) (x := (liftM x : m α))
+
 lemma pathwiseCostAtMost_mono {oa : AddWriterT ω m α} {w₁ w₂ : ω}
     (h : PathwiseCostAtMost oa w₁) (hw : w₁ ≤ w₂) :
     PathwiseCostAtMost oa w₂ := by
@@ -696,6 +706,18 @@ lemma usesCostAtLeast_of_usesCostExactly {ω : Type} [AddMonoid ω] [Preorder ω
     (h : HasQuery.UsesCostExactly oa runtime costFn w) (hbw : b ≤ w) :
     HasQuery.UsesCostAtLeast oa runtime costFn b :=
   AddWriterT.pathwiseCostAtLeast_of_hasCost h hbw
+
+lemma usesCostAtMost_query_of_le {ω : Type} [AddMonoid ω] [Preorder ω]
+    [LawfulMonad m] [HasEvalSet m]
+    (runtime : QueryRuntime spec m) (costFn : spec.Domain → ω) (t : spec.Domain) {b : ω}
+    (ht : costFn t ≤ b) :
+    HasQuery.UsesCostAtMost
+      (fun [HasQuery spec (AddWriterT ω m)] =>
+        HasQuery.query (spec := spec) (m := AddWriterT ω m) t)
+      runtime costFn b :=
+  usesCostAtMost_of_usesCostExactly
+    (hasCost_withAddCost_query (runtime := runtime) (costFn := costFn) (t := t))
+    ht
 
 /-- Unit-cost specialization: every query contributes cost `1`. -/
 def UsesExactlyQueries (oa : Computation spec (AddWriterT ℕ m) α)

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -582,9 +582,12 @@ variable [Monad m] [HasEvalSPMF m]
 /-- The expected weighted query cost of `oa`, instantiated in `runtime` and instrumented by
 `costFn`.
 
-This is the expectation of the additive cost marginal in the base monad's subdistribution
-semantics. For unit-cost query counting, use [`HasQuery.expectedQueries`] below. -/
-noncomputable def expectedCost {ω : Type} [AddMonoid ω]
+This is the primary expectation notion for generic `HasQuery` computations. It is computed from
+the additive cost marginal in the base monad's subdistribution semantics, valued by `val`.
+
+The unit-cost query-counting notion [`HasQuery.expectedQueries`] is a specialization of this
+definition with `costFn := fun _ ↦ 1` and `val := fun n ↦ (n : ENNReal)`. -/
+noncomputable def expectedQueryCost {ω : Type} [AddMonoid ω]
     (oa : Computation spec (AddWriterT ω m) α) (runtime : QueryRuntime spec m)
     (costFn : spec.Domain → ω) (val : ω → ENNReal) : ENNReal :=
   AddWriterT.expectedCost (HasQuery.withAddCost oa runtime costFn) val
@@ -593,20 +596,25 @@ noncomputable def expectedCost {ω : Type} [AddMonoid ω]
 with unit additive cost. -/
 noncomputable abbrev expectedQueries
     (oa : Computation spec (AddWriterT ℕ m) α) (runtime : QueryRuntime spec m) : ENNReal :=
-  AddWriterT.expectedCostNat (HasQuery.withUnitCost oa runtime)
+  HasQuery.expectedQueryCost oa runtime (fun _ ↦ 1) (fun n ↦ (n : ENNReal))
 
-lemma expectedCost_le_of_usesCostAtMost {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
+lemma expectedQueryCost_le_of_usesCostAtMost
+    {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryRuntime spec m}
     {costFn : spec.Domain → ω} {w : ω} {val : ω → ENNReal}
     (h : HasQuery.UsesCostAtMost oa runtime costFn w) (hval : Monotone val) :
-    HasQuery.expectedCost oa runtime costFn val ≤ val w :=
+    HasQuery.expectedQueryCost oa runtime costFn val ≤ val w :=
   AddWriterT.expectedCost_le_of_pathwiseCostAtMost h hval
 
 lemma expectedQueries_le_of_usesAtMostQueries [LawfulMonad m]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryRuntime spec m} {n : ℕ}
     (h : HasQuery.UsesAtMostQueries oa runtime n) :
-    HasQuery.expectedQueries oa runtime ≤ n :=
-  AddWriterT.expectedCostNat_le_of_queryBoundedAboveBy h
+    HasQuery.expectedQueries oa runtime ≤ n := by
+  simpa [HasQuery.expectedQueries, HasQuery.expectedQueryCost] using
+    (AddWriterT.expectedCost_le_of_pathwiseCostAtMost
+      (oa := HasQuery.withUnitCost oa runtime) (w := n) (val := fun k ↦ (k : ENNReal)) h
+      (fun a b hle ↦ by
+        simpa using (Nat.cast_le.mpr hle : (a : ENNReal) ≤ (b : ENNReal))))
 
 end expectedCost
 
@@ -614,33 +622,39 @@ section expectedCostPMF
 
 variable [Monad m] [HasEvalPMF m]
 
-lemma expectedCost_ge_of_usesCostAtLeast {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
+lemma expectedQueryCost_ge_of_usesCostAtLeast
+    {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryRuntime spec m}
     {costFn : spec.Domain → ω} {w : ω} {val : ω → ENNReal}
     (h : HasQuery.UsesCostAtLeast oa runtime costFn w) (hval : Monotone val) :
-    val w ≤ HasQuery.expectedCost oa runtime costFn val := by
+    val w ≤ HasQuery.expectedQueryCost oa runtime costFn val := by
   have h' : AddWriterT.PathwiseCostAtLeast (HasQuery.withAddCost oa runtime costFn) w := by
     simpa [HasQuery.UsesCostAtLeast] using h
-  simpa [HasQuery.expectedCost] using
+  simpa [HasQuery.expectedQueryCost] using
     (AddWriterT.expectedCost_ge_of_pathwiseCostAtLeast
       (oa := HasQuery.withAddCost oa runtime costFn) (w := w) (val := val) h' hval)
 
-lemma expectedCost_eq_of_usesCostExactly {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
+lemma expectedQueryCost_eq_of_usesCostExactly
+    {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryRuntime spec m}
     {costFn : spec.Domain → ω} {w : ω} {val : ω → ENNReal}
     (h : HasQuery.UsesCostExactly oa runtime costFn w) (hval : Monotone val) :
-    HasQuery.expectedCost oa runtime costFn val = val w := by
+    HasQuery.expectedQueryCost oa runtime costFn val = val w := by
   exact le_antisymm
-    (expectedCost_le_of_usesCostAtMost
+    (expectedQueryCost_le_of_usesCostAtMost
       (usesCostAtMost_of_usesCostExactly h le_rfl) hval)
-    (expectedCost_ge_of_usesCostAtLeast
+    (expectedQueryCost_ge_of_usesCostAtLeast
       (usesCostAtLeast_of_usesCostExactly h le_rfl) hval)
 
 lemma expectedQueries_ge_of_usesAtLeastQueries [LawfulMonad m]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryRuntime spec m} {n : ℕ}
     (h : HasQuery.UsesAtLeastQueries oa runtime n) :
-    (n : ENNReal) ≤ HasQuery.expectedQueries oa runtime :=
-  AddWriterT.expectedCostNat_ge_of_queryBoundedBelowBy h
+    (n : ENNReal) ≤ HasQuery.expectedQueries oa runtime := by
+  simpa [HasQuery.expectedQueries, HasQuery.expectedQueryCost] using
+    (AddWriterT.expectedCost_ge_of_pathwiseCostAtLeast
+      (oa := HasQuery.withUnitCost oa runtime) (w := n) (val := fun k ↦ (k : ENNReal)) h
+      (fun a b hle ↦ by
+        simpa using (Nat.cast_le.mpr hle : (a : ENNReal) ≤ (b : ENNReal))))
 
 lemma expectedQueries_eq_of_usesAtMostQueries_of_usesAtLeastQueries
     [LawfulMonad m]
@@ -742,19 +756,36 @@ macro_rules
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT _ _)] → AddWriterT _ _ _))
           $runtime $costFn $w)
 
+/-- `ExpectedQueryCost[ oa in runtime by costFn via val ]` is the expected weighted query cost of
+`oa` when instantiated in `runtime`.
+
+Each query `t` contributes additive cost `costFn t`, and the total cost is then valued by
+`val : ω → ENNReal` before taking expectation. This is the primary expected-cost term for generic
+`HasQuery` constructions. -/
+syntax:max "ExpectedQueryCost[ " term " in " term " by " term " via " term " ]" : term
+
+macro_rules
+  | `(ExpectedQueryCost[ $oa in $runtime by $costFn via $val ]) =>
+      `(HasQuery.expectedQueryCost
+          (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT _ _)] → AddWriterT _ _ _))
+          $runtime $costFn $val)
+
 /-- `ExpectedQueries[ oa in runtime ]` is the expected number of oracle queries made by `oa` when
 run in `runtime`, with each query carrying unit additive cost.
 
 The result is an `ℝ≥0∞` expectation, so it can be compared directly against natural-number
-bounds such as `ExpectedQueries[ oa in runtime ] ≤ n`. This is the expectation of the cost
-marginal, not a separate operational semantics. -/
+bounds such as `ExpectedQueries[ oa in runtime ] ≤ n`.
+
+This is the unit-cost specialization of
+[`ExpectedQueryCost[ oa in runtime by costFn via val ]`], with `costFn := fun _ ↦ 1` and
+`val := fun n ↦ (n : ENNReal)`. -/
 syntax:max "ExpectedQueries[ " term " in " term " ]" : term
 
 macro_rules
   | `(ExpectedQueries[ $oa in $runtime ]) =>
-      `(HasQuery.expectedQueries
+      `(HasQuery.expectedQueryCost
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
-          $runtime)
+          $runtime (fun _ ↦ 1) (fun n ↦ (n : ENNReal)))
 
 end costAccounting
 

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -731,6 +731,17 @@ macro_rules
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
           $runtime $n)
 
+/-- `QueryCost[ oa in runtime ] = n` is the unit-cost specialization of weighted query cost:
+each oracle query contributes additive cost `1`, so the total query cost is just the number of
+queries made by `oa`. -/
+syntax:max "QueryCost[ " term " in " term " ]" " = " term:50 : term
+
+macro_rules
+  | `(QueryCost[ $oa in $runtime ] = $w) =>
+      `(HasQuery.UsesExactlyQueries
+          (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
+          $runtime $w)
+
 /-- `QueryCost[ oa in runtime by costFn ] = w` means that `oa`, instantiated in `runtime` and
 instrumented so that each query `t` contributes cost `costFn t`, has constant total query cost
 `w`.
@@ -745,6 +756,16 @@ macro_rules
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT _ _)] → AddWriterT _ _ _))
           $runtime $costFn $w)
 
+/-- `QueryCost[ oa in runtime ] ≤ n` is the unit-cost specialization of pathwise query-cost upper
+bounds. It says that every execution of `oa` makes at most `n` oracle queries. -/
+syntax:max "QueryCost[ " term " in " term " ]" " ≤ " term:50 : term
+
+macro_rules
+  | `(QueryCost[ $oa in $runtime ] ≤ $w) =>
+      `(HasQuery.UsesAtMostQueries
+          (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
+          $runtime $w)
+
 /-- `QueryCost[ oa in runtime by costFn ] ≤ w` means that every execution path of `oa` has total
 query cost bounded above by `w` under the weighting function `costFn`.
 
@@ -757,6 +778,16 @@ macro_rules
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT _ _)] → AddWriterT _ _ _))
           $runtime $costFn $w)
 
+/-- `QueryCost[ oa in runtime ] ≥ n` is the unit-cost specialization of pathwise query-cost lower
+bounds. It says that every execution of `oa` makes at least `n` oracle queries. -/
+syntax:max "QueryCost[ " term " in " term " ]" " ≥ " term:50 : term
+
+macro_rules
+  | `(QueryCost[ $oa in $runtime ] ≥ $w) =>
+      `(HasQuery.UsesAtLeastQueries
+          (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
+          $runtime $w)
+
 /-- `QueryCost[ oa in runtime by costFn ] ≥ w` means that every execution path of `oa` has total
 query cost bounded below by `w` under the weighting function `costFn`.
 
@@ -768,6 +799,16 @@ macro_rules
       `(HasQuery.UsesCostAtLeast
           (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT _ _)] → AddWriterT _ _ _))
           $runtime $costFn $w)
+
+/-- `ExpectedQueryCost[ oa in runtime ]` is the expected number of oracle queries made by `oa`
+when run in `runtime`, viewed as the unit-cost specialization of weighted expected query cost. -/
+syntax:max "ExpectedQueryCost[ " term " in " term " ]" : term
+
+macro_rules
+  | `(ExpectedQueryCost[ $oa in $runtime ]) =>
+      `(HasQuery.expectedQueryCost
+          (((fun [HasQuery _ _] => $oa) : [HasQuery _ (AddWriterT ℕ _)] → AddWriterT ℕ _ _))
+          $runtime (fun _ ↦ 1) (fun n ↦ (n : ENNReal)))
 
 /-- `ExpectedQueryCost[ oa in runtime by costFn via val ]` is the expected weighted query cost of
 `oa` when instantiated in `runtime`.

--- a/docs/agents/query-tracking.md
+++ b/docs/agents/query-tracking.md
@@ -1,0 +1,334 @@
+# Query Tracking and Cost Semantics
+
+This guide explains the query-tracking stack in `VCVio/OracleComp/QueryTracking/`.
+
+The current design is intentionally **weighted-first**:
+
+- `QueryCost[...]` and `ExpectedQueryCost[...]` are the primary notions.
+- `Queries[...]` and `ExpectedQueries[...]` are the unit-cost specializations.
+
+The stack is also intentionally split into:
+
+- a generic `HasQuery` runtime layer
+- a thin `OracleComp` facade
+- a small `ToMathlib` probability layer for reusable tail-sum facts
+
+## Main Files
+
+| File | Role |
+|------|------|
+| `VCVio/OracleComp/QueryTracking/QueryRuntime.lean` | Generic query-cost accounting for `HasQuery` computations |
+| `VCVio/OracleComp/QueryTracking/CostModel.lean` | `OracleComp`-specific facade over the generic semantics |
+| `ToMathlib/Control/WriterT.lean` | Pathwise and output-indexed cost predicates for `AddWriterT` |
+| `ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean` | Generic PMF tail-sum identities used for expected runtime |
+
+## Layering
+
+### 1. `AddWriterT`: raw cost semantics
+
+The semantic core is a writer monad whose log records cost.
+
+At this level, the key notions are:
+
+- `AddWriterT.PathwiseCostAtMost`
+- `AddWriterT.PathwiseCostAtLeast`
+- `Cost[ oa ] = w`
+- `Cost[ oa ] ≤ w`
+- `Cost[ oa ] ≥ w`
+
+These are **pathwise** statements: they talk about every reachable execution path.
+
+This file also defines the stronger, output-indexed notion:
+
+- `AddWriterT.CostsAs oa f`
+
+This means:
+
+- the cost of `oa` is completely determined by its output
+- there is a function `f` such that every reachable run producing `a` has cost `f a`
+
+That is stronger than a pathwise bound. It is useful when exact cost is determined by the final
+result, but it is not the default semantic notion.
+
+### 2. `QueryRuntime`: generic `HasQuery` accounting
+
+`QueryRuntime spec m` packages a concrete runtime for a generic `HasQuery spec m` world.
+
+This layer interprets generic constructions in:
+
+- the base monad `m`
+- the instrumented monad `AddWriterT ω m`
+
+and exposes the public API:
+
+- exact weighted cost:
+  `QueryCost[ oa in runtime by costFn ] = w`
+- weighted upper/lower bounds:
+  `QueryCost[ oa in runtime by costFn ] ≤ w`
+  `QueryCost[ oa in runtime by costFn ] ≥ w`
+- exact / bounded unit-cost query counting:
+  `Queries[ oa in runtime ] = n`
+  `Queries[ oa in runtime ] ≤ n`
+  `Queries[ oa in runtime ] ≥ n`
+- expected weighted cost:
+  `ExpectedQueryCost[ oa in runtime by costFn via val ]`
+- expected unit-cost query count:
+  `ExpectedQueries[ oa in runtime ]`
+
+The intended reading is:
+
+- `QueryCost[...]` is the general notion
+- `Queries[...]` means the same thing with `costFn := fun _ ↦ 1`
+
+### 3. `CostModel`: `OracleComp` facade
+
+`CostModel.lean` should be read as a free-`OracleComp` view of the same semantics, not as a
+second independent cost semantics.
+
+The important design point is:
+
+- `QueryRuntime` and `AddWriterT` are the semantic core
+- `CostModel` is now a thin facade for `OracleComp`-specific theorems and asymptotic packaging
+
+Use `CostModel` when you want:
+
+- the free-oracle viewpoint
+- `OracleComp`-specific reductions
+- the older asymptotic query-cost packaging
+
+Use `QueryRuntime` when you want:
+
+- a generic theorem over any `HasQuery` construction
+- runtime-instantiated cryptographic constructions
+- weighted expected cost and expected query count
+
+### 4. `ToMathlib`: generic probability facts
+
+Expected-cost proofs should avoid hard-coding query semantics when the real theorem is purely
+probabilistic.
+
+`ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean` contains the generic discrete
+tail-sum identities used by the query-runtime layer:
+
+- `E[T] = ∑ Pr[i < T]`
+- tail domination implies expectation domination
+
+This keeps the query-runtime layer small and makes the stopping-time machinery more plausibly
+upstreamable.
+
+## Three Cost Notions
+
+There are three distinct notions in the current API.
+
+### Pathwise cost
+
+Use this when the statement is about **all runs**.
+
+Examples:
+
+- encryption uses at most one query
+- decryption uses at least zero queries
+- signing uses at most `ρ * |Ω|` queries
+
+This is the natural meaning of:
+
+- `QueryCost[...] ≤ w`
+- `Queries[...] ≤ n`
+
+### Output-indexed cost
+
+Use this when cost is determined by the final output.
+
+Examples:
+
+- a single Fiat-Shamir signing attempt queries exactly the returned commitment
+- a verification procedure always makes a fixed number of queries determined by its output shape
+
+This is expressed by:
+
+- `UsesCostAs`
+- `CostsAs`
+
+and is mainly useful as a bridge to exact expected-cost formulas.
+
+### Expected cost
+
+Use this when cost is random and pathwise exact equalities are not the right public theorem.
+
+Examples:
+
+- Fischlin signing has expected query count at most `ρ * |Ω|`
+- Fiat-Shamir-with-aborts signing has expected query count equal to a tail sum
+
+This is expressed by:
+
+- `ExpectedQueryCost[...]`
+- `ExpectedQueries[...]`
+
+## When To Prove Which Theorem
+
+### Prove exact pathwise cost
+
+Use an exact pathwise theorem when every run really has the same cost.
+
+Examples:
+
+- `FiatShamir.verify` uses exactly one query
+- `TTransform.encrypt` uses exactly one query
+- `Fischlin.verify` uses exactly `ρ` queries
+
+### Prove `UsesCostAs`
+
+Use `UsesCostAs` when cost is a function of the output, and you want an expectation theorem of the
+form “expected cost is the expectation of `val ∘ f` over outputs.”
+
+Example:
+
+- one `FiatShamirWithAbort` signing attempt
+
+Do **not** force this notion onto retry loops or search procedures whose cost is not determined by
+the final output.
+
+### Prove a pathwise upper bound
+
+Use a pathwise upper bound when branching or retrying changes the cost across runs.
+
+Examples:
+
+- `TTransform.decrypt` uses at most one query
+- `FiatShamirWithAbort.sign` uses at most `maxAttempts` queries
+- Fischlin signing uses at most `ρ * |Ω|` queries
+
+These are the right first theorems for search loops, aborting schemes, and stopping-time style
+computations.
+
+### Prove expectation via a bridge
+
+After a pathwise bound or a `UsesCostAs` theorem is in place, derive expectation theorems using the
+generic bridge lemmas in `QueryRuntime.lean`.
+
+There are two main patterns:
+
+- `UsesCostAs` gives an exact output-expectation formula
+- pathwise bounds give expectation upper/lower bounds
+
+For natural-valued costs, the tail-sum lemmas give sharper expectation theorems.
+
+## Notation Guide
+
+### Weighted cost
+
+```lean
+QueryCost[ oa in runtime by costFn ] = w
+QueryCost[ oa in runtime by costFn ] ≤ w
+QueryCost[ oa in runtime by costFn ] ≥ w
+```
+
+### Unit-cost query counting
+
+```lean
+Queries[ oa in runtime ] = n
+Queries[ oa in runtime ] ≤ n
+Queries[ oa in runtime ] ≥ n
+```
+
+These are just the weighted statements specialized to `fun _ ↦ 1`.
+
+### Expected weighted cost
+
+```lean
+ExpectedQueryCost[ oa in runtime by costFn via val ]
+```
+
+The `val` parameter interprets the weighted cost in `ENNReal`. For unit-count expectations, use:
+
+```lean
+ExpectedQueries[ oa in runtime ]
+```
+
+## Worked Examples
+
+### Fiat-Shamir
+
+See `VCVio/CryptoFoundations/FiatShamir.lean`.
+
+This is the clean “exact one query” example.
+
+- signing and verification support exact unit-cost statements
+- the single-query cost is also a good example of `UsesCostAs`
+
+### Fischlin
+
+See `VCVio/CryptoFoundations/Fischlin.lean`.
+
+This is the first substantial bounded-cost example.
+
+- verification uses exactly `ρ` queries
+- signing uses at most `ρ * |Ω|`
+- the weighted theorem layer generalizes the unit-cost one
+
+This file is the best reference for:
+
+- weighted pathwise upper bounds
+- expected weighted cost from pathwise bounds
+
+### T-transform and U-transform
+
+See:
+
+- `VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean`
+- `VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean`
+
+These illustrate:
+
+- exact cost theorems for simple FO-style constructions
+- upper bounds for branch-sensitive decryption
+- weighted multi-query accounting
+
+### Fiat-Shamir with aborts
+
+See `VCVio/CryptoFoundations/FiatShamirWithAbort.lean`.
+
+This is the main stopping-time example.
+
+The key progression is:
+
+1. one attempt has output-determined cost
+2. the full retry loop has only a pathwise upper bound
+3. expected query count is expressed by a tail sum
+4. the tail sum is rewritten semantically in terms of abort-prefix probabilities
+5. geometric upper bounds follow from bounds on the one-step abort probability
+
+This is the main reference for:
+
+- tail-sum expectation theorems
+- stopping-time style query bounds
+
+## Typeclass Hygiene
+
+The query-tracking files now try to keep theorem signatures narrow.
+
+Preferred pattern:
+
+- put only genuinely shared assumptions in section variable blocks
+- localize `HasEvalSet`, `HasEvalSPMF`, `HasEvalPMF`, and `LawfulMonad` to the smallest section or
+  theorem that needs them
+- if a proof needs extra decidability or classical choice, install it locally with `classical` or
+  a local instance
+
+Avoid:
+
+- wide sections followed by repeated `omit ... in`
+- theorem statements carrying large blocks of unused typeclass assumptions
+
+## Implementation Pattern
+
+When adding a new example or construction:
+
+1. Prove the pathwise exact/bounded theorem first.
+2. If cost is output-determined, add a `UsesCostAs` theorem.
+3. Derive expected-cost theorems from those generic bridges.
+4. If the cost is natural-valued and behaves like a stopping time, look for a tail-sum theorem
+   rather than forcing a coarse worst-case expectation bound.
+
+This keeps the theorem layer mathematically honest and makes the public API easier to read.

--- a/scripts/style-exceptions.txt
+++ b/scripts/style-exceptions.txt
@@ -1,1 +1,2 @@
 ToMathlib/Control/WriterT.lean : line 6 : ERR_MOD : Module docstring missing, or too late
+ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean : line 6 : ERR_MOD : Module docstring missing, or too late


### PR DESCRIPTION
## Summary
- make weighted query cost, rather than unit query count, the primary `QueryRuntime` / `CostModel` interface
- add generic `PMF` tail-sum and expectation-domination lemmas in `ToMathlib`, then use them to derive exact and geometric expected-query theorems for Fiat-Shamir with aborts
- generalize the construction-level accounting layer across Fiat-Shamir, Fischlin, the FO T-transform, and the FO U-transform to support weighted pathwise and expected query-cost bounds
- unify the `OracleComp` cost facade around `instrumentedRun`, update the FO runtime plumbing in `Composed`, and refresh downstream call sites such as ML-KEM security

## Highlights
- `QueryRuntime`
  - makes `expectedQueryCost` the primary notion and defines `expectedQueries` as the unit-cost specialization
  - extends `QueryCost[...]` and `ExpectedQueryCost[...]` so weighted costs are first-class while `Queries[...]` and `ExpectedQueries[...]` remain readable unit-cost aliases
  - adds weighted pathwise combinators, output-determined expectation bridges, and tail-probability-to-expectation lemmas
- `ToMathlib`
  - adds `PMF` tail-sum identities and expectation domination lemmas in `ToMathlib/Probability/ProbabilityMassFunction/TailSums`
- `CryptoFoundations`
  - `FiatShamir`: weighted exact and expected query-cost theorems
  - `Fischlin`: weighted pathwise and expected signing bounds
  - `TTransform`: weighted exact / zero / upper-bound query-cost theorems
  - `UTransform`: weighted family-cost bounds, expected-cost theorems, and unit-cost corollaries
  - `FiatShamirWithAbort`: pathwise bounds, exact tail formulas, abort-prefix interpretations, and geometric expected-query bounds
- `CostModel` / downstream cleanup
  - refactors `CostModel` into a thin `OracleComp` facade over the generic instrumentation core via `instrumentedRun`
  - simplifies the FO runtime surface in `Composed`
  - updates the ML-KEM security proof call site to the new FO runtime signature

## Verification
- `python3 scripts/lint-style.py ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean VCVio/OracleComp/QueryTracking/QueryRuntime.lean VCVio/OracleComp/QueryTracking/CostModel.lean VCVio/CryptoFoundations/FiatShamir.lean VCVio/CryptoFoundations/FiatShamirWithAbort.lean VCVio/CryptoFoundations/Fischlin.lean VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean LatticeCrypto/MLKEM/Security.lean`
- `lake build ToMathlib.Probability.ProbabilityMassFunction.TailSums VCVio.OracleComp.QueryTracking.QueryRuntime VCVio.OracleComp.QueryTracking.CostModel VCVio.CryptoFoundations.FiatShamir VCVio.CryptoFoundations.FiatShamirWithAbort VCVio.CryptoFoundations.Fischlin VCVio.CryptoFoundations.FujisakiOkamoto.TTransform VCVio.CryptoFoundations.FujisakiOkamoto.UTransform VCVio.CryptoFoundations.FujisakiOkamoto.Composed LatticeCrypto.MLKEM.Security`
- `lake build VCVio`
- `git diff --check`
- GitHub Actions PR checks are green on `5220b11`

This PR body was updated by the assistant on behalf of Quang Dao using GPT-5 Codex.
