### PR TITLE
feat(SimSemantics): cross-type bind, OptionT/simulateQ, and Q-state invariant decomposition

### DIFF
--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -699,3 +699,20 @@ theorem List.forIn_mprod_yield_eq_foldlM
     simp only [bind_assoc, pure_bind]
     congr 1; funext ⟨b', c'⟩
     exact ih b' c'
+
+section CrossTypeBind
+
+/-- If the first steps agree after projection, and continuations agree on matching inputs,
+    then the full bind computations agree. Generalizes `bind_congr` to different source types. -/
+theorem bind_eq_of_map_eq {m : Type → Type*} [Monad m] [LawfulMonad m]
+    {α₁ α₂ β : Type} {m₁ : m α₁} {m₂ : m α₂}
+    {f₁ : α₁ → m β} {f₂ : α₂ → m β}
+    (proj : α₁ → α₂)
+    (h_first : proj <$> m₁ = m₂)
+    (h_cont : ∀ a₁, f₁ a₁ = f₂ (proj a₁)) :
+    m₁ >>= f₁ = m₂ >>= f₂ := by
+  rw [← h_first, map_eq_bind_pure_comp, bind_assoc]
+  simp only [Function.comp, pure_bind]
+  exact bind_congr fun a₁ => h_cont a₁
+
+end CrossTypeBind

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -91,6 +91,20 @@ lemma mem_support_query (t : spec.Domain) (u : spec.Range t) :
 
 alias support_liftM_query := support_query
 
+/-- Support-aware bind congruence: if two continuations agree on all elements in the support
+    of `mx`, the resulting bind computations are equal. -/
+theorem bind_congr_of_forall_mem_support (mx : OracleComp spec α) {f g : α → OracleComp spec β}
+    (h : ∀ x ∈ support mx, f x = g x) : mx >>= f = mx >>= g := by
+  induction mx using OracleComp.inductionOn with
+  | pure a =>
+    simp only [pure_bind]
+    exact h a (by simp [support_pure])
+  | query_bind q k ih =>
+    change liftM (query q) >>= (fun u => k u >>= f) =
+      liftM (query q) >>= (fun u => k u >>= g)
+    exact bind_congr fun u => ih u (fun x hx =>
+      h x ((mem_support_bind_iff _ _ _).mpr ⟨u, by simp, hx⟩))
+
 end support
 
 section finSupport

--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -144,9 +144,8 @@ omit [LawfulMonad n] in
   rw [simulateQ_bind]
   exact bind_congr fun x => simulateQ_option_elim impl x my my'
 
-omit [LawfulMonad n] in
 /-- `simulateQ` distributes through `OptionT.bind`, stated via `OptionT.run`. -/
-lemma simulateQ_optionT_bind' [LawfulMonad n]
+lemma simulateQ_optionT_bind'
     (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
     simulateQ impl (mx >>= f).run =
     (simulateQ impl mx.run >>= fun a => simulateQ impl (f a).run : OptionT n β) := by
@@ -154,26 +153,23 @@ lemma simulateQ_optionT_bind' [LawfulMonad n]
   refine bind_congr fun x => ?_
   induction x <;> simp only [Option.elim_none, Option.elim_some, simulateQ_pure]
 
-omit [LawfulMonad n] in
 /-- `simulateQ` distributes through `OptionT.bind`, stated via `Option.elimM`. -/
-lemma simulateQ_optionT_bind'' [LawfulMonad n]
+lemma simulateQ_optionT_bind''
     (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
     simulateQ impl (mx >>= f).run =
     Option.elimM (simulateQ impl mx.run) (pure none) (fun a => simulateQ impl (f a).run) := by
   simp
 
-omit [LawfulMonad n] in
 /-- `simulateQ` distributes through `OptionT.bind`: the simulated OptionT-bind is the
     OptionT-bind of the simulated pieces. -/
-lemma simulateQ_optionT_bind [LawfulMonad n]
+lemma simulateQ_optionT_bind
     (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
     simulateQ impl (mx >>= f : OptionT (OracleComp spec) β) =
     (simulateQ impl mx >>= fun a => simulateQ impl (f a) : OptionT n β) := by
   apply simulateQ_optionT_bind'
 
-omit [LawfulMonad n] in
 /-- `simulateQ` commutes with `OptionT.lift`. -/
-@[simp] lemma simulateQ_optionT_lift [LawfulMonad n]
+@[simp] lemma simulateQ_optionT_lift
     (comp : OracleComp spec α) :
     simulateQ impl (OptionT.lift comp : OptionT (OracleComp spec) α) =
       (OptionT.lift (simulateQ impl comp) : OptionT n α) := by

--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -127,3 +127,34 @@ example (mx : OptionT (OracleComp spec₁) α)
   simulateQ impl₂ <| simulateQ impl₁ <| mx
 
 end tests
+
+section OptionT
+
+omit [LawfulMonad n] in
+/-- `simulateQ` distributes through `OptionT.bind`: the simulated OptionT-bind is the
+    OptionT-bind of the simulated pieces. -/
+lemma simulateQ_optionT_bind [LawfulMonad n]
+    (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
+    simulateQ impl (@Bind.bind (OptionT (OracleComp spec)) _ _ _ mx f) =
+    @Bind.bind (OptionT n) _ _ _
+      (simulateQ impl mx)
+      (fun a => simulateQ impl (f a)) := by
+  change simulateQ impl (@Bind.bind (OracleComp spec) _ _ _
+    mx (fun opt => match opt with | some a => f a | none => pure none)) = _
+  rw [simulateQ_bind]
+  change _ = @Bind.bind n _ _ _
+    (simulateQ impl mx) (fun opt => match opt with
+      | some a => simulateQ impl (f a) | none => pure none)
+  exact bind_congr fun opt => match opt with
+    | none => simulateQ_pure impl none
+    | some _ => rfl
+
+omit [LawfulMonad n] in
+/-- `simulateQ` commutes with `OptionT.lift`. -/
+@[simp] lemma simulateQ_optionT_lift [LawfulMonad n]
+    (comp : OracleComp spec α) :
+    simulateQ impl (OptionT.lift comp : OptionT (OracleComp spec) α) =
+      (OptionT.lift (simulateQ impl comp) : OptionT n α) := by
+  simp only [OptionT.lift, OptionT.mk, simulateQ_bind, simulateQ_pure]
+
+end OptionT

--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -135,10 +135,8 @@ omit [LawfulMonad n] in
     OptionT-bind of the simulated pieces. -/
 lemma simulateQ_optionT_bind [LawfulMonad n]
     (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
-    simulateQ impl (@Bind.bind (OptionT (OracleComp spec)) _ _ _ mx f) =
-    @Bind.bind (OptionT n) _ _ _
-      (simulateQ impl mx)
-      (fun a => simulateQ impl (f a)) := by
+    simulateQ impl (mx >>= f : OptionT (OracleComp spec) β) =
+    (simulateQ impl mx >>= fun a => simulateQ impl (f a) : OptionT n β) := by
   change simulateQ impl (@Bind.bind (OracleComp spec) _ _ _
     mx (fun opt => match opt with | some a => f a | none => pure none)) = _
   rw [simulateQ_bind]

--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -131,21 +131,45 @@ end tests
 section OptionT
 
 omit [LawfulMonad n] in
+@[simp] lemma simulateQ_option_elim (x : Option α) (my : OracleComp spec β)
+    (my' : α → OracleComp spec β) : simulateQ impl (x.elim my my') =
+    x.elim (simulateQ impl my) (fun x => simulateQ impl (my' x)) := by
+  cases x <;> simp
+
+@[simp] lemma simulateQ_option_elimM (mx : OracleComp spec (Option α))
+    (my : OracleComp spec β) (my' : α → OracleComp spec β) :
+    simulateQ impl (Option.elimM mx my my') =
+    Option.elimM (simulateQ impl mx) (simulateQ impl my) (fun x => simulateQ impl (my' x)) := by
+  unfold Option.elimM
+  rw [simulateQ_bind]
+  exact bind_congr fun x => simulateQ_option_elim impl x my my'
+
+omit [LawfulMonad n] in
+/-- `simulateQ` distributes through `OptionT.bind`, stated via `OptionT.run`. -/
+lemma simulateQ_optionT_bind' [LawfulMonad n]
+    (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
+    simulateQ impl (mx >>= f).run =
+    (simulateQ impl mx.run >>= fun a => simulateQ impl (f a).run : OptionT n β) := by
+  rw [OptionT.run_bind, Option.elimM, simulateQ_bind]
+  refine bind_congr fun x => ?_
+  induction x <;> simp only [Option.elim_none, Option.elim_some, simulateQ_pure]
+
+omit [LawfulMonad n] in
+/-- `simulateQ` distributes through `OptionT.bind`, stated via `Option.elimM`. -/
+lemma simulateQ_optionT_bind'' [LawfulMonad n]
+    (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
+    simulateQ impl (mx >>= f).run =
+    Option.elimM (simulateQ impl mx.run) (pure none) (fun a => simulateQ impl (f a).run) := by
+  simp
+
+omit [LawfulMonad n] in
 /-- `simulateQ` distributes through `OptionT.bind`: the simulated OptionT-bind is the
     OptionT-bind of the simulated pieces. -/
 lemma simulateQ_optionT_bind [LawfulMonad n]
     (mx : OptionT (OracleComp spec) α) (f : α → OptionT (OracleComp spec) β) :
     simulateQ impl (mx >>= f : OptionT (OracleComp spec) β) =
     (simulateQ impl mx >>= fun a => simulateQ impl (f a) : OptionT n β) := by
-  change simulateQ impl (@Bind.bind (OracleComp spec) _ _ _
-    mx (fun opt => match opt with | some a => f a | none => pure none)) = _
-  rw [simulateQ_bind]
-  change _ = @Bind.bind n _ _ _
-    (simulateQ impl mx) (fun opt => match opt with
-      | some a => simulateQ impl (f a) | none => pure none)
-  exact bind_congr fun opt => match opt with
-    | none => simulateQ_pure impl none
-    | some _ => rfl
+  apply simulateQ_optionT_bind'
 
 omit [LawfulMonad n] in
 /-- `simulateQ` commutes with `OptionT.lift`. -/

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -676,4 +676,82 @@ theorem tvDist_simulateQ_le_probEvent_bad_dist
       (tvDist_map_le (m := OracleComp spec) (α := α × σ) (β := α) Prod.fst sim₁ sim₂)
   exact le_trans h_map h_tv_joint
 
+section SndInvariant
+
+/-- Project a product-state query implementation to the first component,
+    fixing the second component at a constant value. -/
+def QueryImpl.projectFst {ι : Type} {spec : OracleSpec ι} {σ Q : Type}
+    (impl : QueryImpl spec (StateT (σ × Q) ProbComp)) (q₀ : Q) :
+    QueryImpl spec (StateT σ ProbComp) :=
+  fun t => StateT.mk fun s => Prod.map id Prod.fst <$> (impl t).run (s, q₀)
+
+/-- Support-aware bind congruence for ProbComp: if two continuations agree on all
+    support elements, then the binds are equal. -/
+private theorem ProbComp.bind_congr_of_forall_mem_support
+    {α β : Type} (mx : ProbComp α) {f g : α → ProbComp β}
+    (h : ∀ x ∈ support mx, f x = g x) : mx >>= f = mx >>= g := by
+  induction mx using ProbComp.inductionOn with
+  | pure a =>
+    simp only [pure_bind]
+    exact h a (by simp [support_pure])
+  | query_bind n k ih =>
+    simp only [bind_assoc]
+    exact OracleComp.bind_congr' rfl (fun u => ih u (fun x hx =>
+      h x ((mem_support_bind_iff _ _ _).mpr ⟨u, by simp, hx⟩)))
+
+/-- If the Q-component of product state `(σ × Q)` is invariant under all oracle queries
+    starting from `q₀`, then the full `simulateQ` computation decomposes: running with `(s, q₀)`
+    produces the same result as running the projected implementation on `s` alone, with `q₀`
+    appended back.
+
+    This generalizes `map_run_simulateQ_eq_of_query_map_eq` from all-states commutativity
+    to support-based invariance. -/
+theorem simulateQ_run_eq_of_snd_invariant
+    {ι : Type} {spec : OracleSpec ι} {σ Q α : Type}
+    (impl : QueryImpl spec (StateT (σ × Q) ProbComp))
+    (q₀ : Q)
+    (h_inv : ∀ (t : spec.Domain) (s : σ) (x : _ × (σ × Q)),
+      x ∈ support ((impl t).run (s, q₀)) → x.2.2 = q₀)
+    (oa : OracleComp spec α) (s : σ) :
+    (simulateQ impl oa).run (s, q₀) =
+    (fun p => (p.1, (p.2, q₀))) <$> (simulateQ (QueryImpl.projectFst impl q₀) oa).run s := by
+  induction oa using OracleComp.inductionOn generalizing s with
+  | pure x =>
+    simp [simulateQ_pure, StateT.run_pure]
+  | query_bind t oa ih =>
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+      OracleQuery.cont_query, id_map, StateT.run_bind]
+    -- Push <$> through >>= on RHS
+    rw [map_bind]
+    -- Unfold projectFst to align first computations
+    -- (projectFst impl q₀ t).run s = Prod.map id Prod.fst <$> (impl t).run (s, q₀)
+    -- Then bind_map_left to get (impl t).run (s, q₀) >>= ... on both sides
+    conv_rhs =>
+      rw [show (QueryImpl.projectFst impl q₀ t).run s =
+        Prod.map id Prod.fst <$> (impl t).run (s, q₀) from rfl]
+    rw [bind_map_left]
+    -- Now both sides: (impl t).run (s, q₀) >>= continuation
+    refine ProbComp.bind_congr_of_forall_mem_support _ (fun ⟨u, s', q'⟩ hx => ?_)
+    have hq : q' = q₀ := h_inv t s ⟨u, s', q'⟩ hx
+    subst hq
+    simp only [Prod.map, id]
+    exact ih u s'
+
+/-- `run'` projection corollary of `simulateQ_run_eq_of_snd_invariant`. -/
+theorem simulateQ_run'_eq_of_snd_invariant
+    {ι : Type} {spec : OracleSpec ι} {σ Q α : Type}
+    (impl : QueryImpl spec (StateT (σ × Q) ProbComp))
+    (q₀ : Q)
+    (h_inv : ∀ (t : spec.Domain) (s : σ) (x : _ × (σ × Q)),
+      x ∈ support ((impl t).run (s, q₀)) → x.2.2 = q₀)
+    (oa : OracleComp spec α) (s : σ) :
+    (simulateQ impl oa).run' (s, q₀) =
+    (simulateQ (QueryImpl.projectFst impl q₀) oa).run' s := by
+  have hrun := simulateQ_run_eq_of_snd_invariant impl q₀ h_inv oa s
+  change Prod.fst <$> (simulateQ impl oa).run (s, q₀) =
+    Prod.fst <$> (simulateQ (QueryImpl.projectFst impl q₀) oa).run s
+  rw [hrun, Functor.map_map]
+
+end SndInvariant
+
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 import VCVio.ProgramLogic.Relational.Basic
 import VCVio.EvalDist.TVDist
+import VCVio.OracleComp.EvalDist
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.SimSemantics.StateT
 
@@ -678,26 +679,12 @@ theorem tvDist_simulateQ_le_probEvent_bad_dist
 
 section SndInvariant
 
-/-- Project a product-state query implementation to the first component,
-    fixing the second component at a constant value. -/
-def QueryImpl.projectFst {ι : Type} {spec : OracleSpec ι} {σ Q : Type}
+/-- Given a `StateT (σ × Q) ProbComp` query implementation, fix the second state component
+    at `q₀` and project to `StateT σ ProbComp`. -/
+def QueryImpl.fixSndStateT {ι : Type} {spec : OracleSpec ι} {σ Q : Type}
     (impl : QueryImpl spec (StateT (σ × Q) ProbComp)) (q₀ : Q) :
     QueryImpl spec (StateT σ ProbComp) :=
   fun t => StateT.mk fun s => Prod.map id Prod.fst <$> (impl t).run (s, q₀)
-
-/-- Support-aware bind congruence for ProbComp: if two continuations agree on all
-    support elements, then the binds are equal. -/
-private theorem ProbComp.bind_congr_of_forall_mem_support
-    {α β : Type} (mx : ProbComp α) {f g : α → ProbComp β}
-    (h : ∀ x ∈ support mx, f x = g x) : mx >>= f = mx >>= g := by
-  induction mx using ProbComp.inductionOn with
-  | pure a =>
-    simp only [pure_bind]
-    exact h a (by simp [support_pure])
-  | query_bind n k ih =>
-    simp only [bind_assoc]
-    exact OracleComp.bind_congr' rfl (fun u => ih u (fun x hx =>
-      h x ((mem_support_bind_iff _ _ _).mpr ⟨u, by simp, hx⟩)))
 
 /-- If the Q-component of product state `(σ × Q)` is invariant under all oracle queries
     starting from `q₀`, then the full `simulateQ` computation decomposes: running with `(s, q₀)`
@@ -714,7 +701,7 @@ theorem simulateQ_run_eq_of_snd_invariant
       x ∈ support ((impl t).run (s, q₀)) → x.2.2 = q₀)
     (oa : OracleComp spec α) (s : σ) :
     (simulateQ impl oa).run (s, q₀) =
-    (fun p => (p.1, (p.2, q₀))) <$> (simulateQ (QueryImpl.projectFst impl q₀) oa).run s := by
+    (fun p => (p.1, (p.2, q₀))) <$> (simulateQ (QueryImpl.fixSndStateT impl q₀) oa).run s := by
   induction oa using OracleComp.inductionOn generalizing s with
   | pure x =>
     simp [simulateQ_pure, StateT.run_pure]
@@ -723,15 +710,15 @@ theorem simulateQ_run_eq_of_snd_invariant
       OracleQuery.cont_query, id_map, StateT.run_bind]
     -- Push <$> through >>= on RHS
     rw [map_bind]
-    -- Unfold projectFst to align first computations
-    -- (projectFst impl q₀ t).run s = Prod.map id Prod.fst <$> (impl t).run (s, q₀)
+    -- Unfold fixSndStateT to align first computations
+    -- (fixSndStateT impl q₀ t).run s = Prod.map id Prod.fst <$> (impl t).run (s, q₀)
     -- Then bind_map_left to get (impl t).run (s, q₀) >>= ... on both sides
     conv_rhs =>
-      rw [show (QueryImpl.projectFst impl q₀ t).run s =
+      rw [show (QueryImpl.fixSndStateT impl q₀ t).run s =
         Prod.map id Prod.fst <$> (impl t).run (s, q₀) from rfl]
     rw [bind_map_left]
     -- Now both sides: (impl t).run (s, q₀) >>= continuation
-    refine ProbComp.bind_congr_of_forall_mem_support _ (fun ⟨u, s', q'⟩ hx => ?_)
+    refine OracleComp.bind_congr_of_forall_mem_support _ (fun ⟨u, s', q'⟩ hx => ?_)
     have hq : q' = q₀ := h_inv t s ⟨u, s', q'⟩ hx
     subst hq
     simp only [Prod.map, id]
@@ -746,10 +733,10 @@ theorem simulateQ_run'_eq_of_snd_invariant
       x ∈ support ((impl t).run (s, q₀)) → x.2.2 = q₀)
     (oa : OracleComp spec α) (s : σ) :
     (simulateQ impl oa).run' (s, q₀) =
-    (simulateQ (QueryImpl.projectFst impl q₀) oa).run' s := by
+    (simulateQ (QueryImpl.fixSndStateT impl q₀) oa).run' s := by
   have hrun := simulateQ_run_eq_of_snd_invariant impl q₀ h_inv oa s
   change Prod.fst <$> (simulateQ impl oa).run (s, q₀) =
-    Prod.fst <$> (simulateQ (QueryImpl.projectFst impl q₀) oa).run s
+    Prod.fst <$> (simulateQ (QueryImpl.fixSndStateT impl q₀) oa).run s
   rw [hrun, Functor.map_map]
 
 end SndInvariant


### PR DESCRIPTION
## Summary

- `bind_eq_of_map_eq` — cross-type monadic bind composition via projection, generalizing `bind_congr` to different source types (ToMathlib/General.lean)
- `simulateQ_optionT_{bind,lift}` — `simulateQ` distributes through `OptionT` (SimSemantics/SimulateQ.lean)
- `QueryImpl.projectFst` + `simulateQ_run{,'}_eq_of_snd_invariant` — when the second component of product state is invariant under oracle queries, the full `simulateQ` decomposes into the projected single-component implementation (ProgramLogic/Relational/SimulateQ.lean)