### PR TITLE
Port Merkle tree definitions from ArkLib

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -25,6 +25,9 @@ import ToMathlib.Control.StateT
 import ToMathlib.Control.WriterT
 import ToMathlib.Data.ENNReal.AbsDiff
 import ToMathlib.Data.ENNReal.SumSquares
+import ToMathlib.Data.IndexedBinaryTree.Basic
+import ToMathlib.Data.IndexedBinaryTree.Equiv
+import ToMathlib.Data.IndexedBinaryTree.Lemmas
 import ToMathlib.General
 import ToMathlib.OrderEnrichedCategory
 import ToMathlib.PFunctor.Basic

--- a/ToMathlib/Data/IndexedBinaryTree/Basic.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Basic.lean
@@ -1,0 +1,719 @@
+/-
+Copyright (c) 2024 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Bolton Bailey
+-/
+
+-- TODO minimize imports
+import Mathlib.Tactic.Use
+import Mathlib.Data.Set.Basic
+
+
+/-!
+# Inductive Indexed Binary Trees
+
+## A Note about Process/API when working with this
+
+I am trying to follow a process of making simp theorems and procedures
+that decompose the trees as much as possible.
+
+1. Use casework to take a tree of a known structure and specify the parts of that structure
+2. Push maps or other functions on this down to the bottom of the (tree / syntax tree)
+3. I then have e.g. `FullData.internal value1 left1 right1 = FullData.internal value2 left2 right2`
+4. and then I can congruence the values and subtrees
+
+## Notes & TODOs
+
+- [ ] `aesop` extension for the above?
+- [ ] Split off a `Defs.lean` file
+
+- Functions for navigating tree
+  - [x] Go to parent if it exists
+  - [ ] Go to left child if it exists
+  - [ ] Go to right child if it exists
+  - [ ] Go to sibling if it exists
+  - [ ] Return pair of left and right children if they exist
+- Define a datatype for indices of trees agnostic of the skeleton,
+  - This type has an equivalence to lists of bools,
+  - and maps from the the other indexing types.
+  - get? functions
+
+-/
+
+namespace BinaryTree
+
+section Skeleton
+
+/--
+Inductive data type for a binary tree skeleton.
+A skeleton is a binary tree without values, used to represent the structure of the tree.
+-/
+inductive Skeleton where
+  | leaf : Skeleton
+  | internal : Skeleton → Skeleton → Skeleton
+
+/-- Type of indices of leaves of a skeleton -/
+inductive SkeletonLeafIndex : Skeleton → Type
+  | ofLeaf : SkeletonLeafIndex Skeleton.leaf
+  | ofLeft {left right : Skeleton} (idxLeft : SkeletonLeafIndex left) :
+      SkeletonLeafIndex (Skeleton.internal left right)
+  | ofRight {left right : Skeleton} (idxRight : SkeletonLeafIndex right) :
+      SkeletonLeafIndex (Skeleton.internal left right)
+
+/-- Type of indices of internal nodes of a skeleton -/
+inductive SkeletonInternalIndex : Skeleton → Type
+  | ofInternal {left right} : SkeletonInternalIndex (Skeleton.internal left right)
+  | ofLeft {left right : Skeleton} (idxLeft : SkeletonInternalIndex left) :
+      SkeletonInternalIndex (Skeleton.internal left right)
+  | ofRight {left right : Skeleton} (idxRight : SkeletonInternalIndex right) :
+      SkeletonInternalIndex (Skeleton.internal left right)
+
+/-- Type of indices of any node of a skeleton -/
+inductive SkeletonNodeIndex : Skeleton → Type
+  | ofLeaf : SkeletonNodeIndex Skeleton.leaf
+  | ofInternal {left right} :
+      SkeletonNodeIndex (Skeleton.internal left right)
+  | ofLeft {left right : Skeleton} (idxLeft : SkeletonNodeIndex left) :
+      SkeletonNodeIndex (Skeleton.internal left right)
+  | ofRight {left right : Skeleton} (idxRight : SkeletonNodeIndex right) :
+      SkeletonNodeIndex (Skeleton.internal left right)
+
+/-- Construct a `SkeletonNodeIndex` from a `SkeletonLeafIndex` -/
+def SkeletonLeafIndex.toNodeIndex {s : Skeleton} (idx : SkeletonLeafIndex s) :
+    SkeletonNodeIndex s :=
+  match idx with
+  | SkeletonLeafIndex.ofLeaf => SkeletonNodeIndex.ofLeaf
+  | SkeletonLeafIndex.ofLeft idxLeft =>
+    SkeletonNodeIndex.ofLeft (SkeletonLeafIndex.toNodeIndex idxLeft)
+  | SkeletonLeafIndex.ofRight idxRight =>
+    SkeletonNodeIndex.ofRight (SkeletonLeafIndex.toNodeIndex idxRight)
+
+/-- Construct a `SkeletonNodeIndex` from a `SkeletonInternalIndex` -/
+def SkeletonInternalIndex.toNodeIndex {s : Skeleton} (idx : SkeletonInternalIndex s) :
+    SkeletonNodeIndex s :=
+  match idx with
+  | SkeletonInternalIndex.ofInternal => SkeletonNodeIndex.ofInternal
+  | SkeletonInternalIndex.ofLeft idxLeft =>
+    SkeletonNodeIndex.ofLeft (SkeletonInternalIndex.toNodeIndex idxLeft)
+  | SkeletonInternalIndex.ofRight idxRight =>
+    SkeletonNodeIndex.ofRight (SkeletonInternalIndex.toNodeIndex idxRight)
+
+end Skeleton
+
+/-!
+This section contains predicates about indices determined by their neighborhood in the tree.
+-/
+
+section Local
+
+def SkeletonLeafIndex.isRoot {s : Skeleton} (idx : SkeletonLeafIndex s) : Bool :=
+  match idx with
+  | SkeletonLeafIndex.ofLeaf => true
+  | SkeletonLeafIndex.ofLeft _ => false
+  | SkeletonLeafIndex.ofRight _ => false
+
+def SkeletonInternalIndex.isRoot {s : Skeleton} (idx : SkeletonInternalIndex s) : Bool :=
+  match idx with
+  | SkeletonInternalIndex.ofInternal => true
+  | SkeletonInternalIndex.ofLeft _ => false
+  | SkeletonInternalIndex.ofRight _ => false
+
+def SkeletonNodeIndex.isRoot {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :=
+  match idx with
+  | SkeletonNodeIndex.ofLeaf => true
+  | SkeletonNodeIndex.ofInternal => true
+  | SkeletonNodeIndex.ofLeft _ => false
+  | SkeletonNodeIndex.ofRight _ => false
+
+def SkeletonLeafIndex.isLeaf {s : Skeleton} (idx : SkeletonLeafIndex s) : Bool :=
+  match idx with
+  | SkeletonLeafIndex.ofLeaf => true
+  | SkeletonLeafIndex.ofLeft _ => false
+  | SkeletonLeafIndex.ofRight _ => false
+
+def SkeletonInternalIndex.isLeaf {s : Skeleton} (idx : SkeletonInternalIndex s) : Bool :=
+  match idx with
+  | SkeletonInternalIndex.ofInternal => false
+  | SkeletonInternalIndex.ofLeft _ => false
+  | SkeletonInternalIndex.ofRight _ => false
+
+def SkeletonNodeIndex.isLeaf {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :=
+  match idx with
+  | SkeletonNodeIndex.ofLeaf => true
+  | SkeletonNodeIndex.ofInternal => false
+  | SkeletonNodeIndex.ofLeft _ => false
+  | SkeletonNodeIndex.ofRight _ => false
+
+end Local
+
+section Data
+
+/--
+A binary tree with values stored at leaves.
+-/
+inductive LeafData (α : Type) : Skeleton → Type
+  | leaf (value : α) : LeafData α Skeleton.leaf
+  | internal {left right} (leftData : LeafData α left) (rightData : LeafData α right) :
+      LeafData α (Skeleton.internal left right)
+  deriving Repr
+
+/--
+A binary tree with values stored in internal nodes.
+-/
+inductive InternalData (α : Type) : Skeleton → Type
+  | leaf : InternalData α Skeleton.leaf
+  | internal {left right} (value : α)
+      (leftData : InternalData α left)
+      (rightData : InternalData α right) : InternalData α (Skeleton.internal left right)
+  deriving Repr
+
+/--
+A binary tree with values stored at both leaves and internal nodes.
+-/
+inductive FullData (α : Type) : Skeleton → Type
+  | leaf (value : α) : FullData α Skeleton.leaf
+  | internal {left right} (value : α)
+      (leftData : FullData α left)
+      (rightData : FullData α right) :
+      FullData α (Skeleton.internal left right)
+  deriving Repr
+
+end Data
+
+section Subtree
+
+/--
+Get the left subtree of a `LeafData`.
+-/
+def LeafData.leftSubtree {α : Type} {s_left s_right : Skeleton}
+    (tree : LeafData α (Skeleton.internal s_left s_right)) :
+    LeafData α s_left :=
+  match tree with
+  | LeafData.internal left _right =>
+    left
+
+/-- Get the right subtree of a `LeafData`. -/
+def LeafData.rightSubtree {α : Type} {s_left s_right : Skeleton}
+    (tree : LeafData α (Skeleton.internal s_left s_right)) :
+    LeafData α s_right :=
+  match tree with
+  | LeafData.internal _left right =>
+    right
+
+/-- Get the left subtree of a `InternalData`. -/
+def InternalData.leftSubtree {α : Type} {s_left s_right : Skeleton}
+    (tree : InternalData α (Skeleton.internal s_left s_right)) :
+    InternalData α s_left :=
+  match tree with
+  | InternalData.internal _ left _right =>
+    left
+
+/-- Get the right subtree of a `InternalData`. -/
+def InternalData.rightSubtree {α : Type} {s_left s_right : Skeleton}
+    (tree : InternalData α (Skeleton.internal s_left s_right)) :
+    InternalData α s_right :=
+  match tree with
+  | InternalData.internal _ _left right =>
+    right
+
+/-- Get the left subtree of a `FullData`. -/
+def FullData.leftSubtree {α : Type} {s_left s_right : Skeleton}
+    (tree : FullData α (Skeleton.internal s_left s_right)) :
+    FullData α s_left :=
+  match tree with
+  | FullData.internal _ left _right =>
+    left
+
+/-- Get the right subtree of a `FullData`. -/
+def FullData.rightSubtree {α : Type} {s_left s_right : Skeleton}
+    (tree : FullData α (Skeleton.internal s_left s_right)) :
+    FullData α s_right :=
+  match tree with
+  | FullData.internal _ _left right =>
+    right
+
+@[simp]
+theorem LeafData.leftSubtree_internal {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right) :
+    (LeafData.internal left right).leftSubtree = left := by
+  rfl
+
+@[simp]
+theorem LeafData.rightSubtree_internal {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right) :
+    (LeafData.internal left right).rightSubtree = right := by
+  rfl
+
+@[simp]
+theorem InternalData.leftSubtree_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : InternalData α s_left) (right : InternalData α s_right) :
+    (InternalData.internal value left right).leftSubtree = left := by
+  rfl
+
+@[simp]
+theorem InternalData.rightSubtree_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : InternalData α s_left) (right : InternalData α s_right) :
+    (InternalData.internal value left right).rightSubtree = right := by
+  rfl
+
+@[simp]
+theorem FullData.leftSubtree_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right) :
+    (FullData.internal value left right).leftSubtree = left := by
+  rfl
+
+@[simp]
+theorem FullData.rightSubtree_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right) :
+    (FullData.internal value left right).rightSubtree = right := by
+  rfl
+
+end Subtree
+
+section get
+
+/-- Get a value of a `LeafData` at an index. -/
+def LeafData.get {s} {α : Type}
+    (tree : LeafData α s) (idx : SkeletonLeafIndex s) : α :=
+  match tree, idx with
+  | LeafData.leaf value, SkeletonLeafIndex.ofLeaf => value
+  | LeafData.internal left _, SkeletonLeafIndex.ofLeft idxLeft =>
+    LeafData.get left idxLeft
+  | LeafData.internal _ right, SkeletonLeafIndex.ofRight idxRight =>
+    LeafData.get right idxRight
+
+/-- Get a value of a `InternalData` at an index. -/
+def InternalData.get {s} {α : Type}
+    (tree : InternalData α s) (idx : SkeletonInternalIndex s) : α :=
+  match tree, idx with
+  | InternalData.internal value _ _, SkeletonInternalIndex.ofInternal => value
+  | InternalData.internal _ left _, SkeletonInternalIndex.ofLeft idxLeft =>
+    InternalData.get left idxLeft
+  | InternalData.internal _ _ right, SkeletonInternalIndex.ofRight idxRight =>
+    InternalData.get right idxRight
+
+/-- Get a value of a `FullData` at an index. -/
+def FullData.get {s} {α : Type}
+    (tree : FullData α s) (idx : SkeletonNodeIndex s) : α :=
+  match tree, idx with
+  | FullData.leaf value, SkeletonNodeIndex.ofLeaf => value
+  | FullData.internal value _ _, SkeletonNodeIndex.ofInternal => value
+  | FullData.internal _ left _, SkeletonNodeIndex.ofLeft idxLeft =>
+    FullData.get left idxLeft
+  | FullData.internal _ _ right, SkeletonNodeIndex.ofRight idxRight =>
+    FullData.get right idxRight
+
+@[simp]
+theorem LeafData.get_leaf {α} (a : α) :
+    (LeafData.leaf a).get SkeletonLeafIndex.ofLeaf = a := by
+  rfl
+
+@[simp]
+theorem LeafData.get_ofLeft {s_left s_right : Skeleton} {α : Type}
+    (tree : LeafData α (Skeleton.internal s_left s_right))
+    (idxLeft : SkeletonLeafIndex s_left) :
+    tree.get (SkeletonLeafIndex.ofLeft idxLeft) =
+      tree.leftSubtree.get idxLeft := by
+  match tree with
+  | LeafData.internal left _ =>
+    rfl
+
+@[simp]
+theorem LeafData.get_ofRight {s_left s_right : Skeleton} {α : Type}
+    (tree : LeafData α (Skeleton.internal s_left s_right))
+    (idxRight : SkeletonLeafIndex s_right) :
+    tree.get (SkeletonLeafIndex.ofRight idxRight) =
+      tree.rightSubtree.get idxRight := by
+  match tree with
+  | LeafData.internal _ right =>
+    rfl
+
+@[simp]
+theorem LeafData.get_internal_ofLeft {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right)
+    (idxLeft : SkeletonLeafIndex s_left) :
+    (LeafData.internal left right).get (SkeletonLeafIndex.ofLeft idxLeft) =
+      left.get idxLeft := by
+  rfl
+
+@[simp]
+theorem LeafData.get_internal_ofRight {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right)
+    (idxRight : SkeletonLeafIndex s_right) :
+    (LeafData.internal left right).get (SkeletonLeafIndex.ofRight idxRight) =
+      right.get idxRight := by
+  rfl
+
+@[simp]
+theorem FullData.get_leaf {α} (a : α) :
+    (FullData.leaf a).get SkeletonNodeIndex.ofLeaf = a := by
+  rfl
+
+end get
+
+section forget
+
+/-- Convert a `FullData` to a `LeafData` by dropping the internal node values. -/
+def FullData.toLeafData {α : Type} {s : Skeleton}
+    (tree : FullData α s) : LeafData α s :=
+  match tree with
+  | FullData.leaf value => LeafData.leaf value
+  | FullData.internal _ left right =>
+    LeafData.internal (left.toLeafData) (right.toLeafData)
+
+/-- Convert a `FullData` to a `InternalData` by dropping the leaf node values. -/
+def FullData.toInternalData {α : Type} {s : Skeleton}
+    (tree : FullData α s) : InternalData α s :=
+  match tree with
+  | FullData.leaf _ => InternalData.leaf
+  | FullData.internal value left right =>
+    InternalData.internal value (left.toInternalData) (right.toInternalData)
+
+@[simp]
+theorem FullData.toLeafData_leaf {α} (a : α) :
+    (FullData.leaf a).toLeafData = LeafData.leaf a := by
+  rfl
+
+theorem FullData.toLeafData_leftSubtree {α} {s_left s_right : Skeleton}
+    (tree : FullData α (Skeleton.internal s_left s_right)) :
+    tree.toLeafData.leftSubtree =
+      tree.leftSubtree.toLeafData := by
+  match tree with
+  | FullData.internal _ left _right =>
+    rfl
+
+theorem FullData.toLeafData_rightSubtree {α} {s_left s_right : Skeleton}
+    (tree : FullData α (Skeleton.internal s_left s_right)) :
+    tree.toLeafData.rightSubtree =
+      tree.rightSubtree.toLeafData := by
+  match tree with
+  | FullData.internal _ _left right =>
+    rfl
+
+theorem FullData.toLeafData_eq_leaf {α} (a : α) (tree)
+    (h : LeafData.leaf a = tree.toLeafData) :
+    tree = FullData.leaf a := by
+  cases tree with
+  | leaf value =>
+    simp only [FullData.toLeafData] at h
+    cases h
+    rfl
+
+@[simp]
+theorem FullData.toLeafData_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right) :
+    (FullData.internal value left right).toLeafData =
+      LeafData.internal (left.toLeafData) (right.toLeafData) := by
+  rfl
+
+end forget
+
+section root
+
+/-- Get the root index of a skeleton. -/
+def getRootIndex (s : Skeleton) : SkeletonNodeIndex s := match s with
+  | Skeleton.leaf => SkeletonNodeIndex.ofLeaf
+  | Skeleton.internal _ _ =>
+    SkeletonNodeIndex.ofInternal
+
+/-- Get the root value of a FullData. -/
+def FullData.getRootValue {s} {α : Type} (tree : FullData α s) :=
+  tree.get (getRootIndex s)
+
+@[simp]
+theorem FullData.getRootValue_leaf {α} (a : α) :
+    (FullData.leaf a).getRootValue = a := by
+  rfl
+
+@[simp]
+theorem FullData.internal_getRootValue {s_left s_right : Skeleton} {α : Type}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right) :
+    (FullData.internal value left right).getRootValue =
+      value := by
+  rfl
+
+end root
+
+section depth
+
+/-- Depth of a SkeletonLeafIndex -/
+def SkeletonLeafIndex.depth {s : Skeleton} : SkeletonLeafIndex s → Nat
+  | SkeletonLeafIndex.ofLeaf => 0
+  | SkeletonLeafIndex.ofLeft idxLeft => idxLeft.depth + 1
+  | SkeletonLeafIndex.ofRight idxRight => idxRight.depth + 1
+
+/-- Depth of a SkeletonInternalIndex -/
+def SkeletonInternalIndex.depth {s : Skeleton} : SkeletonInternalIndex s → Nat
+  | SkeletonInternalIndex.ofInternal => 0
+  | SkeletonInternalIndex.ofLeft idxLeft => idxLeft.depth + 1
+  | SkeletonInternalIndex.ofRight idxRight => idxRight.depth + 1
+
+/-- Depth of a SkeletonNodeIndex -/
+def SkeletonNodeIndex.depth {s : Skeleton} : SkeletonNodeIndex s → Nat
+  | SkeletonNodeIndex.ofLeaf => 0
+  | SkeletonNodeIndex.ofInternal => 0
+  | SkeletonNodeIndex.ofLeft idxLeft => idxLeft.depth + 1
+  | SkeletonNodeIndex.ofRight idxRight => idxRight.depth + 1
+
+end depth
+
+section Navigation
+
+/--
+Get the parent of a `SkeletonNodeIndex`, or `none` if the index is the root.
+-/
+def SkeletonNodeIndex.parent {s : Skeleton} (idx : SkeletonNodeIndex s) :
+    Option (SkeletonNodeIndex s) :=
+  match idx with
+  | SkeletonNodeIndex.ofLeaf => none
+  | SkeletonNodeIndex.ofInternal => none
+  | SkeletonNodeIndex.ofLeft (.ofLeaf) => some .ofInternal
+  | SkeletonNodeIndex.ofLeft (.ofInternal) => some .ofInternal
+  | SkeletonNodeIndex.ofLeft idxLeft =>
+    idxLeft.parent.map (SkeletonNodeIndex.ofLeft)
+  | SkeletonNodeIndex.ofRight (.ofLeaf) => some .ofInternal
+  | SkeletonNodeIndex.ofRight (.ofInternal) => some .ofInternal
+  | SkeletonNodeIndex.ofRight idxRight =>
+    idxRight.parent.map (SkeletonNodeIndex.ofRight)
+
+/--
+Return the sibling node index of a given `SkeletonNodeIndex`. Or `none` if the node is the root
+-/
+def SkeletonNodeIndex.sibling {s : Skeleton} (idx : SkeletonNodeIndex s) :
+    Option (SkeletonNodeIndex s) :=
+  match idx with
+  -- s consists of s single leaf, idx is this leaf and is hence the root
+  | SkeletonNodeIndex.ofLeaf => none
+  -- idx is the root node of a nontrivial tree
+  | SkeletonNodeIndex.ofInternal => none
+  -- idx is in the left subtree of a nontrivial tree
+  | @SkeletonNodeIndex.ofLeft left right idxLeft =>
+    match idxLeft with
+    -- If idx is a leaf, then its sibling is the root of the right subtree
+    | SkeletonNodeIndex.ofLeaf => some (getRootIndex right).ofRight
+    -- If idx is an internal node, then its sibling is the root of the left subtree
+    | SkeletonNodeIndex.ofInternal => some (getRootIndex right).ofRight
+    -- If idx is in the left subtree of the left subtree,
+    -- we can find its sibling by considering only the left subtree
+    | SkeletonNodeIndex.ofLeft idxLeftLeft =>
+      idxLeftLeft.ofLeft.sibling.map (SkeletonNodeIndex.ofLeft)
+    | SkeletonNodeIndex.ofRight idxLeftRight =>
+      idxLeftRight.ofRight.sibling.map (SkeletonNodeIndex.ofLeft)
+  | @SkeletonNodeIndex.ofRight left right idxRight =>
+    match idxRight with
+    | SkeletonNodeIndex.ofLeaf => some (getRootIndex left).ofLeft
+    | SkeletonNodeIndex.ofInternal => some (getRootIndex left).ofLeft
+    | SkeletonNodeIndex.ofLeft idxRightLeft =>
+      idxRightLeft.ofLeft.sibling.map (SkeletonNodeIndex.ofRight)
+    | SkeletonNodeIndex.ofRight idxRightRight =>
+      idxRightRight.ofRight.sibling.map (SkeletonNodeIndex.ofRight)
+
+/--
+Return the left child of a `SkeletonNodeIndex`, or `none` if the index is a leaf.
+-/
+def SkeletonNodeIndex.leftChild {s : Skeleton} (idx : SkeletonNodeIndex s) :
+    Option (SkeletonNodeIndex s) :=
+  match idx with
+  | SkeletonNodeIndex.ofLeaf => none
+  | @SkeletonNodeIndex.ofInternal left right =>
+    some (SkeletonNodeIndex.ofLeft (getRootIndex left))
+  | SkeletonNodeIndex.ofLeft idxLeft =>
+    idxLeft.leftChild.map (SkeletonNodeIndex.ofLeft)
+  | SkeletonNodeIndex.ofRight idxRight =>
+    idxRight.leftChild.map (SkeletonNodeIndex.ofRight)
+
+/--
+Return the right child of a `SkeletonNodeIndex`, or `none` if the index is a leaf.
+-/
+def SkeletonNodeIndex.rightChild {s : Skeleton} (idx : SkeletonNodeIndex s) :
+    Option (SkeletonNodeIndex s) :=
+  match idx with
+  | SkeletonNodeIndex.ofLeaf => none
+  | @SkeletonNodeIndex.ofInternal left right =>
+    some (SkeletonNodeIndex.ofRight (getRootIndex right))
+  | SkeletonNodeIndex.ofLeft idxLeft =>
+    idxLeft.rightChild.map (SkeletonNodeIndex.ofLeft)
+  | SkeletonNodeIndex.ofRight idxRight =>
+    idxRight.rightChild.map (SkeletonNodeIndex.ofRight)
+
+
+end Navigation
+
+section Paths
+
+
+/--
+Given a `Skeleton`, and a node index of the skeleton,
+return a list of node indices which are the ancestors of the node,
+starting with the root node, and going down to but not including the node itself.
+-/
+
+def SkeletonNodeIndex.path {s : Skeleton} (idx : SkeletonNodeIndex s) :
+    List (SkeletonNodeIndex s) :=
+  match idx with
+  | SkeletonNodeIndex.ofLeaf => []
+  | SkeletonNodeIndex.ofInternal => []
+  | SkeletonNodeIndex.ofLeft idxLeft =>
+    SkeletonNodeIndex.ofInternal :: idxLeft.path.map SkeletonNodeIndex.ofLeft
+  | SkeletonNodeIndex.ofRight idxRight =>
+    SkeletonNodeIndex.ofInternal :: idxRight.path.map SkeletonNodeIndex.ofRight
+
+/-- Find the siblings of a node and its ancestors, starting with the child of the root -/
+def FullData.copath {α} {s} (cache_tree : FullData α s) :
+    BinaryTree.SkeletonLeafIndex s → List α
+  | .ofLeaf => []
+  | .ofLeft idxLeft =>
+    (cache_tree.rightSubtree).getRootValue ::
+      (copath cache_tree.leftSubtree idxLeft)
+  | .ofRight idxRight =>
+    (cache_tree.leftSubtree).getRootValue ::
+      (copath cache_tree.rightSubtree idxRight)
+
+end Paths
+
+section map
+
+
+def LeafData.map {α β : Type} (f : α → β) {s : Skeleton}
+    (tree : LeafData α s) : LeafData β s :=
+  match tree with
+  | LeafData.leaf value => LeafData.leaf (f value)
+  | LeafData.internal left right =>
+    LeafData.internal (left.map f) (right.map f)
+
+def InternalData.map {α β : Type} (f : α → β) {s : Skeleton}
+    (tree : InternalData α s) : InternalData β s :=
+  match tree with
+  | InternalData.leaf => InternalData.leaf
+  | InternalData.internal value left right =>
+    InternalData.internal (f value) (left.map f) (right.map f)
+
+def FullData.map {α β : Type} (f : α → β) {s : Skeleton}
+    (tree : FullData α s) : FullData β s :=
+  match tree with
+  | FullData.leaf value => FullData.leaf (f value)
+  | FullData.internal value left right =>
+    FullData.internal (f value) (left.map f) (right.map f)
+
+@[simp]
+theorem FullData.map_leaf {α β} (f : α → β) (a : α) :
+    (FullData.leaf a).map f = FullData.leaf (f a) := by
+  rfl
+
+@[simp]
+theorem FullData.map_internal {α β} {s_left s_right : Skeleton}
+    (f : α → β) (value : α) (left : FullData α s_left) (right : FullData α s_right) :
+    (FullData.internal value left right).map f =
+      FullData.internal (f value) (left.map f) (right.map f) := by
+  rfl
+
+@[simp]
+theorem LeafData.map_leaf {α β} (f : α → β) (a : α) :
+    (LeafData.leaf a).map f = LeafData.leaf (f a) := by
+  rfl
+
+@[simp]
+theorem LeafData.map_internal {α β} {s_left s_right : Skeleton}
+    (f : α → β) (left : LeafData α s_left) (right : LeafData α s_right) :
+    (LeafData.internal left right).map f =
+      LeafData.internal (left.map f) (right.map f) := by
+  rfl
+
+
+theorem FullData.map_getRootValue {α β : Type} {s : Skeleton}
+    (f : α → β) (tree : FullData α s) :
+    (tree.map f).getRootValue = f (tree.getRootValue) := by
+  match tree with
+  | FullData.leaf value => rfl
+  | FullData.internal value left right =>
+    rfl
+
+end map
+
+section ComposeBuild
+
+/-!
+## Build
+
+This section contains theorems about building full trees from leaf trees.
+-/
+
+def LeafData.composeBuild {α : Type} {s : Skeleton} (leaf_data_tree : LeafData α s)
+    (compose : α → α → α) :
+    FullData α s :=
+  match s, leaf_data_tree with
+  | Skeleton.leaf, LeafData.leaf value =>
+    FullData.leaf value
+  | Skeleton.internal _ _, LeafData.internal left right =>
+    let left_tree := LeafData.composeBuild left compose
+    let right_tree := LeafData.composeBuild right compose
+    FullData.internal
+      (compose left_tree.getRootValue right_tree.getRootValue)
+      left_tree
+      right_tree
+
+theorem LeafData.composeBuild_leaf {α} (a : α)
+    (compose : α → α → α) :
+    (LeafData.leaf a).composeBuild compose = FullData.leaf a := by
+  rfl
+
+theorem LeafData.composeBuild_internal {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right)
+    (compose : α → α → α) :
+    (LeafData.internal left right).composeBuild compose =
+      FullData.internal
+        (compose (left.composeBuild compose).getRootValue (right.composeBuild compose).getRootValue)
+        (left.composeBuild compose)
+        (right.composeBuild compose) := by
+  rfl
+
+theorem LeafData.composeBuild_getRootValue {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right)
+    (compose : α → α → α) :
+    ((LeafData.internal left right).composeBuild compose).getRootValue =
+      compose (left.composeBuild compose).getRootValue (right.composeBuild compose).getRootValue := by
+  rfl
+
+def Option.doubleBind {α β γ : Type} (f : α → β → Option γ)
+    (x : Option α) (y : Option β) : Option γ :=
+  match x, y with
+  | none, _ => none
+  | _, none => none
+  | some a, some b => f a b
+
+def Option.doubleBind_v2 {α β γ : Type} (f : α → β → Option γ)
+    (x : Option α) (y : Option β) : Option γ := do
+  let a ← x
+  let b ← y
+  f a b
+
+def Option.doubleBind_v3 {α β γ : Type} (f : α → β → Option γ)
+    (x : Option α) (y : Option β) : Option γ := do f (← x) (← y)
+
+def LeafData.optionComposeBuild {α : Type} {s : Skeleton} (leaf_data_tree : LeafData α s)
+    (compose : α → α → Option α) :
+    FullData (Option α) s :=
+  (leaf_data_tree.map (.some)).composeBuild (Option.doubleBind compose)
+
+@[simp]
+theorem LeafData.optionComposeBuild_leaf {α} (a : α)
+    (compose : α → α → Option α) :
+    (LeafData.leaf a).optionComposeBuild compose = FullData.leaf (.some a) := by
+  rfl
+
+@[simp]
+theorem LeafData.optionComposeBuild_internal {α} {s_left s_right : Skeleton}
+    (left : LeafData α s_left) (right : LeafData α s_right)
+    (compose : α → α → Option α) :
+    (LeafData.internal left right).optionComposeBuild compose =
+      FullData.internal
+        (Option.doubleBind compose
+          (left.optionComposeBuild compose).getRootValue
+          (right.optionComposeBuild compose).getRootValue)
+        (left.optionComposeBuild compose)
+        (right.optionComposeBuild compose) := by
+  rfl
+
+end ComposeBuild
+
+end BinaryTree

--- a/ToMathlib/Data/IndexedBinaryTree/Basic.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Basic.lean
@@ -106,18 +106,21 @@ This section contains predicates about indices determined by their neighborhood 
 
 section Local
 
+/-- Check whether a leaf index is the root of its tree. -/
 def SkeletonLeafIndex.isRoot {s : Skeleton} (idx : SkeletonLeafIndex s) : Bool :=
   match idx with
   | SkeletonLeafIndex.ofLeaf => true
   | SkeletonLeafIndex.ofLeft _ => false
   | SkeletonLeafIndex.ofRight _ => false
 
+/-- Check whether an internal-node index is the root of its tree. -/
 def SkeletonInternalIndex.isRoot {s : Skeleton} (idx : SkeletonInternalIndex s) : Bool :=
   match idx with
   | SkeletonInternalIndex.ofInternal => true
   | SkeletonInternalIndex.ofLeft _ => false
   | SkeletonInternalIndex.ofRight _ => false
 
+/-- Check whether a node index is the root of its tree. -/
 def SkeletonNodeIndex.isRoot {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :=
   match idx with
   | SkeletonNodeIndex.ofLeaf => true
@@ -125,12 +128,15 @@ def SkeletonNodeIndex.isRoot {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :
   | SkeletonNodeIndex.ofLeft _ => false
   | SkeletonNodeIndex.ofRight _ => false
 
+/-- Every `SkeletonLeafIndex` points to a leaf. -/
 def SkeletonLeafIndex.isLeaf {s : Skeleton} (_ : SkeletonLeafIndex s) : Bool :=
   true
 
+/-- No `SkeletonInternalIndex` points to a leaf. -/
 def SkeletonInternalIndex.isLeaf {s : Skeleton} (_ : SkeletonInternalIndex s) : Bool :=
   false
 
+/-- Check whether a node index points to a leaf of the tree. -/
 def SkeletonNodeIndex.isLeaf {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :=
   match idx with
   | SkeletonNodeIndex.ofLeaf => true
@@ -343,6 +349,90 @@ theorem FullData.get_leaf {α} (a : α) :
     (FullData.leaf a).get SkeletonNodeIndex.ofLeaf = a := by
   rfl
 
+@[simp]
+theorem InternalData.get_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : InternalData α s_left) (right : InternalData α s_right) :
+    (InternalData.internal value left right).get SkeletonInternalIndex.ofInternal = value := by
+  rfl
+
+@[simp]
+theorem InternalData.get_ofLeft {s_left s_right : Skeleton} {α}
+    (tree : InternalData α (Skeleton.internal s_left s_right))
+    (idxLeft : SkeletonInternalIndex s_left) :
+    tree.get (SkeletonInternalIndex.ofLeft idxLeft) =
+      tree.leftSubtree.get idxLeft := by
+  match tree with
+  | InternalData.internal _ left _ =>
+    rfl
+
+@[simp]
+theorem InternalData.get_ofRight {s_left s_right : Skeleton} {α}
+    (tree : InternalData α (Skeleton.internal s_left s_right))
+    (idxRight : SkeletonInternalIndex s_right) :
+    tree.get (SkeletonInternalIndex.ofRight idxRight) =
+      tree.rightSubtree.get idxRight := by
+  match tree with
+  | InternalData.internal _ _ right =>
+    rfl
+
+@[simp]
+theorem InternalData.get_internal_ofLeft {α} {s_left s_right : Skeleton}
+    (value : α) (left : InternalData α s_left) (right : InternalData α s_right)
+    (idxLeft : SkeletonInternalIndex s_left) :
+    (InternalData.internal value left right).get (SkeletonInternalIndex.ofLeft idxLeft) =
+      left.get idxLeft := by
+  rfl
+
+@[simp]
+theorem InternalData.get_internal_ofRight {α} {s_left s_right : Skeleton}
+    (value : α) (left : InternalData α s_left) (right : InternalData α s_right)
+    (idxRight : SkeletonInternalIndex s_right) :
+    (InternalData.internal value left right).get (SkeletonInternalIndex.ofRight idxRight) =
+      right.get idxRight := by
+  rfl
+
+@[simp]
+theorem FullData.get_internal {α} {s_left s_right : Skeleton}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right) :
+    (FullData.internal value left right).get SkeletonNodeIndex.ofInternal = value := by
+  rfl
+
+@[simp]
+theorem FullData.get_ofLeft {s_left s_right : Skeleton} {α}
+    (tree : FullData α (Skeleton.internal s_left s_right))
+    (idxLeft : SkeletonNodeIndex s_left) :
+    tree.get (SkeletonNodeIndex.ofLeft idxLeft) =
+      tree.leftSubtree.get idxLeft := by
+  match tree with
+  | FullData.internal _ left _ =>
+    rfl
+
+@[simp]
+theorem FullData.get_ofRight {s_left s_right : Skeleton} {α}
+    (tree : FullData α (Skeleton.internal s_left s_right))
+    (idxRight : SkeletonNodeIndex s_right) :
+    tree.get (SkeletonNodeIndex.ofRight idxRight) =
+      tree.rightSubtree.get idxRight := by
+  match tree with
+  | FullData.internal _ _ right =>
+    rfl
+
+@[simp]
+theorem FullData.get_internal_ofLeft {α} {s_left s_right : Skeleton}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right)
+    (idxLeft : SkeletonNodeIndex s_left) :
+    (FullData.internal value left right).get (SkeletonNodeIndex.ofLeft idxLeft) =
+      left.get idxLeft := by
+  rfl
+
+@[simp]
+theorem FullData.get_internal_ofRight {α} {s_left s_right : Skeleton}
+    (value : α) (left : FullData α s_left) (right : FullData α s_right)
+    (idxRight : SkeletonNodeIndex s_right) :
+    (FullData.internal value left right).get (SkeletonNodeIndex.ofRight idxRight) =
+      right.get idxRight := by
+  rfl
+
 end get
 
 section forget
@@ -368,6 +458,7 @@ theorem FullData.toLeafData_leaf {α} (a : α) :
     (FullData.leaf a).toLeafData = LeafData.leaf a := by
   rfl
 
+@[simp]
 theorem FullData.toLeafData_leftSubtree {α} {s_left s_right : Skeleton}
     (tree : FullData α (Skeleton.internal s_left s_right)) :
     tree.toLeafData.leftSubtree =
@@ -376,6 +467,7 @@ theorem FullData.toLeafData_leftSubtree {α} {s_left s_right : Skeleton}
   | FullData.internal _ left _right =>
     rfl
 
+@[simp]
 theorem FullData.toLeafData_rightSubtree {α} {s_left s_right : Skeleton}
     (tree : FullData α (Skeleton.internal s_left s_right)) :
     tree.toLeafData.rightSubtree =
@@ -384,7 +476,7 @@ theorem FullData.toLeafData_rightSubtree {α} {s_left s_right : Skeleton}
   | FullData.internal _ _left right =>
     rfl
 
-theorem FullData.toLeafData_eq_leaf {α} (a : α) (tree)
+theorem FullData.toLeafData_eq_leaf {α} (a : α) (tree : FullData α Skeleton.leaf)
     (h : LeafData.leaf a = tree.toLeafData) :
     tree = FullData.leaf a := by
   cases tree with
@@ -485,7 +577,7 @@ def SkeletonNodeIndex.sibling {s : Skeleton} (idx : SkeletonNodeIndex s) :
     match idxLeft with
     -- If idx is a leaf, then its sibling is the root of the right subtree
     | SkeletonNodeIndex.ofLeaf => some (getRootIndex right).ofRight
-    -- If idx is an internal node, then its sibling is the root of the left subtree
+    -- If idx is an internal node, then its sibling is the root of the right subtree
     | SkeletonNodeIndex.ofInternal => some (getRootIndex right).ofRight
     -- If idx is in the left subtree of the left subtree,
     -- we can find its sibling by considering only the left subtree
@@ -567,6 +659,7 @@ end Paths
 section map
 
 
+/-- Apply a function to every value stored in a `LeafData`. -/
 def LeafData.map {α β : Type _} (f : α → β) {s : Skeleton}
     (tree : LeafData α s) : LeafData β s :=
   match tree with
@@ -574,6 +667,7 @@ def LeafData.map {α β : Type _} (f : α → β) {s : Skeleton}
   | LeafData.internal left right =>
     LeafData.internal (left.map f) (right.map f)
 
+/-- Apply a function to every value stored in an `InternalData`. -/
 def InternalData.map {α β : Type _} (f : α → β) {s : Skeleton}
     (tree : InternalData α s) : InternalData β s :=
   match tree with
@@ -581,6 +675,7 @@ def InternalData.map {α β : Type _} (f : α → β) {s : Skeleton}
   | InternalData.internal value left right =>
     InternalData.internal (f value) (left.map f) (right.map f)
 
+/-- Apply a function to every value stored in a `FullData`. -/
 def FullData.map {α β : Type _} (f : α → β) {s : Skeleton}
     (tree : FullData α s) : FullData β s :=
   match tree with
@@ -616,10 +711,7 @@ theorem LeafData.map_internal {α β} {s_left s_right : Skeleton}
 theorem FullData.map_getRootValue {α β : Type _} {s : Skeleton}
     (f : α → β) (tree : FullData α s) :
     (tree.map f).getRootValue = f (tree.getRootValue) := by
-  match tree with
-  | FullData.leaf value => rfl
-  | FullData.internal value left right =>
-    rfl
+  cases tree <;> rfl
 
 end map
 
@@ -631,25 +723,28 @@ section ComposeBuild
 This section contains theorems about building full trees from leaf trees.
 -/
 
+/-- Build a `FullData` tree by hashing together the roots of child subtrees. -/
 def LeafData.composeBuild {α : Type _} {s : Skeleton} (leaf_data_tree : LeafData α s)
     (compose : α → α → α) :
     FullData α s :=
-  match s, leaf_data_tree with
-  | Skeleton.leaf, LeafData.leaf value =>
-    FullData.leaf value
-  | Skeleton.internal _ _, LeafData.internal left right =>
-    let left_tree := LeafData.composeBuild left compose
-    let right_tree := LeafData.composeBuild right compose
-    FullData.internal
-      (compose left_tree.getRootValue right_tree.getRootValue)
-      left_tree
-      right_tree
+  match leaf_data_tree with
+  | .leaf value =>
+    .leaf value
+  | .internal left right =>
+    let leftTree := left.composeBuild compose
+    let rightTree := right.composeBuild compose
+    .internal
+      (compose leftTree.getRootValue rightTree.getRootValue)
+      leftTree
+      rightTree
 
+@[simp]
 theorem LeafData.composeBuild_leaf {α} (a : α)
     (compose : α → α → α) :
     (LeafData.leaf a).composeBuild compose = FullData.leaf a := by
   rfl
 
+@[simp]
 theorem LeafData.composeBuild_internal {α} {s_left s_right : Skeleton}
     (left : LeafData α s_left) (right : LeafData α s_right)
     (compose : α → α → α) :
@@ -660,6 +755,7 @@ theorem LeafData.composeBuild_internal {α} {s_left s_right : Skeleton}
         (right.composeBuild compose) := by
   rfl
 
+@[simp]
 theorem LeafData.composeBuild_getRootValue {α} {s_left s_right : Skeleton}
     (left : LeafData α s_left) (right : LeafData α s_right)
     (compose : α → α → α) :
@@ -668,6 +764,7 @@ theorem LeafData.composeBuild_getRootValue {α} {s_left s_right : Skeleton}
         (right.composeBuild compose).getRootValue := by
   rfl
 
+/-- Lift a binary function through two `Option` arguments. -/
 def Option.doubleBind {α β γ : Type _} (f : α → β → Option γ)
     (x : Option α) (y : Option β) : Option γ :=
   match x, y with
@@ -675,6 +772,7 @@ def Option.doubleBind {α β γ : Type _} (f : α → β → Option γ)
   | _, none => none
   | some a, some b => f a b
 
+/-- Build a tree while allowing failures in the composition function. -/
 def LeafData.optionComposeBuild {α : Type _} {s : Skeleton} (leaf_data_tree : LeafData α s)
     (compose : α → α → Option α) :
     FullData (Option α) s :=

--- a/ToMathlib/Data/IndexedBinaryTree/Basic.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Basic.lean
@@ -125,24 +125,18 @@ def SkeletonNodeIndex.isRoot {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :
   | SkeletonNodeIndex.ofLeft _ => false
   | SkeletonNodeIndex.ofRight _ => false
 
-def SkeletonLeafIndex.isLeaf {s : Skeleton} (idx : SkeletonLeafIndex s) : Bool :=
-  match idx with
-  | SkeletonLeafIndex.ofLeaf => true
-  | SkeletonLeafIndex.ofLeft _ => false
-  | SkeletonLeafIndex.ofRight _ => false
+def SkeletonLeafIndex.isLeaf {s : Skeleton} (_ : SkeletonLeafIndex s) : Bool :=
+  true
 
-def SkeletonInternalIndex.isLeaf {s : Skeleton} (idx : SkeletonInternalIndex s) : Bool :=
-  match idx with
-  | SkeletonInternalIndex.ofInternal => false
-  | SkeletonInternalIndex.ofLeft _ => false
-  | SkeletonInternalIndex.ofRight _ => false
+def SkeletonInternalIndex.isLeaf {s : Skeleton} (_ : SkeletonInternalIndex s) : Bool :=
+  false
 
 def SkeletonNodeIndex.isLeaf {s : Skeleton} (idx : SkeletonNodeIndex s) : Bool :=
   match idx with
   | SkeletonNodeIndex.ofLeaf => true
   | SkeletonNodeIndex.ofInternal => false
-  | SkeletonNodeIndex.ofLeft _ => false
-  | SkeletonNodeIndex.ofRight _ => false
+  | SkeletonNodeIndex.ofLeft idxLeft => idxLeft.isLeaf
+  | SkeletonNodeIndex.ofRight idxRight => idxRight.isLeaf
 
 end Local
 
@@ -151,7 +145,7 @@ section Data
 /--
 A binary tree with values stored at leaves.
 -/
-inductive LeafData (α : Type) : Skeleton → Type
+inductive LeafData (α : Type _) : Skeleton → Type _
   | leaf (value : α) : LeafData α Skeleton.leaf
   | internal {left right} (leftData : LeafData α left) (rightData : LeafData α right) :
       LeafData α (Skeleton.internal left right)
@@ -160,7 +154,7 @@ inductive LeafData (α : Type) : Skeleton → Type
 /--
 A binary tree with values stored in internal nodes.
 -/
-inductive InternalData (α : Type) : Skeleton → Type
+inductive InternalData (α : Type _) : Skeleton → Type _
   | leaf : InternalData α Skeleton.leaf
   | internal {left right} (value : α)
       (leftData : InternalData α left)
@@ -170,7 +164,7 @@ inductive InternalData (α : Type) : Skeleton → Type
 /--
 A binary tree with values stored at both leaves and internal nodes.
 -/
-inductive FullData (α : Type) : Skeleton → Type
+inductive FullData (α : Type _) : Skeleton → Type _
   | leaf (value : α) : FullData α Skeleton.leaf
   | internal {left right} (value : α)
       (leftData : FullData α left)
@@ -185,7 +179,7 @@ section Subtree
 /--
 Get the left subtree of a `LeafData`.
 -/
-def LeafData.leftSubtree {α : Type} {s_left s_right : Skeleton}
+def LeafData.leftSubtree {α : Type _} {s_left s_right : Skeleton}
     (tree : LeafData α (Skeleton.internal s_left s_right)) :
     LeafData α s_left :=
   match tree with
@@ -193,7 +187,7 @@ def LeafData.leftSubtree {α : Type} {s_left s_right : Skeleton}
     left
 
 /-- Get the right subtree of a `LeafData`. -/
-def LeafData.rightSubtree {α : Type} {s_left s_right : Skeleton}
+def LeafData.rightSubtree {α : Type _} {s_left s_right : Skeleton}
     (tree : LeafData α (Skeleton.internal s_left s_right)) :
     LeafData α s_right :=
   match tree with
@@ -201,7 +195,7 @@ def LeafData.rightSubtree {α : Type} {s_left s_right : Skeleton}
     right
 
 /-- Get the left subtree of a `InternalData`. -/
-def InternalData.leftSubtree {α : Type} {s_left s_right : Skeleton}
+def InternalData.leftSubtree {α : Type _} {s_left s_right : Skeleton}
     (tree : InternalData α (Skeleton.internal s_left s_right)) :
     InternalData α s_left :=
   match tree with
@@ -209,7 +203,7 @@ def InternalData.leftSubtree {α : Type} {s_left s_right : Skeleton}
     left
 
 /-- Get the right subtree of a `InternalData`. -/
-def InternalData.rightSubtree {α : Type} {s_left s_right : Skeleton}
+def InternalData.rightSubtree {α : Type _} {s_left s_right : Skeleton}
     (tree : InternalData α (Skeleton.internal s_left s_right)) :
     InternalData α s_right :=
   match tree with
@@ -217,7 +211,7 @@ def InternalData.rightSubtree {α : Type} {s_left s_right : Skeleton}
     right
 
 /-- Get the left subtree of a `FullData`. -/
-def FullData.leftSubtree {α : Type} {s_left s_right : Skeleton}
+def FullData.leftSubtree {α : Type _} {s_left s_right : Skeleton}
     (tree : FullData α (Skeleton.internal s_left s_right)) :
     FullData α s_left :=
   match tree with
@@ -225,7 +219,7 @@ def FullData.leftSubtree {α : Type} {s_left s_right : Skeleton}
     left
 
 /-- Get the right subtree of a `FullData`. -/
-def FullData.rightSubtree {α : Type} {s_left s_right : Skeleton}
+def FullData.rightSubtree {α : Type _} {s_left s_right : Skeleton}
     (tree : FullData α (Skeleton.internal s_left s_right)) :
     FullData α s_right :=
   match tree with
@@ -273,7 +267,7 @@ end Subtree
 section get
 
 /-- Get a value of a `LeafData` at an index. -/
-def LeafData.get {s} {α : Type}
+def LeafData.get {s} {α : Type _}
     (tree : LeafData α s) (idx : SkeletonLeafIndex s) : α :=
   match tree, idx with
   | LeafData.leaf value, SkeletonLeafIndex.ofLeaf => value
@@ -283,7 +277,7 @@ def LeafData.get {s} {α : Type}
     LeafData.get right idxRight
 
 /-- Get a value of a `InternalData` at an index. -/
-def InternalData.get {s} {α : Type}
+def InternalData.get {s} {α : Type _}
     (tree : InternalData α s) (idx : SkeletonInternalIndex s) : α :=
   match tree, idx with
   | InternalData.internal value _ _, SkeletonInternalIndex.ofInternal => value
@@ -293,7 +287,7 @@ def InternalData.get {s} {α : Type}
     InternalData.get right idxRight
 
 /-- Get a value of a `FullData` at an index. -/
-def FullData.get {s} {α : Type}
+def FullData.get {s} {α : Type _}
     (tree : FullData α s) (idx : SkeletonNodeIndex s) : α :=
   match tree, idx with
   | FullData.leaf value, SkeletonNodeIndex.ofLeaf => value
@@ -309,7 +303,7 @@ theorem LeafData.get_leaf {α} (a : α) :
   rfl
 
 @[simp]
-theorem LeafData.get_ofLeft {s_left s_right : Skeleton} {α : Type}
+theorem LeafData.get_ofLeft {s_left s_right : Skeleton} {α : Type _}
     (tree : LeafData α (Skeleton.internal s_left s_right))
     (idxLeft : SkeletonLeafIndex s_left) :
     tree.get (SkeletonLeafIndex.ofLeft idxLeft) =
@@ -319,7 +313,7 @@ theorem LeafData.get_ofLeft {s_left s_right : Skeleton} {α : Type}
     rfl
 
 @[simp]
-theorem LeafData.get_ofRight {s_left s_right : Skeleton} {α : Type}
+theorem LeafData.get_ofRight {s_left s_right : Skeleton} {α : Type _}
     (tree : LeafData α (Skeleton.internal s_left s_right))
     (idxRight : SkeletonLeafIndex s_right) :
     tree.get (SkeletonLeafIndex.ofRight idxRight) =
@@ -354,7 +348,7 @@ end get
 section forget
 
 /-- Convert a `FullData` to a `LeafData` by dropping the internal node values. -/
-def FullData.toLeafData {α : Type} {s : Skeleton}
+def FullData.toLeafData {α : Type _} {s : Skeleton}
     (tree : FullData α s) : LeafData α s :=
   match tree with
   | FullData.leaf value => LeafData.leaf value
@@ -362,7 +356,7 @@ def FullData.toLeafData {α : Type} {s : Skeleton}
     LeafData.internal (left.toLeafData) (right.toLeafData)
 
 /-- Convert a `FullData` to a `InternalData` by dropping the leaf node values. -/
-def FullData.toInternalData {α : Type} {s : Skeleton}
+def FullData.toInternalData {α : Type _} {s : Skeleton}
     (tree : FullData α s) : InternalData α s :=
   match tree with
   | FullData.leaf _ => InternalData.leaf
@@ -417,7 +411,7 @@ def getRootIndex (s : Skeleton) : SkeletonNodeIndex s := match s with
     SkeletonNodeIndex.ofInternal
 
 /-- Get the root value of a FullData. -/
-def FullData.getRootValue {s} {α : Type} (tree : FullData α s) :=
+def FullData.getRootValue {s} {α : Type _} (tree : FullData α s) :=
   tree.get (getRootIndex s)
 
 @[simp]
@@ -426,7 +420,7 @@ theorem FullData.getRootValue_leaf {α} (a : α) :
   rfl
 
 @[simp]
-theorem FullData.internal_getRootValue {s_left s_right : Skeleton} {α : Type}
+theorem FullData.internal_getRootValue {s_left s_right : Skeleton} {α : Type _}
     (value : α) (left : FullData α s_left) (right : FullData α s_right) :
     (FullData.internal value left right).getRootValue =
       value := by
@@ -573,21 +567,21 @@ end Paths
 section map
 
 
-def LeafData.map {α β : Type} (f : α → β) {s : Skeleton}
+def LeafData.map {α β : Type _} (f : α → β) {s : Skeleton}
     (tree : LeafData α s) : LeafData β s :=
   match tree with
   | LeafData.leaf value => LeafData.leaf (f value)
   | LeafData.internal left right =>
     LeafData.internal (left.map f) (right.map f)
 
-def InternalData.map {α β : Type} (f : α → β) {s : Skeleton}
+def InternalData.map {α β : Type _} (f : α → β) {s : Skeleton}
     (tree : InternalData α s) : InternalData β s :=
   match tree with
   | InternalData.leaf => InternalData.leaf
   | InternalData.internal value left right =>
     InternalData.internal (f value) (left.map f) (right.map f)
 
-def FullData.map {α β : Type} (f : α → β) {s : Skeleton}
+def FullData.map {α β : Type _} (f : α → β) {s : Skeleton}
     (tree : FullData α s) : FullData β s :=
   match tree with
   | FullData.leaf value => FullData.leaf (f value)
@@ -619,7 +613,7 @@ theorem LeafData.map_internal {α β} {s_left s_right : Skeleton}
   rfl
 
 
-theorem FullData.map_getRootValue {α β : Type} {s : Skeleton}
+theorem FullData.map_getRootValue {α β : Type _} {s : Skeleton}
     (f : α → β) (tree : FullData α s) :
     (tree.map f).getRootValue = f (tree.getRootValue) := by
   match tree with
@@ -637,7 +631,7 @@ section ComposeBuild
 This section contains theorems about building full trees from leaf trees.
 -/
 
-def LeafData.composeBuild {α : Type} {s : Skeleton} (leaf_data_tree : LeafData α s)
+def LeafData.composeBuild {α : Type _} {s : Skeleton} (leaf_data_tree : LeafData α s)
     (compose : α → α → α) :
     FullData α s :=
   match s, leaf_data_tree with
@@ -674,23 +668,14 @@ theorem LeafData.composeBuild_getRootValue {α} {s_left s_right : Skeleton}
         (right.composeBuild compose).getRootValue := by
   rfl
 
-def Option.doubleBind {α β γ : Type} (f : α → β → Option γ)
+def Option.doubleBind {α β γ : Type _} (f : α → β → Option γ)
     (x : Option α) (y : Option β) : Option γ :=
   match x, y with
   | none, _ => none
   | _, none => none
   | some a, some b => f a b
 
-def Option.doubleBind_v2 {α β γ : Type} (f : α → β → Option γ)
-    (x : Option α) (y : Option β) : Option γ := do
-  let a ← x
-  let b ← y
-  f a b
-
-def Option.doubleBind_v3 {α β γ : Type} (f : α → β → Option γ)
-    (x : Option α) (y : Option β) : Option γ := do f (← x) (← y)
-
-def LeafData.optionComposeBuild {α : Type} {s : Skeleton} (leaf_data_tree : LeafData α s)
+def LeafData.optionComposeBuild {α : Type _} {s : Skeleton} (leaf_data_tree : LeafData α s)
     (compose : α → α → Option α) :
     FullData (Option α) s :=
   (leaf_data_tree.map (.some)).composeBuild (Option.doubleBind compose)

--- a/ToMathlib/Data/IndexedBinaryTree/Basic.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Basic.lean
@@ -563,36 +563,21 @@ def SkeletonNodeIndex.parent {s : Skeleton} (idx : SkeletonNodeIndex s) :
     idxRight.parent.map (SkeletonNodeIndex.ofRight)
 
 /--
-Return the sibling node index of a given `SkeletonNodeIndex`. Or `none` if the node is the root
+Return the sibling node index of a given `SkeletonNodeIndex`. Or `none` if the node is the root.
 -/
 def SkeletonNodeIndex.sibling {s : Skeleton} (idx : SkeletonNodeIndex s) :
     Option (SkeletonNodeIndex s) :=
   match idx with
-  -- s consists of s single leaf, idx is this leaf and is hence the root
-  | SkeletonNodeIndex.ofLeaf => none
-  -- idx is the root node of a nontrivial tree
-  | SkeletonNodeIndex.ofInternal => none
-  -- idx is in the left subtree of a nontrivial tree
-  | @SkeletonNodeIndex.ofLeft left right idxLeft =>
-    match idxLeft with
-    -- If idx is a leaf, then its sibling is the root of the right subtree
-    | SkeletonNodeIndex.ofLeaf => some (getRootIndex right).ofRight
-    -- If idx is an internal node, then its sibling is the root of the right subtree
-    | SkeletonNodeIndex.ofInternal => some (getRootIndex right).ofRight
-    -- If idx is in the left subtree of the left subtree,
-    -- we can find its sibling by considering only the left subtree
-    | SkeletonNodeIndex.ofLeft idxLeftLeft =>
-      idxLeftLeft.ofLeft.sibling.map (SkeletonNodeIndex.ofLeft)
-    | SkeletonNodeIndex.ofRight idxLeftRight =>
-      idxLeftRight.ofRight.sibling.map (SkeletonNodeIndex.ofLeft)
-  | @SkeletonNodeIndex.ofRight left right idxRight =>
-    match idxRight with
-    | SkeletonNodeIndex.ofLeaf => some (getRootIndex left).ofLeft
-    | SkeletonNodeIndex.ofInternal => some (getRootIndex left).ofLeft
-    | SkeletonNodeIndex.ofLeft idxRightLeft =>
-      idxRightLeft.ofLeft.sibling.map (SkeletonNodeIndex.ofRight)
-    | SkeletonNodeIndex.ofRight idxRightRight =>
-      idxRightRight.ofRight.sibling.map (SkeletonNodeIndex.ofRight)
+  | .ofLeaf => none
+  | .ofInternal => none
+  | @SkeletonNodeIndex.ofLeft _ right .ofLeaf => some (.ofRight (getRootIndex right))
+  | @SkeletonNodeIndex.ofLeft _ right .ofInternal => some (.ofRight (getRootIndex right))
+  | .ofLeft (.ofLeft idxLL) => idxLL.ofLeft.sibling.map .ofLeft
+  | .ofLeft (.ofRight idxLR) => idxLR.ofRight.sibling.map .ofLeft
+  | @SkeletonNodeIndex.ofRight left _ .ofLeaf => some (.ofLeft (getRootIndex left))
+  | @SkeletonNodeIndex.ofRight left _ .ofInternal => some (.ofLeft (getRootIndex left))
+  | .ofRight (.ofLeft idxRL) => idxRL.ofLeft.sibling.map .ofRight
+  | .ofRight (.ofRight idxRR) => idxRR.ofRight.sibling.map .ofRight
 
 /--
 Return the left child of a `SkeletonNodeIndex`, or `none` if the index is a leaf.
@@ -766,11 +751,8 @@ theorem LeafData.composeBuild_getRootValue {α} {s_left s_right : Skeleton}
 
 /-- Lift a binary function through two `Option` arguments. -/
 def Option.doubleBind {α β γ : Type _} (f : α → β → Option γ)
-    (x : Option α) (y : Option β) : Option γ :=
-  match x, y with
-  | none, _ => none
-  | _, none => none
-  | some a, some b => f a b
+    (x : Option α) (y : Option β) : Option γ := do
+  f (← x) (← y)
 
 /-- Build a tree while allowing failures in the composition function. -/
 def LeafData.optionComposeBuild {α : Type _} {s : Skeleton} (leaf_data_tree : LeafData α s)

--- a/ToMathlib/Data/IndexedBinaryTree/Basic.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Basic.lean
@@ -547,7 +547,6 @@ Given a `Skeleton`, and a node index of the skeleton,
 return a list of node indices which are the ancestors of the node,
 starting with the root node, and going down to but not including the node itself.
 -/
-
 def SkeletonNodeIndex.path {s : Skeleton} (idx : SkeletonNodeIndex s) :
     List (SkeletonNodeIndex s) :=
   match idx with
@@ -671,7 +670,8 @@ theorem LeafData.composeBuild_getRootValue {α} {s_left s_right : Skeleton}
     (left : LeafData α s_left) (right : LeafData α s_right)
     (compose : α → α → α) :
     ((LeafData.internal left right).composeBuild compose).getRootValue =
-      compose (left.composeBuild compose).getRootValue (right.composeBuild compose).getRootValue := by
+      compose (left.composeBuild compose).getRootValue
+        (right.composeBuild compose).getRootValue := by
   rfl
 
 def Option.doubleBind {α β γ : Type} (f : α → β → Option γ)

--- a/ToMathlib/Data/IndexedBinaryTree/Equiv.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Equiv.lean
@@ -1,6 +1,11 @@
+/-
+Copyright (c) 2024 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
 import ToMathlib.Data.IndexedBinaryTree.Basic
 import Mathlib.Logic.Equiv.Prod
-
 
 /-!
 # Equivalences
@@ -62,16 +67,16 @@ theorem InternalData.ofFun_get {α} {s} (tree : InternalData α s) :
   | @internal l r value left right =>
     have ihL := InternalData.ofFun_get (s := l) left
     have ihR := InternalData.ofFun_get (s := r) right
-    simp [InternalData.ofFun, InternalData.get, ihL, ihR]
+    simp [InternalData.ofFun, ihL, ihR]
 
 @[simp]
 theorem InternalData.get_ofFun {α} {s} (f : SkeletonInternalIndex s → α) :
     (InternalData.ofFun s f).get = f := by
   funext idx
   induction idx with
-  | ofInternal => simp [InternalData.ofFun, InternalData.get]
-  | ofLeft idx ih => simp [InternalData.ofFun, InternalData.get, ih]
-  | ofRight idx ih => simp [InternalData.ofFun, InternalData.get, ih]
+  | ofInternal => simp [InternalData.ofFun]
+  | ofLeft idx ih => simp [InternalData.ofFun, ih]
+  | ofRight idx ih => simp [InternalData.ofFun, ih]
 
 /-- Build `FullData` from a function on all node indices. -/
 def FullData.ofFun {α : Type _} (s : Skeleton)
@@ -92,7 +97,7 @@ theorem FullData.ofFun_get {α} {s} (tree : FullData α s) :
   | @internal l r value left right =>
     have ihL := FullData.ofFun_get (s := l) left
     have ihR := FullData.ofFun_get (s := r) right
-    simp [FullData.ofFun, FullData.get, ihL, ihR]
+    simp [FullData.ofFun, ihL, ihR]
 
 @[simp]
 theorem FullData.get_ofFun {α} {s} (f : SkeletonNodeIndex s → α) :
@@ -100,12 +105,12 @@ theorem FullData.get_ofFun {α} {s} (f : SkeletonNodeIndex s → α) :
   funext idx
   induction idx with
   | ofLeaf => simp [FullData.ofFun, FullData.get_leaf]
-  | ofInternal => simp [FullData.ofFun, FullData.get]
-  | ofLeft idx ih => simp [FullData.ofFun, FullData.get, ih]
-  | ofRight idx ih => simp [FullData.ofFun, FullData.get, ih]
+  | ofInternal => simp [FullData.ofFun]
+  | ofLeft idx ih => simp [FullData.ofFun, ih]
+  | ofRight idx ih => simp [FullData.ofFun, ih]
 
 /-- `LeafData`s are equivalent to functions from `SkeletonLeafIndex` to values -/
-def LeafData.EquivIndexFun {α : Type _} (s : Skeleton) :
+def LeafData.equivIndexFun {α : Type _} (s : Skeleton) :
     LeafData α s ≃ (SkeletonLeafIndex s → α) where
   toFun := fun tree idx => tree.get idx
   invFun := fun f => LeafData.ofFun s f
@@ -113,7 +118,7 @@ def LeafData.EquivIndexFun {α : Type _} (s : Skeleton) :
   right_inv := LeafData.get_ofFun (s := s)
 
 /-- `InternalData`s are equivalent to functions from `SkeletonInternalIndex` to values -/
-def InternalData.EquivIndexFun {α : Type _} (s : Skeleton) :
+def InternalData.equivIndexFun {α : Type _} (s : Skeleton) :
     InternalData α s ≃ (SkeletonInternalIndex s → α) where
   toFun := fun tree idx => tree.get idx
   invFun := fun f => InternalData.ofFun s f
@@ -121,7 +126,7 @@ def InternalData.EquivIndexFun {α : Type _} (s : Skeleton) :
   right_inv := InternalData.get_ofFun (s := s)
 
 /-- `FullData`s are equivalent to functions from `SkeletonNodeIndex` to values -/
-def FullData.EquivIndexFun {α : Type _} (s : Skeleton) :
+def FullData.equivIndexFun {α : Type _} (s : Skeleton) :
     FullData α s ≃ (SkeletonNodeIndex s → α) where
   toFun := fun tree idx => tree.get idx
   invFun := fun f => FullData.ofFun s f
@@ -160,80 +165,77 @@ def SkeletonNodeIndex.toSum {s : Skeleton} :
       | .inl idxRight => Sum.inl (SkeletonInternalIndex.ofRight idxRight)
       | .inr idxRight => Sum.inr (SkeletonLeafIndex.ofRight idxRight)
 
-/-
-Equivalence between the sum of internal/leaf indices and node indices.
-This is the canonical bijection given by `toNodeIndex` and `toSum`.
--/
-def SkeletonNodeIndex.SumEquiv (s : Skeleton) :
-    SkeletonInternalIndex s ⊕ SkeletonLeafIndex s ≃ SkeletonNodeIndex s :=
-{ toFun := fun x =>
-    match x with
+/-- Equivalence between node indices and the sum of internal and leaf indices. -/
+def SkeletonNodeIndex.sumEquiv (s : Skeleton) :
+    SkeletonInternalIndex s ⊕ SkeletonLeafIndex s ≃ SkeletonNodeIndex s where
+  toFun
     | Sum.inl idx => idx.toNodeIndex
     | Sum.inr idx => idx.toNodeIndex
-  , invFun := fun idx => idx.toSum
-  , left_inv := by
-      intro x; cases x with
-      | inl i =>
-          induction i with
-          | ofInternal =>
-              simp [SkeletonNodeIndex.toSum, SkeletonInternalIndex.toNodeIndex]
-          | ofLeft i ih =>
-              cases hSum : (i.toNodeIndex).toSum with
-              | inl _ =>
-                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex] using ih
-              | inr _ =>
-                  simp [hSum] at ih
-          | ofRight i ih =>
-              cases hSum : (i.toNodeIndex).toSum with
-              | inl _ =>
-                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex] using ih
-              | inr _ =>
-                  simp [hSum] at ih
-      | inr j =>
-          induction j with
-          | ofLeaf =>
-              simp [SkeletonNodeIndex.toSum, SkeletonLeafIndex.toNodeIndex]
-          | ofLeft j ih =>
-              cases hSum : (j.toNodeIndex).toSum with
-              | inl _ =>
-                  simp [hSum] at ih
-              | inr _ =>
-                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonLeafIndex.toNodeIndex] using ih
-          | ofRight j ih =>
-              cases hSum : (j.toNodeIndex).toSum with
-              | inl _ =>
-                  simp [hSum] at ih
-              | inr _ =>
-                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonLeafIndex.toNodeIndex] using ih
-  , right_inv := by
-      intro idx
-      induction idx with
-      | ofLeaf => simp [SkeletonNodeIndex.toSum, SkeletonLeafIndex.toNodeIndex]
-      | ofInternal => simp [SkeletonNodeIndex.toSum, SkeletonInternalIndex.toNodeIndex]
-      | ofLeft idx ih =>
-          cases hSum : idx.toSum with
-          | inl _ =>
-              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
-                     SkeletonLeafIndex.toNodeIndex] using ih
-          | inr _ =>
-              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
-                     SkeletonLeafIndex.toNodeIndex] using ih
-      | ofRight idx ih =>
-          cases hSum : idx.toSum with
-          | inl _ =>
-              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
-                     SkeletonLeafIndex.toNodeIndex] using ih
-          | inr _ =>
-              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
-                     SkeletonLeafIndex.toNodeIndex] using ih }
+  invFun := fun idx => idx.toSum
+  left_inv := by
+    intro x
+    cases x with
+    | inl i =>
+        induction i with
+        | ofInternal =>
+            simp [SkeletonNodeIndex.toSum, SkeletonInternalIndex.toNodeIndex]
+        | ofLeft i ih =>
+            cases hSum : (i.toNodeIndex).toSum with
+            | inl _ =>
+                simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex] using ih
+            | inr _ =>
+                simp [hSum] at ih
+        | ofRight i ih =>
+            cases hSum : (i.toNodeIndex).toSum with
+            | inl _ =>
+                simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex] using ih
+            | inr _ =>
+                simp [hSum] at ih
+    | inr j =>
+        induction j with
+        | ofLeaf =>
+            simp [SkeletonNodeIndex.toSum, SkeletonLeafIndex.toNodeIndex]
+        | ofLeft j ih =>
+            cases hSum : (j.toNodeIndex).toSum with
+            | inl _ =>
+                simp [hSum] at ih
+            | inr _ =>
+                simpa [SkeletonNodeIndex.toSum, hSum, SkeletonLeafIndex.toNodeIndex] using ih
+        | ofRight j ih =>
+            cases hSum : (j.toNodeIndex).toSum with
+            | inl _ =>
+                simp [hSum] at ih
+            | inr _ =>
+                simpa [SkeletonNodeIndex.toSum, hSum, SkeletonLeafIndex.toNodeIndex] using ih
+  right_inv := by
+    intro idx
+    induction idx with
+    | ofLeaf => simp [SkeletonNodeIndex.toSum, SkeletonLeafIndex.toNodeIndex]
+    | ofInternal => simp [SkeletonNodeIndex.toSum, SkeletonInternalIndex.toNodeIndex]
+    | ofLeft idx ih =>
+        cases hSum : idx.toSum with
+        | inl _ =>
+            simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+              SkeletonLeafIndex.toNodeIndex] using ih
+        | inr _ =>
+            simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+              SkeletonLeafIndex.toNodeIndex] using ih
+    | ofRight idx ih =>
+        cases hSum : idx.toSum with
+        | inl _ =>
+            simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+              SkeletonLeafIndex.toNodeIndex] using ih
+        | inr _ =>
+            simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+              SkeletonLeafIndex.toNodeIndex] using ih
 
 /-- Equivalence between `FullData` and the product of `InternalData` and `LeafData` -/
-def FullData.Equiv {α : Type _} (s : Skeleton) :
+def FullData.equiv {α : Type _} (s : Skeleton) :
     FullData α s ≃ InternalData α s × LeafData α s :=
-  (FullData.EquivIndexFun s).trans <|
-    (Equiv.arrowCongr (SkeletonNodeIndex.SumEquiv s).symm (Equiv.refl α)).trans <|
+  (FullData.equivIndexFun s).trans <|
+    (Equiv.arrowCongr (SkeletonNodeIndex.sumEquiv s).symm (Equiv.refl α)).trans <|
       (Equiv.sumArrowEquivProdArrow (SkeletonInternalIndex s) (SkeletonLeafIndex s) α).trans <|
-        Equiv.prodCongr (InternalData.EquivIndexFun s).symm (LeafData.EquivIndexFun s).symm
+        Equiv.prodCongr (InternalData.equivIndexFun s).symm (LeafData.equivIndexFun s).symm
 
 
 end Equivalences

--- a/ToMathlib/Data/IndexedBinaryTree/Equiv.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Equiv.lean
@@ -1,4 +1,5 @@
 import ToMathlib.Data.IndexedBinaryTree.Basic
+import Mathlib.Logic.Equiv.Prod
 
 
 /-!
@@ -13,7 +14,7 @@ namespace BinaryTree
 section Equivalences
 
 /-- Build `LeafData` from a function on leaf indices. -/
-def LeafData.ofFun {α : Type} (s : Skeleton)
+def LeafData.ofFun {α : Type _} (s : Skeleton)
     (f : SkeletonLeafIndex s → α) : LeafData α s :=
   match s with
   | .leaf => LeafData.leaf (f SkeletonLeafIndex.ofLeaf)
@@ -43,7 +44,7 @@ theorem LeafData.get_ofFun {α} {s} (f : SkeletonLeafIndex s → α) :
   | ofRight idx ih => simp [LeafData.ofFun, ih]
 
 /-- Build `InternalData` from a function on internal indices. -/
-def InternalData.ofFun {α : Type} (s : Skeleton)
+def InternalData.ofFun {α : Type _} (s : Skeleton)
     (f : SkeletonInternalIndex s → α) : InternalData α s :=
   match s with
   | .leaf => InternalData.leaf
@@ -73,7 +74,7 @@ theorem InternalData.get_ofFun {α} {s} (f : SkeletonInternalIndex s → α) :
   | ofRight idx ih => simp [InternalData.ofFun, InternalData.get, ih]
 
 /-- Build `FullData` from a function on all node indices. -/
-def FullData.ofFun {α : Type} (s : Skeleton)
+def FullData.ofFun {α : Type _} (s : Skeleton)
     (f : SkeletonNodeIndex s → α) : FullData α s :=
   match s with
   | .leaf => FullData.leaf (f SkeletonNodeIndex.ofLeaf)
@@ -104,74 +105,41 @@ theorem FullData.get_ofFun {α} {s} (f : SkeletonNodeIndex s → α) :
   | ofRight idx ih => simp [FullData.ofFun, FullData.get, ih]
 
 /-- `LeafData`s are equivalent to functions from `SkeletonLeafIndex` to values -/
-def LeafData.EquivIndexFun {α : Type} (s : Skeleton) :
+def LeafData.EquivIndexFun {α : Type _} (s : Skeleton) :
     LeafData α s ≃ (SkeletonLeafIndex s → α) where
   toFun := fun tree idx => tree.get idx
   invFun := fun f => LeafData.ofFun s f
-  left_inv := by
-    intro tree
-    cases s with
-    | leaf =>
-        cases tree with
-        | leaf value =>
-            simp [LeafData.ofFun, LeafData.get_leaf]
-    | @internal l r =>
-        cases tree with
-        | internal left right =>
-            simp [LeafData.ofFun]
-  right_inv := by
-    intro f
-    simp [LeafData.get_ofFun (s := s) f]
+  left_inv := LeafData.ofFun_get (s := s)
+  right_inv := LeafData.get_ofFun (s := s)
 
 /-- `InternalData`s are equivalent to functions from `SkeletonInternalIndex` to values -/
-def InternalData.EquivIndexFun {α : Type} (s : Skeleton) :
+def InternalData.EquivIndexFun {α : Type _} (s : Skeleton) :
     InternalData α s ≃ (SkeletonInternalIndex s → α) where
   toFun := fun tree idx => tree.get idx
   invFun := fun f => InternalData.ofFun s f
-  left_inv := by
-    intro tree
-    cases s with
-    | leaf =>
-        cases tree with
-        | leaf => simp [InternalData.ofFun]
-    | @internal l r =>
-        cases tree with
-        | internal value left right => simp [InternalData.ofFun, InternalData.get]
-  right_inv := by
-    intro f
-    simp [InternalData.get_ofFun (s := s) f]
+  left_inv := InternalData.ofFun_get (s := s)
+  right_inv := InternalData.get_ofFun (s := s)
 
 /-- `FullData`s are equivalent to functions from `SkeletonNodeIndex` to values -/
-def FullData.EquivIndexFun {α : Type} (s : Skeleton) :
+def FullData.EquivIndexFun {α : Type _} (s : Skeleton) :
     FullData α s ≃ (SkeletonNodeIndex s → α) where
   toFun := fun tree idx => tree.get idx
   invFun := fun f => FullData.ofFun s f
-  left_inv := by
-    intro tree
-    cases s with
-    | leaf =>
-        cases tree with
-        | leaf value => simp [FullData.ofFun, FullData.get_leaf]
-    | @internal l r =>
-        cases tree with
-        | internal value left right =>
-            simp [FullData.ofFun, FullData.get]
-  right_inv := by
-    intro f
-    simp [FullData.get_ofFun (s := s) f]
+  left_inv := FullData.ofFun_get (s := s)
+  right_inv := FullData.get_ofFun (s := s)
 
 /-- A `LeafData` can be interpreted as a function from `SkeletonLeafIndex` to values -/
-instance {α : Type} {s : Skeleton} :
+instance {α : Type _} {s : Skeleton} :
     CoeFun (LeafData α s) fun (_ : LeafData α s) => SkeletonLeafIndex s → α where
   coe := fun tree idx => tree.get idx
 
 /-- An `InternalData` can be interpreted as a function from `SkeletonInternalIndex` to values -/
-instance {α : Type} {s : Skeleton} :
+instance {α : Type _} {s : Skeleton} :
     CoeFun (InternalData α s) fun (_ : InternalData α s) => SkeletonInternalIndex s → α where
   coe := fun tree idx => tree.get idx
 
 /-- A `FullData` can be interpreted as a function from `SkeletonNodeIndex` to values -/
-instance {α : Type} {s : Skeleton} :
+instance {α : Type _} {s : Skeleton} :
     CoeFun (FullData α s) fun (_ : FullData α s) => SkeletonNodeIndex s → α where
   coe := fun tree idx => tree.get idx
 
@@ -259,52 +227,13 @@ def SkeletonNodeIndex.SumEquiv (s : Skeleton) :
               simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
                      SkeletonLeafIndex.toNodeIndex] using ih }
 
-/-
-Precomposition by an equivalence on the domain.
-Given `e : α ≃ β`, this yields `(β → γ) ≃ (α → γ)`.
--/
-def Equiv.precomp {α β γ} (e : α ≃ β) : (β → γ) ≃ (α → γ) :=
-{ toFun := fun f a => f (e a)
-  , invFun := fun g b => g (e.invFun b)
-  , left_inv := by intro f; funext b; simp
-  , right_inv := by intro g; funext a; simp }
-
-/-
-Equivalence between functions from a sum type and a product of functions.
--/
-def SumFunEquivProd (α β γ : Type) : ((α ⊕ β) → γ) ≃ (α → γ) × (β → γ) :=
-{ toFun := fun f => (fun a => f (.inl a), fun b => f (.inr b))
-  , invFun := fun p x => match x with | .inl a => p.fst a | .inr b => p.snd b
-  , left_inv := by intro f; funext x; cases x <;> rfl
-  , right_inv := by intro p; cases p; rfl }
-
 /-- Equivalence between `FullData` and the product of `InternalData` and `LeafData` -/
-def FullData.Equiv {α} (s : Skeleton) :
-    FullData α s ≃ InternalData α s × LeafData α s := by
-  calc
-    FullData α s ≃ (SkeletonNodeIndex s → α) := FullData.EquivIndexFun s
-    _ ≃ ((SkeletonInternalIndex s ⊕ SkeletonLeafIndex s) → α) :=
-      (Equiv.precomp (SkeletonNodeIndex.SumEquiv s))
-    _ ≃ (SkeletonInternalIndex s → α) × (SkeletonLeafIndex s → α) :=
-      (SumFunEquivProd (SkeletonInternalIndex s) (SkeletonLeafIndex s) α)
-    _ ≃ InternalData α s × LeafData α s := by
-      refine
-        { toFun := (fun p => ((InternalData.EquivIndexFun s).invFun p.fst,
-                               (LeafData.EquivIndexFun s).invFun p.snd))
-          , invFun := (fun q => ((InternalData.EquivIndexFun s).toFun q.fst,
-                                 (LeafData.EquivIndexFun s).toFun q.snd))
-          , left_inv := ?_
-          , right_inv := ?_ };
-      · intro p; cases p with
-        | mk f g =>
-          exact Prod.ext
-            ((InternalData.EquivIndexFun s).right_inv f)
-            ((LeafData.EquivIndexFun s).right_inv g)
-      · intro q; cases q with
-        | mk tInt tLeaf =>
-          exact Prod.ext
-            ((InternalData.EquivIndexFun s).left_inv tInt)
-            ((LeafData.EquivIndexFun s).left_inv tLeaf)
+def FullData.Equiv {α : Type _} (s : Skeleton) :
+    FullData α s ≃ InternalData α s × LeafData α s :=
+  (FullData.EquivIndexFun s).trans <|
+    (Equiv.arrowCongr (SkeletonNodeIndex.SumEquiv s).symm (Equiv.refl α)).trans <|
+      (Equiv.sumArrowEquivProdArrow (SkeletonInternalIndex s) (SkeletonLeafIndex s) α).trans <|
+        Equiv.prodCongr (InternalData.EquivIndexFun s).symm (LeafData.EquivIndexFun s).symm
 
 
 end Equivalences

--- a/ToMathlib/Data/IndexedBinaryTree/Equiv.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Equiv.lean
@@ -1,0 +1,312 @@
+import ToMathlib.Data.IndexedBinaryTree.Basic
+
+
+/-!
+# Equivalences
+
+This section contains theorems about equivalences between different tree indexing types
+and data structures.
+-/
+
+namespace BinaryTree
+
+section Equivalences
+
+/-- Build `LeafData` from a function on leaf indices. -/
+def LeafData.ofFun {α : Type} (s : Skeleton)
+    (f : SkeletonLeafIndex s → α) : LeafData α s :=
+  match s with
+  | .leaf => LeafData.leaf (f SkeletonLeafIndex.ofLeaf)
+  | .internal l r =>
+      LeafData.internal
+        (LeafData.ofFun l (fun idx => f (SkeletonLeafIndex.ofLeft idx)))
+        (LeafData.ofFun r (fun idx => f (SkeletonLeafIndex.ofRight idx)))
+
+@[simp]
+theorem LeafData.ofFun_get {α} {s} (tree : LeafData α s) :
+    LeafData.ofFun s (fun idx => tree.get idx) = tree := by
+  cases tree with
+  | leaf value =>
+    simp [LeafData.ofFun, LeafData.get_leaf]
+  | @internal l r left right =>
+    have ihL := LeafData.ofFun_get (s := l) left
+    have ihR := LeafData.ofFun_get (s := r) right
+    simp [LeafData.ofFun, ihL, ihR]
+
+@[simp]
+theorem LeafData.get_ofFun {α} {s} (f : SkeletonLeafIndex s → α) :
+    (LeafData.ofFun s f).get = f := by
+  funext idx
+  induction idx with
+  | ofLeaf => simp [LeafData.ofFun, LeafData.get_leaf]
+  | ofLeft idx ih => simp [LeafData.ofFun, ih]
+  | ofRight idx ih => simp [LeafData.ofFun, ih]
+
+/-- Build `InternalData` from a function on internal indices. -/
+def InternalData.ofFun {α : Type} (s : Skeleton)
+    (f : SkeletonInternalIndex s → α) : InternalData α s :=
+  match s with
+  | .leaf => InternalData.leaf
+  | .internal l r =>
+      InternalData.internal
+        (f SkeletonInternalIndex.ofInternal)
+        (InternalData.ofFun l (fun idx => f (SkeletonInternalIndex.ofLeft idx)))
+        (InternalData.ofFun r (fun idx => f (SkeletonInternalIndex.ofRight idx)))
+
+@[simp]
+theorem InternalData.ofFun_get {α} {s} (tree : InternalData α s) :
+    InternalData.ofFun s (fun idx => tree.get idx) = tree := by
+  cases tree with
+  | leaf => simp [InternalData.ofFun]
+  | @internal l r value left right =>
+    have ihL := InternalData.ofFun_get (s := l) left
+    have ihR := InternalData.ofFun_get (s := r) right
+    simp [InternalData.ofFun, InternalData.get, ihL, ihR]
+
+@[simp]
+theorem InternalData.get_ofFun {α} {s} (f : SkeletonInternalIndex s → α) :
+    (InternalData.ofFun s f).get = f := by
+  funext idx
+  induction idx with
+  | ofInternal => simp [InternalData.ofFun, InternalData.get]
+  | ofLeft idx ih => simp [InternalData.ofFun, InternalData.get, ih]
+  | ofRight idx ih => simp [InternalData.ofFun, InternalData.get, ih]
+
+/-- Build `FullData` from a function on all node indices. -/
+def FullData.ofFun {α : Type} (s : Skeleton)
+    (f : SkeletonNodeIndex s → α) : FullData α s :=
+  match s with
+  | .leaf => FullData.leaf (f SkeletonNodeIndex.ofLeaf)
+  | .internal l r =>
+      FullData.internal
+        (f SkeletonNodeIndex.ofInternal)
+        (FullData.ofFun l (fun idx => f (SkeletonNodeIndex.ofLeft idx)))
+        (FullData.ofFun r (fun idx => f (SkeletonNodeIndex.ofRight idx)))
+
+@[simp]
+theorem FullData.ofFun_get {α} {s} (tree : FullData α s) :
+    FullData.ofFun s (fun idx => tree.get idx) = tree := by
+  cases tree with
+  | leaf value => simp [FullData.ofFun, FullData.get_leaf]
+  | @internal l r value left right =>
+    have ihL := FullData.ofFun_get (s := l) left
+    have ihR := FullData.ofFun_get (s := r) right
+    simp [FullData.ofFun, FullData.get, ihL, ihR]
+
+@[simp]
+theorem FullData.get_ofFun {α} {s} (f : SkeletonNodeIndex s → α) :
+    (FullData.ofFun s f).get = f := by
+  funext idx
+  induction idx with
+  | ofLeaf => simp [FullData.ofFun, FullData.get_leaf]
+  | ofInternal => simp [FullData.ofFun, FullData.get]
+  | ofLeft idx ih => simp [FullData.ofFun, FullData.get, ih]
+  | ofRight idx ih => simp [FullData.ofFun, FullData.get, ih]
+
+/-- `LeafData`s are equivalent to functions from `SkeletonLeafIndex` to values -/
+def LeafData.EquivIndexFun {α : Type} (s : Skeleton) :
+    LeafData α s ≃ (SkeletonLeafIndex s → α) where
+  toFun := fun tree idx => tree.get idx
+  invFun := fun f => LeafData.ofFun s f
+  left_inv := by
+    intro tree
+    cases s with
+    | leaf =>
+        cases tree with
+        | leaf value =>
+            simp [LeafData.ofFun, LeafData.get_leaf]
+    | @internal l r =>
+        cases tree with
+        | internal left right =>
+            simp [LeafData.ofFun]
+  right_inv := by
+    intro f
+    simp [LeafData.get_ofFun (s := s) f]
+
+/-- `InternalData`s are equivalent to functions from `SkeletonInternalIndex` to values -/
+def InternalData.EquivIndexFun {α : Type} (s : Skeleton) :
+    InternalData α s ≃ (SkeletonInternalIndex s → α) where
+  toFun := fun tree idx => tree.get idx
+  invFun := fun f => InternalData.ofFun s f
+  left_inv := by
+    intro tree
+    cases s with
+    | leaf =>
+        cases tree with
+        | leaf => simp [InternalData.ofFun]
+    | @internal l r =>
+        cases tree with
+        | internal value left right => simp [InternalData.ofFun, InternalData.get]
+  right_inv := by
+    intro f
+    simp [InternalData.get_ofFun (s := s) f]
+
+/-- `FullData`s are equivalent to functions from `SkeletonNodeIndex` to values -/
+def FullData.EquivIndexFun {α : Type} (s : Skeleton) :
+    FullData α s ≃ (SkeletonNodeIndex s → α) where
+  toFun := fun tree idx => tree.get idx
+  invFun := fun f => FullData.ofFun s f
+  left_inv := by
+    intro tree
+    cases s with
+    | leaf =>
+        cases tree with
+        | leaf value => simp [FullData.ofFun, FullData.get_leaf]
+    | @internal l r =>
+        cases tree with
+        | internal value left right =>
+            simp [FullData.ofFun, FullData.get]
+  right_inv := by
+    intro f
+    simp [FullData.get_ofFun (s := s) f]
+
+/-- A `LeafData` can be interpreted as a function from `SkeletonLeafIndex` to values -/
+instance {α : Type} {s : Skeleton} :
+    CoeFun (LeafData α s) fun (_ : LeafData α s) => SkeletonLeafIndex s → α where
+  coe := fun tree idx => tree.get idx
+
+/-- An `InternalData` can be interpreted as a function from `SkeletonInternalIndex` to values -/
+instance {α : Type} {s : Skeleton} :
+    CoeFun (InternalData α s) fun (_ : InternalData α s) => SkeletonInternalIndex s → α where
+  coe := fun tree idx => tree.get idx
+
+/-- A `FullData` can be interpreted as a function from `SkeletonNodeIndex` to values -/
+instance {α : Type} {s : Skeleton} :
+    CoeFun (FullData α s) fun (_ : FullData α s) => SkeletonNodeIndex s → α where
+  coe := fun tree idx => tree.get idx
+
+/--
+A function taking a `SkeletonNodeIndex s`
+to either a `SkeletonInternalIndex s` or a `SkeletonLeafIndex s`
+-/
+def SkeletonNodeIndex.toSum {s : Skeleton} :
+    SkeletonNodeIndex s → SkeletonInternalIndex s ⊕ SkeletonLeafIndex s :=
+  fun idx =>
+    match idx with
+    | SkeletonNodeIndex.ofLeaf => Sum.inr (SkeletonLeafIndex.ofLeaf)
+    | SkeletonNodeIndex.ofInternal => Sum.inl (SkeletonInternalIndex.ofInternal)
+    | SkeletonNodeIndex.ofLeft idxLeft => match idxLeft.toSum with
+      | .inl idxLeft => Sum.inl (SkeletonInternalIndex.ofLeft idxLeft)
+      | .inr idxLeft => Sum.inr (SkeletonLeafIndex.ofLeft idxLeft)
+    | SkeletonNodeIndex.ofRight idxRight => match idxRight.toSum with
+      | .inl idxRight => Sum.inl (SkeletonInternalIndex.ofRight idxRight)
+      | .inr idxRight => Sum.inr (SkeletonLeafIndex.ofRight idxRight)
+
+/-
+Equivalence between the sum of internal/leaf indices and node indices.
+This is the canonical bijection given by `toNodeIndex` and `toSum`.
+-/
+def SkeletonNodeIndex.SumEquiv (s : Skeleton) :
+    SkeletonInternalIndex s ⊕ SkeletonLeafIndex s ≃ SkeletonNodeIndex s :=
+{ toFun := fun x =>
+    match x with
+    | Sum.inl idx => idx.toNodeIndex
+    | Sum.inr idx => idx.toNodeIndex
+  , invFun := fun idx => idx.toSum
+  , left_inv := by
+      intro x; cases x with
+      | inl i =>
+          induction i with
+          | ofInternal =>
+              simp [SkeletonNodeIndex.toSum, SkeletonInternalIndex.toNodeIndex]
+          | ofLeft i ih =>
+              cases hSum : (i.toNodeIndex).toSum with
+              | inl _ =>
+                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex] using ih
+              | inr _ =>
+                  simp [hSum] at ih
+          | ofRight i ih =>
+              cases hSum : (i.toNodeIndex).toSum with
+              | inl _ =>
+                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex] using ih
+              | inr _ =>
+                  simp [hSum] at ih
+      | inr j =>
+          induction j with
+          | ofLeaf =>
+              simp [SkeletonNodeIndex.toSum, SkeletonLeafIndex.toNodeIndex]
+          | ofLeft j ih =>
+              cases hSum : (j.toNodeIndex).toSum with
+              | inl _ =>
+                  simp [hSum] at ih
+              | inr _ =>
+                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonLeafIndex.toNodeIndex] using ih
+          | ofRight j ih =>
+              cases hSum : (j.toNodeIndex).toSum with
+              | inl _ =>
+                  simp [hSum] at ih
+              | inr _ =>
+                  simpa [SkeletonNodeIndex.toSum, hSum, SkeletonLeafIndex.toNodeIndex] using ih
+  , right_inv := by
+      intro idx
+      induction idx with
+      | ofLeaf => simp [SkeletonNodeIndex.toSum, SkeletonLeafIndex.toNodeIndex]
+      | ofInternal => simp [SkeletonNodeIndex.toSum, SkeletonInternalIndex.toNodeIndex]
+      | ofLeft idx ih =>
+          cases hSum : idx.toSum with
+          | inl _ =>
+              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+                     SkeletonLeafIndex.toNodeIndex] using ih
+          | inr _ =>
+              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+                     SkeletonLeafIndex.toNodeIndex] using ih
+      | ofRight idx ih =>
+          cases hSum : idx.toSum with
+          | inl _ =>
+              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+                     SkeletonLeafIndex.toNodeIndex] using ih
+          | inr _ =>
+              simpa [SkeletonNodeIndex.toSum, hSum, SkeletonInternalIndex.toNodeIndex,
+                     SkeletonLeafIndex.toNodeIndex] using ih }
+
+/-
+Precomposition by an equivalence on the domain.
+Given `e : α ≃ β`, this yields `(β → γ) ≃ (α → γ)`.
+-/
+def Equiv.precomp {α β γ} (e : α ≃ β) : (β → γ) ≃ (α → γ) :=
+{ toFun := fun f a => f (e a)
+  , invFun := fun g b => g (e.invFun b)
+  , left_inv := by intro f; funext b; simp
+  , right_inv := by intro g; funext a; simp }
+
+/-
+Equivalence between functions from a sum type and a product of functions.
+-/
+def SumFunEquivProd (α β γ : Type) : ((α ⊕ β) → γ) ≃ (α → γ) × (β → γ) :=
+{ toFun := fun f => (fun a => f (.inl a), fun b => f (.inr b))
+  , invFun := fun p x => match x with | .inl a => p.fst a | .inr b => p.snd b
+  , left_inv := by intro f; funext x; cases x <;> rfl
+  , right_inv := by intro p; cases p; rfl }
+
+/-- Equivalence between `FullData` and the product of `InternalData` and `LeafData` -/
+def FullData.Equiv {α} (s : Skeleton) :
+    FullData α s ≃ InternalData α s × LeafData α s := by
+  calc
+    FullData α s ≃ (SkeletonNodeIndex s → α) := FullData.EquivIndexFun s
+    _ ≃ ((SkeletonInternalIndex s ⊕ SkeletonLeafIndex s) → α) :=
+      (Equiv.precomp (SkeletonNodeIndex.SumEquiv s))
+    _ ≃ (SkeletonInternalIndex s → α) × (SkeletonLeafIndex s → α) :=
+      (SumFunEquivProd (SkeletonInternalIndex s) (SkeletonLeafIndex s) α)
+    _ ≃ InternalData α s × LeafData α s := by
+      refine
+        { toFun := (fun p => ((InternalData.EquivIndexFun s).invFun p.fst,
+                               (LeafData.EquivIndexFun s).invFun p.snd))
+          , invFun := (fun q => ((InternalData.EquivIndexFun s).toFun q.fst,
+                                 (LeafData.EquivIndexFun s).toFun q.snd))
+          , left_inv := ?_
+          , right_inv := ?_ };
+      · intro p; cases p with
+        | mk f g =>
+          exact Prod.ext
+            ((InternalData.EquivIndexFun s).right_inv f)
+            ((LeafData.EquivIndexFun s).right_inv g)
+      · intro q; cases q with
+        | mk tInt tLeaf =>
+          exact Prod.ext
+            ((InternalData.EquivIndexFun s).left_inv tInt)
+            ((LeafData.EquivIndexFun s).left_inv tLeaf)
+
+
+end Equivalences
+
+end BinaryTree

--- a/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
@@ -138,53 +138,38 @@ instance {s} : Functor (fun α => FullData α s) where
   map f x := x.map f
 
 
-instance {s} : LawfulFunctor (fun α => LeafData α s) := by
-  refine
-    { map_const := rfl
-      id_map := ?_
-      comp_map := ?_ }
-  · intro α x
+instance {s} : LawfulFunctor (fun α => LeafData α s) where
+  map_const := rfl
+  id_map x := by
     induction x with
     | leaf value => simp [Functor.map, LeafData.map]
-    | internal left right ihL ihR =>
-      simp_all [Functor.map, LeafData.map]
-  · intro α β γ g h x
+    | internal left right ihL ihR => simp_all [Functor.map, LeafData.map]
+  comp_map g h x := by
     induction x with
     | leaf value => simp [Functor.map, LeafData.map]
-    | internal left right ihL ihR =>
-      simp_all [Functor.map, LeafData.map]
+    | internal left right ihL ihR => simp_all [Functor.map, LeafData.map]
 
-instance {s} : LawfulFunctor (fun α => InternalData α s) := by
-  refine
-    { map_const := rfl
-      id_map := ?_
-      comp_map := ?_ }
-  · intro α x
+instance {s} : LawfulFunctor (fun α => InternalData α s) where
+  map_const := rfl
+  id_map x := by
     induction x with
     | leaf => simp [Functor.map, InternalData.map]
-    | internal value tL tR ihL ihR =>
-      simp_all [Functor.map, InternalData.map]
-  · intro α β γ g h x
+    | internal value tL tR ihL ihR => simp_all [Functor.map, InternalData.map]
+  comp_map g h x := by
     induction x with
     | leaf => simp [Functor.map, InternalData.map]
-    | internal value tL tR ihL ihR =>
-      simp_all [Functor.map, InternalData.map]
+    | internal value tL tR ihL ihR => simp_all [Functor.map, InternalData.map]
 
-instance {s} : LawfulFunctor (fun α => FullData α s) := by
-  refine
-    { map_const := rfl
-      id_map := ?_
-      comp_map := ?_ }
-  · intro α x
+instance {s} : LawfulFunctor (fun α => FullData α s) where
+  map_const := rfl
+  id_map x := by
     induction x with
     | leaf value => simp [Functor.map, FullData.map]
-    | internal value tL tR ihL ihR =>
-      simp_all [Functor.map, FullData.map]
-  · intro α β γ g h x
+    | internal value tL tR ihL ihR => simp_all [Functor.map, FullData.map]
+  comp_map g h x := by
     induction x with
     | leaf value => simp [Functor.map, FullData.map]
-    | internal value tL tR ihL ihR =>
-      simp_all [Functor.map, FullData.map]
+    | internal value tL tR ihL ihR => simp_all [Functor.map, FullData.map]
 
 end Navigation
 

--- a/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
@@ -107,7 +107,6 @@ theorem SkeletonNodeIndex.rightChild_bind_parent {s : Skeleton}
         simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
 
 /-- The parent of a leftChild is none or the node -/
-
 theorem SkeletonNodeIndex.parent_of_depth_zero {s : Skeleton}
     (idx : SkeletonNodeIndex s) (h : idx.depth = 0) :
     parent idx = none := by

--- a/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
@@ -1,0 +1,189 @@
+import ToMathlib.Data.IndexedBinaryTree.Basic
+
+
+/-!
+# Lemmas about Indexed Binary Trees
+
+## TODOs
+
+- More relationships between tree navigations
+  - Which navigation sequences are equivalent to each other?
+  - How do these navigations affect depth?
+- API for flattening a tree to a list
+- Define `Lattice` structure on trees
+  - a subset relation on trees, mappings of indices to indices of supertrees
+
+
+-/
+
+namespace BinaryTree
+
+section Navigation
+
+/-- The parent of a left child, when it exists, is the node itself. -/
+theorem SkeletonNodeIndex.leftChild_bind_parent {s : Skeleton}
+    (idx : SkeletonNodeIndex s) :
+    idx.leftChild >>= parent = idx.leftChild.map (fun _ => idx) := by
+  induction idx with
+  | ofLeaf =>
+    simp [SkeletonNodeIndex.leftChild, Option.bind]
+  | @ofInternal left right =>
+    cases left
+    <;>
+    simp [SkeletonNodeIndex.leftChild, SkeletonNodeIndex.parent, Option.bind, getRootIndex]
+  | @ofLeft left right idxLeft ih =>
+    -- Analyze whether the left child of idxLeft exists
+    cases hchild : idxLeft.leftChild with
+    | none =>
+      simp [SkeletonNodeIndex.leftChild, Option.bind, hchild]
+    | some child =>
+      -- From the IH specialized with hchild, we get that the parent of child is idxLeft
+      have hc : parent child = some idxLeft := by
+        simpa [SkeletonNodeIndex.leftChild, Option.bind, hchild] using ih
+      -- Now consider the shape of the child to compute the parent of (ofLeft child)
+      cases child with
+      | ofLeaf => cases hc
+      | ofInternal => cases hc
+      | ofLeft _ =>
+        simp [SkeletonNodeIndex.leftChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+      | ofRight _ =>
+        simp [SkeletonNodeIndex.leftChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+  | @ofRight left right idxRight ih =>
+    -- Analyze whether the left child of idxRight exists
+    cases hchild : idxRight.leftChild with
+    | none =>
+      simp [SkeletonNodeIndex.leftChild, Option.bind, hchild]
+    | some child =>
+      have hc : parent child = some idxRight := by
+        simpa [SkeletonNodeIndex.leftChild, Option.bind, hchild] using ih
+      cases child with
+      | ofLeaf => cases hc
+      | ofInternal => cases hc
+      | ofLeft _ =>
+        simp [SkeletonNodeIndex.leftChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+      | ofRight _ =>
+        simp [SkeletonNodeIndex.leftChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+
+/-- The parent of a right child, when it exists, is the node itself. -/
+theorem SkeletonNodeIndex.rightChild_bind_parent {s : Skeleton}
+    (idx : SkeletonNodeIndex s) :
+    idx.rightChild >>= parent = idx.rightChild.map (fun _ => idx) := by
+  induction idx with
+  | ofLeaf =>
+    simp [SkeletonNodeIndex.rightChild, Option.bind]
+  | @ofInternal left right =>
+    cases right
+    <;>
+    simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, getRootIndex]
+  | @ofLeft left right idxLeft ih =>
+    -- Analyze whether the right child of idxLeft exists
+    cases hchild : idxLeft.rightChild with
+    | none =>
+      simp [SkeletonNodeIndex.rightChild, Option.bind, hchild]
+    | some child =>
+      have hc : parent child = some idxLeft := by
+        simpa [SkeletonNodeIndex.rightChild, Option.bind, hchild] using ih
+      cases child with
+      | ofLeaf => cases hc
+      | ofInternal => cases hc
+      | ofLeft _ =>
+        simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+      | ofRight _ =>
+        simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+  | @ofRight left right idxRight ih =>
+    -- Analyze whether the right child of idxRight exists
+    cases hchild : idxRight.rightChild with
+    | none =>
+      simp [SkeletonNodeIndex.rightChild, Option.bind, hchild]
+    | some child =>
+      have hc : parent child = some idxRight := by
+        simpa [SkeletonNodeIndex.rightChild, Option.bind, hchild] using ih
+      cases child with
+      | ofLeaf => cases hc
+      | ofInternal => cases hc
+      | ofLeft _ =>
+        simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+      | ofRight _ =>
+        simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
+
+/-- The parent of a leftChild is none or the node -/
+
+theorem SkeletonNodeIndex.parent_of_depth_zero {s : Skeleton}
+    (idx : SkeletonNodeIndex s) (h : idx.depth = 0) :
+    parent idx = none := by
+  cases idx with
+  | ofLeaf => rfl
+  | ofInternal => rfl
+  | ofLeft idxLeft =>
+    unfold depth at h
+    simp_all
+  | ofRight idxRight =>
+    unfold depth at h
+    simp_all
+
+-- TODO?: reorder the arguments to `LeafData` etc. so that the skeleton comes first?
+
+instance {s} : Functor (fun α => LeafData α s) where
+  map f x := x.map f
+
+instance {s} : Functor (fun α => InternalData α s) where
+  map f x := x.map f
+
+instance {s} : Functor (fun α => FullData α s) where
+  map f x := x.map f
+
+
+instance {s} : LawfulFunctor (fun α => LeafData α s) := by
+  classical
+  refine
+    { map_const := rfl
+      id_map := ?_
+      comp_map := ?_ }
+  · intro α x
+    induction x with
+    | leaf value => simp [Functor.map, LeafData.map]
+    | @internal left right tl tr ihL ihR =>
+      simp_all [Functor.map, LeafData.map]
+  · intro α β γ g h x
+    induction x with
+    | leaf value => simp [Functor.map, LeafData.map]
+    | @internal left right ihL ihR =>
+      simp_all [Functor.map, LeafData.map]
+
+instance {s} : LawfulFunctor (fun α => InternalData α s) := by
+  classical
+  refine
+    { map_const := rfl
+      id_map := ?_
+      comp_map := ?_ }
+  · intro α x
+    induction x with
+    | leaf => simp [Functor.map, InternalData.map]
+    | @internal value tL tR ihL ihR =>
+      simp_all [Functor.map, InternalData.map]
+  · intro α β γ g h x
+    induction x with
+    | leaf => simp [Functor.map, InternalData.map]
+    | @internal value tL tR ihL ihR =>
+      simp_all [Functor.map, InternalData.map]
+
+instance {s} : LawfulFunctor (fun α => FullData α s) := by
+  classical
+  refine
+    { map_const := rfl
+      id_map := ?_
+      comp_map := ?_ }
+  · intro α x
+    induction x with
+    | leaf value => simp [Functor.map, FullData.map]
+    | @internal value tL tR ihL ihR =>
+      simp_all [Functor.map, FullData.map]
+  · intro α β γ g h x
+    induction x with
+    | leaf value => simp [Functor.map, FullData.map]
+    | @internal value tL tR ihL ihR =>
+      simp_all [Functor.map, FullData.map]
+
+end Navigation
+
+end BinaryTree

--- a/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2024 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
 import ToMathlib.Data.IndexedBinaryTree.Basic
 
 
@@ -106,7 +112,7 @@ theorem SkeletonNodeIndex.rightChild_bind_parent {s : Skeleton}
       | ofRight _ =>
         simp [SkeletonNodeIndex.rightChild, SkeletonNodeIndex.parent, Option.bind, hchild, hc]
 
-/-- The parent of a leftChild is none or the node -/
+/-- The parent of a node of depth zero is none. -/
 theorem SkeletonNodeIndex.parent_of_depth_zero {s : Skeleton}
     (idx : SkeletonNodeIndex s) (h : idx.depth = 0) :
     parent idx = none := by

--- a/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
+++ b/ToMathlib/Data/IndexedBinaryTree/Lemmas.lean
@@ -133,7 +133,6 @@ instance {s} : Functor (fun α => FullData α s) where
 
 
 instance {s} : LawfulFunctor (fun α => LeafData α s) := by
-  classical
   refine
     { map_const := rfl
       id_map := ?_
@@ -141,16 +140,15 @@ instance {s} : LawfulFunctor (fun α => LeafData α s) := by
   · intro α x
     induction x with
     | leaf value => simp [Functor.map, LeafData.map]
-    | @internal left right tl tr ihL ihR =>
+    | internal left right ihL ihR =>
       simp_all [Functor.map, LeafData.map]
   · intro α β γ g h x
     induction x with
     | leaf value => simp [Functor.map, LeafData.map]
-    | @internal left right ihL ihR =>
+    | internal left right ihL ihR =>
       simp_all [Functor.map, LeafData.map]
 
 instance {s} : LawfulFunctor (fun α => InternalData α s) := by
-  classical
   refine
     { map_const := rfl
       id_map := ?_
@@ -158,16 +156,15 @@ instance {s} : LawfulFunctor (fun α => InternalData α s) := by
   · intro α x
     induction x with
     | leaf => simp [Functor.map, InternalData.map]
-    | @internal value tL tR ihL ihR =>
+    | internal value tL tR ihL ihR =>
       simp_all [Functor.map, InternalData.map]
   · intro α β γ g h x
     induction x with
     | leaf => simp [Functor.map, InternalData.map]
-    | @internal value tL tR ihL ihR =>
+    | internal value tL tR ihL ihR =>
       simp_all [Functor.map, InternalData.map]
 
 instance {s} : LawfulFunctor (fun α => FullData α s) := by
-  classical
   refine
     { map_const := rfl
       id_map := ?_
@@ -175,12 +172,12 @@ instance {s} : LawfulFunctor (fun α => FullData α s) := by
   · intro α x
     induction x with
     | leaf value => simp [Functor.map, FullData.map]
-    | @internal value tL tR ihL ihR =>
+    | internal value tL tR ihL ihR =>
       simp_all [Functor.map, FullData.map]
   · intro α β γ g h x
     induction x with
     | leaf value => simp [Functor.map, FullData.map]
-    | @internal value tL tR ihL ihR =>
+    | internal value tL tR ihL ihR =>
       simp_all [Functor.map, FullData.map]
 
 end Navigation

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -23,9 +23,11 @@ import VCVio.CryptoFoundations.HardnessAssumptions.EntropySmoothing
 import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 import VCVio.CryptoFoundations.HardnessAssumptions.OneWay
 import VCVio.CryptoFoundations.IdenSchemeWithAbort
+import VCVio.CryptoFoundations.InductiveMerkleTree
 import VCVio.CryptoFoundations.KEMDEM
 import VCVio.CryptoFoundations.KeyEncapMech
 import VCVio.CryptoFoundations.MacAlg
+import VCVio.CryptoFoundations.MerkleTree
 import VCVio.CryptoFoundations.PRF
 import VCVio.CryptoFoundations.PRG
 import VCVio.CryptoFoundations.SecExp

--- a/VCVio/CryptoFoundations/InductiveMerkleTree.lean
+++ b/VCVio/CryptoFoundations/InductiveMerkleTree.lean
@@ -52,7 +52,7 @@ open List OracleSpec OracleComp BinaryTree
 
 section spec
 
-variable (α : Type)
+variable (α : Type _)
 
 /-- Define the domain & range of the (single) oracle needed for constructing a Merkle tree with
     elements from some type `α`.
@@ -71,7 +71,7 @@ lemma range_def (z) : (spec α).Range z = α := rfl
 end spec
 
 
-variable {α : Type}
+variable {α : Type _}
 
 /-- Example: a single hash computation -/
 @[simp, grind]
@@ -144,29 +144,6 @@ def generateProof {s} (cache_tree : FullData α s) :
   | .ofRight idxRight =>
     List.Vector.cons ((cache_tree.leftSubtree).getRootValue)
       (generateProof cache_tree.rightSubtree idxRight)
-
-@[simp, grind]
-theorem generateProof_leaf (a : α) :
-    generateProof (FullData.leaf a) SkeletonLeafIndex.ofLeaf = List.Vector.nil := by
-  rfl
-
-@[simp, grind]
-theorem generateProof_ofLeft {sleft sright : Skeleton}
-    (cache_tree : FullData α (Skeleton.internal sleft sright))
-    (idxLeft : SkeletonLeafIndex sleft) :
-    generateProof cache_tree (BinaryTree.SkeletonLeafIndex.ofLeft idxLeft) =
-      List.Vector.cons ((cache_tree.rightSubtree).getRootValue)
-        (generateProof cache_tree.leftSubtree idxLeft) := by
-  rfl
-
-@[simp, grind]
-theorem generateProof_ofRight {sleft sright : Skeleton}
-    (cache_tree : FullData α (Skeleton.internal sleft sright))
-    (idxRight : SkeletonLeafIndex sright) :
-    generateProof cache_tree (BinaryTree.SkeletonLeafIndex.ofRight idxRight) =
-      List.Vector.cons ((cache_tree.leftSubtree).getRootValue)
-        (generateProof cache_tree.rightSubtree idxRight) := by
-  rfl
 
 /--
 Given a leaf index, a leaf value at that index, and a proof of the corresponding depth,

--- a/VCVio/CryptoFoundations/InductiveMerkleTree.lean
+++ b/VCVio/CryptoFoundations/InductiveMerkleTree.lean
@@ -95,25 +95,26 @@ A functional form of merkle tree construction, that doesn't depend on the monad.
 This receives an explicit hash function
 -/
 @[simp, grind]
-def buildMerkleTree_with_hash {s} (leaf_tree : LeafData α s) (hashFn : α → α → α) :
+def buildMerkleTreeWithHash {s} (leaf_tree : LeafData α s) (hashFn : α → α → α) :
     (FullData α s) :=
   match leaf_tree with
   | LeafData.leaf a => FullData.leaf a
   | LeafData.internal left right =>
-    let leftTree := buildMerkleTree_with_hash left hashFn
-    let rightTree := buildMerkleTree_with_hash right hashFn
+    let leftTree := buildMerkleTreeWithHash left hashFn
+    let rightTree := buildMerkleTreeWithHash right hashFn
     let rootHash := hashFn (leftTree.getRootValue) (rightTree.getRootValue)
     FullData.internal rootHash leftTree rightTree
 
 /--
 Running the monadic version of `buildMerkleTree` with an oracle function `f`
-is equivalent to running the functional version of `buildMerkleTree_with_hash`
+is equivalent to running the functional version of `buildMerkleTreeWithHash`
 with the same oracle function.
 -/
+@[simp, grind =]
 lemma simulateQ_buildMerkleTree {s} (leaf_data_tree : LeafData α s)
     (f : QueryImpl (spec α) Id) :
     simulateQ f (buildMerkleTree leaf_data_tree)
-    = buildMerkleTree_with_hash leaf_data_tree fun (left right : α) =>
+    = buildMerkleTreeWithHash leaf_data_tree fun (left right : α) =>
       (f ⟨left, right⟩) := by
   induction s with
   | leaf =>
@@ -123,8 +124,8 @@ lemma simulateQ_buildMerkleTree {s} (leaf_data_tree : LeafData α s)
   | internal s_left s_right left_ih right_ih =>
     match leaf_data_tree with
     | LeafData.internal left right =>
-      simp only [buildMerkleTree, buildMerkleTree_with_hash, singleHash,
-        simulateQ_bind, simulateQ_pure] at left_ih right_ih ⊢
+      simp only [buildMerkleTree, buildMerkleTreeWithHash, singleHash,
+        simulateQ_bind, simulateQ_pure]
       rw [left_ih left, right_ih right]; rfl
 
 /--
@@ -170,34 +171,35 @@ It receives an explicit hash function `hashFn` that combines two hashes into one
 And recursively calls itself down the tree.
 -/
 @[simp, grind]
-def getPutativeRoot_with_hash {s} :
+def getPutativeRootWithHash {s} :
     (idx : BinaryTree.SkeletonLeafIndex s) → (leafValue : α) →
       List.Vector α idx.depth → (hashFn : α → α → α) → α
   | BinaryTree.SkeletonLeafIndex.ofLeaf, leafValue, _, _ =>
       leafValue
   | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft, leafValue, proof, hashFn =>
-      hashFn (getPutativeRoot_with_hash idxLeft leafValue proof.tail hashFn) proof.head
+      hashFn (getPutativeRootWithHash idxLeft leafValue proof.tail hashFn) proof.head
   | BinaryTree.SkeletonLeafIndex.ofRight idxRight, leafValue, proof, hashFn =>
-      hashFn proof.head (getPutativeRoot_with_hash idxRight leafValue proof.tail hashFn)
+      hashFn proof.head (getPutativeRootWithHash idxRight leafValue proof.tail hashFn)
 
 /--
 Running the monadic version of `getPutativeRoot` with an oracle function `f`,
-it is equivalent to running the functional version of `getPutativeRoot_with_hash`
+it is equivalent to running the functional version of `getPutativeRootWithHash`
 -/
+@[simp, grind =]
 lemma simulateQ_getPutativeRoot {s} (idx : BinaryTree.SkeletonLeafIndex s)
     (leafValue : α) (proof : List.Vector α idx.depth) (f : QueryImpl (spec α) Id) :
     simulateQ f (getPutativeRoot idx leafValue proof)
       =
-    getPutativeRoot_with_hash idx leafValue proof fun (left right : α) => (f ⟨left, right⟩) := by
+    getPutativeRootWithHash idx leafValue proof fun (left right : α) => (f ⟨left, right⟩) := by
   induction idx generalizing leafValue with
   | ofLeaf =>
       rfl
   | ofLeft idxLeft ih =>
-      simp only [getPutativeRoot, getPutativeRoot_with_hash, singleHash, simulateQ_bind]
+      simp only [getPutativeRoot, getPutativeRootWithHash, singleHash, simulateQ_bind]
       rw [ih]
       rfl
   | ofRight idxRight ih =>
-      simp only [getPutativeRoot, getPutativeRoot_with_hash, singleHash, simulateQ_bind]
+      simp only [getPutativeRoot, getPutativeRootWithHash, singleHash, simulateQ_bind]
       rw [ih]
       rfl
 
@@ -208,7 +210,7 @@ Works by computing the putative root based on the branch, and comparing that to 
 Outputs `failure` if the proof is invalid.
 -/
 @[simp, grind]
-def verifyProof {α} [DecidableEq α] {s}
+def verifyProof [DecidableEq α] {s}
     (idx : BinaryTree.SkeletonLeafIndex s) (leafValue : α) (rootValue : α)
     (proof : List.Vector α idx.depth) : OptionT (OracleComp (spec α)) Unit := do
   let putative_root ← getPutativeRoot idx leafValue proof
@@ -216,35 +218,34 @@ def verifyProof {α} [DecidableEq α] {s}
 
 /--
 A functional form of the completeness theorem for Merkle trees.
-This references the functional versions of `getPutativeRoot` and `buildMerkleTree_with_hash`
+This references the functional versions of `getPutativeRoot` and `buildMerkleTreeWithHash`
 -/
 @[simp, grind]
-theorem functional_completeness (α : Type) {s : Skeleton}
+theorem functional_completeness {s : Skeleton}
   (idx : SkeletonLeafIndex s)
   (leaf_data_tree : LeafData α s)
   (hash : α → α → α) :
-  (getPutativeRoot_with_hash
+  getPutativeRootWithHash
     idx
     (leaf_data_tree.get idx)
-    (generateProof
-      (buildMerkleTree_with_hash leaf_data_tree hash) idx)
-    (hash)) =
-  (buildMerkleTree_with_hash leaf_data_tree hash).getRootValue := by
+    (generateProof (buildMerkleTreeWithHash leaf_data_tree hash) idx)
+    hash =
+  (buildMerkleTreeWithHash leaf_data_tree hash).getRootValue := by
   induction idx with
   | ofLeaf =>
       cases leaf_data_tree with
       | leaf a =>
-          simp [buildMerkleTree_with_hash, getPutativeRoot_with_hash]
+          simp [buildMerkleTreeWithHash, getPutativeRootWithHash]
   | ofLeft idxLeft ih =>
       cases leaf_data_tree with
       | internal left right =>
-          simp [LeafData.get_ofLeft, buildMerkleTree_with_hash, generateProof,
-            getPutativeRoot_with_hash, ih, FullData.internal_getRootValue]
+          simp [LeafData.get_ofLeft, buildMerkleTreeWithHash, generateProof,
+            getPutativeRootWithHash, ih, FullData.internal_getRootValue]
   | ofRight idxRight ih =>
       cases leaf_data_tree with
       | internal left right =>
-          simp [LeafData.get_ofRight, buildMerkleTree_with_hash, generateProof,
-            getPutativeRoot_with_hash, ih, FullData.internal_getRootValue]
+          simp [LeafData.get_ofRight, buildMerkleTreeWithHash, generateProof,
+            getPutativeRootWithHash, ih, FullData.internal_getRootValue]
 
 
 /--

--- a/VCVio/CryptoFoundations/InductiveMerkleTree.lean
+++ b/VCVio/CryptoFoundations/InductiveMerkleTree.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 
-import VCVio
+import VCVio.OracleComp.QueryTracking.RandomOracle
 import ToMathlib.Data.IndexedBinaryTree.Basic
 import Mathlib.Data.Vector.Snoc
 
@@ -130,32 +130,32 @@ lemma simulateQ_buildMerkleTree {s} (leaf_data_tree : LeafData α s)
 /--
 Generate a Merkle proof for a leaf at a given idx
 The proof consists of the sibling hashes needed to recompute the root.
+Its length is indexed by the leaf depth, so malformed extra hashes are unrepresentable.
 
 TODO rename this to copath and move to BinaryTree?
 -/
 @[simp, grind]
 def generateProof {s} (cache_tree : FullData α s) :
-    BinaryTree.SkeletonLeafIndex s → List α
-  | .ofLeaf => []
+    (idx : BinaryTree.SkeletonLeafIndex s) → List.Vector α idx.depth
+  | .ofLeaf => List.Vector.nil
   | .ofLeft idxLeft =>
-    (cache_tree.rightSubtree).getRootValue ::
+    List.Vector.cons ((cache_tree.rightSubtree).getRootValue)
       (generateProof cache_tree.leftSubtree idxLeft)
   | .ofRight idxRight =>
-    (cache_tree.leftSubtree).getRootValue ::
+    List.Vector.cons ((cache_tree.leftSubtree).getRootValue)
       (generateProof cache_tree.rightSubtree idxRight)
 
 @[simp, grind]
-theorem generateProof_leaf (a : α) (idx) :
-    generateProof (FullData.leaf a) idx = [] := by
-  cases idx with
-  | ofLeaf => rfl
+theorem generateProof_leaf (a : α) :
+    generateProof (FullData.leaf a) SkeletonLeafIndex.ofLeaf = List.Vector.nil := by
+  rfl
 
 @[simp, grind]
 theorem generateProof_ofLeft {sleft sright : Skeleton}
     (cache_tree : FullData α (Skeleton.internal sleft sright))
     (idxLeft : SkeletonLeafIndex sleft) :
     generateProof cache_tree (BinaryTree.SkeletonLeafIndex.ofLeft idxLeft) =
-      (cache_tree.rightSubtree).getRootValue ::
+      List.Vector.cons ((cache_tree.rightSubtree).getRootValue)
         (generateProof cache_tree.leftSubtree idxLeft) := by
   rfl
 
@@ -164,36 +164,28 @@ theorem generateProof_ofRight {sleft sright : Skeleton}
     (cache_tree : FullData α (Skeleton.internal sleft sright))
     (idxRight : SkeletonLeafIndex sright) :
     generateProof cache_tree (BinaryTree.SkeletonLeafIndex.ofRight idxRight) =
-      (cache_tree.leftSubtree).getRootValue ::
+      List.Vector.cons ((cache_tree.leftSubtree).getRootValue)
         (generateProof cache_tree.rightSubtree idxRight) := by
   rfl
 
 /--
-Given a leaf index, a leaf value at that index, and putative proof,
+Given a leaf index, a leaf value at that index, and a proof of the corresponding depth,
 returns the hash that would be the root of the tree if the proof was valid.
 i.e. the hash obtained by combining the leaf in sequence with each member of the proof,
 according to its index.
 -/
 @[simp, grind]
-def getPutativeRoot {s} (idx : BinaryTree.SkeletonLeafIndex s) (leafValue : α)
-    (proof : List α) : OracleComp (spec α) α :=
-  match proof with
-  | [] => return leafValue -- If no proof, the root is just the leaf value
-  | siblingBelowRootHash :: restProof => do
-    match idx with
-    | BinaryTree.SkeletonLeafIndex.ofLeaf =>
-      -- This indicates that the proof is longer than the depth of the tree, which is invalid.
-      -- A more well-typed version using `Vector` might prevent this.
-      -- For now, we just return the leaf value.
+def getPutativeRoot {s} :
+    (idx : BinaryTree.SkeletonLeafIndex s) → (leafValue : α) →
+      List.Vector α idx.depth → OracleComp (spec α) α
+  | BinaryTree.SkeletonLeafIndex.ofLeaf, leafValue, _ => do
       return leafValue
-    | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft =>
-      -- Recursively get the hash of the ancestor of the leaf which is just below the root
-      let ancestorBelowRootHash ← getPutativeRoot idxLeft leafValue restProof
-      singleHash ancestorBelowRootHash siblingBelowRootHash
-    | BinaryTree.SkeletonLeafIndex.ofRight idxRight =>
-      -- Recursively get the hash of the ancestor of the leaf which is just below the root
-      let ancestorBelowRootHash ← getPutativeRoot idxRight leafValue restProof
-      singleHash siblingBelowRootHash ancestorBelowRootHash
+  | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft, leafValue, proof => do
+      let ancestorBelowRootHash ← getPutativeRoot idxLeft leafValue proof.tail
+      singleHash ancestorBelowRootHash proof.head
+  | BinaryTree.SkeletonLeafIndex.ofRight idxRight, leafValue, proof => do
+      let ancestorBelowRootHash ← getPutativeRoot idxRight leafValue proof.tail
+      singleHash proof.head ancestorBelowRootHash
 
 /--
 A functional version of `getPutativeRoot` that does not depend on the monad.
@@ -201,55 +193,36 @@ It receives an explicit hash function `hashFn` that combines two hashes into one
 And recursively calls itself down the tree.
 -/
 @[simp, grind]
-def getPutativeRoot_with_hash {s} (idx : BinaryTree.SkeletonLeafIndex s)
-    (leafValue : α) (proof : List α) (hashFn : α → α → α) : α :=
-  match proof with
-  | [] => leafValue -- If no proof, the root is just the leaf value
-  | siblingBelowRootHash :: restProof =>
-    match idx with
-    | BinaryTree.SkeletonLeafIndex.ofLeaf =>
-      -- This indicates that the proof is longer than the depth of the tree, which is invalid.
-      -- A more well-typed version using `Vector` might prevent this.
-      -- For now, we just return the leaf value.
+def getPutativeRoot_with_hash {s} :
+    (idx : BinaryTree.SkeletonLeafIndex s) → (leafValue : α) →
+      List.Vector α idx.depth → (hashFn : α → α → α) → α
+  | BinaryTree.SkeletonLeafIndex.ofLeaf, leafValue, _, _ =>
       leafValue
-    | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft =>
-      -- Recursively get the hash of the ancestor of the leaf which is just below the root
-      hashFn (getPutativeRoot_with_hash idxLeft leafValue restProof hashFn) siblingBelowRootHash
-    | BinaryTree.SkeletonLeafIndex.ofRight idxRight =>
-      -- Recursively get the hash of the ancestor of the leaf which is just below the root
-      hashFn siblingBelowRootHash (getPutativeRoot_with_hash idxRight leafValue restProof hashFn)
+  | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft, leafValue, proof, hashFn =>
+      hashFn (getPutativeRoot_with_hash idxLeft leafValue proof.tail hashFn) proof.head
+  | BinaryTree.SkeletonLeafIndex.ofRight idxRight, leafValue, proof, hashFn =>
+      hashFn proof.head (getPutativeRoot_with_hash idxRight leafValue proof.tail hashFn)
 
 /--
 Running the monadic version of `getPutativeRoot` with an oracle function `f`,
 it is equivalent to running the functional version of `getPutativeRoot_with_hash`
 -/
 lemma simulateQ_getPutativeRoot {s} (idx : BinaryTree.SkeletonLeafIndex s)
-    (leafValue : α) (proof : List α) (f : QueryImpl (spec α) Id) :
+    (leafValue : α) (proof : List.Vector α idx.depth) (f : QueryImpl (spec α) Id) :
     simulateQ f (getPutativeRoot idx leafValue proof)
       =
     getPutativeRoot_with_hash idx leafValue proof fun (left right : α) => (f ⟨left, right⟩) := by
-  induction proof generalizing s with
-  | nil =>
-    unfold getPutativeRoot
-    simp only [getPutativeRoot_with_hash]
-    rfl
-  | cons siblingBelowRootHash restProof ih =>
-    unfold getPutativeRoot
-    cases s with
-    | leaf =>
-      cases idx with
-      | ofLeaf =>
-        rfl
-    | internal s_left s_right =>
-      cases idx with
-      | ofLeft idxLeft =>
-        simp only [singleHash, simulateQ_bind, simulateQ_pure,
-          getPutativeRoot_with_hash] at ih ⊢
-        rw [ih]; rfl
-      | ofRight idxRight =>
-        simp only [singleHash, simulateQ_bind, simulateQ_pure,
-          getPutativeRoot_with_hash] at ih ⊢
-        rw [ih]; rfl
+  induction idx generalizing leafValue with
+  | ofLeaf =>
+      rfl
+  | ofLeft idxLeft ih =>
+      simp only [getPutativeRoot, getPutativeRoot_with_hash, singleHash, simulateQ_bind]
+      rw [ih]
+      rfl
+  | ofRight idxRight ih =>
+      simp only [getPutativeRoot, getPutativeRoot_with_hash, singleHash, simulateQ_bind]
+      rw [ih]
+      rfl
 
 /--
 Verify a Merkle proof `proof` that a given `leaf` at index `i` is in the Merkle tree with given
@@ -260,7 +233,7 @@ Outputs `failure` if the proof is invalid.
 @[simp, grind]
 def verifyProof {α} [DecidableEq α] {s}
     (idx : BinaryTree.SkeletonLeafIndex s) (leafValue : α) (rootValue : α)
-    (proof : List α) : OptionT (OracleComp (spec α)) Unit := do
+    (proof : List.Vector α idx.depth) : OptionT (OracleComp (spec α)) Unit := do
   let putative_root ← getPutativeRoot idx leafValue proof
   guard (putative_root = rootValue)
 
@@ -280,25 +253,21 @@ theorem functional_completeness (α : Type) {s : Skeleton}
       (buildMerkleTree_with_hash leaf_data_tree hash) idx)
     (hash)) =
   (buildMerkleTree_with_hash leaf_data_tree hash).getRootValue := by
-  induction s with
-  | leaf =>
-    match leaf_data_tree with
-    | LeafData.leaf a =>
-      cases idx with
-      | ofLeaf =>
-        simp [buildMerkleTree_with_hash, getPutativeRoot_with_hash]
-  | internal s_left s_right left_ih right_ih =>
-    match leaf_data_tree with
-    | LeafData.internal left right =>
-      cases idx with
-      | ofLeft idxLeft =>
-        simp_rw [LeafData.get_ofLeft, LeafData.leftSubtree_internal, buildMerkleTree_with_hash,
-          generateProof_ofLeft, FullData.rightSubtree, FullData.leftSubtree,
-          getPutativeRoot_with_hash, left_ih, FullData.internal_getRootValue]
-      | ofRight idxRight =>
-        simp_rw [LeafData.get_ofRight, LeafData.rightSubtree_internal, buildMerkleTree_with_hash,
-          generateProof_ofRight, FullData.leftSubtree, FullData.rightSubtree,
-          getPutativeRoot_with_hash, right_ih, FullData.internal_getRootValue]
+  induction idx with
+  | ofLeaf =>
+      cases leaf_data_tree with
+      | leaf a =>
+          simp [buildMerkleTree_with_hash, getPutativeRoot_with_hash]
+  | ofLeft idxLeft ih =>
+      cases leaf_data_tree with
+      | internal left right =>
+          simp [LeafData.get_ofLeft, buildMerkleTree_with_hash, generateProof,
+            getPutativeRoot_with_hash, ih, FullData.internal_getRootValue]
+  | ofRight idxRight ih =>
+      cases leaf_data_tree with
+      | internal left right =>
+          simp [LeafData.get_ofRight, buildMerkleTree_with_hash, generateProof,
+            getPutativeRoot_with_hash, ih, FullData.internal_getRootValue]
 
 
 /--

--- a/VCVio/CryptoFoundations/InductiveMerkleTree.lean
+++ b/VCVio/CryptoFoundations/InductiveMerkleTree.lean
@@ -1,0 +1,322 @@
+/-
+Copyright (c) 2024 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import VCVio
+import ToMathlib.Data.IndexedBinaryTree.Basic
+import Mathlib.Data.Vector.Snoc
+
+/-!
+# Inductive Merkle Trees
+
+This file implements Merkle Trees. In contrast to the other Merkle tree implementation in
+`VCVio.CryptoFoundations.MerkleTree`, this one is defined inductively.
+
+## Implementation Notes
+
+This works with trees that are indexed inductive binary trees,
+(i.e. indexed in that their definitions and methods carry parameters regarding their structure)
+as defined in `ToMathlib.Data.IndexedBinaryTree`.
+
+* We found that the inductive definition seems likely to be convenient for a few reasons:
+  * It allows us to handle non-perfect trees.
+  * It can allow us to use trees of arbitrary structure in the extractor.
+* I considered the indexed type useful because the completeness theorem and extractibility theorems
+  take indices or sets of indices as parameters,
+  and because we are working with trees of arbitrary structure,
+  this lets us avoid having to check that these indices are valid.
+
+## Plan/TODOs
+
+- [x] Basic Merkle tree API
+  - [x] `buildMerkleTree`
+  - [x] `generateProof`
+  - [x] `getPutativeRoot`
+  - [x] `verifyProof`
+- [x] Completeness theorem
+- [ ] Collision Lemma (See SNARGs book 18.3)
+  - (this is really not a lemma about oracles, so it could go with the binary tree API)
+- [ ] Extractibility (See SNARGs book 18.5)
+- [ ] Multi-leaf proofs
+- [ ] Arbirary arity trees
+- [ ] Multi-instance
+
+-/
+
+
+namespace InductiveMerkleTree
+
+open List OracleSpec OracleComp BinaryTree
+
+section spec
+
+variable (α : Type)
+
+/-- Define the domain & range of the (single) oracle needed for constructing a Merkle tree with
+    elements from some type `α`.
+
+  We may instantiate `α` with `BitVec n` or `Fin (2 ^ n)` to construct a Merkle tree for boolean
+  vectors of length `n`. -/
+@[reducible]
+def spec : OracleSpec (α × α) := (α × α) →ₒ α
+
+@[simp, grind]
+lemma domain_def : (spec α).Domain = (α × α) := rfl
+
+@[simp]
+lemma range_def (z) : (spec α).Range z = α := rfl
+
+end spec
+
+
+variable {α : Type}
+
+/-- Example: a single hash computation -/
+@[simp, grind]
+def singleHash (left : α) (right : α) : OracleComp (spec α) α := do
+  let out ← query (spec := spec α) ⟨left, right⟩
+  return out
+
+/-- Build the full Merkle tree, returning the tree populated with data on all its nodes -/
+@[simp, grind]
+def buildMerkleTree {s} (leaf_tree : LeafData α s) : OracleComp (spec α) (FullData α s) :=
+  match leaf_tree with
+  | LeafData.leaf a => do return (FullData.leaf a)
+  | LeafData.internal left right => do
+    let leftTree ← buildMerkleTree left
+    let rightTree ← buildMerkleTree right
+    let rootHash ← singleHash leftTree.getRootValue rightTree.getRootValue
+    return FullData.internal rootHash leftTree rightTree
+
+/--
+A functional form of merkle tree construction, that doesn't depend on the monad.
+This receives an explicit hash function
+-/
+@[simp, grind]
+def buildMerkleTree_with_hash {s} (leaf_tree : LeafData α s) (hashFn : α → α → α) :
+    (FullData α s) :=
+  match leaf_tree with
+  | LeafData.leaf a => FullData.leaf a
+  | LeafData.internal left right =>
+    let leftTree := buildMerkleTree_with_hash left hashFn
+    let rightTree := buildMerkleTree_with_hash right hashFn
+    let rootHash := hashFn (leftTree.getRootValue) (rightTree.getRootValue)
+    FullData.internal rootHash leftTree rightTree
+
+/--
+Running the monadic version of `buildMerkleTree` with an oracle function `f`
+is equivalent to running the functional version of `buildMerkleTree_with_hash`
+with the same oracle function.
+-/
+lemma simulateQ_buildMerkleTree {s} (leaf_data_tree : LeafData α s)
+    (f : QueryImpl (spec α) Id) :
+    simulateQ f (buildMerkleTree leaf_data_tree)
+    = buildMerkleTree_with_hash leaf_data_tree fun (left right : α) =>
+      (f ⟨left, right⟩) := by
+  induction s with
+  | leaf =>
+    match leaf_data_tree with
+    | LeafData.leaf a =>
+      rfl
+  | internal s_left s_right left_ih right_ih =>
+    match leaf_data_tree with
+    | LeafData.internal left right =>
+      simp only [buildMerkleTree, buildMerkleTree_with_hash, singleHash,
+        simulateQ_bind, simulateQ_pure] at left_ih right_ih ⊢
+      rw [left_ih left, right_ih right]; rfl
+
+/--
+Generate a Merkle proof for a leaf at a given idx
+The proof consists of the sibling hashes needed to recompute the root.
+
+TODO rename this to copath and move to BinaryTree?
+-/
+@[simp, grind]
+def generateProof {s} (cache_tree : FullData α s) :
+    BinaryTree.SkeletonLeafIndex s → List α
+  | .ofLeaf => []
+  | .ofLeft idxLeft =>
+    (cache_tree.rightSubtree).getRootValue ::
+      (generateProof cache_tree.leftSubtree idxLeft)
+  | .ofRight idxRight =>
+    (cache_tree.leftSubtree).getRootValue ::
+      (generateProof cache_tree.rightSubtree idxRight)
+
+@[simp, grind]
+theorem generateProof_leaf (a : α) (idx) :
+    generateProof (FullData.leaf a) idx = [] := by
+  cases idx with
+  | ofLeaf => rfl
+
+@[simp, grind]
+theorem generateProof_ofLeft {sleft sright : Skeleton}
+    (cache_tree : FullData α (Skeleton.internal sleft sright))
+    (idxLeft : SkeletonLeafIndex sleft) :
+    generateProof cache_tree (BinaryTree.SkeletonLeafIndex.ofLeft idxLeft) =
+      (cache_tree.rightSubtree).getRootValue ::
+        (generateProof cache_tree.leftSubtree idxLeft) := by
+  rfl
+
+@[simp, grind]
+theorem generateProof_ofRight {sleft sright : Skeleton}
+    (cache_tree : FullData α (Skeleton.internal sleft sright))
+    (idxRight : SkeletonLeafIndex sright) :
+    generateProof cache_tree (BinaryTree.SkeletonLeafIndex.ofRight idxRight) =
+      (cache_tree.leftSubtree).getRootValue ::
+        (generateProof cache_tree.rightSubtree idxRight) := by
+  rfl
+
+/--
+Given a leaf index, a leaf value at that index, and putative proof,
+returns the hash that would be the root of the tree if the proof was valid.
+i.e. the hash obtained by combining the leaf in sequence with each member of the proof,
+according to its index.
+-/
+@[simp, grind]
+def getPutativeRoot {s} (idx : BinaryTree.SkeletonLeafIndex s) (leafValue : α)
+    (proof : List α) : OracleComp (spec α) α :=
+  match proof with
+  | [] => return leafValue -- If no proof, the root is just the leaf value
+  | siblingBelowRootHash :: restProof => do
+    match idx with
+    | BinaryTree.SkeletonLeafIndex.ofLeaf =>
+      -- This indicates that the proof is longer than the depth of the tree, which is invalid.
+      -- A more well-typed version using `Vector` might prevent this.
+      -- For now, we just return the leaf value.
+      return leafValue
+    | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft =>
+      -- Recursively get the hash of the ancestor of the leaf which is just below the root
+      let ancestorBelowRootHash ← getPutativeRoot idxLeft leafValue restProof
+      singleHash ancestorBelowRootHash siblingBelowRootHash
+    | BinaryTree.SkeletonLeafIndex.ofRight idxRight =>
+      -- Recursively get the hash of the ancestor of the leaf which is just below the root
+      let ancestorBelowRootHash ← getPutativeRoot idxRight leafValue restProof
+      singleHash siblingBelowRootHash ancestorBelowRootHash
+
+/--
+A functional version of `getPutativeRoot` that does not depend on the monad.
+It receives an explicit hash function `hashFn` that combines two hashes into one.
+And recursively calls itself down the tree.
+-/
+@[simp, grind]
+def getPutativeRoot_with_hash {s} (idx : BinaryTree.SkeletonLeafIndex s)
+    (leafValue : α) (proof : List α) (hashFn : α → α → α) : α :=
+  match proof with
+  | [] => leafValue -- If no proof, the root is just the leaf value
+  | siblingBelowRootHash :: restProof =>
+    match idx with
+    | BinaryTree.SkeletonLeafIndex.ofLeaf =>
+      -- This indicates that the proof is longer than the depth of the tree, which is invalid.
+      -- A more well-typed version using `Vector` might prevent this.
+      -- For now, we just return the leaf value.
+      leafValue
+    | BinaryTree.SkeletonLeafIndex.ofLeft idxLeft =>
+      -- Recursively get the hash of the ancestor of the leaf which is just below the root
+      hashFn (getPutativeRoot_with_hash idxLeft leafValue restProof hashFn) siblingBelowRootHash
+    | BinaryTree.SkeletonLeafIndex.ofRight idxRight =>
+      -- Recursively get the hash of the ancestor of the leaf which is just below the root
+      hashFn siblingBelowRootHash (getPutativeRoot_with_hash idxRight leafValue restProof hashFn)
+
+/--
+Running the monadic version of `getPutativeRoot` with an oracle function `f`,
+it is equivalent to running the functional version of `getPutativeRoot_with_hash`
+-/
+lemma simulateQ_getPutativeRoot {s} (idx : BinaryTree.SkeletonLeafIndex s)
+    (leafValue : α) (proof : List α) (f : QueryImpl (spec α) Id) :
+    simulateQ f (getPutativeRoot idx leafValue proof)
+      =
+    getPutativeRoot_with_hash idx leafValue proof fun (left right : α) => (f ⟨left, right⟩) := by
+  induction proof generalizing s with
+  | nil =>
+    unfold getPutativeRoot
+    simp only [getPutativeRoot_with_hash]
+    rfl
+  | cons siblingBelowRootHash restProof ih =>
+    unfold getPutativeRoot
+    cases s with
+    | leaf =>
+      cases idx with
+      | ofLeaf =>
+        rfl
+    | internal s_left s_right =>
+      cases idx with
+      | ofLeft idxLeft =>
+        simp only [singleHash, simulateQ_bind, simulateQ_pure,
+          getPutativeRoot_with_hash] at ih ⊢
+        rw [ih]; rfl
+      | ofRight idxRight =>
+        simp only [singleHash, simulateQ_bind, simulateQ_pure,
+          getPutativeRoot_with_hash] at ih ⊢
+        rw [ih]; rfl
+
+/--
+Verify a Merkle proof `proof` that a given `leaf` at index `i` is in the Merkle tree with given
+`root`.
+Works by computing the putative root based on the branch, and comparing that to the actual root.
+Outputs `failure` if the proof is invalid.
+-/
+@[simp, grind]
+def verifyProof {α} [DecidableEq α] {s}
+    (idx : BinaryTree.SkeletonLeafIndex s) (leafValue : α) (rootValue : α)
+    (proof : List α) : OptionT (OracleComp (spec α)) Unit := do
+  let putative_root ← getPutativeRoot idx leafValue proof
+  guard (putative_root = rootValue)
+
+/--
+A functional form of the completeness theorem for Merkle trees.
+This references the functional versions of `getPutativeRoot` and `buildMerkleTree_with_hash`
+-/
+@[simp, grind]
+theorem functional_completeness (α : Type) {s : Skeleton}
+  (idx : SkeletonLeafIndex s)
+  (leaf_data_tree : LeafData α s)
+  (hash : α → α → α) :
+  (getPutativeRoot_with_hash
+    idx
+    (leaf_data_tree.get idx)
+    (generateProof
+      (buildMerkleTree_with_hash leaf_data_tree hash) idx)
+    (hash)) =
+  (buildMerkleTree_with_hash leaf_data_tree hash).getRootValue := by
+  induction s with
+  | leaf =>
+    match leaf_data_tree with
+    | LeafData.leaf a =>
+      cases idx with
+      | ofLeaf =>
+        simp [buildMerkleTree_with_hash, getPutativeRoot_with_hash]
+  | internal s_left s_right left_ih right_ih =>
+    match leaf_data_tree with
+    | LeafData.internal left right =>
+      cases idx with
+      | ofLeft idxLeft =>
+        simp_rw [LeafData.get_ofLeft, LeafData.leftSubtree_internal, buildMerkleTree_with_hash,
+          generateProof_ofLeft, FullData.rightSubtree, FullData.leftSubtree,
+          getPutativeRoot_with_hash, left_ih, FullData.internal_getRootValue]
+      | ofRight idxRight =>
+        simp_rw [LeafData.get_ofRight, LeafData.rightSubtree_internal, buildMerkleTree_with_hash,
+          generateProof_ofRight, FullData.leftSubtree, FullData.rightSubtree,
+          getPutativeRoot_with_hash, right_ih, FullData.internal_getRootValue]
+
+
+/--
+Completeness theorem for Merkle trees.
+
+The proof proceeds by reducing to the functional completeness theorem by a theorem about
+the OracleComp monad,
+and then applying the functional version of the completeness theorem.
+-/
+@[simp]
+theorem completeness [DecidableEq α] [SampleableType α] {s}
+    (leaf_data_tree : LeafData α s) (idx : BinaryTree.SkeletonLeafIndex s)
+    (preexisting_cache : (spec α).QueryCache) :
+    NeverFail ((simulateQ (randomOracle) (do
+      let cache ← buildMerkleTree leaf_data_tree
+      let proof := generateProof cache idx
+      let _ ← verifyProof idx (leaf_data_tree.get idx) (cache.getRootValue) proof
+      )).run preexisting_cache) := by
+  grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+
+end InductiveMerkleTree

--- a/VCVio/CryptoFoundations/InductiveMerkleTree.lean
+++ b/VCVio/CryptoFoundations/InductiveMerkleTree.lean
@@ -62,7 +62,7 @@ variable (α : Type _)
 @[reducible]
 def spec : OracleSpec (α × α) := (α × α) →ₒ α
 
-@[simp, grind]
+@[simp, grind =]
 lemma domain_def : (spec α).Domain = (α × α) := rfl
 
 @[simp]
@@ -220,7 +220,7 @@ def verifyProof [DecidableEq α] {s}
 A functional form of the completeness theorem for Merkle trees.
 This references the functional versions of `getPutativeRoot` and `buildMerkleTreeWithHash`
 -/
-@[simp, grind]
+@[simp, grind =]
 theorem functional_completeness {s : Skeleton}
   (idx : SkeletonLeafIndex s)
   (leaf_data_tree : LeafData α s)

--- a/VCVio/CryptoFoundations/MerkleTree.lean
+++ b/VCVio/CryptoFoundations/MerkleTree.lean
@@ -275,12 +275,15 @@ def getPutativeRoot_with_hash {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (proof : L
         let newLeaf := hashFn (proof.head, leaf)
         getPutativeRoot_with_hash i' newLeaf proof.tail hashFn
 
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
 @[simp, grind =]
 lemma simulateQ_query_eq (f : QueryImpl (spec α) Id) (x : α × α) :
     simulateQ f (liftM (query x)) = f x := by
-  simpa using (simulateQ_query (impl := f) (q := query x))
+  rw [simulateQ_query (impl := f) (q := query x)]
+  rfl
 
 
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
 @[simp, grind =]
 lemma simulateQ_listVector_mmap_query (f : QueryImpl (spec α) Id) {m : ℕ}
     (xs : List.Vector (α × α) m) :
@@ -297,6 +300,7 @@ lemma simulateQ_listVector_mmap_query (f : QueryImpl (spec α) Id) {m : ℕ}
     obtain ⟨fst, snd⟩ := x
     rfl
 
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
 @[simp, grind =]
 lemma simulateQ_buildLayer_eq (f : QueryImpl (spec α) Id) (n : ℕ)
     (leaves : List.Vector α (2 ^ (n + 1))) :
@@ -307,6 +311,7 @@ lemma simulateQ_buildLayer_eq (f : QueryImpl (spec α) Id) (n : ℕ)
     domain_def]
   rfl
 
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
 @[simp, grind =]
 lemma simulateQ_buildMerkleTree_eq (f : QueryImpl (spec α) Id) (n : ℕ)
     (leaves : List.Vector α (2 ^ n)) :
@@ -331,6 +336,7 @@ lemma simulateQ_buildMerkleTree_eq (f : QueryImpl (spec α) Id) (n : ℕ)
     simp only [buildMerkleTree, buildMerkleTree_with_hash]
     simp only [sqb, simulateQ_buildLayer_eq, ih, sqp]
 
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
 @[simp, grind =]
 lemma simulateQ_getPutativeRoot_eq (f : QueryImpl (spec α) Id) {n : ℕ} (i : Fin (2 ^ n))
     (leaf : α) (proof : List.Vector α n) :
@@ -348,6 +354,7 @@ lemma simulateQ_getPutativeRoot_eq (f : QueryImpl (spec α) Id) {n : ℕ} (i : F
       simp_all only [Nat.mod_two_not_eq_zero]
       rfl
 
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
 /-- A functional completeness theorem for Merkle proofs built from `buildMerkleTree_with_hash`. -/
 theorem functional_completeness {n : ℕ} (leaves : List.Vector α (2 ^ n)) (i : Fin (2 ^ n))
     (hashFn : α × α → α) :
@@ -360,8 +367,8 @@ theorem functional_completeness {n : ℕ} (leaves : List.Vector α (2 ^ n)) (i :
     subst hi
     simp only [buildMerkleTree_with_hash, Fin.isValue, Nat.pow_zero, getPutativeRoot_with_hash,
       getRoot, Fin.zero_eta, Vector.get_zero, List.Vector.head]
-    simp_all only [Fin.isValue, Nat.reduceAdd, Fin.coe_ofNat_eq_mod, Nat.zero_mod, Nat.pow_zero, eq_mpr_eq_cast,
-      cast_eq, Nat.succ_eq_add_one, length_cons]
+    simp_all only [Fin.isValue, Nat.reduceAdd, Fin.coe_ofNat_eq_mod, Nat.zero_mod,
+      Nat.pow_zero, eq_mpr_eq_cast, cast_eq, Nat.succ_eq_add_one, length_cons]
     split
     rename_i x a tail property
     simp_all only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue]
@@ -384,7 +391,6 @@ theorem functional_completeness {n : ℕ} (leaves : List.Vector α (2 ^ n)) (i :
         simp [lastLayer, buildLayer_with_hash, siblingIndex, hsign, hdiv]
       -- Unfold and apply the induction hypothesis on the upper tree.
       -- `generateProof` and `getRoot` reduce via `Cache.upper_cons` and `Cache.leaves_cons`.
-
       simp [buildMerkleTree_with_hash, lastLayer, generateProof,
         getPutativeRoot_with_hash, getRoot, hsign, hnew]
       simpa [getRoot, Cache.cons, lastLayer, upperCache] using

--- a/VCVio/CryptoFoundations/MerkleTree.lean
+++ b/VCVio/CryptoFoundations/MerkleTree.lean
@@ -1,0 +1,440 @@
+/-
+Copyright (c) 2024 ArkLib Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao, Fawad Haider
+-/
+
+import VCVio.OracleComp.QueryTracking.RandomOracle
+
+/-!
+  # Merkle Trees as a vector commitment
+
+  ## Notes & TODOs
+
+  We want this treatment to be as comprehensive as possible. In particular, our formalization
+  should (eventually) include all complexities such as the following:
+
+  - Multi-instance extraction & simulation
+  - Dealing with arbitrary trees (may have arity > 2, or is not complete)
+  - Path pruning optimization
+-/
+
+namespace MerkleTree
+
+open List OracleSpec OracleComp
+
+variable (α : Type)
+
+/-- Define the domain & range of the (single) oracle needed for constructing a Merkle tree with
+    elements from some type `α`.
+
+  We may instantiate `α` with `BitVec n` or `Fin (2 ^ n)` to construct a Merkle tree for boolean
+  vectors of length `n`. -/
+@[reducible]
+def spec : OracleSpec (α × α) := (α × α) →ₒ α
+
+@[simp, grind =]
+lemma domain_def : (spec α).Domain = (α × α) := rfl
+
+@[simp]
+lemma range_def {x} : (spec α).Range x = α := rfl
+
+section
+
+variable [DecidableEq α] [Inhabited α] [Fintype α]
+
+/-- Example: a single hash computation -/
+def singleHash (left : α) (right : α) : OracleComp (spec α) α := do
+  let out ← query (spec := spec α) ⟨left, right⟩
+  return out
+
+/-- Cache for Merkle tree. Indexed by `j : Fin (n + 1)`, i.e. `j = 0, 1, ..., n`. -/
+def Cache (n : ℕ) := (layer : Fin (n + 1)) → List.Vector α (2 ^ layer.val)
+
+/-- Add a base layer to the cache -/
+def Cache.cons (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (cache : Cache α n) :
+    Cache α (n + 1) :=
+  Fin.snoc cache leaves
+
+/-- Removes the leaves layer to the cache, returning only the layers of the tree above this -/
+def Cache.upper (n : ℕ) (cache : Cache α (n + 1)) :
+    Cache α n :=
+  Fin.init cache
+
+/-- Returns the leaves of the cache -/
+def Cache.leaves (n : ℕ) (cache : Cache α (n + 1)) :
+    List.Vector α (2 ^ (n + 1)) := cache (Fin.last _)
+
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
+@[simp, grind]
+lemma Cache.upper_cons (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (cache : Cache α n) :
+    Cache.upper α n (Cache.cons α n leaves cache) = cache := by
+  simp [Cache.upper, Cache.cons]
+
+omit [DecidableEq α] [Inhabited α] [Fintype α] in
+@[simp, grind]
+lemma Cache.leaves_cons (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (cache : Cache α n) :
+    Cache.leaves α n (Cache.cons α n leaves cache) = leaves := by
+  simp [Cache.leaves, Cache.cons]
+
+/-- Compute the next layer of the Merkle tree -/
+def buildLayer (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) :
+    OracleComp (spec α) (List.Vector α (2 ^ n)) := do
+  let leaves : List.Vector α (2 ^ n * 2) := by rwa [pow_succ] at leaves
+  -- Pair up the leaves to form pairs
+  let pairs : List.Vector (α × α) (2 ^ n) :=
+    List.Vector.ofFn (fun i =>
+      (leaves.get ⟨2 * i, by grind only⟩, leaves.get ⟨2 * i + 1, by grind only⟩))
+  -- Hash each pair to get the next layer
+  let hashes : List.Vector α (2 ^ n) ←
+    List.Vector.mmap (fun ⟨left, right⟩ => query (spec := spec α) ⟨left, right⟩) pairs
+  return hashes
+
+/-- Build the full Merkle tree, returning the cache -/
+def buildMerkleTree (α) (n : ℕ) (leaves : List.Vector α (2 ^ n)) :
+    OracleComp (spec α) (Cache α n) := do
+  match n with
+  | 0 => do
+    return fun j => (by
+      rw [Fin.val_eq_zero j]
+      exact leaves)
+  | n + 1 => do
+    let lastLayer ← buildLayer α n leaves
+    let cache ← buildMerkleTree α n lastLayer
+    return Cache.cons α n leaves cache
+
+/-- Get the root of the Merkle tree -/
+@[simp, grind]
+def getRoot {n : ℕ} (cache : Cache α n) : α :=
+  (cache 0).get ⟨0, by simp⟩
+
+/-- Figure out the indices of the Merkle tree nodes that are needed to
+recompute the root from the given leaf -/
+def findNeighbors {n : ℕ} (i : Fin (2 ^ n)) (layer : Fin n) :
+    Fin (2 ^ (layer.val + 1)) :=
+  -- `finFunctionFinEquiv.invFun` gives the little-endian order, e.g. `6 = 011 little`
+  -- so we need to reverse it to get the big-endian order, e.g. `6 = 110 big`
+  let bits := (Vector.ofFn (finFunctionFinEquiv.invFun i)).reverse
+  -- `6 = 110 big`, `layer = 1`, we get `neighbor = 10 big`
+  let m := layer.val + 1
+  have hm : m ≤ n := Nat.succ_le_of_lt layer.isLt
+  let neighbor : _root_.Vector (Fin 2) m :=
+    Vector.ofFn fun j : Fin m =>
+      let j' : Fin n := ⟨j.val, lt_of_lt_of_le j.isLt hm⟩
+      let bit := bits.get j'
+      if j.val = layer.val then bit + 1 else bit
+  -- `10 big` => `01 little` => `2`
+  finFunctionFinEquiv.toFun neighbor.reverse.get
+
+end
+
+@[simp, grind =]
+theorem getRoot_trivial (a : α) : getRoot α <$> (buildMerkleTree α 0 ⟨[a], rfl⟩) = pure a := by
+  simp [getRoot, buildMerkleTree, List.Vector.head]
+
+@[simp, grind =]
+theorem getRoot_single (a b : α) :
+    getRoot α <$> buildMerkleTree α 1 ⟨[a, b], rfl⟩ = (query (spec := spec α) (a, b)) := by
+  simp [buildMerkleTree, buildLayer, List.Vector.ofFn, List.Vector.get]
+  rfl
+
+section
+
+variable [DecidableEq α] [Inhabited α] [Fintype α]
+
+/-- Sibling index in a perfect binary tree layer indexed by `Fin (2 ^ (n + 1))`. -/
+def siblingIndex {n : ℕ} (i : Fin (2 ^ (n + 1))) : Fin (2 ^ (n + 1)) :=
+  if h : i.val % 2 = 0 then
+    ⟨i.val + 1, by
+      have hi : i.val < 2 ^ (n + 1) := i.isLt
+      have hEven : Even (2 ^ (n + 1)) := by
+        exact (Nat.even_pow).2 ⟨even_two, Nat.succ_ne_zero n⟩
+      have hmod : (2 ^ (n + 1)) % 2 = 0 := (Nat.even_iff).1 hEven
+      have hle : i.val + 1 ≤ 2 ^ (n + 1) := Nat.succ_le_of_lt hi
+      have hne : i.val + 1 ≠ 2 ^ (n + 1) := by
+        intro hEq
+        have hiVal : i.val = 2 ^ (n + 1) - 1 := by grind only
+        have hpos : 0 < 2 ^ (n + 1) := by
+          exact pow_pos (by decide : 0 < (2 : ℕ)) _
+        have hle1 : 1 ≤ 2 ^ (n + 1) := Nat.succ_le_of_lt hpos
+        have hmodPred : (2 ^ (n + 1) - 1) % 2 = 1 := by
+          have : (2 ^ (n + 1) - 1 + 1) % 2 = 0 := by
+            simp [Nat.sub_add_cancel hle1, hmod]
+          exact (Nat.succ_mod_two_eq_zero_iff (m := 2 ^ (n + 1) - 1)).1 this
+        have : i.val % 2 = 1 := by simp [hiVal, hmodPred]
+        grind only
+      exact lt_of_le_of_ne hle hne⟩
+  else
+    ⟨i.val - 1, by
+      have hi : i.val < 2 ^ (n + 1) := i.isLt
+      grind only [= Lean.Grind.toInt_fin]⟩
+
+/-- Generate a Merkle proof that a given leaf at index `i` is in the Merkle tree. The proof consists
+  of the Merkle tree nodes that are needed to recompute the root from the given leaf. -/
+def generateProof {n : ℕ} (i : Fin (2 ^ n)) (cache : Cache α n) :
+    List.Vector α n :=
+  match n with
+  | 0 => List.Vector.nil
+  | n + 1 =>
+      List.Vector.cons ((cache.leaves).get (siblingIndex i))
+        (generateProof ⟨i.val / 2, by grind only⟩ (cache.upper))
+
+/--
+Given a leaf index, a leaf at that index, and putative proof,
+returns the hash that would be the root of the tree if the proof was valid.
+i.e. the hash obtained by combining the leaf in sequence with each member of the proof,
+according to its index.
+-/
+def getPutativeRoot {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (proof : List.Vector α n) :
+    OracleComp (spec α) α := do
+  match h : n with
+  | 0 => do
+    -- When we have an empty proof, the root is just the leaf
+    return leaf
+  | n + 1 => do
+    -- Get the sign bit of `i`
+    let signBit := i.val % 2
+    -- Show that `i / 2` is in `Fin (2 ^ (n - 1))`
+    let i' : Fin (2 ^ n) := ⟨i.val / 2, by grind only⟩
+    if signBit = 0 then
+      -- `i` is a left child
+      let newLeaf ← query (spec := spec α) ⟨leaf, proof.head⟩
+      getPutativeRoot i' newLeaf proof.tail
+    else
+      -- `i` is a right child
+      let newLeaf ← query (spec := spec α) ⟨proof.head, leaf⟩
+      getPutativeRoot i' newLeaf proof.tail
+
+/-- Verify a Merkle proof `proof` that a given `leaf` at index `i` is in the Merkle tree with given
+  `root`.
+  Works by computing the putative root based on the branch, and comparing that to the actual root.
+  Outputs `failure` if the proof is invalid. -/
+def verifyProof {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (root : α) (proof : List.Vector α n) :
+    OptionT (OracleComp (spec α)) Unit := do
+  let putative_root ← getPutativeRoot α i leaf proof
+  guard (putative_root = root)
+
+@[grind]
+theorem buildLayer_neverFails (α : Type) [inst : DecidableEq α]
+    [inst_1 : SampleableType α] [(spec α).DecidableEq]
+    (preexisting_cache : (spec α).QueryCache) (n : ℕ)
+    (leaves : List.Vector α (2 ^ (n + 1))) : NeverFail
+      ((simulateQ (randomOracle (spec := spec α))
+        (buildLayer α n leaves)).run preexisting_cache) := by
+  grind only [buildLayer, = HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+
+/--
+Building a Merkle tree never results in failure
+(no matter what queries have already been made to the oracle before it runs).
+-/
+@[grind]
+theorem buildMerkleTree_neverFails (α : Type) [DecidableEq α]
+    [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
+    (leaves : List.Vector α (2 ^ n)) (preexisting_cache : (spec α).QueryCache) :
+    NeverFail
+      ((simulateQ (randomOracle (spec := spec α))
+        (buildMerkleTree α n leaves)).run preexisting_cache) := by
+  grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+
+/-- A purely functional version of `buildLayer`, given an explicit hash function. -/
+def buildLayer_with_hash (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (hashFn : α × α → α) :
+    List.Vector α (2 ^ n) :=
+  let leaves : List.Vector α (2 ^ n * 2) := by rwa [pow_succ] at leaves
+  let pairs : List.Vector (α × α) (2 ^ n) :=
+    List.Vector.ofFn (fun i =>
+      (leaves.get ⟨2 * i, by grind only⟩, leaves.get ⟨2 * i + 1, by grind only⟩))
+  pairs.map hashFn
+
+/-- A purely functional version of `buildMerkleTree`, given an explicit hash function. -/
+def buildMerkleTree_with_hash (n : ℕ) (leaves : List.Vector α (2 ^ n)) (hashFn : α × α → α) :
+    Cache α n :=
+  match n with
+  | 0 =>
+      fun j => by
+        rw [Fin.val_eq_zero j]
+        exact leaves
+  | n + 1 =>
+      let lastLayer := buildLayer_with_hash (α := α) n leaves hashFn
+      let cache := buildMerkleTree_with_hash n lastLayer hashFn
+      Cache.cons α n leaves cache
+
+/--
+A purely functional version of `getPutativeRoot`, given an explicit hash function.
+-/
+def getPutativeRoot_with_hash {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (proof : List.Vector α n)
+    (hashFn : α × α → α) : α :=
+  match n with
+  | 0 => leaf
+  | n + 1 =>
+      let signBit := i.val % 2
+      let i' : Fin (2 ^ n) := ⟨i.val / 2, by grind only⟩
+      if signBit = 0 then
+        let newLeaf := hashFn (leaf, proof.head)
+        getPutativeRoot_with_hash i' newLeaf proof.tail hashFn
+      else
+        let newLeaf := hashFn (proof.head, leaf)
+        getPutativeRoot_with_hash i' newLeaf proof.tail hashFn
+
+@[simp, grind =]
+lemma simulateQ_query_eq (f : QueryImpl (spec α) Id) (x : α × α) :
+    simulateQ f (liftM (query x)) = f x := by
+  simpa using (simulateQ_query (impl := f) (q := query x))
+
+
+@[simp, grind =]
+lemma simulateQ_listVector_mmap_query (f : QueryImpl (spec α) Id) {m : ℕ}
+    (xs : List.Vector (α × α) m) :
+    simulateQ f (List.Vector.mmap (fun x => liftM (query x)) xs) =
+      xs.map f := by
+  induction xs using List.Vector.inductionOn with
+  | nil =>
+    unfold simulateQ List.Vector.mmap
+    simp_all only [vector_eq_nil, domain_def]
+  | @cons m x xs ih =>
+    unfold simulateQ at *
+    simp_all only [domain_def, Nat.succ_eq_add_one, Vector.mmap_cons, bind_pure_comp,
+      PFunctor.FreeM.mapM_bind', PFunctor.FreeM.mapM_map, Vector.map_cons]
+    obtain ⟨fst, snd⟩ := x
+    rfl
+
+@[simp, grind =]
+lemma simulateQ_buildLayer_eq (f : QueryImpl (spec α) Id) (n : ℕ)
+    (leaves : List.Vector α (2 ^ (n + 1))) :
+    simulateQ f (buildLayer α n leaves) =
+      buildLayer_with_hash (α := α) n leaves f := by
+  unfold buildLayer
+  simp_all only [range_def, eq_mp_eq_cast, cast_eq, bind_pure, simulateQ_listVector_mmap_query,
+    domain_def]
+  rfl
+
+@[simp, grind =]
+lemma simulateQ_buildMerkleTree_eq (f : QueryImpl (spec α) Id) (n : ℕ)
+    (leaves : List.Vector α (2 ^ n)) :
+    simulateQ f (buildMerkleTree α n leaves) =
+      buildMerkleTree_with_hash (α := α) n leaves f := by
+  induction n with
+  | zero =>
+    simp_all only [Cache, Nat.reduceAdd, buildMerkleTree, Nat.pow_zero, eq_mpr_eq_cast]
+    rfl
+  | succ n ih =>
+    have sqb : ∀ {β γ : Type} (ma : OracleComp (spec α) β) (k : β → OracleComp (spec α) γ),
+        simulateQ f (ma >>= k) = simulateQ f (k (simulateQ f ma)) := by
+      intros β γ ma k
+      rw [simulateQ_bind]
+      rfl
+    have sqp : ∀ {β : Type} (a : β),
+        simulateQ f (pure a : OracleComp (spec α) β) = a := by
+      intros β a
+      rw [simulateQ_pure]
+      show (pure a : Id β) = a
+      rfl
+    simp only [buildMerkleTree, buildMerkleTree_with_hash]
+    simp only [sqb, simulateQ_buildLayer_eq, ih, sqp]
+
+@[simp, grind =]
+lemma simulateQ_getPutativeRoot_eq (f : QueryImpl (spec α) Id) {n : ℕ} (i : Fin (2 ^ n))
+    (leaf : α) (proof : List.Vector α n) :
+    simulateQ f (getPutativeRoot α i leaf proof) =
+      getPutativeRoot_with_hash (α := α) i leaf proof f := by
+  induction n generalizing leaf with
+  | zero =>
+    simp_all only [getPutativeRoot, vector_eq_nil]
+    rfl
+  | succ n ih =>
+    by_cases hsign : i.val % 2 = 0
+    · simp [getPutativeRoot, getPutativeRoot_with_hash, hsign, ih]
+      rfl
+    · simp [getPutativeRoot, getPutativeRoot_with_hash, hsign, ih]
+      simp_all only [Nat.mod_two_not_eq_zero]
+      rfl
+
+/-- A functional completeness theorem for Merkle proofs built from `buildMerkleTree_with_hash`. -/
+theorem functional_completeness {n : ℕ} (leaves : List.Vector α (2 ^ n)) (i : Fin (2 ^ n))
+    (hashFn : α × α → α) :
+    getPutativeRoot_with_hash (α := α) i leaves[i]
+        (generateProof α i (buildMerkleTree_with_hash (α := α) n leaves hashFn)) hashFn =
+      getRoot α (buildMerkleTree_with_hash (α := α) n leaves hashFn) := by
+  induction n with
+  | zero =>
+    have hi : i = 0 := Fin.eq_zero i
+    subst hi
+    simp only [buildMerkleTree_with_hash, Fin.isValue, Nat.pow_zero, getPutativeRoot_with_hash,
+      getRoot, Fin.zero_eta, Vector.get_zero, List.Vector.head]
+    simp_all only [Fin.isValue, Nat.reduceAdd, Fin.coe_ofNat_eq_mod, Nat.zero_mod, Nat.pow_zero, eq_mpr_eq_cast,
+      cast_eq, Nat.succ_eq_add_one, length_cons]
+    split
+    rename_i x a tail property
+    simp_all only [Nat.succ_eq_add_one, Nat.reduceAdd, Fin.isValue]
+    rfl
+  | succ n ih =>
+    -- Abbreviate the upper layer and the upper tree.
+    let lastLayer := buildLayer_with_hash (α := α) n leaves hashFn
+    let upperCache := buildMerkleTree_with_hash (α := α) n lastLayer hashFn
+    -- Split on whether `i` is a left or right child at the bottom layer.
+    by_cases hsign : i.val % 2 = 0
+    · -- Left child: sibling is `i + 1`.
+      have hdiv : 2 * (i.val / 2) = i.val := by
+        have h := Nat.mod_add_div i.val 2
+        -- `i % 2 = 0` implies `2 * (i / 2) = i`.
+        simpa [hsign] using h
+      have hright : 2 * (i.val / 2) + 1 = i.val + 1 := by grind only
+      have hnew :
+          hashFn (leaves.get i, leaves.get (siblingIndex i)) =
+            lastLayer.get ⟨i.val / 2, by grind only⟩ := by
+        simp [lastLayer, buildLayer_with_hash, siblingIndex, hsign, hdiv]
+      -- Unfold and apply the induction hypothesis on the upper tree.
+      -- `generateProof` and `getRoot` reduce via `Cache.upper_cons` and `Cache.leaves_cons`.
+
+      simp [buildMerkleTree_with_hash, lastLayer, generateProof,
+        getPutativeRoot_with_hash, getRoot, hsign, hnew]
+      simpa [getRoot, Cache.cons, lastLayer, upperCache] using
+        (ih (leaves := lastLayer) (i := ⟨i.val / 2, by grind only⟩))
+    · -- Right child: sibling is `i - 1`.
+      have hmod1 : i.val % 2 = 1 := by
+        rcases Nat.mod_two_eq_zero_or_one i.val with h0 | h1
+        · exact (hsign h0).elim
+        · exact h1
+      have hdiv : 2 * (i.val / 2) = i.val - 1 := by
+        have h := Nat.mod_add_div i.val 2
+        -- `i % 2 = 1` implies `1 + 2 * (i / 2) = i`.
+        have : 1 + 2 * (i.val / 2) = i.val := by simpa [hmod1] using h
+        grind only
+      have hright : 2 * (i.val / 2) + 1 = i.val := by grind only
+      have hnew :
+          hashFn (leaves.get (siblingIndex i), leaves.get i) =
+            lastLayer.get ⟨i.val / 2, by grind only⟩ := by
+        have hiPos : 1 ≤ i.val := by grind only
+        have hi' :
+            (⟨i.val - 1 + 1, by simp [Nat.sub_add_cancel hiPos]⟩ :
+                Fin (2 ^ (n + 1))) =
+              i := by
+          ext
+          simp [Nat.sub_add_cancel hiPos]
+        simp [lastLayer, buildLayer_with_hash, siblingIndex, hmod1, hdiv, hi']
+      simp [buildMerkleTree_with_hash, lastLayer, generateProof,
+        getPutativeRoot_with_hash, getRoot, hsign, hnew]
+      simpa [getRoot, Cache.cons, lastLayer, upperCache] using
+        (ih (leaves := lastLayer) (i := ⟨i.val / 2, by grind only⟩))
+
+omit [Inhabited α] [Fintype α] in
+/-- Completeness theorem for Merkle trees: for any full binary tree with `2 ^ n` leaves, and for any
+  index `i`, the verifier accepts the opening proof at index `i` generated by the prover.
+-/
+theorem completeness [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
+    (leaves : List.Vector α (2 ^ n)) (i : Fin (2 ^ n))
+    (preexisting_cache : (spec α).QueryCache) :
+    NeverFail ((
+      simulateQ (randomOracle (spec := spec α)) (do
+        let cache ← buildMerkleTree α n leaves
+        let proof := generateProof α i cache
+        let _ ← verifyProof α i leaves[i] (getRoot α cache) proof)).run preexisting_cache :
+      ProbComp (Unit × (spec α).QueryCache)) := by
+  grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+
+-- theorem soundness (i : Fin (2 ^ n)) (leaf : α) (proof : Vector α n) :
+--     verifyMerkleProof i leaf proof = pure true →
+--     getMerkleRoot (buildMerkleTree n (leaf ::ᵥ proof)) = leaf := sorry
+
+end
+
+end MerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree.lean
+++ b/VCVio/CryptoFoundations/MerkleTree.lean
@@ -84,7 +84,7 @@ def buildLayer (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) :
   -- Pair up the leaves to form pairs
   let pairs : List.Vector (α × α) (2 ^ n) :=
     List.Vector.ofFn (fun i =>
-      (leaves.get ⟨2 * i, by grind only⟩, leaves.get ⟨2 * i + 1, by grind only⟩))
+      (leaves.get ⟨2 * i, by omega⟩, leaves.get ⟨2 * i + 1, by omega⟩))
   -- Hash each pair to get the next layer
   let hashes : List.Vector α (2 ^ n) ←
     List.Vector.mmap (fun ⟨left, right⟩ => query (spec := spec α) ⟨left, right⟩) pairs
@@ -153,7 +153,7 @@ def siblingIndex {n : ℕ} (i : Fin (2 ^ (n + 1))) : Fin (2 ^ (n + 1)) :=
       have hle : i.val + 1 ≤ 2 ^ (n + 1) := Nat.succ_le_of_lt hi
       have hne : i.val + 1 ≠ 2 ^ (n + 1) := by
         intro hEq
-        have hiVal : i.val = 2 ^ (n + 1) - 1 := by grind only
+        have hiVal : i.val = 2 ^ (n + 1) - 1 := by omega
         have hpos : 0 < 2 ^ (n + 1) := by
           exact pow_pos (by decide : 0 < (2 : ℕ)) _
         have hle1 : 1 ≤ 2 ^ (n + 1) := Nat.succ_le_of_lt hpos
@@ -177,7 +177,7 @@ def generateProof {n : ℕ} (i : Fin (2 ^ n)) (cache : Cache α n) :
   | 0 => List.Vector.nil
   | n + 1 =>
       List.Vector.cons ((cache.leaves).get (siblingIndex i))
-        (generateProof ⟨i.val / 2, by grind only⟩ (cache.upper))
+        (generateProof ⟨i.val / 2, by omega⟩ (cache.upper))
 
 /--
 Given a leaf index, a leaf at that index, and putative proof,
@@ -195,7 +195,7 @@ def getPutativeRoot {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (proof : List.Vector
     -- Get the sign bit of `i`
     let signBit := i.val % 2
     -- Show that `i / 2` is in `Fin (2 ^ (n - 1))`
-    let i' : Fin (2 ^ n) := ⟨i.val / 2, by grind only⟩
+    let i' : Fin (2 ^ n) := ⟨i.val / 2, by omega⟩
     if signBit = 0 then
       -- `i` is a left child
       let newLeaf ← query (spec := spec α) ⟨leaf, proof.head⟩
@@ -242,7 +242,7 @@ def buildLayer_with_hash (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (hash
   let leaves : List.Vector α (2 ^ n * 2) := cast (by rw [pow_succ]) leaves
   let pairs : List.Vector (α × α) (2 ^ n) :=
     List.Vector.ofFn (fun i =>
-      (leaves.get ⟨2 * i, by grind only⟩, leaves.get ⟨2 * i + 1, by grind only⟩))
+      (leaves.get ⟨2 * i, by omega⟩, leaves.get ⟨2 * i + 1, by omega⟩))
   pairs.map hashFn
 
 /-- A purely functional version of `buildMerkleTree`, given an explicit hash function. -/
@@ -267,7 +267,7 @@ def getPutativeRoot_with_hash {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (proof : L
   | 0 => leaf
   | n + 1 =>
       let signBit := i.val % 2
-      let i' : Fin (2 ^ n) := ⟨i.val / 2, by grind only⟩
+      let i' : Fin (2 ^ n) := ⟨i.val / 2, by omega⟩
       if signBit = 0 then
         let newLeaf := hashFn (leaf, proof.head)
         getPutativeRoot_with_hash i' newLeaf proof.tail hashFn

--- a/VCVio/CryptoFoundations/MerkleTree.lean
+++ b/VCVio/CryptoFoundations/MerkleTree.lean
@@ -66,13 +66,13 @@ def Cache.leaves (n : ℕ) (cache : Cache α (n + 1)) :
     List.Vector α (2 ^ (n + 1)) := cache (Fin.last _)
 
 omit [DecidableEq α] [Inhabited α] [Fintype α] in
-@[simp, grind]
+@[simp, grind =]
 lemma Cache.upper_cons (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (cache : Cache α n) :
     Cache.upper α n (Cache.cons α n leaves cache) = cache := by
   simp [Cache.upper, Cache.cons]
 
 omit [DecidableEq α] [Inhabited α] [Fintype α] in
-@[simp, grind]
+@[simp, grind =]
 lemma Cache.leaves_cons (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (cache : Cache α n) :
     Cache.leaves α n (Cache.cons α n leaves cache) = leaves := by
   simp [Cache.leaves, Cache.cons]
@@ -214,7 +214,7 @@ def verifyProof {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (root : α) (proof : Lis
   let putative_root ← getPutativeRoot α i leaf proof
   guard (putative_root = root)
 
-@[grind]
+@[grind .]
 theorem buildLayer_neverFails (α : Type _) [DecidableEq α]
     [SampleableType α] [(spec α).DecidableEq]
     (preexisting_cache : (spec α).QueryCache) (n : ℕ)
@@ -227,7 +227,7 @@ theorem buildLayer_neverFails (α : Type _) [DecidableEq α]
 Building a Merkle tree never results in failure
 (no matter what queries have already been made to the oracle before it runs).
 -/
-@[grind]
+@[grind .]
 theorem buildMerkleTree_neverFails (α : Type _) [DecidableEq α]
     [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
     (leaves : List.Vector α (2 ^ n)) (preexisting_cache : (spec α).QueryCache) :

--- a/VCVio/CryptoFoundations/MerkleTree.lean
+++ b/VCVio/CryptoFoundations/MerkleTree.lean
@@ -23,7 +23,7 @@ namespace MerkleTree
 
 open List OracleSpec OracleComp
 
-variable (α : Type)
+variable (α : Type _)
 
 /-- Define the domain & range of the (single) oracle needed for constructing a Merkle tree with
     elements from some type `α`.
@@ -80,7 +80,7 @@ lemma Cache.leaves_cons (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (cache
 /-- Compute the next layer of the Merkle tree -/
 def buildLayer (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) :
     OracleComp (spec α) (List.Vector α (2 ^ n)) := do
-  let leaves : List.Vector α (2 ^ n * 2) := by rwa [pow_succ] at leaves
+  let leaves : List.Vector α (2 ^ n * 2) := cast (by rw [pow_succ]) leaves
   -- Pair up the leaves to form pairs
   let pairs : List.Vector (α × α) (2 ^ n) :=
     List.Vector.ofFn (fun i =>
@@ -215,8 +215,8 @@ def verifyProof {n : ℕ} (i : Fin (2 ^ n)) (leaf : α) (root : α) (proof : Lis
   guard (putative_root = root)
 
 @[grind]
-theorem buildLayer_neverFails (α : Type) [inst : DecidableEq α]
-    [inst_1 : SampleableType α] [(spec α).DecidableEq]
+theorem buildLayer_neverFails (α : Type _) [DecidableEq α]
+    [SampleableType α] [(spec α).DecidableEq]
     (preexisting_cache : (spec α).QueryCache) (n : ℕ)
     (leaves : List.Vector α (2 ^ (n + 1))) : NeverFail
       ((simulateQ (randomOracle (spec := spec α))
@@ -228,7 +228,7 @@ Building a Merkle tree never results in failure
 (no matter what queries have already been made to the oracle before it runs).
 -/
 @[grind]
-theorem buildMerkleTree_neverFails (α : Type) [DecidableEq α]
+theorem buildMerkleTree_neverFails (α : Type _) [DecidableEq α]
     [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
     (leaves : List.Vector α (2 ^ n)) (preexisting_cache : (spec α).QueryCache) :
     NeverFail
@@ -239,7 +239,7 @@ theorem buildMerkleTree_neverFails (α : Type) [DecidableEq α]
 /-- A purely functional version of `buildLayer`, given an explicit hash function. -/
 def buildLayer_with_hash (n : ℕ) (leaves : List.Vector α (2 ^ (n + 1))) (hashFn : α × α → α) :
     List.Vector α (2 ^ n) :=
-  let leaves : List.Vector α (2 ^ n * 2) := by rwa [pow_succ] at leaves
+  let leaves : List.Vector α (2 ^ n * 2) := cast (by rw [pow_succ]) leaves
   let pairs : List.Vector (α × α) (2 ^ n) :=
     List.Vector.ofFn (fun i =>
       (leaves.get ⟨2 * i, by grind only⟩, leaves.get ⟨2 * i + 1, by grind only⟩))
@@ -307,8 +307,7 @@ lemma simulateQ_buildLayer_eq (f : QueryImpl (spec α) Id) (n : ℕ)
     simulateQ f (buildLayer α n leaves) =
       buildLayer_with_hash (α := α) n leaves f := by
   unfold buildLayer
-  simp_all only [range_def, eq_mp_eq_cast, cast_eq, bind_pure, simulateQ_listVector_mmap_query,
-    domain_def]
+  simp_all only [range_def, cast_eq, bind_pure, simulateQ_listVector_mmap_query, domain_def]
   rfl
 
 omit [DecidableEq α] [Inhabited α] [Fintype α] in
@@ -322,12 +321,12 @@ lemma simulateQ_buildMerkleTree_eq (f : QueryImpl (spec α) Id) (n : ℕ)
     simp_all only [Cache, Nat.reduceAdd, buildMerkleTree, Nat.pow_zero, eq_mpr_eq_cast]
     rfl
   | succ n ih =>
-    have sqb : ∀ {β γ : Type} (ma : OracleComp (spec α) β) (k : β → OracleComp (spec α) γ),
+    have sqb : ∀ {β γ : Type _} (ma : OracleComp (spec α) β) (k : β → OracleComp (spec α) γ),
         simulateQ f (ma >>= k) = simulateQ f (k (simulateQ f ma)) := by
       intros β γ ma k
       rw [simulateQ_bind]
       rfl
-    have sqp : ∀ {β : Type} (a : β),
+    have sqp : ∀ {β : Type _} (a : β),
         simulateQ f (pure a : OracleComp (spec α) β) = a := by
       intros β a
       rw [simulateQ_pure]
@@ -433,13 +432,8 @@ theorem completeness [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
       simulateQ (randomOracle (spec := spec α)) (do
         let cache ← buildMerkleTree α n leaves
         let proof := generateProof α i cache
-        let _ ← verifyProof α i leaves[i] (getRoot α cache) proof)).run preexisting_cache :
-      ProbComp (Unit × (spec α).QueryCache)) := by
+        let _ ← verifyProof α i leaves[i] (getRoot α cache) proof)).run preexisting_cache) := by
   grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
-
--- theorem soundness (i : Fin (2 ^ n)) (leaf : α) (proof : Vector α n) :
---     verifyMerkleProof i leaf proof = pure true →
---     getMerkleRoot (buildMerkleTree n (leaf ::ᵥ proof)) = leaf := sorry
 
 end
 


### PR DESCRIPTION
## Summary

- Ports two Merkle tree implementations from [ArkLib](https://github.com/Verified-zkEVM/ArkLib) upstream to VCVio for reuse by other downstream projects.
- Adds `IndexedBinaryTree`, a pure-math indexed inductive binary tree data structure (skeleton, leaf/internal/full data, navigation, equivalences), to `ToMathlib/Data/`.
- Adds `MerkleTree` (vector-indexed, perfect binary trees) and `InductiveMerkleTree` (skeleton-indexed, arbitrary-shape trees) to `VCVio/CryptoFoundations/`, both with build, proof generation, verification, and completeness theorems.

### New files

| File | Description |
|---|---|
| `ToMathlib/Data/IndexedBinaryTree/Basic.lean` | Skeleton, index types, data types, navigation, copath, map, composeBuild |
| `ToMathlib/Data/IndexedBinaryTree/Lemmas.lean` | Navigation lemmas, Functor/LawfulFunctor instances |
| `ToMathlib/Data/IndexedBinaryTree/Equiv.lean` | Equivalences between tree data and functions on indices |
| `VCVio/CryptoFoundations/MerkleTree.lean` | Merkle tree for perfect binary trees (vector-indexed) |
| `VCVio/CryptoFoundations/InductiveMerkleTree.lean` | Merkle tree for arbitrary-shape binary trees (skeleton-indexed) |

## Test plan

- [x] `lake build` passes for all 5 new files
- [ ] CI passes

Posted by Cursor assistant (model: claude-4.6-opus-high-thinking) on behalf of the user (Quang Dao) with approval.


Made with [Cursor](https://cursor.com)