### PR TITLE
Remove redundant `by exact` and `by rfl` tactic wrappers

### DIFF
--- a/Examples/ElGamal/Basic.lean
+++ b/Examples/ElGamal/Basic.lean
@@ -274,8 +274,8 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
               true)
     _ = Pr[= true | do
           let pk ← ($ᵗ G : ProbComp G)
-          ($ᵗ Bool : ProbComp Bool)] := by
-      exact probOutput_bind_congr' ($ᵗ G) true (fun pk => by
+          ($ᵗ Bool : ProbComp Bool)] :=
+      probOutput_bind_congr' ($ᵗ G) true (fun pk => by
         simpa [probOutput_uniformSample] using hhalf pk)
     _ = 1 / 2 := by
       rw [probOutput_bind_eq_tsum]
@@ -316,8 +316,8 @@ theorem elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
         Pr[= true | AsymmEncAlg.IND_CPA_OneTime_Game_ProbComp
           (encAlg := elGamalAsymmEnc F G gen) adv] =
         Pr[= true | DiffieHellman.ddhExpReal (F := F) gen
-          (IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv)] := by
-      exact probOutput_congr rfl (IND_CPA_OneTime_game_evalDist_eq_ddhExpReal adv)
+          (IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv)] :=
+      probOutput_congr rfl (IND_CPA_OneTime_game_evalDist_eq_ddhExpReal adv)
     simpa [AsymmEncAlg.IND_CPA_OneTime_signedAdvantageReal] using
       congrArg (fun p : ℝ≥0∞ => |p.toReal - 1 / 2|) hprob
   have h_rand : (1 : ℝ) / 2 =
@@ -348,8 +348,8 @@ theorem elGamal_IND_CPA_le_q_mul_ddh
     |AsymmEncAlg.IND_CPA_OneTime_signedAdvantageReal
         (encAlg := elGamalAsymmEnc F G gen) adv|
       = 2 * DiffieHellman.ddhGuessAdvantage gen
-          (IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv) := by
-            exact elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
+          (IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv) :=
+            elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
               (F := F) (G := G) (gen := gen) hg adv
     _ ≤ 2 * ε := by
         linarith [hddh adv]

--- a/Examples/ElGamal/Hash.lean
+++ b/Examples/ElGamal/Hash.lean
@@ -422,8 +422,8 @@ theorem esIdeal_eq_half
         inner]
     _ = Pr[= true | do
           let hk ← ($ᵗ HK : ProbComp HK)
-          ($ᵗ Bool : ProbComp Bool)] := by
-      exact probOutput_bind_congr' ($ᵗ HK) true (fun hk => by
+          ($ᵗ Bool : ProbComp Bool)] :=
+      probOutput_bind_congr' ($ᵗ HK) true (fun hk => by
         simpa [probOutput_uniformSample] using hhalf hk)
     _ = 1 / 2 := by
       rw [probOutput_bind_eq_tsum]
@@ -482,8 +482,8 @@ theorem hashedElGamal_IND_CPA_bound
       |(Pr[= true | ddhExpReal g (ddhReduction (F := F) (hash := hash) adv)]).toReal -
           (Pr[= true | ddhExpRand g (ddhReduction (F := F) (hash := hash) adv)]).toReal| +
         |(Pr[= true | ddhExpRand g (ddhReduction (F := F) (hash := hash) adv)]).toReal -
-          (Pr[= true | EntropySmoothing.idealExp (esReduction (F := F) (g := g) adv)]).toReal| := by
-      exact abs_sub_le _ _ _
+          (Pr[= true | EntropySmoothing.idealExp (esReduction (F := F) (g := g) adv)]).toReal| :=
+      abs_sub_le _ _ _
     _ = ddhDistAdvantage g (ddhReduction (F := F) (hash := hash) adv) +
         |(Pr[= true |
           EntropySmoothing.realExp F g hash (esReduction (F := F) (g := g) adv)]).toReal -

--- a/Examples/ElGamal/ReductionCost.lean
+++ b/Examples/ElGamal/ReductionCost.lean
@@ -446,8 +446,7 @@ lemma IND_CPA_OneTime_DDHReduction_open_inRuntime
       (IND_CPA_OneTime_DDHReduction_open
         (State := adv.State) g A B T)
       (oneTimeINDCPARuntime (gen := gen) adv)
-      = IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv g A B T := by
-  rfl
+      = IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv g A B T := rfl
 
 /-- Cost-transform theorem for the closed one-time ElGamal DDH reduction.
 
@@ -626,8 +625,8 @@ lemma oneTimeINDCPASecurityGame_advantage_eq_oneTimeDDHReductionSecurityGame_adv
     |AsymmEncAlg.IND_CPA_OneTime_signedAdvantageReal
         (encAlg := elGamalAsymmEnc F G gen) adv| =
       2 * DiffieHellman.ddhGuessAdvantage gen
-        (IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv) := by
-          exact elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
+        (IND_CPA_OneTime_DDHReduction (F := F) (G := G) (gen := gen) adv) :=
+          elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
             (F := F) (G := G) (gen := gen) hg adv
     _ =
       DiffieHellman.ddhDistAdvantage gen

--- a/Examples/OneTimePad.lean
+++ b/Examples/OneTimePad.lean
@@ -86,8 +86,8 @@ lemma cipherGivenMsg_equiv (sp : ℕ) (msg₀ msg₁ : BitVec sp) :
       (oneTimePad.PerfectSecrecyCipherGivenMsgExp sp msg₁) := by
   simp only [SymmEncAlg.PerfectSecrecyCipherGivenMsgExp, oneTimePad, simulateQ_id']
   let c := msg₀ ^^^ msg₁
-  have hxor : Function.Bijective (fun x : BitVec sp => x ^^^ c) := by
-    exact Function.Involutive.bijective fun x => by
+  have hxor : Function.Bijective (fun x : BitVec sp => x ^^^ c) :=
+    Function.Involutive.bijective fun x => by
       rw [BitVec.xor_assoc, BitVec.xor_self, BitVec.xor_zero]
   change GameEquiv (($ᵗ BitVec sp) >>= fun k => pure (k ^^^ msg₀))
     (($ᵗ BitVec sp) >>= fun k => pure (k ^^^ msg₁))

--- a/LatticeCrypto/DiscreteGaussian.lean
+++ b/LatticeCrypto/DiscreteGaussian.lean
@@ -85,8 +85,8 @@ theorem discreteGaussianSum_summable (σ μ : ℝ) (hσ : 0 < σ) :
 
 /-- The discrete Gaussian normalizing constant is strictly positive when `σ > 0`. -/
 theorem discreteGaussianSum_pos (σ μ : ℝ) (hσ : 0 < σ) :
-    0 < discreteGaussianSum σ μ := by
-  exact (discreteGaussianSum_summable σ μ hσ).tsum_pos
+    0 < discreteGaussianSum σ μ :=
+  (discreteGaussianSum_summable σ μ hσ).tsum_pos
     (fun z => discreteGaussianWeight_nonneg σ μ z) 0
     (discreteGaussianWeight_pos σ μ 0)
 

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -341,10 +341,9 @@ private theorem decomposeCoeff_eq (r : Coeff) {gamma2 : ℕ} (hγ : 0 < gamma2) 
     exact Nat.mod_add_div _ _
   have hdiv' : ((t + alpha * (r.val / alpha) : ℕ) : Coeff) = r := by
     calc
-      ((t + alpha * (r.val / alpha) : ℕ) : Coeff) = (r.val : Coeff) := by
-        exact congrArg (fun n : ℕ => (n : Coeff)) hdiv
-      _ = r := by
-        exact ZMod.natCast_zmod_val r
+      ((t + alpha * (r.val / alpha) : ℕ) : Coeff) = (r.val : Coeff) :=
+        congrArg (fun n : ℕ => (n : Coeff)) hdiv
+      _ = r := ZMod.natCast_zmod_val r
   by_cases h : t ≤ alpha / 2
   · have base : ((alpha : Coeff) * ((r.val / alpha : ℕ) : Coeff)) + intToCoeff (t : ℤ) = r := by
       calc
@@ -704,8 +703,8 @@ private theorem highBitsCoeff_add_eq_of_small_of_isApproved (p : Params)
   have hvlower : -((p.gamma2 - 1 : ℕ) : ℤ) ≤ v := by
     dsimp [v]
     omega
-  have hvbound : v.natAbs ≤ p.gamma2 - 1 := by
-    exact natAbs_le_of_bounds hvlower hvupper
+  have hvbound : v.natAbs ≤ p.gamma2 - 1 :=
+    natAbs_le_of_bounds hvlower hvupper
   have hzcast : s = intToCoeff z := by
     simpa [z] using centeredRepr_cast s
   have hcandidate : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v = r + s := by
@@ -729,14 +728,14 @@ private theorem highBitsCoeff_add_eq_of_small_of_isApproved (p : Params)
     omega
   have hdifflower : -((alpha - 1 : ℕ) : ℤ) ≤ v - w := by
     omega
-  have hdiffbound : (v - w).natAbs ≤ alpha - 1 := by
-    exact natAbs_le_of_bounds hdifflower hdiffupper
-  have hrepr_diff : LatticeCrypto.centeredRepr (intToCoeff (v - w)) = v - w := by
-    exact centeredRepr_eq_of_natAbs_le (z := v - w) hdiffbound hsmallq
+  have hdiffbound : (v - w).natAbs ≤ alpha - 1 :=
+    natAbs_le_of_bounds hdifflower hdiffupper
+  have hrepr_diff : LatticeCrypto.centeredRepr (intToCoeff (v - w)) = v - w :=
+    centeredRepr_eq_of_natAbs_le (z := v - w) hdiffbound hsmallq
   have heq :
       (((alpha : ℕ) : Coeff) * (u : Coeff)) + intToCoeff w =
-        (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v := by
-    exact hdecomp_rs.trans hcandidate.symm
+        (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v :=
+    hdecomp_rs.trans hcandidate.symm
   have hneq' : u ≠ r1 := by
     simpa [u, r1, decrs, decr, highBitsCoeff] using hneq
   have hlt_or_gt : r1 < u ∨ u < r1 := lt_or_gt_of_ne hneq'.symm
@@ -821,8 +820,8 @@ private theorem highBitsCoeff_add_eq_of_small_of_isApproved (p : Params)
         have hwvupper : w - v ≤ ((alpha - 1 : ℕ) : ℤ) := by omega
         have hwvlower : -((alpha - 1 : ℕ) : ℤ) ≤ w - v := by omega
         exact natAbs_le_of_bounds hwvlower hwvupper
-      have hrepr_diff' : LatticeCrypto.centeredRepr (intToCoeff (w - v)) = w - v := by
-        exact centeredRepr_eq_of_natAbs_le (z := w - v) hdiffbound' hsmallq
+      have hrepr_diff' : LatticeCrypto.centeredRepr (intToCoeff (w - v)) = w - v :=
+        centeredRepr_eq_of_natAbs_le (z := w - v) hdiffbound' hsmallq
       have hrepr_eq := congrArg LatticeCrypto.centeredRepr hdeltaeq
       rw [hrepr_diff'] at hrepr_eq
       have hbig' : alpha ≤ (w - v).natAbs := by
@@ -848,8 +847,8 @@ private theorem highBitsCoeff_nonneg_repr_of_isApproved (p : Params)
     simpa [alpha, m] using alphaMulUseHintModulus_eq_modulus_sub_one_of_isApproved p hp
   have hu_lt_m : u < m := by
     simpa [alpha, m] using hu
-  have huqm1 : alpha * u < modulus - 1 := by
-    exact lt_of_lt_of_eq (Nat.mul_lt_mul_of_pos_left hu_lt_m hα) hqm1
+  have huqm1 : alpha * u < modulus - 1 :=
+    lt_of_lt_of_eq (Nat.mul_lt_mul_of_pos_left hu_lt_m hα) hqm1
   have hltα : n < alpha := by
     dsimp [alpha]
     omega
@@ -911,8 +910,8 @@ private theorem highBitsCoeff_neg_repr_of_isApproved (p : Params)
     simpa [alpha, m] using alphaMulUseHintModulus_eq_modulus_sub_one_of_isApproved p hp
   have hu_lt_m : u < m := by
     simpa [alpha, m] using hu
-  have huqm1 : alpha * u < modulus - 1 := by
-    exact lt_of_lt_of_eq (Nat.mul_lt_mul_of_pos_left hu_lt_m hα) hqm1
+  have huqm1 : alpha * u < modulus - 1 :=
+    lt_of_lt_of_eq (Nat.mul_lt_mul_of_pos_left hu_lt_m hα) hqm1
   have hltαn : n < alpha := by
     dsimp [alpha]
     omega
@@ -926,8 +925,8 @@ private theorem highBitsCoeff_neg_repr_of_isApproved (p : Params)
     calc
       alpha = alpha * 1 := by ring
       _ ≤ alpha * u := Nat.mul_le_mul_left alpha (show 1 ≤ u by omega)
-  have hltq : alpha * u - n < modulus := by
-    exact lt_of_le_of_lt (Nat.sub_le _ _) (lt_trans huqm1 (by omega))
+  have hltq : alpha * u - n < modulus :=
+    lt_of_le_of_lt (Nat.sub_le _ _) (lt_trans huqm1 (by omega))
   have hval :
       (intToCoeff (((alpha * u - n : ℕ) : ℤ))).val = alpha * u - n := by
     simpa [intToCoeff] using (ZMod.val_natCast_of_lt (n := modulus) (a := alpha * u - n) hltq)
@@ -945,8 +944,8 @@ private theorem highBitsCoeff_neg_repr_of_isApproved (p : Params)
                 _ = alpha * (u - 1) := by rw [Nat.add_sub_cancel]]
             rw [Nat.mul_comm]
       _ = (alpha - n) + (u - 1) * alpha := by rw [add_comm]
-  have hltα : alpha - n < alpha := by
-    exact Nat.sub_lt hα hn0
+  have hltα : alpha - n < alpha :=
+    Nat.sub_lt hα hn0
   have hmod : (alpha * u - n) % alpha = alpha - n := by
     rw [hrepr, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hltα]
   have hdiv : (alpha * u - n) / alpha = u - 1 := by
@@ -1424,8 +1423,8 @@ private theorem useHintCoeff_correct_of_small_of_isApproved (p : Params)
               rw [hvnat]
               exact_mod_cast hvupα
             exact_mod_cast this
-          have hnatabs_lt_alpha : v.natAbs < alpha := by
-            exact lt_of_le_of_ne hnatabs_le_alpha (by simpa using hvEqAlpha)
+          have hnatabs_lt_alpha : v.natAbs < alpha :=
+            lt_of_le_of_ne hnatabs_le_alpha (by simpa using hvEqAlpha)
           have hnatabs_gt_gamma : p.gamma2 < v.natAbs := by
             have : (p.gamma2 : ℤ) < ((v.natAbs : ℕ) : ℤ) := by
               rw [hvnat]

--- a/LatticeCrypto/MLDSA/Signature.lean
+++ b/LatticeCrypto/MLDSA/Signature.lean
@@ -166,8 +166,8 @@ private lemma fipsSignLoop_exists
     (sig : FIPSSignature p prims)
     (h : fipsSignLoop p prims nttOps sk aHat mu rhoDoublePrime maxAttempts = some sig) :
     ∃ i ∈ List.range maxAttempts,
-      fipsSignAttempt p prims nttOps sk aHat mu rhoDoublePrime (i * p.l) = some sig := by
-  exact List.exists_of_findSome?_eq_some h
+      fipsSignAttempt p prims nttOps sk aHat mu rhoDoublePrime (i * p.l) = some sig :=
+  List.exists_of_findSome?_eq_some h
 
 private lemma fipsSignAttempt_spec
     (sk : SecretKey p) (aHat : TqMatrix p.k p.l)

--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -305,8 +305,8 @@ private theorem byteDecode_byteEncode_of_bound {d : Nat} (hd : 0 < d) (f : Rq)
   apply Vector.ext
   intro i hi
   have hcoeffBound : ((f[i]'hi : Coeff).val) < 2 ^ d := hbound ⟨i, hi⟩
-  have hlenDigits : (Nat.digitsAppend 2 d ((f[i]'hi : Coeff).val)).length = d := by
-    exact Nat.length_digitsAppend (by decide) d hcoeffBound
+  have hlenDigits : (Nat.digitsAppend 2 d ((f[i]'hi : Coeff).val)).length = d :=
+    Nat.length_digitsAppend (by decide) d hcoeffBound
   have hcoeffBits :
       List.ofFn (fun j : Fin d =>
         (bytesToBits (byteEncode d f)).getD (i * d + j.val) 0)
@@ -344,13 +344,13 @@ private theorem byteDecode_byteEncode_of_bound {d : Nat} (hd : 0 < d) (f : Rq)
       simpa [hroundtripBitsLen] using hijBits
     have hleft :
         (bytesToBits (bitsToBytes bits)).getD (i * d + j.val) 0 =
-          (bytesToBits (bitsToBytes bits))[i * d + j.val] := by
-      exact array_getD_eq_getElem (a := bytesToBits (bitsToBytes bits)) (i := i * d + j.val)
+          (bytesToBits (bitsToBytes bits))[i * d + j.val] :=
+      array_getD_eq_getElem (a := bytesToBits (bitsToBytes bits)) (i := i * d + j.val)
         (fallback := 0) hijRound
     have hdigitElem :
         (Nat.digitsAppend 2 d ((f[i]'hi : Coeff).val)).getD j.val 0 =
-          (Nat.digitsAppend 2 d ((f[i]'hi : Coeff).val))[j.val] := by
-      exact List.getD_eq_getElem _ _ (by
+          (Nat.digitsAppend 2 d ((f[i]'hi : Coeff).val))[j.val] :=
+      List.getD_eq_getElem _ _ (by
         rw [hlenDigits]
         exact j.isLt)
     have hbitPos :
@@ -392,8 +392,8 @@ private theorem byteDecode_byteEncode_of_bound {d : Nat} (hd : 0 < d) (f : Rq)
 
 private theorem byteDecode_one_coeff (bytes : ByteArray) (idx : Fin ringDegree) :
     ((byteDecode 1 bytes).get idx : Coeff).val = (bytesToBits bytes).getD idx.val 0 := by
-  have hbitMod : (bytesToBits bytes).getD idx.val 0 < modulus := by
-    exact lt_trans (bytesToBits_getD_lt_two bytes idx.val) (by decide)
+  have hbitMod : (bytesToBits bytes).getD idx.val 0 < modulus :=
+    lt_trans (bytesToBits_getD_lt_two bytes idx.val) (by decide)
   have hcast :
       (((bytesToBits bytes).getD idx.val 0 : Nat) : Coeff).val =
         (bytesToBits bytes).getD idx.val 0 :=
@@ -442,8 +442,8 @@ private def byteEncode12VecByte {k : Nat}
     (v : TqVec k) (idx : Fin (384 * k)) : UInt8 :=
   let poly := idx.val / 384
   let byte := idx.val % 384
-  have hpoly : poly < k := by
-    exact Nat.div_lt_of_lt_mul idx.isLt
+  have hpoly : poly < k :=
+    Nat.div_lt_of_lt_mul idx.isLt
   have hbyte : byte < 384 := Nat.mod_lt _ (by decide)
   byteEncode12PolyByte (v[poly]'hpoly) ⟨byte, hbyte⟩
 
@@ -502,8 +502,7 @@ private theorem getByteD_byteEncode12Poly (f : Tq) {j : Nat} (hj : j < 384) :
   simp [byteEncode12Poly]
 
 private theorem tq_getElem_eq_coeffs (f : Tq) {i : Nat} (hi : i < ringDegree) :
-    f[i] = f.coeffs[i] := by
-  rfl
+    f[i] = f.coeffs[i] := rfl
 
 /-- Encode a vector of `k` polynomials with 12-bit coefficients. -/
 def byteEncode12Vec {k : Nat} (v : TqVec k) : ByteArray :=
@@ -568,8 +567,8 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
       have hbMod : b % 16 < 16 := Nat.mod_lt _ (by decide)
       omega
     have hbDiv : b / 16 < 256 := by
-      have hb : b < 4096 := by
-        exact lt_trans (ZMod.val_lt _) (by decide)
+      have hb : b < 4096 :=
+        lt_trans (ZMod.val_lt _) (by decide)
       exact Nat.div_lt_of_lt_mul hb
     have hdiv0 : (3 * pair) / 3 = pair := by omega
     have hdiv1 : (3 * pair + 1) / 3 = pair := by omega
@@ -643,8 +642,8 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
           (((b0 + 256 * (b1 % 16) : Nat) : Coeff))
         else
           (((b1 / 16 + 16 * b2 : Nat) : Coeff)))
-        = Array.ofFn (fun idx : Fin ringDegree => f.coeffs[idx.val]) := by
-            exact congrArg Array.ofFn hfun
+        = Array.ofFn (fun idx : Fin ringDegree => f.coeffs[idx.val]) :=
+            congrArg Array.ofFn hfun
     _ = f.coeffs.toArray := by
       apply Array.ext
       · simp
@@ -732,8 +731,8 @@ private theorem byteDecode12Vec_byteEncode12Vec {k : Nat} (v : TqVec k) :
   rw [Vector.toArray_ofFn]
   calc
     Array.ofFn (fun idx : Fin k => byteDecode12VecPoly (byteEncode12Vec v) idx)
-        = Array.ofFn (fun idx : Fin k => v[idx.val]) := by
-            exact congrArg Array.ofFn hfun
+        = Array.ofFn (fun idx : Fin k => v[idx.val]) :=
+            congrArg Array.ofFn hfun
     _ = v.toArray := by
       apply Array.ext
       · simp
@@ -755,8 +754,8 @@ def byteEncodeVec (d : Nat) {k : Nat} (v : RqVec k) : ByteArray :=
       have hchunk : 0 < chunkSize := by
         dsimp [chunkSize]
         omega
-      have hpoly : poly < k := by
-        exact Nat.div_lt_of_lt_mul idx.isLt
+      have hpoly : poly < k :=
+        Nat.div_lt_of_lt_mul idx.isLt
       have hbyte : byte < chunkSize := Nat.mod_lt _ hchunk
       getByteD (byteEncode d (v[poly]'hpoly)) byte
 
@@ -869,8 +868,8 @@ private theorem compress_val_lt_pow {d : Nat} (hpow : (1 <<< d) < modulus) (x : 
     exact hmul
   have hmod : shifted % (1 <<< d) < (1 <<< d) := Nat.mod_lt _ hpowPos
   have hltMod : shifted % (1 <<< d) < modulus := lt_trans hmod hpow
-  have hval : (((shifted % (1 <<< d) : Nat) : Coeff)).val = shifted % (1 <<< d) := by
-    exact ZMod.val_cast_of_lt hltMod
+  have hval : (((shifted % (1 <<< d) : Nat) : Coeff)).val = shifted % (1 <<< d) :=
+    ZMod.val_cast_of_lt hltMod
   calc
     (compress d x : Coeff).val = shifted % (1 <<< d) := by
       simpa [compress, shifted] using hval
@@ -906,12 +905,12 @@ private def byteDecode1Msg (msg : Message) : Rq :=
 private theorem byteDecode1Msg_val (msg : Message) (idx : Fin ringDegree) :
     ((byteDecode1Msg msg).get idx : Coeff).val =
       (bytesToBits (ByteArray.mk msg.toArray)).getD idx.val 0 := by
-  have hbitMod : (bytesToBits (ByteArray.mk msg.toArray)).getD idx.val 0 < modulus := by
-    exact lt_trans (bytesToBits_getD_lt_two (ByteArray.mk msg.toArray) idx.val) (by decide)
+  have hbitMod : (bytesToBits (ByteArray.mk msg.toArray)).getD idx.val 0 < modulus :=
+    lt_trans (bytesToBits_getD_lt_two (ByteArray.mk msg.toArray) idx.val) (by decide)
   have hcast :
       ((((bytesToBits (ByteArray.mk msg.toArray)).getD idx.val 0 : Nat) : Coeff).val) =
-        (bytesToBits (ByteArray.mk msg.toArray)).getD idx.val 0 := by
-    exact ZMod.val_cast_of_lt hbitMod
+        (bytesToBits (ByteArray.mk msg.toArray)).getD idx.val 0 :=
+    ZMod.val_cast_of_lt hbitMod
   unfold byteDecode1Msg
   simpa using hcast
 
@@ -988,12 +987,12 @@ private theorem byteEncode1Msg_byteDecode1Msg (msg : Message) :
       let idx : Fin ringDegree := ⟨i, hi⟩
       rw [Array.getElem_ofFn]
       have hbitLt :
-          (bytesToBits (ByteArray.mk msg.toArray)).getD i 0 < 2 := by
-        exact bytesToBits_getD_lt_two (ByteArray.mk msg.toArray) i
+          (bytesToBits (ByteArray.mk msg.toArray)).getD i 0 < 2 :=
+        bytesToBits_getD_lt_two (ByteArray.mk msg.toArray) i
       have hget :
           (bytesToBits (ByteArray.mk msg.toArray)).getD i 0 =
-            (bytesToBits (ByteArray.mk msg.toArray))[i] := by
-        exact array_getD_eq_getElem
+            (bytesToBits (ByteArray.mk msg.toArray))[i] :=
+        array_getD_eq_getElem
           (a := bytesToBits (ByteArray.mk msg.toArray)) (i := i) (fallback := 0) hi2
       rw [byteDecode1Msg_val (msg := msg) idx, Nat.mod_eq_of_lt hbitLt, hget]
   apply Vector.toArray_inj.mp
@@ -1012,8 +1011,8 @@ private theorem byteDecode1Msg_byteEncode1Msg_of_bound (f : Rq)
     (hbound : ∀ idx : Fin ringDegree, ((f[idx.val] : Coeff).val) < 2) :
     byteDecode1Msg (byteEncode1Msg f) = f := by
   calc
-    byteDecode1Msg (byteEncode1Msg f) = byteDecode 1 (ByteArray.mk (byteEncode1Msg f).toArray) := by
-      exact byteDecode1Msg_eq_byteDecode1 (msg := byteEncode1Msg f)
+    byteDecode1Msg (byteEncode1Msg f) = byteDecode 1 (ByteArray.mk (byteEncode1Msg f).toArray) :=
+      byteDecode1Msg_eq_byteDecode1 (msg := byteEncode1Msg f)
     _ = byteDecode 1 (byteEncode 1 f) := by
       rw [byteArray_byteEncode1Msg (f := f)]
     _ = f := byteDecode_byteEncode_of_bound (d := 1) (by decide) f (by simpa using hbound)

--- a/LatticeCrypto/Ring/Norms.lean
+++ b/LatticeCrypto/Ring/Norms.lean
@@ -218,8 +218,8 @@ theorem cInfNorm_le_of_coeff_le {p : Poly (ZMod q) n} {b : ℕ}
   cInfNorm_le_iff.mpr h
 
 theorem coeff_le_cInfNorm (p : Poly (ZMod q) n) (i : Fin n) :
-    (centeredRepr (p.get i)).natAbs ≤ cInfNorm p := by
-  exact Finset.le_sup (f := fun i => (centeredRepr (p.get i)).natAbs) (Finset.mem_univ i)
+    (centeredRepr (p.get i)).natAbs ≤ cInfNorm p :=
+  Finset.le_sup (f := fun i => (centeredRepr (p.get i)).natAbs) (Finset.mem_univ i)
 
 /-- Every polynomial has centered infinity norm at most `q / 2`. -/
 theorem cInfNorm_le_halfq (p : Poly (ZMod q) n) : cInfNorm p ≤ q / 2 :=

--- a/LatticeCrypto/Ring/Smoke.lean
+++ b/LatticeCrypto/Ring/Smoke.lean
@@ -51,8 +51,7 @@ def piKernel (Coeff : Type*) [Zero Coeff] (n : Nat) :
     simp [piBackend]
   coeff_ofArray := by
     intro a h i
-    have hi : i.val < a.size := by
-      exact Nat.lt_of_lt_of_eq i.isLt h.symm
+    have hi : i.val < a.size := Nat.lt_of_lt_of_eq i.isLt h.symm
     simp [piBackend, hi]
   ofArray_toArray := by
     intro p

--- a/LatticeCrypto/Ring/Transform.lean
+++ b/LatticeCrypto/Ring/Transform.lean
@@ -184,12 +184,12 @@ def coeffMatTransposeVecMul {rows cols : Nat}
   ops.unhatVec (ops.matTransposeVecMul A (ops.hatVec v))
 
 @[simp] theorem hatVec_get {k : Nat} (v : PolyVec ring.Poly k) (i : Fin k) :
-    (ops.hatVec v).get i = ops.toHat (v.get i) := by
-  exact Vector.get_map v ops.toHat i
+    (ops.hatVec v).get i = ops.toHat (v.get i) :=
+  Vector.get_map v ops.toHat i
 
 @[simp] theorem unhatVec_get {k : Nat} (v : PolyVec Hat k) (i : Fin k) :
-    (ops.unhatVec v).get i = ops.fromHat (v.get i) := by
-  exact Vector.get_map v ops.fromHat i
+    (ops.unhatVec v).get i = ops.fromHat (v.get i) :=
+  Vector.get_map v ops.fromHat i
 
 /-- Algebraic laws asserting that a `TransformOps` instance is a ring isomorphism.
 

--- a/LatticeCrypto/Ring/VectorBackend.lean
+++ b/LatticeCrypto/Ring/VectorBackend.lean
@@ -82,8 +82,7 @@ def vectorKernel (Coeff : Type u) [Zero Coeff] (n : Nat) :
     exact p.size_toArray
   coeff_ofArray := by
     intro a h i
-    have hi : i.val < a.size := by
-      exact Nat.lt_of_lt_of_eq i.isLt h.symm
+    have hi : i.val < a.size := Nat.lt_of_lt_of_eq i.isLt h.symm
     simp [vectorBackend, hi, Vector.get]
   ofArray_toArray := by
     intro p

--- a/ToMathlib/Control/Lawful/MonadState.lean
+++ b/ToMathlib/Control/Lawful/MonadState.lean
@@ -19,8 +19,8 @@ helper lemmas that are still locally useful under the `ToMathlib` import path.
 universe u v
 
 @[simp] theorem toMonadState_get_eq_monadStateOf_get {m : Type u → Type v} {σ : Type u}
-    [MonadStateOf σ m] : (MonadState.get : m σ) = MonadStateOf.get := by
-  exact (monadStateOf_get_eq_get (σ := σ) (m := m)).symm
+    [MonadStateOf σ m] : (MonadState.get : m σ) = MonadStateOf.get :=
+  (monadStateOf_get_eq_get (σ := σ) (m := m)).symm
 
 @[simp] theorem toMonadState_set_eq_monadStateOf_set {m : Type u → Type v} {σ : Type u}
     [MonadStateOf σ m] : (MonadState.set : σ → m PUnit) = MonadStateOf.set := rfl

--- a/ToMathlib/Control/Monad/RelationalAlgebra.lean
+++ b/ToMathlib/Control/Monad/RelationalAlgebra.lean
@@ -91,8 +91,8 @@ theorem triple_bind {pre : l} {x : m₁ α} {y : m₂ β}
     (hxy : Triple pre x y cut)
     (hfg : ∀ a b, Triple (cut a b) (f a) (g b) post) :
     Triple pre (x >>= f) (y >>= g) post := by
-  have hcut : pre ≤ RelWP x y (fun a b => RelWP (f a) (g b) post) := by
-    exact le_trans hxy (relWP_mono x y hfg)
+  have hcut : pre ≤ RelWP x y (fun a b => RelWP (f a) (g b) post) :=
+    le_trans hxy (relWP_mono x y hfg)
   exact le_trans hcut (relWP_bind_le x y f g post)
 
 /-- Mapping on the left program is monotone for relational WP. -/
@@ -197,8 +197,8 @@ noncomputable instance instOptionTRight :
       | some b => post a b)
   rwp_pure a b post := by
     simp
-  rwp_mono hpost := by
-    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a ob => by
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a ob => by
       cases ob with
       | none => exact le_rfl
       | some b => simpa using hpost a b)
@@ -241,8 +241,8 @@ noncomputable instance instOptionTLeft :
       | some a => post a b)
   rwp_pure a b post := by
     simp
-  rwp_mono hpost := by
-    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun oa b => by
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun oa b => by
       cases oa with
       | none => exact le_rfl
       | some a => simpa using hpost a b)
@@ -295,8 +295,8 @@ noncomputable instance instExceptTRight (ε : Type u) :
       | Except.ok b => post a b)
   rwp_pure a b post := by
     simp
-  rwp_mono hpost := by
-    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a eb => by
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun a eb => by
       cases eb with
       | error e => exact le_rfl
       | ok b => simpa using hpost a b)
@@ -342,8 +342,8 @@ noncomputable instance instExceptTLeft (ε : Type u) :
       | Except.ok a => post a b)
   rwp_pure a b post := by
     simp
-  rwp_mono hpost := by
-    exact MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun ea b => by
+  rwp_mono hpost :=
+    MAlgRelOrdered.rwp_mono (m₁ := m₁) (m₂ := m₂) (l := l) (fun ea b => by
       cases ea with
       | error e => exact le_rfl
       | ok a => simpa using hpost a b)

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -25,14 +25,13 @@ namespace ENNReal
 lemma one_sub_one_sub_mul_one_sub {x y : ℝ≥0∞} (hx : x ≤ 1) (hy : y ≤ 1) :
     1 - (1 - x) * (1 - y) = x + y - x * y := by
   have hxy : x * y ≤ x + y := by
-    have hxy_le_x : x * y ≤ x := by
-      exact mul_le_of_le_one_right' hy
+    have hxy_le_x : x * y ≤ x := mul_le_of_le_one_right' hy
     have hxy_le_y : x * y ≤ y := by
       apply mul_le_of_le_one_left (by positivity) hx;
     exact le_trans hxy_le_x ( le_add_of_nonneg_right <| by positivity )
   have hxy' : (1 - x) * (1 - y) ≤ 1 := by
-    calc (1 - x) * (1 - y) ≤ 1 * 1 := by
-          exact mul_le_mul' (tsub_le_self) (tsub_le_self)
+    calc (1 - x) * (1 - y) ≤ 1 * 1 :=
+          mul_le_mul' (tsub_le_self) (tsub_le_self)
         _ = 1 := one_mul 1
   rw [← ENNReal.toReal_eq_toReal_iff' (by aesop) (by aesop),
     ENNReal.toReal_sub_of_le, ENNReal.toReal_mul, ENNReal.toReal_sub_of_le,

--- a/ToMathlib/PFunctor/Cofree.lean
+++ b/ToMathlib/PFunctor/Cofree.lean
@@ -115,8 +115,7 @@ instance : Comonad (CofreeC F) where
     extend (extend t f) g = extend t (fun x => g (extend x f)) := by
   let l : CofreeC F α → CofreeC F γ := fun x => extend (extend x f) g
   let r : CofreeC F α → CofreeC F γ := fun x => extend x (fun y => g (extend y f))
-  have hr_corec : r = M.corec (F := constProd F γ) (extendF (fun y => g (extend y f))) := by
-    rfl
+  have hr_corec : r = M.corec (F := constProd F γ) (extendF (fun y => g (extend y f))) := rfl
   have hl_corec : l = M.corec (F := constProd F γ) (extendF (fun y => g (extend y f))) := by
     apply (M.corec_unique (P := constProd F γ)
       (g := extendF (fun y => g (extend y f))) (f := l))

--- a/ToMathlib/ProbabilityTheory/FinRatPMF.lean
+++ b/ToMathlib/ProbabilityTheory/FinRatPMF.lean
@@ -179,8 +179,7 @@ instance : Monad Raw where
   bind := Raw.bind
 
 @[simp] lemma pure_toList (a : α) :
-    (Pure.pure a : Raw α).toList = [(a, 1)] := by
-  rfl
+    (Pure.pure a : Raw α).toList = [(a, 1)] := rfl
 
 @[simp] lemma bind_toList (f : Raw α) (g : α → Raw β) :
     (f >>= g).toList =
@@ -311,8 +310,8 @@ lemma sum_prob_eq_sum [DecidableEq α] (p : Raw α) :
     rcases List.mem_filter.1 ha with ⟨ha, _⟩
     exact List.mem_toFinset.2 (List.mem_map.2 ⟨a, ha, hax⟩)
   calc
-    p.support.sum p.prob = s.sum p.prob := by
-      exact Finset.sum_subset hs (by
+    p.support.sum p.prob = s.sum p.prob :=
+      Finset.sum_subset hs (by
         intro x _ hx
         exact prob_eq_zero_of_not_mem_support p hx)
     _ = (p.toList.map Prod.snd).sum := by
@@ -438,8 +437,8 @@ lemma support_uniformList_of_nodup [DecidableEq α] {l : List α} (hl : l ≠ []
   have hprob : (Raw.uniform (α := α)).prob x = (Fintype.card α : ℚ≥0)⁻¹ := by
     calc
       (Raw.uniform (α := α)).prob x
-          = @Raw.prob _ (FinEnum.decEq) (Raw.uniform (α := α)) x := by
-              exact Raw.prob_eq_prob inferInstance (FinEnum.decEq) (Raw.uniform (α := α)) x
+          = @Raw.prob _ (FinEnum.decEq) (Raw.uniform (α := α)) x :=
+              Raw.prob_eq_prob inferInstance (FinEnum.decEq) (Raw.uniform (α := α)) x
       _ = (Fintype.card α : ℚ≥0)⁻¹ := prob_uniform (α := α) x
   simp [hprob]
 
@@ -575,11 +574,11 @@ lemma mem_support_bind_iff [DecidableEq α] [DecidableEq β] (m : Raw α) (f : �
   · rintro ⟨x, hx, hy⟩
     have hmx : m.prob x ≠ 0 := (mem_support_iff m x).1 hx
     have hfy : (f x).prob y ≠ 0 := (mem_support_iff (f x) y).1 hy
-    have hpos : 0 < m.prob x * (f x).prob y := by
-      exact mul_pos (pos_iff_ne_zero.mpr hmx) (pos_iff_ne_zero.mpr hfy)
+    have hpos : 0 < m.prob x * (f x).prob y :=
+      mul_pos (pos_iff_ne_zero.mpr hmx) (pos_iff_ne_zero.mpr hfy)
     have hle :
-        m.prob x * (f x).prob y ≤ ∑ a ∈ m.support, m.prob a * (f a).prob y := by
-      exact Finset.single_le_sum
+        m.prob x * (f x).prob y ≤ ∑ a ∈ m.support, m.prob a * (f a).prob y :=
+      Finset.single_le_sum
         (f := fun a => m.prob a * (f a).prob y) (fun _ _ => by exact zero_le _) hx
     exact pos_iff_ne_zero.mp (lt_of_lt_of_le hpos hle)
 
@@ -657,16 +656,16 @@ private lemma probOfList_toList_eq_getD [DecidableEq α] [BEq α] [Hashable α]
     have hnot : x ∉ m := by
       rw [Std.HashMap.mem_iff_isSome_getElem?]
       simp [hopt]
-    have hfind : m.toList.find? (fun a => a.1 == x) = none := by
-      exact (Std.HashMap.find?_toList_eq_none_iff_not_mem (m := m) (k := x)).2 hnot
+    have hfind : m.toList.find? (fun a => a.1 == x) = none :=
+      (Std.HashMap.find?_toList_eq_none_iff_not_mem (m := m) (k := x)).2 hnot
     simp [hfind]
   | some q =>
     have hxmem : x ∈ m := by
       rw [Std.HashMap.mem_iff_isSome_getElem?]
       simp [hopt]
     have hkey : m.getKey? x = some x := Std.HashMap.getKey?_eq_some (m := m) hxmem
-    have hfind : m.toList.find? (fun a => a.1 == x) = some (x, q) := by
-      exact (Std.HashMap.find?_toList_eq_some_iff_getKey?_eq_some_and_getElem?_eq_some
+    have hfind : m.toList.find? (fun a => a.1 == x) = some (x, q) :=
+      (Std.HashMap.find?_toList_eq_some_iff_getKey?_eq_some_and_getElem?_eq_some
         (m := m) (k := x) (k' := x) (v := q)).2 ⟨hkey, hopt⟩
     simp [hfind]
 
@@ -703,8 +702,8 @@ private lemma probOfNormalizeMap_eq_prob [DecidableEq α] [BEq α] [Hashable α]
 private lemma snd_ne_zero_of_mem_normalizeMap_toList [BEq α] [Hashable α]
     [LawfulBEq α] [LawfulHashable α] (p : Raw α) {a : α × ℚ≥0}
     (ha : a ∈ (normalizeMap p).toList) : a.2 ≠ 0 := by
-  have hsome : (normalizeMap p)[a.1]? = some a.2 := by
-    exact (Std.HashMap.mem_toList_iff_getElem?_eq_some (m := normalizeMap p)
+  have hsome : (normalizeMap p)[a.1]? = some a.2 :=
+    (Std.HashMap.mem_toList_iff_getElem?_eq_some (m := normalizeMap p)
       (k := a.1) (v := a.2)).1 ha
   unfold normalizeMap at hsome
   rw [Std.HashMap.getElem?_filter'] at hsome
@@ -969,8 +968,8 @@ lemma bind_eq_out (ma : FinRatPMF α) (f : α → FinRatPMF β) :
 
 private lemma out_bind_sameDist (ma : FinRatPMF α) (f : α → FinRatPMF β) :
     SameDist (Quotient.out (ma >>= f))
-      (Raw.bind (Quotient.out ma) (fun a => Quotient.out (f a))) := by
-  exact Quotient.exact ((Quotient.out_eq (ma >>= f)).trans (bind_eq_out ma f))
+      (Raw.bind (Quotient.out ma) (fun a => Quotient.out (f a))) :=
+  Quotient.exact ((Quotient.out_eq (ma >>= f)).trans (bind_eq_out ma f))
 
 /-! ### Connection to `PMF` -/
 
@@ -1013,8 +1012,8 @@ lemma toPMF_out (p : FinRatPMF α) :
             (Raw.bind (Quotient.out ma) (fun a => Quotient.out (f a))) := by
               rw [bind_eq_out, toPMF_mk]
     _ = @Raw.toPMF _ (Classical.decEq _) (Quotient.out ma) >>=
-          fun a => @Raw.toPMF _ (Classical.decEq _) (Quotient.out (f a)) := by
-            exact Raw.toPMF_bind _ _
+          fun a => @Raw.toPMF _ (Classical.decEq _) (Quotient.out (f a)) :=
+            Raw.toPMF_bind _ _
     _ = toPMF ma >>= fun a => toPMF (f a) := by
           rw [← toPMF_out ma]
           congr 1
@@ -1042,13 +1041,13 @@ lemma toPMF_injective : Function.Injective (toPMF (α := α)) := by
   intro x
   have hfun :
       (@Raw.toPMF _ (Classical.decEq _) a : PMF α) x =
-      (@Raw.toPMF _ (Classical.decEq _) b : PMF α) x := by
-    exact congrFun (congrArg DFunLike.coe hpq) x
+      (@Raw.toPMF _ (Classical.decEq _) b : PMF α) x :=
+    congrFun (congrArg DFunLike.coe hpq) x
   rw [Raw.toPMF_apply, Raw.toPMF_apply] at hfun
   have key' :
       ((@Raw.prob _ (Classical.decEq _) a x : ℚ≥0) : NNReal) =
-      ((@Raw.prob _ (Classical.decEq _) b x : ℚ≥0) : NNReal) := by
-    exact congrArg ENNReal.toNNReal hfun
+      ((@Raw.prob _ (Classical.decEq _) b x : ℚ≥0) : NNReal) :=
+    congrArg ENNReal.toNNReal hfun
   calc @Raw.prob _ (Classical.decEq _) a x
       = a.prob x := Raw.prob_eq_prob _ _ _ _
     _ = b.prob x := by exact_mod_cast key'
@@ -1070,8 +1069,8 @@ noncomputable instance : LawfulMonad FinRatPMF := LawfulMonad.mk'
     calc
       toPMF (pure x >>= f) = PMF.pure x >>= fun a => toPMF (f a) := by
         rw [toPMF_bind, toPMF_pure]
-      _ = toPMF (f x) := by
-            exact pure_bind (m := PMF) x (fun a => toPMF (f a)))
+      _ = toPMF (f x) :=
+            pure_bind (m := PMF) x (fun a => toPMF (f a)))
   (bind_assoc := fun m f g => by
     apply toPMF_injective
     calc
@@ -1091,8 +1090,8 @@ noncomputable instance : LawfulMonad FinRatPMF := LawfulMonad.mk'
           = toPMF x >>= fun a => PMF.pure (f a) := by
               rw [toPMF_bind]
               simp
-      _ = f <$> toPMF x := by
-            exact bind_pure_comp (m := PMF) f (toPMF x)
+      _ = f <$> toPMF x :=
+            bind_pure_comp (m := PMF) f (toPMF x)
       _ = toPMF (f <$> x) := by
             rw [show f <$> x = x >>= fun a => pure (f a) by rfl, toPMF_bind]
             simp [map_eq_bind_pure_comp]

--- a/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
+++ b/ToMathlib/ProbabilityTheory/OptimalCoupling.lean
@@ -139,8 +139,8 @@ lemma isClosed_couplings_set (p : SPMF α) (q : SPMF β) :
     rw [this]
     exact isClosed_iInter fun b => isClosed_eq (continuous_finset_sum _
       (fun a _ => continuous_apply _)) continuous_const
-  have h5 : IsClosed {c : Option (α × β) → ℝ | c none = 1 - (∑ z, c (some z))} := by
-    exact isClosed_eq (continuous_apply _) (continuous_const.sub (continuous_finset_sum _
+  have h5 : IsClosed {c : Option (α × β) → ℝ | c none = 1 - (∑ z, c (some z))} :=
+    isClosed_eq (continuous_apply _) (continuous_const.sub (continuous_finset_sum _
       (fun z _ => continuous_apply _)))
   exact (((h1.inter h2).inter h3).inter h4).inter h5
 
@@ -208,8 +208,8 @@ private lemma exists_coupling_of_mem_couplings_set {p : SPMF α} {q : SPMF β}
     {c : Option (α × β) → ℝ} (hc : c ∈ couplings_set p q) :
     ∃ c' : SPMF.Coupling p q, ∀ z, (c'.1.1 z).toReal = c z := by
   rcases hc with ⟨h_nonneg, _, h_row, h_col, h_none⟩
-  have h_total_real : ∑ z : Option (α × β), c z = 1 := by
-    exact sum_option_eq_one_of_none_eq_sub h_nonneg h_none
+  have h_total_real : ∑ z : Option (α × β), c z = 1 :=
+    sum_option_eq_one_of_none_eq_sub h_nonneg h_none
   have h_total :
       ∑ z : Option (α × β), ENNReal.ofReal (c z) = 1 := by
     calc
@@ -320,10 +320,10 @@ lemma SPMF.exists_max_coupling {p : SPMF α} {q : SPMF β}
   apply le_antisymm
   · refine iSup_le ?_
     intro c'
-    have hc'_in : (fun z => (c'.1.1 z).toReal) ∈ couplings_set p q := by
-      exact mem_couplings_set_of_isCoupling c'.1 c'.2
-    have hmax_real : F (fun z => (c'.1.1 z).toReal) ≤ F c_max := by
-      exact (isMaxOn_iff.mp hc_max_prop) _ hc'_in
+    have hc'_in : (fun z => (c'.1.1 z).toReal) ∈ couplings_set p q :=
+      mem_couplings_set_of_isCoupling c'.1 c'.2
+    have hmax_real : F (fun z => (c'.1.1 z).toReal) ≤ F c_max :=
+      (isMaxOn_iff.mp hc_max_prop) _ hc'_in
     have h_obj_left :
         (∑' z, c'.1.1 z * f z) = ENNReal.ofReal (F (fun z => (c'.1.1 z).toReal)) := by
       simpa [F] using (objective_eq_ofReal c'.1 f hf)

--- a/ToMathlib/ProbabilityTheory/SPMF.lean
+++ b/ToMathlib/ProbabilityTheory/SPMF.lean
@@ -261,7 +261,7 @@ theorem bind_eq_pmf_bind {p : SPMF α} {f : α → SPMF β} :
 
 /-- `pure a` in `SPMF` equals `PMF.pure (some a)` as a PMF on `Option α`. -/
 protected lemma pure_eq_pure_some (a : α) :
-    (pure a : SPMF α) = SPMF.mk (PMF.pure (some a)) := by rfl
+    (pure a : SPMF α) = SPMF.mk (PMF.pure (some a)) := rfl
 
 @[simp, grind =]
 lemma toPMF_inj (p q : SPMF α) : p.toPMF = q.toPMF ↔ p = q := by aesop

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
@@ -708,8 +708,8 @@ theorem IND_CPA_advantage_toReal_le_sum_step_signedAdvantageReal_abs
     rw [habs_half]
     calc
       (1 / 2 : ℝ) * |H q - H 0|
-          ≤ (1 / 2 : ℝ) * Finset.sum (Finset.range q) (fun i => |H (i + 1) - H i|) := by
-              exact mul_le_mul_of_nonneg_left htri (by positivity)
+          ≤ (1 / 2 : ℝ) * Finset.sum (Finset.range q) (fun i => |H (i + 1) - H i|) :=
+              mul_le_mul_of_nonneg_left htri (by positivity)
       _ = Finset.sum (Finset.range q) (fun i => |(H (i + 1) - H i) / 2|) := hsum_half
   have hsteps :
       Finset.sum (Finset.range q) (fun i =>

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
@@ -468,8 +468,8 @@ theorem IND_CPA_LR_hybridGame_q_evalDist_eq_left_of_MakesAtMostQueries
 theorem IND_CPA_LR_hybridGame_zero_probOutput_eq_right
     (adversary : encAlg'.IND_CPA_adversary) :
     Pr[= true | encAlg'.IND_CPA_LR_hybridGame adversary 0] =
-      Pr[= true | encAlg'.IND_CPA_LR_experiment adversary false] := by
-  exact (evalDist_ext_iff.mp
+      Pr[= true | encAlg'.IND_CPA_LR_experiment adversary false] :=
+  (evalDist_ext_iff.mp
     (IND_CPA_LR_hybridGame_zero_evalDist_eq_right (encAlg' := encAlg') adversary)) true
 
 /-- If an adversary makes at most `q` fresh LR queries, then the `leftUntil = q` LR-hybrid has
@@ -478,8 +478,8 @@ theorem IND_CPA_LR_hybridGame_q_probOutput_eq_left_of_MakesAtMostQueries
     (adversary : encAlg'.IND_CPA_adversary) (q : ℕ)
     (hq : adversary.MakesAtMostQueries q) :
     Pr[= true | encAlg'.IND_CPA_LR_hybridGame adversary q] =
-      Pr[= true | encAlg'.IND_CPA_LR_experiment adversary true] := by
-  exact (evalDist_ext_iff.mp
+      Pr[= true | encAlg'.IND_CPA_LR_experiment adversary true] :=
+  (evalDist_ext_iff.mp
     (IND_CPA_LR_hybridGame_q_evalDist_eq_left_of_MakesAtMostQueries
       (encAlg' := encAlg') adversary q hq)) true
 

--- a/VCVio/CryptoFoundations/DataEncapMech.lean
+++ b/VCVio/CryptoFoundations/DataEncapMech.lean
@@ -91,8 +91,7 @@ theorem IND_CPA_Advantage_eq_game_bias {dem : DEMScheme (OracleComp spec) K M C}
     (runtime : ProbCompRuntime (OracleComp spec))
     (adversary : dem.IND_CPA_Adversary) :
     dem.IND_CPA_Advantage runtime adversary =
-      (dem.IND_CPA_Game runtime adversary).boolBiasAdvantage := by
-  rfl
+      (dem.IND_CPA_Game runtime adversary).boolBiasAdvantage := rfl
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/FiatShamir.lean
+++ b/VCVio/CryptoFoundations/FiatShamir.lean
@@ -338,8 +338,8 @@ theorem sign_expectedQueryCost_eq_outputExpectation {ω : Type} [AddMonoid ω] [
           (HasQuery.withAddCost
             (fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
               (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
-            runtime costFn)] * val (costFn (msg, sig.1)) := by
-          exact HasQuery.expectedQueryCost_eq_tsum_outputs_of_usesCostAs
+            runtime costFn)] * val (costFn (msg, sig.1)) :=
+          HasQuery.expectedQueryCost_eq_tsum_outputs_of_usesCostAs
             (oa := fun [HasQuery (M × PC →ₒ Ω) (AddWriterT ω m)] =>
               (FiatShamir (m := AddWriterT ω m) σ hr M).sign pk sk msg)
             (runtime := runtime) (costFn := costFn) (f := fun sig ↦ costFn (msg, sig.1))
@@ -397,8 +397,8 @@ theorem verify_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω] [Ha
     (costFn : M × PC → ω) (val : ω → ENNReal) (hval : Monotone val) :
     ExpectedQueryCost[
       (FiatShamir σ hr M).verify pk msg sig in runtime by costFn via val
-    ] = val (costFn (msg, sig.1)) := by
-  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    ] = val (costFn (msg, sig.1)) :=
+  HasQuery.expectedQueryCost_eq_of_usesCostExactly
     (verify_usesExactQueryCost
       (σ := σ) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (msg := msg)
       (sig := sig) (costFn := costFn))

--- a/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamirWithAbort.lean
@@ -360,8 +360,8 @@ theorem signAttempt_expectedQueryCost_eq_outputExpectation
           (HasQuery.withAddCost
             (fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
               fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
-            runtime costFn)] * val (costFn (msg, attempt.1)) := by
-          exact HasQuery.expectedQueryCost_eq_tsum_outputs_of_usesCostAs
+            runtime costFn)] * val (costFn (msg, attempt.1)) :=
+          HasQuery.expectedQueryCost_eq_tsum_outputs_of_usesCostAs
             (oa := fun [HasQuery (M × W' →ₒ C) (AddWriterT ω m)] =>
               fsAbortSignAttempt (m := AddWriterT ω m) ids M pk sk msg)
             (runtime := runtime) (costFn := costFn) (f := fun attempt ↦ costFn (msg, attempt.1))
@@ -619,8 +619,7 @@ private lemma signLoop_inRuntime_succ
             HasQuery.inRuntime
               (fun [HasQuery (M × W' →ₒ C) m] =>
                 fsAbortSignLoop (m := m) ids M pk sk msg n)
-              runtime) := by
-  rfl
+              runtime) := rfl
 
 section
 
@@ -1011,8 +1010,8 @@ theorem sign_abortPrefixProbability_eq_signAttemptAbortProbability_pow
         (fun [HasQuery (M × W' →ₒ C) m] =>
           fsAbortSignLoop (m := m) ids M pk sk msg i)
         runtime] =
-      (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
-  exact signLoop_probNone_eq_signAttemptAbortProbability_pow
+      (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i :=
+  signLoop_probNone_eq_signAttemptAbortProbability_pow
     (ids := ids) (M := M) (runtime := runtime) (pk := pk) (sk := sk) (msg := msg) i
 
 end
@@ -1097,8 +1096,8 @@ theorem sign_expectedQueries_eq_sum_abortPrefixProbabilities
           HasQuery.queryCountDist
             (fun [HasQuery (M × W' →ₒ C) (AddWriterT ℕ m)] =>
               (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
-            runtime] := by
-              exact sign_expectedQueries_eq_sum_reachedAttemptProbabilities
+            runtime] :=
+              sign_expectedQueries_eq_sum_reachedAttemptProbabilities
                 (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
                 (msg := msg) (maxAttempts := maxAttempts)
     _ = ∑ i ∈ Finset.range maxAttempts,
@@ -1132,8 +1131,8 @@ theorem sign_expectedQueries_eq_sum_signAttemptAbortProbability_powers
           HasQuery.inRuntime
             (fun [HasQuery (M × W' →ₒ C) m] =>
               fsAbortSignLoop (m := m) ids M pk sk msg i)
-            runtime] := by
-              exact sign_expectedQueries_eq_sum_abortPrefixProbabilities
+            runtime] :=
+              sign_expectedQueries_eq_sum_abortPrefixProbabilities
                 (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
                 (msg := msg) (maxAttempts := maxAttempts)
     _ = ∑ i ∈ Finset.range maxAttempts,
@@ -1221,8 +1220,8 @@ theorem sign_expectedQueries_le_geometric_of_signAttemptAbortProbability_le
     ExpectedQueries[
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
     ] ≤
-      ∑' i : ℕ, (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
-          exact sign_expectedQueries_le_tsum_signAttemptAbortProbability_powers
+      ∑' i : ℕ, (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i :=
+          sign_expectedQueries_le_tsum_signAttemptAbortProbability_powers
             (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
             (msg := msg) (maxAttempts := maxAttempts)
     _ ≤ ∑' i : ℕ, q ^ i := by
@@ -1238,8 +1237,8 @@ theorem sign_expectedQueries_le_geometric
     ExpectedQueries[
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
     ] ≤
-      (1 - signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg)⁻¹ := by
-  exact sign_expectedQueries_le_geometric_of_signAttemptAbortProbability_le
+      (1 - signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg)⁻¹ :=
+  sign_expectedQueries_le_geometric_of_signAttemptAbortProbability_le
     (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
     (msg := msg) (maxAttempts := maxAttempts) le_rfl
 

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -373,8 +373,8 @@ private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
         have htell :
             AddWriterT.PathwiseCostAtMost
               (AddWriterT.addTell (M := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
-              w := by
-          exact AddWriterT.pathwiseCostAtMost_mono
+              w :=
+          AddWriterT.pathwiseCostAtMost_mono
             (AddWriterT.pathwiseCostAtMost_addTell
               (m := m) (costFn ⟨pk, msg, comList, i, chal, resp⟩))
             (hcost _)
@@ -673,8 +673,8 @@ theorem sign_usesWeightedQueryCostAtMost
             (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
             (msg := msg) (comList := comList) (i := i)
             (FinEnum.toList Ω) (none : Option (Ω × P × Fin (2 ^ b))) costFn)
-          ((FinEnum.toList Ω).length • w) := by
-      exact fischlinSearchAuxWithAddCost_pathwiseCostAtMost
+          ((FinEnum.toList Ω).length • w) :=
+      fischlinSearchAuxWithAddCost_pathwiseCostAtMost
         σ (κ := κ) (runtime := runtime) (pk := pk) (sk := sk) (sc := (commits i).2)
         (msg := msg) (comList := comList) (i := i)
         (challenges := FinEnum.toList Ω) (best := none) (costFn := costFn) (w := w)

--- a/VCVio/CryptoFoundations/Fork.lean
+++ b/VCVio/CryptoFoundations/Fork.lean
@@ -209,8 +209,8 @@ private lemma probOutput_collision_given_seed_le (s : Fin (qb i + 1))
       ≤ Pr[= x₁ | (simulateQ seededOracle main).run' seed] *
           (Pr[= (some s : Option (Fin (qb i + 1))) |
             (pure (cf x₁) : OracleComp spec (Option (Fin (qb i + 1))))] *
-            (↑(Fintype.card (spec.Range i)) : ℝ≥0∞)⁻¹) := by
-          exact mul_le_mul' le_rfl hterm
+            (↑(Fintype.card (spec.Range i)) : ℝ≥0∞)⁻¹) :=
+          mul_le_mul' le_rfl hterm
     _ = Pr[= x₁ | (simulateQ seededOracle main).run' seed] *
           Pr[= (some s : Option (Fin (qb i + 1))) |
             (pure (cf x₁) : OracleComp spec (Option (Fin (qb i + 1))))] *
@@ -285,8 +285,8 @@ private lemma probOutput_collision_le_main_div (s : Fin (qb i + 1)) :
             cf <$> (simulateQ seededOracle main).run' seed] /
           ↑(Fintype.card (spec.Range i)))) =
       Pr[= (some s : Option (Fin (qb i + 1))) | cf <$> main] /
-        ↑(Fintype.card (spec.Range i)) := by
-    exact hStep2.trans <| hStep3.trans <| by rw [hSeed]
+        ↑(Fintype.card (spec.Range i)) :=
+    hStep2.trans <| hStep3.trans <| by rw [hSeed]
   exact hChain ▸ hStep1
 
 omit [spec.DecidableEq] in
@@ -633,8 +633,8 @@ theorem le_probOutput_fork (s : Fin (qb i + 1)) :
                   if cf a_1.1 = some s then
                     pure (some (a.1, a_1.1))
                   else
-                    pure none) := by
-              exact if_neg hu''
+                    pure none) :=
+              if_neg hu''
             have hmono' :
                 Pr[= z |
                   (simulateQ seededOracle main).run ((seed.takeAtIndex i ↑s).addValue i u) >>=
@@ -681,8 +681,8 @@ theorem le_probOutput_fork (s : Fin (qb i + 1)) :
                     Pr[= (some s : Option (Fin (qb i + 1))) |
                       if (seed i)[↑s]? = some u then
                         (pure (some s) : OracleComp spec (Option (Fin (qb i + 1))))
-                      else pure none] := by
-              exact le_add_of_nonneg_right (zero_le _)
+                      else pure none] :=
+              le_add_of_nonneg_right (zero_le _)
             exact le_trans hmono' hadd
         · have hts' : (some t : Option (Fin (qb i + 1))) ≠ some s := by
             simpa using hts
@@ -705,8 +705,8 @@ theorem le_probOutput_fork (s : Fin (qb i + 1)) :
           exact zero_le _
   have hNoGuardMinusLeRhs :
       Pr[= z | noGuardComp] - Pr[= (some s : Option (Fin (qb i + 1))) | collisionComp] ≤
-        Pr[= z | f <$> fork main qb js i cf] := by
-    exact (tsub_le_iff_right).2 hNoGuardLeAdd
+        Pr[= z | f <$> fork main qb js i cf] :=
+    (tsub_le_iff_right).2 hNoGuardLeAdd
   have hNoGuardGeSquare :
       Pr[= s | cf <$> main] ^ 2 ≤ Pr[= z | noGuardComp] := by
     simpa [z, noGuardComp] using
@@ -846,8 +846,8 @@ theorem le_probEvent_isSome_fork :
           (let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
            let h : ℝ≥0∞ := Fintype.card (spec.Range i)
            let q := qb i + 1
-           acc * (acc / q - h⁻¹)) ≤ 1 := by
-    exact (ENNReal.le_sub_iff_add_le_right hpre_ne_top hpre_le_one).1
+           acc * (acc / q - h⁻¹)) ≤ 1 :=
+    (ENNReal.le_sub_iff_add_le_right hpre_ne_top hpre_le_one).1
       (probOutput_none_fork_le (main := main) (qb := qb) (js := js) (i := i) (cf := cf))
   exact (ENNReal.le_sub_iff_add_le_right hnone_ne_top probOutput_le_one).2
     (by simpa [add_comm] using hfork)

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
@@ -142,8 +142,8 @@ theorem encrypt_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω]
     (pk : PK) (msg : M) (costFn : M → ω) (val : ω → ENNReal) (hval : Monotone val) :
     ExpectedQueryCost[
       (TTransform pke).encrypt pk msg in runtime by costFn via val
-    ] = val (costFn msg) := by
-  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    ] = val (costFn msg) :=
+  HasQuery.expectedQueryCost_eq_of_usesCostExactly
     (encrypt_usesExactQueryCost
       (runtime := runtime) (pke := pke) (pk := pk) (msg := msg) (costFn := costFn))
     hval
@@ -188,8 +188,8 @@ theorem decrypt_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
     (hdec : pke.decrypt sk c = none) :
     ExpectedQueryCost[
       (TTransform pke).decrypt (pk, sk) c in runtime by costFn via val
-    ] = val 0 := by
-  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    ] = val 0 :=
+  HasQuery.expectedQueryCost_eq_of_usesCostExactly
     (decrypt_usesZeroQueryCost_of_decrypt_eq_none
       (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
       (costFn := costFn) hdec)
@@ -224,8 +224,8 @@ theorem decrypt_expectedQueryCost_eq_of_decrypt_eq_some {ω : Type}
     (hdec : pke.decrypt sk c = some msg) :
     ExpectedQueryCost[
       (TTransform pke).decrypt (pk, sk) c in runtime by costFn via val
-    ] = val (costFn msg) := by
-  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    ] = val (costFn msg) :=
+  HasQuery.expectedQueryCost_eq_of_usesCostExactly
     (decrypt_usesExactQueryCost_of_decrypt_eq_some
       (runtime := runtime) (pke := pke) (pk := pk) (sk := sk) (c := c)
       (costFn := costFn) hdec)

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
@@ -297,8 +297,8 @@ theorem encaps_expectedQueryCost_eq_of_constantOracleWeights {ω : Type}
     (hKeys : ∀ kd, costFn (Sum.inr kd) = wKey) :
     ExpectedQueryCost[
       (UTransform pke kdInput policy).encaps pk in runtime by costFn via val
-    ] = val (wCoins + wKey) := by
-  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    ] = val (wCoins + wKey) :=
+  HasQuery.expectedQueryCost_eq_of_usesCostExactly
     (encaps_usesExactFamilyWeightedCost
       (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy) (pk := pk)
       (costFn := costFn) (wCoins := wCoins) (wKey := wKey) hCoins hKeys)
@@ -318,8 +318,8 @@ theorem encaps_expectedQueryCost_le {ω : Type}
     (hKeys : ∀ kd, costFn (Sum.inr kd) ≤ wKey) :
     ExpectedQueryCost[
       (UTransform pke kdInput policy).encaps pk in runtime by costFn via val
-    ] ≤ val (wCoins + wKey) := by
-  exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
+    ] ≤ val (wCoins + wKey) :=
+  HasQuery.expectedQueryCost_le_of_usesCostAtMost
     (encaps_usesWeightedQueryCostAtMost
       (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy) (pk := pk)
       (costFn := costFn) (wCoins := wCoins) (wKey := wKey) hCoins hKeys)
@@ -332,8 +332,8 @@ theorem encaps_expectedQueries_eq_two [HasEvalPMF m]
     (kdInput : M → C → KD)
     (policy : FujisakiOkamoto.RejectionPolicy K C)
     (pk : PK) :
-    ExpectedQueries[ (UTransform pke kdInput policy).encaps pk in runtime ] = 2 := by
-  exact HasQuery.expectedQueries_eq_of_usesExactlyQueries
+    ExpectedQueries[ (UTransform pke kdInput policy).encaps pk in runtime ] = 2 :=
+  HasQuery.expectedQueries_eq_of_usesExactlyQueries
     (encaps_usesExactlyTwoQueries
       (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy) (pk := pk))
 
@@ -445,8 +445,8 @@ theorem decaps_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
     (hdec : pke.decrypt sk c = none) :
     ExpectedQueryCost[
       (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime by costFn via val
-    ] = val 0 := by
-  exact HasQuery.expectedQueryCost_eq_of_usesCostExactly
+    ] = val 0 :=
+  HasQuery.expectedQueryCost_eq_of_usesCostExactly
     (decaps_usesZeroQueryCost_of_decrypt_eq_none
       (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
       (pk := pk) (sk := sk) (fb := fb) (c := c) (costFn := costFn) hdec)
@@ -468,8 +468,8 @@ theorem decaps_expectedQueryCost_le {ω : Type}
     (hKeys : ∀ kd, costFn (Sum.inr kd) ≤ wKey) :
     ExpectedQueryCost[
       (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime by costFn via val
-    ] ≤ val (wCoins + wKey) := by
-  exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
+    ] ≤ val (wCoins + wKey) :=
+  HasQuery.expectedQueryCost_le_of_usesCostAtMost
     (decaps_usesWeightedQueryCostAtMost
       (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
       (pk := pk) (sk := sk) (fb := fb) (c := c) (costFn := costFn)
@@ -497,8 +497,8 @@ theorem decaps_expectedQueries_le_two [HasEvalPMF m]
     (kdInput : M → C → KD)
     (policy : FujisakiOkamoto.RejectionPolicy K C)
     (pk : PK) (sk : SK) (fb : policy.FallbackState) (c : C) :
-    ExpectedQueries[ (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime ] ≤ 2 := by
-  exact HasQuery.expectedQueries_le_of_usesAtMostQueries
+    ExpectedQueries[ (UTransform pke kdInput policy).decaps ((pk, sk), fb) c in runtime ] ≤ 2 :=
+  HasQuery.expectedQueries_le_of_usesAtMostQueries
     (decaps_usesAtMostTwoQueries
       (runtime := runtime) (pke := pke) (kdInput := kdInput) (policy := policy)
       (pk := pk) (sk := sk) (fb := fb) (c := c))

--- a/VCVio/CryptoFoundations/IdenSchemeWithAbort.lean
+++ b/VCVio/CryptoFoundations/IdenSchemeWithAbort.lean
@@ -129,8 +129,8 @@ lemma perfectHVZK_iff_hvzk_zero
   · intro h
     dsimp [HVZK] at h
     intro s w hs
-    have hzero : tvDist (ids.honestExecution s w) (sim s) = 0 := by
-      exact le_antisymm (h s w hs) (by
+    have hzero : tvDist (ids.honestExecution s w) (sim s) = 0 :=
+      le_antisymm (h s w hs) (by
         simpa using (tvDist_nonneg (ids.honestExecution s w) (sim s)))
     simpa using (tvDist_eq_zero_iff (ids.honestExecution s w) (sim s)).mp hzero
 

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -103,8 +103,7 @@ theorem IND_CPA_Advantage_eq_game_bias {kem : KEMScheme (OracleComp spec) K PK S
     (runtime : ProbCompRuntime (OracleComp spec))
     (adversary : kem.IND_CPA_Adversary) :
     kem.IND_CPA_Advantage runtime adversary =
-      (kem.IND_CPA_Game runtime adversary).boolBiasAdvantage := by
-  rfl
+      (kem.IND_CPA_Game runtime adversary).boolBiasAdvantage := rfl
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/SigmaProtocol.lean
+++ b/VCVio/CryptoFoundations/SigmaProtocol.lean
@@ -126,8 +126,8 @@ lemma perfectHVZK_iff_hvzk_zero
   · intro h
     dsimp [HVZK] at h
     intro x w hx
-    have hzero : tvDist (σ.realTranscript x w) (simTranscript x) = 0 := by
-      exact le_antisymm (h x w hx) (by
+    have hzero : tvDist (σ.realTranscript x w) (simTranscript x) = 0 :=
+      le_antisymm (h x w hx) (by
         simpa using (tvDist_nonneg (σ.realTranscript x w) (simTranscript x)))
     simpa using (tvDist_eq_zero_iff (σ.realTranscript x w) (simTranscript x)).mp hzero
 

--- a/VCVio/CryptoFoundations/SymmEncAlg.lean
+++ b/VCVio/CryptoFoundations/SymmEncAlg.lean
@@ -184,10 +184,9 @@ theorem perfectSecrecyAtAllPriors_iff_ciphertextRowsEqualAt
         _ = 1 * q := by rw [μ.tsum_coe]
         _ = q := by simp
     calc
-      μ msg * Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp sp msg] = μ msg * q := by rfl
+      μ msg * Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp sp msg] = μ msg * q := rfl
       _ = μ msg * (∑' m : M sp, μ m * row m) := by rw [← hsum]
-      _ = μ msg * (∑' m : M sp, μ m * Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp sp m]) := by
-            rfl
+      _ = μ msg * (∑' m : M sp, μ m * Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp sp m]) := rfl
 
 /-- Standard perfect secrecy at one security parameter, expressed as independence:
 `Pr[(M, C)] = Pr[M] * Pr[C]`. This is the canonical code-level definition. -/

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -133,8 +133,8 @@ lemma probOutput_ne_zero (h : x ∈ support mx) : Pr[= x | mx] ≠ 0 := by simp 
 
 @[aesop unsafe apply]
 lemma probOutput_ne_zero' [HasEvalFinset m] [DecidableEq α]
-    (h : x ∈ finSupport mx) : Pr[= x | mx] ≠ 0 := by
-  exact probOutput_ne_zero mx x (mem_support_of_mem_finSupport h)
+    (h : x ∈ finSupport mx) : Pr[= x | mx] ≠ 0 :=
+  probOutput_ne_zero mx x (mem_support_of_mem_finSupport h)
 
 @[simp]
 lemma support_probOutput : Function.support (probOutput mx) = support mx := by aesop

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -513,8 +513,8 @@ lemma probEvent_bind_le_add {mx : m α} {my : α → m β}
         split_ifs <;> simp
     _ = (∑' x, Pr[= x | mx]) * ε₂ + Pr[ fun x => ¬p x | mx] := by
         rw [ENNReal.tsum_add, ENNReal.tsum_mul_right, probEvent_eq_tsum_ite]
-    _ ≤ 1 * ε₂ + ε₁ := by
-        exact add_le_add (mul_le_mul' tsum_probOutput_le_one le_rfl) h₁
+    _ ≤ 1 * ε₂ + ε₁ :=
+        add_le_add (mul_le_mul' tsum_probOutput_le_one le_rfl) h₁
     _ = ε₁ + ε₂ := by ring
 
 /-- `probEvent` version of `probEvent_bind_mono` with additive error bound. -/
@@ -534,8 +534,8 @@ lemma probEvent_bind_congr_le_add {mx : m α} {my oc : α → m β}
     _ = (∑' x, Pr[= x | mx] * Pr[ q | oc x]) + ∑' x, Pr[= x | mx] * ε := ENNReal.tsum_add
     _ = (∑' x, Pr[= x | mx] * Pr[ q | oc x]) + (∑' x, Pr[= x | mx]) * ε := by
         rw [ENNReal.tsum_mul_right]
-    _ ≤ (∑' x, Pr[= x | mx] * Pr[ q | oc x]) + ε := by
-        exact add_le_add le_rfl (mul_le_of_le_one_left (zero_le _) tsum_probOutput_le_one)
+    _ ≤ (∑' x, Pr[= x | mx] * Pr[ q | oc x]) + ε :=
+        add_le_add le_rfl (mul_le_of_le_one_left (zero_le _) tsum_probOutput_le_one)
 
 end congr_mono
 

--- a/VCVio/EvalDist/TVDist.lean
+++ b/VCVio/EvalDist/TVDist.lean
@@ -124,8 +124,8 @@ lemma tvDist_le_probEvent_of_probOutput_eq_of_not
   rw [hsum]
   calc
     (∑' x, ENNReal.absDiff (Pr[= x | mx]) (Pr[= x | my])) / 2
-      ≤ (∑' x, if p x then (Pr[= x | mx] + Pr[= x | my]) else 0) / 2 := by
-          exact ENNReal.div_le_div_right
+      ≤ (∑' x, if p x then (Pr[= x | mx] + Pr[= x | my]) else 0) / 2 :=
+          ENNReal.div_le_div_right
             (ENNReal.tsum_le_tsum fun x => by
               by_cases hx : p x
               · simpa [hx] using ENNReal.absDiff_le_add (Pr[= x | mx]) (Pr[= x | my])

--- a/VCVio/OracleComp/Coercions/Add.lean
+++ b/VCVio/OracleComp/Coercions/Add.lean
@@ -235,7 +235,7 @@ end instances
 lemma liftM_eq_liftM_liftM [spec₁ ⊂ₒ spec₂]
     [MonadLift (OracleQuery spec₂) (OracleQuery spec₃)] (q : OracleQuery spec₁ α) :
     (liftM q : OracleQuery spec₃ α) =
-      (liftM (liftM q : OracleQuery spec₂ α) : OracleQuery spec₃ α) := by rfl
+      (liftM (liftM q : OracleQuery spec₂ α) : OracleQuery spec₃ α) := rfl
 
 end OracleQuery
 

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -260,7 +260,7 @@ instance {σ : Type _} [MonadLift (OracleQuery spec) (OracleQuery superSpec)] :
 @[simp]
 lemma liftM_StateT_eq {σ : Type _} [MonadLift (OracleQuery spec) (OracleQuery superSpec)]
     (mx : StateT σ (OracleComp spec) α) : (liftM mx : StateT σ (OracleComp superSpec) α) =
-      StateT.mk fun s => liftM (StateT.run mx s) := by rfl
+      StateT.mk fun s => liftM (StateT.run mx s) := rfl
 
 end StateT
 

--- a/VCVio/OracleComp/Constructions/GenerateSeed.lean
+++ b/VCVio/OracleComp/Constructions/GenerateSeed.lean
@@ -190,7 +190,6 @@ lemma probOutput_pop_some_eq_probOutput_prepend
         seed' j = u :: rest j := hcons.symm
         _ = (rest.prependValues [u]) j := by simp [QuerySeed.prependValues]
     · have hrestj : rest j = seed' j := by
-        exact by
           have := congrArg (fun s => s j) hrest
           simpa [Function.update_of_ne hj] using this
       calc
@@ -203,8 +202,8 @@ lemma probOutput_pop_some_eq_probOutput_prepend
       simp [QuerySeed.prependValues]
     have hpop' :
         (rest.prependValues [u]).pop i =
-          some (u, Function.update (rest.prependValues [u]) i (rest i)) := by
-      exact QuerySeed.pop_eq_some_of_cons
+          some (u, Function.update (rest.prependValues [u]) i (rest i)) :=
+      QuerySeed.pop_eq_some_of_cons
         (seed := rest.prependValues [u]) (i := i) (u := u)
         (us := rest i) hcons_pre
     have hupdate : Function.update (rest.prependValues [u]) i (rest i) = rest := by
@@ -218,11 +217,10 @@ lemma probOutput_pop_some_eq_probOutput_prepend
     Pr[= some (u, rest) | (fun seed => seed.pop i) <$> generateSeed spec qc js]
         = Pr[= some (u, rest) |
             generateSeed spec qc js >>= fun seed =>
-              (pure (seed.pop i) : ProbComp (Option (spec.Range i × QuerySeed spec)))] := by
-            rfl
+              (pure (seed.pop i) : ProbComp (Option (spec.Range i × QuerySeed spec)))] := rfl
     _ = Pr[= rest.prependValues [u] | generateSeed spec qc js] *
-          Pr[= some (u, rest) | pure ((rest.prependValues [u]).pop i)] := by
-            exact probOutput_bind_eq_mul
+          Pr[= some (u, rest) | pure ((rest.prependValues [u]).pop i)] :=
+            probOutput_bind_eq_mul
               (mx := generateSeed spec qc js)
               (my := fun seed =>
                 (pure (seed.pop i) : ProbComp (Option (spec.Range i × QuerySeed spec))))

--- a/VCVio/OracleComp/FinRatPMF.lean
+++ b/VCVio/OracleComp/FinRatPMF.lean
@@ -43,8 +43,8 @@ local instance instSpecFintypeOfFinEnum : spec.Fintype where
         (Fintype.card (spec.Range t) : ℚ≥0)⁻¹ := by
     calc
       @Raw.prob _ (Classical.decEq _) (Raw.uniform (α := spec.Range t)) x
-          = @Raw.prob _ (FinEnum.decEq) (Raw.uniform (α := spec.Range t)) x := by
-              exact Raw.prob_eq_prob (Classical.decEq _) (FinEnum.decEq)
+          = @Raw.prob _ (FinEnum.decEq) (Raw.uniform (α := spec.Range t)) x :=
+              Raw.prob_eq_prob (Classical.decEq _) (FinEnum.decEq)
                 (Raw.uniform (α := spec.Range t)) x
       _ = (Fintype.card (spec.Range t) : ℚ≥0)⁻¹ := Raw.prob_uniform (α := spec.Range t) x
   rw [PMF.uniformOfFintype_apply]
@@ -53,8 +53,8 @@ local instance instSpecFintypeOfFinEnum : spec.Fintype where
       = ((Fintype.card (spec.Range t) : ENNReal)⁻¹)
   calc
     (((@Raw.prob _ (Classical.decEq _) (Raw.uniform (α := spec.Range t)) x : NNReal) : ENNReal))
-        = (((((Fintype.card (spec.Range t) : ℚ≥0)⁻¹ : ℚ≥0) : NNReal) : ENNReal)) := by
-            exact congrArg
+        = (((((Fintype.card (spec.Range t) : ℚ≥0)⁻¹ : ℚ≥0) : NNReal) : ENNReal)) :=
+            congrArg
               (fun q : ℚ≥0 => ((q : NNReal) : ENNReal))
               hprob
     _ = ((Fintype.card (spec.Range t) : ENNReal)⁻¹) := by

--- a/VCVio/OracleComp/OracleComp.lean
+++ b/VCVio/OracleComp/OracleComp.lean
@@ -53,7 +53,7 @@ lemma pure_ne_liftM (x : α) (q : OracleQuery spec α) :
 
 @[simp, grind =]
 protected lemma liftM_map (q : OracleQuery spec α) (f : α → β) :
-    liftM (n := OracleComp spec) (f <$> q) = f <$> liftM q := by rfl
+    liftM (n := OracleComp spec) (f <$> q) = f <$> liftM q := rfl
 
 /-- `coin` is the computation representing a coin flip, given a coin flipping oracle. -/
 @[inline]

--- a/VCVio/OracleComp/QueryTracking/CountingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CountingOracle.lean
@@ -248,8 +248,8 @@ lemma sub_mem_support_snd_map_simulate {oa : OracleComp spec α}
     (h : qc' ∈ support (((fun z : α × QueryCount ι => z.2) <$> simulate oa qc) :
       OracleComp spec (QueryCount ι))) :
     qc' - qc ∈ support (((fun z : α × QueryCount ι => z.2) <$> simulate oa 0) :
-      OracleComp spec (QueryCount ι)) := by
-  exact (mem_support_snd_map_simulate_iff_of_le (oa := oa)
+      OracleComp spec (QueryCount ι)) :=
+  (mem_support_snd_map_simulate_iff_of_le (oa := oa)
     (hqc := le_of_mem_support_snd_map_simulate h)).1 h
 
 end snd_map

--- a/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryRuntime.lean
@@ -310,8 +310,8 @@ lemma expectedCost_le_of_support_bound [HasEvalSPMF m]
     (h : ∀ w ∈ support oa.costs, val w ≤ c) :
     expectedCost oa val ≤ c := by
   unfold expectedCost
-  have hmass : ∑' w : ω, Pr[= w | oa.costs] ≤ 1 := by
-    exact tsum_probOutput_le_one (mx := oa.costs)
+  have hmass : ∑' w : ω, Pr[= w | oa.costs] ≤ 1 :=
+    tsum_probOutput_le_one (mx := oa.costs)
   calc
     ∑' w : ω, Pr[= w | oa.costs] * val w
         ≤ ∑' w : ω, Pr[= w | oa.costs] * c := by
@@ -506,8 +506,8 @@ lemma pathwiseCostAtLeast_probCompLift [LawfulMonad m] [MonadLiftT ProbComp m] (
 
 lemma pathwiseCostEqOnSupport_probCompLift [LawfulMonad m] [MonadLiftT ProbComp m]
     (x : ProbComp α) :
-    PathwiseCostEqOnSupport (monadLift x : AddWriterT ω m α) 0 := by
-  exact ⟨
+    PathwiseCostEqOnSupport (monadLift x : AddWriterT ω m α) 0 :=
+  ⟨
     pathwiseCostAtMost_probCompLift (m := m) (ω := ω) x,
     pathwiseCostAtLeast_probCompLift (m := m) (ω := ω) x
   ⟩
@@ -1213,8 +1213,8 @@ lemma expectedQueryCost_eq_of_usesCostExactly
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryRuntime spec m}
     {costFn : spec.Domain → ω} {w : ω} {val : ω → ENNReal}
     (h : HasQuery.UsesCostExactly oa runtime costFn w) (hval : Monotone val) :
-    HasQuery.expectedQueryCost oa runtime costFn val = val w := by
-  exact le_antisymm
+    HasQuery.expectedQueryCost oa runtime costFn val = val w :=
+  le_antisymm
     (expectedQueryCost_le_of_usesCostAtMost
       (usesCostAtMost_of_usesCostExactly h le_rfl) hval)
     (expectedQueryCost_ge_of_usesCostAtLeast
@@ -1235,16 +1235,16 @@ lemma expectedQueries_eq_of_usesAtMostQueries_of_usesAtLeastQueries
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryRuntime spec m} {n : ℕ}
     (hUpper : HasQuery.UsesAtMostQueries oa runtime n)
     (hLower : HasQuery.UsesAtLeastQueries oa runtime n) :
-    HasQuery.expectedQueries oa runtime = n := by
-  exact le_antisymm
+    HasQuery.expectedQueries oa runtime = n :=
+  le_antisymm
     (expectedQueries_le_of_usesAtMostQueries hUpper)
     (expectedQueries_ge_of_usesAtLeastQueries hLower)
 
 lemma expectedQueries_eq_of_usesExactlyQueries [LawfulMonad m]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryRuntime spec m} {n : ℕ}
     (h : HasQuery.UsesExactlyQueries oa runtime n) :
-    HasQuery.expectedQueries oa runtime = n := by
-  exact expectedQueries_eq_of_usesAtMostQueries_of_usesAtLeastQueries
+    HasQuery.expectedQueries oa runtime = n :=
+  expectedQueries_eq_of_usesAtMostQueries_of_usesAtLeastQueries
     (m := m) (oa := oa) (runtime := runtime) (n := n)
     (usesAtMostQueries_of_usesExactlyQueries h le_rfl)
     (usesAtLeastQueries_of_usesExactlyQueries h le_rfl)

--- a/VCVio/OracleComp/QueryTracking/ResourceProfile.lean
+++ b/VCVio/OracleComp/QueryTracking/ResourceProfile.lean
@@ -219,12 +219,12 @@ noncomputable def evalAddMonoidHom [AddCommMonoid ω] (weights : κ → ω) :
   simp [eval]
 
 @[simp] lemma eval_add [AddCommMonoid ω] (a b : ResourceProfile ω κ) (weights : κ → ω) :
-    (a + b).eval weights = a.eval weights + b.eval weights := by
-  exact (evalAddMonoidHom (ω := ω) (κ := κ) weights).map_add a b
+    (a + b).eval weights = a.eval weights + b.eval weights :=
+  (evalAddMonoidHom (ω := ω) (κ := κ) weights).map_add a b
 
 @[simp] lemma eval_nsmul [AddCommMonoid ω] (n : ℕ) (a : ResourceProfile ω κ) (weights : κ → ω) :
-    (n • a).eval weights = n • a.eval weights := by
-  exact map_nsmul (evalAddMonoidHom (ω := ω) (κ := κ) weights) n a
+    (n • a).eval weights = n • a.eval weights :=
+  map_nsmul (evalAddMonoidHom (ω := ω) (κ := κ) weights) n a
 
 @[simp] lemma eval_sum [AddCommMonoid ω] {ι : Type*} (s : Finset ι)
     (f : ι → ResourceProfile ω κ) (weights : κ → ω) :
@@ -268,13 +268,13 @@ noncomputable def instantiateAddMonoidHom [AddCommMonoid ω]
 
 @[simp] lemma instantiate_add [AddCommMonoid ω]
     (a b : ResourceProfile ω κ) (impl : κ → ResourceProfile ω κ') :
-    (a + b).instantiate impl = a.instantiate impl + b.instantiate impl := by
-  exact (instantiateAddMonoidHom (ω := ω) impl).map_add a b
+    (a + b).instantiate impl = a.instantiate impl + b.instantiate impl :=
+  (instantiateAddMonoidHom (ω := ω) impl).map_add a b
 
 @[simp] lemma instantiate_nsmul [AddCommMonoid ω]
     (n : ℕ) (a : ResourceProfile ω κ) (impl : κ → ResourceProfile ω κ') :
-    (n • a).instantiate impl = n • a.instantiate impl := by
-  exact map_nsmul (instantiateAddMonoidHom (ω := ω) impl) n a
+    (n • a).instantiate impl = n • a.instantiate impl :=
+  map_nsmul (instantiateAddMonoidHom (ω := ω) impl) n a
 
 /-- Instantiating symbolic capabilities is associative.
 

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -983,8 +983,8 @@ lemma tsum_probOutput_generateSeed_weight_takeAtIndex
           conv_rhs => rw [← Finset.mul_sum]
           have hcard_ne_zero : (↑(Fintype.card (spec₀.Range t)) : ENNReal) ≠ 0 := by
             exact_mod_cast Fintype.card_pos.ne'
-          have hcard_ne_top : (↑(Fintype.card (spec₀.Range t)) : ENNReal) ≠ ⊤ := by
-            exact ENNReal.natCast_ne_top (n := Fintype.card (spec₀.Range t))
+          have hcard_ne_top : (↑(Fintype.card (spec₀.Range t)) : ENNReal) ≠ ⊤ :=
+            ENNReal.natCast_ne_top (n := Fintype.card (spec₀.Range t))
           rw [← mul_assoc, ENNReal.mul_inv_cancel hcard_ne_zero hcard_ne_top, one_mul]
           simp
         · -- Case 2a: t = i₀, k > 0 — both pop some, k decreases

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -488,10 +488,9 @@ lemma relTriple_uniformSample_bij
       calc
         (do
             let a ← evalDist ($ᵗ α : ProbComp α)
-            pure (f a)) = f <$> evalDist ($ᵗ α : ProbComp α) := by
-              rfl
-        _ = evalDist (f <$> ($ᵗ α : ProbComp α)) := by
-          exact (evalDist_map ($ᵗ α : ProbComp α) f).symm
+            pure (f a)) = f <$> evalDist ($ᵗ α : ProbComp α) := rfl
+        _ = evalDist (f <$> ($ᵗ α : ProbComp α)) :=
+          (evalDist_map ($ᵗ α : ProbComp α) f).symm
         _ = evalDist ($ᵗ α : ProbComp α) := by
           apply evalDist_ext
           intro x

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -175,8 +175,8 @@ theorem relTriple'_iff_couplingPost
           _ = Pr[ fun y : α => y = x | evalDist oa] := by
                 apply probEvent_ext
                 intro y hy
-                have hyfin : y ∈ finSupport oa := by
-                  exact mem_finSupport_of_mem_support_evalDist (oa := oa) (x := y) hy
+                have hyfin : y ∈ finSupport oa :=
+                  mem_finSupport_of_mem_support_evalDist (oa := oa) (x := y) hy
                 simp [packA, hyfin]
           _ = Pr[= x | evalDist oa] := by simp
       have hvalB : Subtype.val <$> pb = evalDist ob := by
@@ -194,8 +194,8 @@ theorem relTriple'_iff_couplingPost
           _ = Pr[ fun x : β => x = y | evalDist ob] := by
                 apply probEvent_ext
                 intro x hx
-                have hxfin : x ∈ finSupport ob := by
-                  exact mem_finSupport_of_mem_support_evalDist (oa := ob) (x := x) hx
+                have hxfin : x ∈ finSupport ob :=
+                  mem_finSupport_of_mem_support_evalDist (oa := ob) (x := x) hx
                 simp [packB, hxfin]
           _ = Pr[= y | evalDist ob] := by simp
       have hsub_nonempty : Nonempty (SPMF.Coupling pa pb) := by
@@ -311,8 +311,8 @@ theorem relTriple'_iff_couplingPost
               = Pr[ fun z : α × β => R z.1 z.2 | c.1] := by
                   simpa [RelPost.indicator] using
                     indicator_objective_eq_probEvent (mx := c.1) (R := R)
-          _ = Pr[ fun z : A × B => R z.1.1 z.2.1 | packPair <$> c.1] := by
-                exact (hlift_obj c).symm
+          _ = Pr[ fun z : A × B => R z.1.1 z.2.1 | packPair <$> c.1] :=
+                (hlift_obj c).symm
           _ ≤ Pr[ fun z : α × β => R z.1 z.2 | cMax.1] := by
             rw [hpush_obj]
             refine le_of_eq_of_le ?_ (hsub_le_max cLift)
@@ -408,8 +408,8 @@ theorem eRelTriple_bind
         congr 1; ext z; exact ENNReal.mul_iSup ..
     _ ≤ ⨆ (D : ∀ z : α × β,
             SPMF.Coupling (evalDist (fa z.1)) (evalDist (fb z.2))),
-          ∑' z, Pr[= z | c.1] * (∑' w, Pr[= w | (D z).1] * post w.1 w.2) := by
-        exact ENNReal_tsum_iSup_le _
+          ∑' z, Pr[= z | c.1] * (∑' w, Pr[= w | (D z).1] * post w.1 w.2) :=
+        ENNReal_tsum_iSup_le _
     _ ≤ ⨆ c' : SPMF.Coupling (evalDist (oa >>= fa)) (evalDist (ob >>= fb)),
           ∑' w, Pr[= w | c'.1] * post w.1 w.2 := by
         refine iSup_le fun D => ?_
@@ -693,7 +693,7 @@ theorem tvDist_eq_one_sub_eRelWP_eqRel
 theorem gameEquiv_of_relTriple'_eqRel
     {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ α}
     (h : RelTriple' oa ob (EqRel α)) :
-    evalDist oa = evalDist ob := by
-  exact evalDist_eq_of_relTriple_eqRel (relTriple'_iff_relTriple.mp h)
+    evalDist oa = evalDist ob :=
+  evalDist_eq_of_relTriple_eqRel (relTriple'_iff_relTriple.mp h)
 
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -324,8 +324,8 @@ theorem relTriple_simulateQ_run'_of_query_map_eq
     RelTriple
       ((simulateQ impl₁ oa).run' s)
       ((simulateQ impl₂ oa).run' (proj s))
-      (EqRel α) := by
-  exact relTriple_eqRel_of_eq (run'_simulateQ_eq_of_query_map_eq impl₁ impl₂ proj hproj oa s)
+      (EqRel α) :=
+  relTriple_eqRel_of_eq (run'_simulateQ_eq_of_query_map_eq impl₁ impl₂ proj hproj oa s)
 
 /-! ## "Identical until bad" fundamental lemma -/
 

--- a/VCVio/ProgramLogic/Unary/Examples.lean
+++ b/VCVio/ProgramLogic/Unary/Examples.lean
@@ -71,7 +71,7 @@ example (x : ExceptT ε m α) (f : α → ExceptT ε m β) (post : β → L) :
 example [MAlgOrdered (OptionT m) L] (x : OptionT m α) (f : α → OptionT m β) (post : β → L) :
     MAlgOrdered.wp (m := OptionT m) (l := L) (x >>= f) post =
       MAlgOrdered.wp (m := OptionT m) (l := L) x
-        (fun a => MAlgOrdered.wp (m := OptionT m) (l := L) (f a) post) := by
-  exact (MAlgOrdered.wp_bind (m := OptionT m) (l := L) x f post)
+        (fun a => MAlgOrdered.wp (m := OptionT m) (l := L) (f a) post) :=
+  (MAlgOrdered.wp_bind (m := OptionT m) (l := L) x f post)
 
 end MAlgOrdered

--- a/VCVio/ProgramLogic/Unary/HoareTriple.lean
+++ b/VCVio/ProgramLogic/Unary/HoareTriple.lean
@@ -61,8 +61,7 @@ private lemma μ_bind_eq_tsum {α : Type}
           refine tsum_congr ?_
           intro y
           rw [mul_assoc]
-    _ = ∑' x, Pr[= x | oa] * μ (ob x) := by
-          rfl
+    _ = ∑' x, Pr[= x | oa] * μ (ob x) := rfl
 
 noncomputable instance instMAlgOrdered :
     MAlgOrdered (OracleComp spec) ℝ≥0∞ where
@@ -286,8 +285,8 @@ theorem wp_liftM_query (t : spec.Domain) (post : spec.Range t → ℝ≥0∞) :
               simp [μ, probOutput_pure]
             have hprob :
                 Pr[= u | (liftM (query t) : OracleComp spec (spec.Range t))] =
-                  (1 / Fintype.card (spec.Range t) : ℝ≥0∞) := by
-              exact (probOutput_query_eq_div (spec := spec) t u)
+                  (1 / Fintype.card (spec.Range t) : ℝ≥0∞) :=
+              (probOutput_query_eq_div (spec := spec) t u)
             rw [hμ]
             simp [hprob]
 


### PR DESCRIPTION
Mechanical proof golf: replace `by exact term` with direct term-mode and `by rfl` with `rfl` where the goal is a definitional equality. No semantic changes.