### PR TITLE
feat(commitment): layered binding bound via CR chain

### DIFF
--- a/Examples/CommitmentScheme/Binding.lean
+++ b/Examples/CommitmentScheme/Binding.lean
@@ -277,3 +277,34 @@ theorem binding_bound {t : ℕ} (A : BindingAdversary M S C t) :
     _ = ((t * (t - 1) + 2 : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) := by
         simpa [Nat.mul_one, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
           add_div_two_mul_nat (t * (t - 1)) 1 (Fintype.card C)
+
+/- **Binding bound via CR chain (looser).**
+
+Same `(t+2)(t+1) / (2|C|)` bound that the layered chain
+`binding ≤ keyed-CR ≤ birthday` of [#284] T1 + T2 produces. Derived by treating
+the `t+2` total queries of the binding game as a single ROM-CR experiment: a
+binding-game win implies a collision in the final cache
+(`binding_win_implies_collision`), and the inner game makes at most `t+2` total
+queries (`bindingInner_totalBound`); apply
+`probEvent_cacheCollision_le_birthday_total_tight` at `n = t+2`. This is the
+same proof shape as `romCRAdvantage_le_birthday` (see
+`VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean`).
+
+Looser than the tight `binding_bound` above by roughly `(t+2)(t+1) / (t(t-1)+2)`
+— about `1 + 4/t²` for large `t` — but composes directly out of the standard-model
+binding-to-CR reduction (`bindingAdvantage_toCommitment_le_keyedCRAdvantage` in
+`VCVio/CryptoFoundations/HashCommitment.lean`) and the ROM CR birthday bound
+(`romCRAdvantage_le_birthday`). -/
+omit [Fintype M] [Fintype S] in
+theorem binding_bound_via_cr_chain {t : ℕ} (A : BindingAdversary M S C t) :
+    Pr[fun z => z.1 = true | bindingGame A] ≤
+    (((t + 2) * (t + 1) : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) := by
+  rw [bindingGame_eq]
+  calc Pr[fun z => z.1 = true | (simulateQ cachingOracle (bindingInner A)).run ∅]
+      ≤ Pr[fun z => CacheHasCollision z.2 |
+          (simulateQ cachingOracle (bindingInner A)).run ∅] :=
+        probEvent_mono (binding_win_implies_collision A)
+    _ ≤ (((t + 2) * (t + 1) : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) :=
+        probEvent_cacheCollision_le_birthday_total_tight
+          (spec := CMOracle M S C) (bindingInner A) (t + 2)
+          (bindingInner_totalBound A) Fintype.card_pos (fun _ => le_refl _)


### PR DESCRIPTION
## Summary

Adds the corollary `binding_bound_via_cr_chain` in `Examples/CommitmentScheme/Binding.lean`, deriving the layered `(t+2)(t+1) / (2|C|)` bound that the chain `binding ≤ keyed-CR ≤ birthday` of #284 T1 + T2 produces. Closes #284 T3.

The existing tight `binding_bound : Pr[win] ≤ (t(t-1)+2) / (2|C|)` is preserved unchanged. The new corollary is looser by roughly `(t+2)(t+1) / (t(t-1)+2)` (about `1 + 4/t²` for large `t`) but composes directly out of:

- `bindingAdvantage_toCommitment_le_keyedCRAdvantage` (#286, standard-model `binding ≤ keyed-CR`), and
- `romCRAdvantage_le_birthday` (#285, ROM-CR ≤ `(t+2)(t+1) / (2|Y|)`).

## Proof shape

Same shape as `romCRAdvantage_le_birthday`:

1. A binding-game win implies a final-cache collision — existing `binding_win_implies_collision`.
2. The inner game makes at most `t+2` total queries — existing `bindingInner_totalBound` (`t` adversary queries + 2 verification queries).
3. Apply `probEvent_cacheCollision_le_birthday_total_tight` at `n = t+2`.