### PR TITLE
feat(crypto): replay forking B1 scaffold (takeBeforeForkAt + prefix-faithfulness)

### DIFF
--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -38,7 +38,22 @@ variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 
 namespace Fork
 
-/-- Trace used by the Fiat-Shamir forking reduction for managed-RO NMA adversaries. -/
+/-- Trace used by the Fiat-Shamir forking reduction for managed-RO NMA adversaries.
+
+Fields:
+
+* `forgery`: the final `(message, (commitment, response))` triple produced by the adversary.
+* `advCache`: snapshot of the adversary's locally programmed random oracle. Only the
+  reduction side reads from it: `runTrace.verified` and the forking bound treat it purely
+  as bookkeeping. In the managed-RO model every adversary challenge query is routed through
+  the live oracle, so programmed entries that ever actually influence a verified forgery
+  also appear in `roCache`; this is the invariant that `euf_cma_to_nma` is responsible for
+  establishing when it bridges `advCache`-only entries back to the live log.
+* `roCache`: the live random-oracle cache populated by managed-RO queries during the run.
+* `queryLog`: the list of `(message, commitment)` hash points actually queried (live). The
+  forking lemma rewinds at a position of this list.
+* `verified`: whether the forgery successfully verifies against a cached challenge for its
+  target. `runTrace` consults only `roCache` for this flag (see its docstring). -/
 structure Trace where
   forgery : M × (Commit × Resp)
   advCache : (unifSpec + (M × Commit →ₒ Chal)).QueryCache
@@ -177,9 +192,13 @@ the adversary-returned cache and the live query log that the forking lemma can r
 The `verified` flag is computed strictly from the live `roCache` so that a successful
 `forkPoint` extraction always pins the verifying challenge to the live random-oracle
 answer at the corresponding outer-log position. Forgeries whose verification depends only
-on programmed entries the adversary supplies in `advCache` are not counted; for the
-managed-RO reductions the relevant `advCache` entries are queried via the live oracle and
-hence also appear in `roCache`. -/
+on programmed entries the adversary supplies in `advCache` are not counted: this is a
+strict strengthening over an `advCache`-fallback variant and strictly shrinks
+`Fork.advantage`. The residual obligation, "every `advCache`-only forgery that would have
+verified also has a corresponding live RO query", is a caller-side invariant that must be
+discharged by the managed-RO CMA→NMA reduction. Downstream, this is the role of
+`euf_cma_to_nma` in `FiatShamir/Sigma/Security.lean`, whose sigma→NMA simulation ensures
+that every `advCache` programming step is mirrored by a live query into `roCache`. -/
 noncomputable def runTrace
     [DecidableEq M] [DecidableEq Commit]
     [SampleableType Chal]
@@ -544,178 +563,6 @@ private theorem queryLog_cache_outer_lockstep
               (Sum.inr ()) (i - l₀.length) = some ω
             rw [List.nil_append]
             exact hlogω
-
-omit [SampleableType Stmt] [SampleableType Wit] in
-/-- Outer-log determinism for `runTrace`'s inner simulation. Because every source of
-randomness inside `(simulateQ (unifFwd + roImpl) Y).run (c₀, l₀)` is channelled through
-the outer wrapped-spec queries (both `unifFwd`'s forwarded `Sum.inl _` samples and
-`roImpl`'s fresh `Sum.inr ()` challenges on cache misses), fixing the outer log
-uniquely determines the inner result and final simulator state. This is the
-bisimulation statement underlying `target_eq_of_mem_forkReplay`. -/
-private theorem inner_det
-    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
-    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
-    {z₁ z₂ : γ × simSt M Commit Chal}
-    {outerLog : QueryLog (wrappedSpec Chal)}
-    (h₁ : (z₁, outerLog) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
-        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
-          (c₀, l₀))).run))
-    (h₂ : (z₂, outerLog) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
-        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
-          (c₀, l₀))).run)) :
-    z₁ = z₂ := by
-  classical
-  induction Y using OracleComp.inductionOn generalizing c₀ l₀ z₁ z₂ outerLog with
-  | pure x =>
-      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
-        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at h₁ h₂
-      obtain ⟨hz₁_eq, _⟩ := h₁
-      obtain ⟨hz₂_eq, _⟩ := h₂
-      rw [hz₁_eq, hz₂_eq]
-  | query_bind t oa ih =>
-      have hY :
-          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
-            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
-            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
-              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
-        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
-          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
-      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h₁ h₂
-      simp only [Set.mem_iUnion, support_map, Set.mem_image] at h₁ h₂
-      obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
-      obtain ⟨us_w₂, hus_w₂, pw₂, hpw₂, hz_eq₂⟩ := h₂
-      have hpw₁_split : (pw₁.1, pw₁.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
-            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
-              (oa us_w₁.1.1)).run us_w₁.1.2)).run) := by
-        change pw₁ ∈ support _
-        exact hpw₁
-      have hpw₂_split : (pw₂.1, pw₂.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
-            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
-              (oa us_w₂.1.1)).run us_w₂.1.2)).run) := by
-        change pw₂ ∈ support _
-        exact hpw₂
-      have hz_eq'₁ : (pw₁.1, us_w₁.2 ++ pw₁.2) = (z₁, outerLog) := by
-        rw [show ((pw₁.1, us_w₁.2 ++ pw₁.2) : _ × QueryLog (wrappedSpec Chal)) =
-              Prod.map id (fun x => us_w₁.2 ++ x) pw₁ from rfl]
-        exact hz_eq₁
-      have hz_eq'₂ : (pw₂.1, us_w₂.2 ++ pw₂.2) = (z₂, outerLog) := by
-        rw [show ((pw₂.1, us_w₂.2 ++ pw₂.2) : _ × QueryLog (wrappedSpec Chal)) =
-              Prod.map id (fun x => us_w₂.2 ++ x) pw₂ from rfl]
-        exact hz_eq₂
-      obtain ⟨hz_eq1₁, hz_eq2₁⟩ := Prod.mk.inj hz_eq'₁
-      obtain ⟨hz_eq1₂, hz_eq2₂⟩ := Prod.mk.inj hz_eq'₂
-      have hzeq₁ : z₁ = pw₁.1 := hz_eq1₁.symm
-      have hzeq₂ : z₂ = pw₂.1 := hz_eq1₂.symm
-      have houter_combined : us_w₁.2 ++ pw₁.2 = us_w₂.2 ++ pw₂.2 :=
-        hz_eq2₁.trans hz_eq2₂.symm
-      subst hzeq₁
-      subst hzeq₂
-      have houter₁ : us_w₁ ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
-            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₁
-      have houter₂ : us_w₂ ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
-            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₂
-      cases t with
-      | inl n =>
-          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run (c₀, l₀) =
-              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
-                fun u => pure (u, (c₀, l₀)) := by
-            simp [QueryImpl.add_apply_inl, unifFwd]
-          rw [hrun] at houter₁ houter₂
-          change us_w₁ ∈ support (simulateQ loggingOracle
-              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
-                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₁
-          change us_w₂ ∈ support (simulateQ loggingOracle
-              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
-                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₂
-          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
-            (spec := wrappedSpec Chal) (Sum.inl n) (fun u => pure (u, (c₀, l₀)))] at houter₁ houter₂
-          rw [support_bind] at houter₁ houter₂
-          simp only [support_map, support_query, Set.mem_univ,
-            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
-            Set.iUnion_const] at houter₁ houter₂
-          obtain ⟨_, ⟨u₁, hu₁_eq⟩, hus_w₁_in⟩ := houter₁
-          obtain ⟨_, ⟨u₂, hu₂_eq⟩, hus_w₂_in⟩ := houter₂
-          subst hu₁_eq
-          subst hu₂_eq
-          rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
-          subst hus_w₁_in
-          subst hus_w₂_in
-          simp only [List.cons_append, List.cons.injEq] at houter_combined
-          obtain ⟨hentry_eq, hpw_snd_eq⟩ := houter_combined
-          have hu_eq : u₁ = u₂ := by
-            obtain ⟨_, hheq⟩ := Sigma.mk.inj hentry_eq
-            exact eq_of_heq hheq
-          subst hu_eq
-          have hpw_snd_eq' : pw₁.2 = pw₂.2 := by
-            simpa using hpw_snd_eq
-          rw [← hpw_snd_eq'] at hpw₂_split
-          exact ih (u := u₁) (c₀ := c₀) (l₀ := l₀) (outerLog := pw₁.2)
-            hpw₁_split hpw₂_split
-      | inr mc =>
-          by_cases hcache : c₀ mc = none
-          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
-                (c₀, l₀) =
-                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
-                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
-              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
-                StateT.run_set, hcache]
-            rw [hrun] at houter₁ houter₂
-            change us_w₁ ∈ support (simulateQ loggingOracle
-                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
-                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
-                    OracleComp _ _))).run at houter₁
-            change us_w₂ ∈ support (simulateQ loggingOracle
-                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
-                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
-                    OracleComp _ _))).run at houter₂
-            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
-              (spec := wrappedSpec Chal) (Sum.inr ())
-              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter₁ houter₂
-            rw [support_bind] at houter₁ houter₂
-            simp only [support_map, support_query, Set.mem_univ,
-              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
-              Set.iUnion_const] at houter₁ houter₂
-            obtain ⟨_, ⟨v₁, hv₁_eq⟩, hus_w₁_in⟩ := houter₁
-            obtain ⟨_, ⟨v₂, hv₂_eq⟩, hus_w₂_in⟩ := houter₂
-            subst hv₁_eq
-            subst hv₂_eq
-            rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
-            subst hus_w₁_in
-            subst hus_w₂_in
-            simp only [List.cons_append, List.cons.injEq] at houter_combined
-            obtain ⟨hentry_eq, hpw_snd_eq⟩ := houter_combined
-            have hv_eq : v₁ = v₂ := by
-              obtain ⟨_, hheq⟩ := Sigma.mk.inj hentry_eq
-              exact eq_of_heq hheq
-            subst hv_eq
-            have hpw_snd_eq' : pw₁.2 = pw₂.2 := by
-              simpa using hpw_snd_eq
-            rw [← hpw_snd_eq'] at hpw₂_split
-            exact ih (u := v₁) (c₀ := c₀.cacheQuery mc v₁) (l₀ := l₀ ++ [mc])
-              (outerLog := pw₁.2) hpw₁_split hpw₂_split
-          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
-            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
-                (c₀, l₀) = pure (v, (c₀, l₀)) := by
-              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
-            rw [hrun] at houter₁ houter₂
-            change us_w₁ ∈ support (simulateQ loggingOracle
-                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₁
-            change us_w₂ ∈ support (simulateQ loggingOracle
-                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₂
-            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter₁ houter₂
-            subst houter₁
-            subst houter₂
-            have hpw_snd_eq' : pw₁.2 = pw₂.2 := by
-              simpa using houter_combined
-            rw [← hpw_snd_eq'] at hpw₂_split
-            exact ih (u := v) (c₀ := c₀) (l₀ := l₀) (outerLog := pw₁.2)
-              hpw₁_split hpw₂_split
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Prefix monotonicity: running `(simulateQ (unifFwd + roImpl) Y).run (c₀, l₀)` produces a
@@ -1525,7 +1372,10 @@ position `↑s`. For the FiatShamir setting this follows from the correspondence
 trace's internal `queryLog : List (M × Commit)` and the outer `QueryLog` of `Sum.inr ()`
 queries: each cache miss in `roImpl` appends to both simultaneously, so a logical index `s`
 into the trace's list corresponds to the same physical position in the outer log. Callers
-discharge `hreach` by establishing this correspondence at the level of `runTrace`. -/
+discharge `hreach` by establishing this correspondence at the level of `runTrace`.
+
+**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`** (transitively via
+`le_probEvent_isSome_forkReplay`). -/
 theorem replayForkingBound
     [DecidableEq M] [DecidableEq Commit]
     [DecidableEq Chal] [SampleableType Chal] [Fintype Chal] [Inhabited Chal]

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -1374,8 +1374,16 @@ queries: each cache miss in `roImpl` appends to both simultaneously, so a logica
 into the trace's list corresponds to the same physical position in the outer log. Callers
 discharge `hreach` by establishing this correspondence at the level of `runTrace`.
 
-**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`** (transitively via
-`le_probEvent_isSome_forkReplay`). -/
+**On typeclass requirements.** The `wrappedSpec Chal` oracle space is
+`unifSpec + (Unit →ₒ Chal)`, and the quantitative section of `ReplayFork.lean` requires the
+typeclass `[OracleSpec.LawfulSubSpec unifSpec spec]` (to factor `probOutput_uniformSample`
+through `liftComp` on the `forkReplay` side). This instance is discharged by Mathlib
+automation at this call site.
+
+**Currently conditional on the two B1 prefix-faithfulness `sorry`s** (transitively via
+`le_probEvent_isSome_forkReplay` → `sq_probOutput_main_le_noGuardReplayComp`
+→ `evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt`
+and `tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt`). -/
 theorem replayForkingBound
     [DecidableEq M] [DecidableEq Commit]
     [DecidableEq Chal] [SampleableType Chal] [Fintype Chal] [Inhabited Chal]

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -135,63 +135,76 @@ lemma forkPoint_getElem?_eq_some_target
             (w := hlt))
   · simp [hverified] at hs
 
+/-- Wrapped oracle spec used by `runTrace`: uniform sampling plus a single counted challenge
+oracle exposing the random-oracle entropy. -/
+abbrev wrappedSpec (Chal : Type) : OracleSpec (ℕ ⊕ Unit) :=
+  unifSpec + (Unit →ₒ Chal)
+
+/-- Internal simulator state of `runTrace`: the cached random-oracle answers paired with
+the chronological list of cache-miss inputs (the trace's `queryLog`). -/
+abbrev simSt (M Commit Chal : Type) [DecidableEq M] [DecidableEq Commit] : Type :=
+  (M × Commit →ₒ Chal).QueryCache × List (M × Commit)
+
+/-- Forwards a uniform-spec query through to the wrapped spec's `Sum.inl` summand without
+touching the simulator state. -/
+noncomputable def unifFwd (M Commit Chal : Type) [DecidableEq M] [DecidableEq Commit] :
+    QueryImpl unifSpec (StateT (simSt M Commit Chal) (OracleComp (wrappedSpec Chal))) :=
+  fun n => monadLift
+    (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) :
+      OracleComp (wrappedSpec Chal) _)
+
+/-- Caching random-oracle implementation: on a cache hit the recorded answer is returned,
+on a cache miss a fresh `Sum.inr ()` query is issued, the answer is cached, and the
+miss input `(msg, c)` is appended to the trace's internal `queryLog`. -/
+noncomputable def roImpl (M Commit Chal : Type) [DecidableEq M] [DecidableEq Commit] :
+    QueryImpl (M × Commit →ₒ Chal)
+      (StateT (simSt M Commit Chal) (OracleComp (wrappedSpec Chal))) :=
+  fun mc => do
+    let (cache, log) ← get
+    match cache mc with
+    | some v => pure v
+    | none =>
+        let v : Chal ← monadLift
+          (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) :
+            OracleComp (wrappedSpec Chal) Chal)
+        set ((cache.cacheQuery mc v : (M × Commit →ₒ Chal).QueryCache),
+          log ++ [mc])
+        pure v
+
 /-- Replay a managed-RO NMA adversary against a single counted challenge oracle, keeping both
 the adversary-returned cache and the live query log that the forking lemma can rewind.
 
-The `verified` flag is computed only from challenge values already present in one of those
-two caches. In particular, this trace does not perform a fresh post-hoc verification query;
-it records exactly the executions whose forgery is already determined by the adversary's
-managed view of the random oracle. -/
+The `verified` flag is computed strictly from the live `roCache` so that a successful
+`forkPoint` extraction always pins the verifying challenge to the live random-oracle
+answer at the corresponding outer-log position. Forgeries whose verification depends only
+on programmed entries the adversary supplies in `advCache` are not counted; for the
+managed-RO reductions the relevant `advCache` entries are queried via the live oracle and
+hence also appear in `roCache`. -/
 noncomputable def runTrace
     [DecidableEq M] [DecidableEq Commit]
     [SampleableType Chal]
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (pk : Stmt) :
-    OracleComp (unifSpec + (Unit →ₒ Chal))
-      (Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) := by
-  let origSpec := unifSpec + (M × Commit →ₒ Chal)
-  let chalSpec : OracleSpec Unit := Unit →ₒ Chal
-  let wrappedSpec := unifSpec + chalSpec
-  let simSt := (M × Commit →ₒ Chal).QueryCache × List (M × Commit)
-  let unifFwd : QueryImpl unifSpec
-      (StateT simSt (OracleComp wrappedSpec)) :=
-    fun n => monadLift
-      (liftM (query (spec := wrappedSpec) (Sum.inl n)) :
-        OracleComp wrappedSpec _)
-  let roImpl : QueryImpl (M × Commit →ₒ Chal)
-      (StateT simSt (OracleComp wrappedSpec)) :=
-    fun mc => do
-      let (cache, log) ← get
-      match cache mc with
-      | some v => pure v
-      | none =>
-          let v : Chal ← monadLift
-            (liftM (query (spec := wrappedSpec) (Sum.inr ())) :
-              OracleComp wrappedSpec Chal)
-          set ((cache.cacheQuery mc v : (M × Commit →ₒ Chal).QueryCache),
-            log ++ [mc])
-          pure v
-  exact do
-    let ((forgery, advCache), st) ←
-      StateT.run (simulateQ (unifFwd + roImpl) (nmaAdv.main pk)) (∅, [])
-    let verified :=
-      match forgery with
-      | (msg, (c, s)) =>
-          match advCache (Sum.inr (msg, c)) with
-          | some ω => σ.verify pk c ω s
-          | none =>
-              match st.1 (msg, c) with
-              | some ω => σ.verify pk c ω s
-              | none => false
-    let (roCache, queryLog) := st
-    pure {
-      forgery := forgery
-      advCache := advCache
-      roCache := roCache
-      queryLog := queryLog
-      verified := verified
-    }
+    OracleComp (wrappedSpec Chal)
+      (Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) := do
+  let ((forgery, advCache), st) ←
+    StateT.run (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (nmaAdv.main pk))
+      (∅, [])
+  let verified :=
+    match forgery with
+    | (msg, (c, s)) =>
+        match st.1 (msg, c) with
+        | some ω => σ.verify pk c ω s
+        | none => false
+  let (roCache, queryLog) := st
+  pure {
+    forgery := forgery
+    advCache := advCache
+    roCache := roCache
+    queryLog := queryLog
+    verified := verified
+  }
 
 /-- Forkable managed-RO NMA experiment. Success means the final forged transcript verifies and
 the corresponding hash point appears in the live query log, so the forking lemma can rewind it. -/
@@ -219,6 +232,1268 @@ noncomputable def advantage
     (qH : ℕ) : ENNReal :=
   Pr[= true | exp σ hr M nmaAdv qH]
 
+section Coupling
+
+variable [DecidableEq M] [DecidableEq Commit]
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Coupling invariant for `runTrace`'s inner simulation: the trace's internal `queryLog`
+grows by exactly the number of `Sum.inr ()` queries issued to the outer wrapped spec.
+Each cache miss in `roImpl` simultaneously appends to the outer log and to the trace's
+`queryLog`, while cache hits and `unifFwd`-forwarded `Sum.inl _` queries do not touch the
+trace `queryLog`. -/
+private theorem queryLog_length_eq_outer_inr_count
+    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
+    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
+    {z : γ × simSt M Commit Chal}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (hz : (z, outerLog) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run)) :
+    z.2.2.length = l₀.length + outerLog.countQ (· = Sum.inr ()) := by
+  classical
+  induction Y using OracleComp.inductionOn generalizing c₀ l₀ z outerLog with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
+        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at hz
+      obtain ⟨hz_eq, hlog_eq⟩ := hz
+      subst hz_eq
+      subst hlog_eq
+      simp [QueryLog.countQ]
+  | query_bind t oa ih =>
+      have hY :
+          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
+              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
+        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
+          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at hz
+      simp only [Set.mem_iUnion, support_map, Set.mem_image] at hz
+      obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := hz
+      have hpw_split : (pw.1, pw.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w.1.1)).run us_w.1.2)).run) := by
+        change pw ∈ support _
+        exact hpw
+      have hih :
+          pw.1.2.2.length = us_w.1.2.2.length + pw.2.countQ (· = Sum.inr ()) :=
+        ih (u := us_w.1.1) (c₀ := us_w.1.2.1) (l₀ := us_w.1.2.2)
+          (z := pw.1) (outerLog := pw.2) hpw_split
+      have hz_eq' : (pw.1, us_w.2 ++ pw.2) = (z, outerLog) := by
+        rw [show ((pw.1, us_w.2 ++ pw.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w.2 ++ x) pw from rfl]
+        exact hz_eq
+      obtain ⟨hz_eq1, hz_eq2⟩ := Prod.mk.inj hz_eq'
+      rw [← hz_eq1, ← hz_eq2]
+      have houter : us_w ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w
+      -- We will show: ∃ u, us_w = ((u, st'), w₁) where w₁ is determined by the case,
+      -- and st' is determined by the case.
+      cases t with
+      | inl n =>
+          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run (c₀, l₀) =
+              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => pure (u, (c₀, l₀)) := by
+            simp [QueryImpl.add_apply_inl, unifFwd]
+          rw [hrun] at houter
+          change us_w ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter
+          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+            (spec := wrappedSpec Chal) (Sum.inl n) (fun u => pure (u, (c₀, l₀)))] at houter
+          rw [support_bind] at houter
+          simp only [support_map, support_query, Set.mem_univ,
+            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+            Set.iUnion_const] at houter
+          obtain ⟨_, ⟨u, hu_eq⟩, hus_w_in_u⟩ := houter
+          subst hu_eq
+          rw [Set.mem_singleton_iff] at hus_w_in_u
+          rw [hih, hus_w_in_u]
+          simp [QueryLog.countQ, QueryLog.getQ]
+      | inr mc =>
+          by_cases hcache : c₀ mc = none
+          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) =
+                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
+                StateT.run_set, hcache]
+            rw [hrun] at houter
+            change us_w ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter
+            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+              (spec := wrappedSpec Chal) (Sum.inr ())
+              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter
+            rw [support_bind] at houter
+            simp only [support_map, support_query, Set.mem_univ,
+              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+              Set.iUnion_const] at houter
+            obtain ⟨_, ⟨v, hv_eq⟩, hus_w_in_u⟩ := houter
+            subst hv_eq
+            rw [Set.mem_singleton_iff] at hus_w_in_u
+            rw [hih]
+            subst hus_w_in_u
+            simp [QueryLog.countQ, QueryLog.getQ]
+            omega
+          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
+            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) = pure (v, (c₀, l₀)) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
+            rw [hrun] at houter
+            change us_w ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter
+            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter
+            subst houter
+            exact hih
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Lockstep value invariant for `runTrace`'s inner simulation. Three coupled invariants
+travel together along the simulation:
+
+* **(prefix)** the trace's internal `queryLog` only ever extends `l₀`;
+* **(monotonicity)** any pre-existing entry in `c₀` is preserved in the final `roCache`;
+* **(lockstep)** every cache-miss entry in the trace's `queryLog` is paired in lockstep with
+  the corresponding `Sum.inr ()` answer in the outer log. Specifically, for every position
+  `i ∈ [l₀.length, z.queryLog.length)`, the trace's cache stores some value `ω` for the
+  query `z.queryLog[i]`, and the outer log's `(i - l₀.length)`-th `Sum.inr ()` response is
+  the same `ω`.
+
+This is the value-level strengthening of `queryLog_length_eq_outer_inr_count`: the latter
+only counts entries, while this lemma threads the recorded values through the cache and the
+outer log together. -/
+private theorem queryLog_cache_outer_lockstep
+    [DecidableEq Chal]
+    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
+    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
+    {z : γ × simSt M Commit Chal}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (hz : (z, outerLog) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run)) :
+    (∃ l_new, z.2.2 = l₀ ++ l_new) ∧
+    (∀ mc ω, c₀ mc = some ω → z.2.1 mc = some ω) ∧
+    (∀ i, l₀.length ≤ i → ∀ (h_hi : i < z.2.2.length),
+      ∃ ω, z.2.1 (z.2.2[i]'h_hi) = some ω ∧
+        QueryLog.getQueryValue? outerLog (Sum.inr ()) (i - l₀.length) = some ω) := by
+  classical
+  induction Y using OracleComp.inductionOn generalizing c₀ l₀ z outerLog with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
+        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at hz
+      obtain ⟨hz_eq, hlog_eq⟩ := hz
+      subst hz_eq
+      subst hlog_eq
+      refine ⟨⟨[], by simp⟩, ?_, ?_⟩
+      · intro mc ω h; exact h
+      · intro i h_lo h_hi
+        change i < l₀.length at h_hi
+        omega
+  | query_bind t oa ih =>
+      have hY :
+          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
+              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
+        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
+          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at hz
+      simp only [Set.mem_iUnion, support_map, Set.mem_image] at hz
+      obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := hz
+      have hpw_split : (pw.1, pw.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w.1.1)).run us_w.1.2)).run) := by
+        change pw ∈ support _
+        exact hpw
+      have hih := ih (u := us_w.1.1) (c₀ := us_w.1.2.1) (l₀ := us_w.1.2.2)
+        (z := pw.1) (outerLog := pw.2) hpw_split
+      have hz_eq' : (pw.1, us_w.2 ++ pw.2) = (z, outerLog) := by
+        rw [show ((pw.1, us_w.2 ++ pw.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w.2 ++ x) pw from rfl]
+        exact hz_eq
+      obtain ⟨hz_eq1, hz_eq2⟩ := Prod.mk.inj hz_eq'
+      have hzeq : z = pw.1 := hz_eq1.symm
+      have houter_eq : outerLog = us_w.2 ++ pw.2 := hz_eq2.symm
+      subst hzeq
+      subst houter_eq
+      have houter : us_w ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w
+      cases t with
+      | inl n =>
+          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run (c₀, l₀) =
+              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => pure (u, (c₀, l₀)) := by
+            simp [QueryImpl.add_apply_inl, unifFwd]
+          rw [hrun] at houter
+          change us_w ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter
+          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+            (spec := wrappedSpec Chal) (Sum.inl n) (fun u => pure (u, (c₀, l₀)))] at houter
+          rw [support_bind] at houter
+          simp only [support_map, support_query, Set.mem_univ,
+            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+            Set.iUnion_const] at houter
+          obtain ⟨_, ⟨u, hu_eq⟩, hus_w_in_u⟩ := houter
+          subst hu_eq
+          rw [Set.mem_singleton_iff] at hus_w_in_u
+          subst hus_w_in_u
+          obtain ⟨⟨l_new, hpref⟩, hmono, hlock⟩ := hih
+          refine ⟨⟨l_new, hpref⟩, hmono, ?_⟩
+          intro i h_lo h_hi
+          obtain ⟨ω, hcache, hlog⟩ := hlock i h_lo h_hi
+          refine ⟨ω, hcache, ?_⟩
+          change QueryLog.getQueryValue?
+            ((⟨Sum.inl n, u⟩ : (j : ℕ ⊕ Unit) × (wrappedSpec Chal).Range j)
+              :: pw.2) (Sum.inr ()) (i - l₀.length) = some ω
+          rw [QueryLog.getQueryValue?_cons_of_ne]
+          · exact hlog
+          · exact Sum.inl_ne_inr
+      | inr mc =>
+          by_cases hcache : c₀ mc = none
+          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) =
+                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
+                StateT.run_set, hcache]
+            rw [hrun] at houter
+            change us_w ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter
+            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+              (spec := wrappedSpec Chal) (Sum.inr ())
+              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter
+            rw [support_bind] at houter
+            simp only [support_map, support_query, Set.mem_univ,
+              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+              Set.iUnion_const] at houter
+            obtain ⟨_, ⟨v, hv_eq⟩, hus_w_in_u⟩ := houter
+            subst hv_eq
+            rw [Set.mem_singleton_iff] at hus_w_in_u
+            subst hus_w_in_u
+            obtain ⟨⟨l_new', hpref'⟩, hmono', hlock'⟩ := hih
+            dsimp only at hpref' hmono' hlock'
+            have hpref_z : pw.1.2.2 = l₀ ++ ([mc] ++ l_new') := by
+              rw [hpref']
+              simp [List.append_assoc]
+            refine ⟨⟨[mc] ++ l_new', hpref_z⟩, ?_, ?_⟩
+            · intro mc' ω hmc'
+              apply hmono'
+              by_cases heq : mc' = mc
+              · subst heq; rw [hcache] at hmc'; exact (Option.some_ne_none ω hmc'.symm).elim
+              · rw [QueryCache.cacheQuery_of_ne _ _ heq]; exact hmc'
+            · intro i h_lo h_hi
+              by_cases hi_eq : i = l₀.length
+              · subst hi_eq
+                have hidx : pw.1.2.2[l₀.length]'h_hi = mc := by
+                  have h_hi'' : l₀.length < (l₀ ++ ([mc] ++ l_new')).length := by
+                    rw [← List.append_assoc, ← hpref']; exact h_hi
+                  have hcongr : pw.1.2.2[l₀.length]'h_hi =
+                      (l₀ ++ ([mc] ++ l_new'))[l₀.length]'h_hi'' :=
+                    List.getElem_of_eq hpref_z _
+                  rw [hcongr]
+                  rw [List.getElem_append_right (Nat.le_refl _)]
+                  simp
+                refine ⟨v, ?_, ?_⟩
+                · rw [hidx]
+                  exact hmono' mc v (QueryCache.cacheQuery_self c₀ mc v)
+                · change QueryLog.getQueryValue?
+                    ((⟨Sum.inr (), v⟩ : (j : ℕ ⊕ Unit) × (wrappedSpec Chal).Range j)
+                      :: pw.2) (Sum.inr ()) (l₀.length - l₀.length) = some v
+                  rw [Nat.sub_self]
+                  exact QueryLog.getQueryValue?_cons_self_zero (Sum.inr ()) v pw.2
+              · have h_lo' : (l₀ ++ [mc]).length ≤ i := by
+                  simp [List.length_append]; omega
+                obtain ⟨ω, hcacheω, hlogω⟩ := hlock' i h_lo' h_hi
+                refine ⟨ω, hcacheω, ?_⟩
+                obtain ⟨k, hk⟩ : ∃ k, i - l₀.length = k + 1 := ⟨i - l₀.length - 1, by omega⟩
+                have hk_eq : k = i - (l₀ ++ [mc]).length := by
+                  simp [List.length_append] at hk ⊢; omega
+                change QueryLog.getQueryValue?
+                  ((⟨Sum.inr (), v⟩ : (j : ℕ ⊕ Unit) × (wrappedSpec Chal).Range j)
+                    :: pw.2) (Sum.inr ()) (i - l₀.length) = some ω
+                rw [hk]
+                rw [QueryLog.getQueryValue?_cons_self_succ]
+                rw [hk_eq]
+                exact hlogω
+          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
+            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) = pure (v, (c₀, l₀)) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
+            rw [hrun] at houter
+            change us_w ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter
+            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter
+            subst houter
+            obtain ⟨⟨l_new, hpref⟩, hmono, hlock⟩ := hih
+            refine ⟨⟨l_new, hpref⟩, hmono, ?_⟩
+            intro i h_lo h_hi
+            obtain ⟨ω, hcacheω, hlogω⟩ := hlock i h_lo h_hi
+            refine ⟨ω, hcacheω, ?_⟩
+            change QueryLog.getQueryValue? ([] ++ pw.2)
+              (Sum.inr ()) (i - l₀.length) = some ω
+            rw [List.nil_append]
+            exact hlogω
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Outer-log determinism for `runTrace`'s inner simulation. Because every source of
+randomness inside `(simulateQ (unifFwd + roImpl) Y).run (c₀, l₀)` is channelled through
+the outer wrapped-spec queries (both `unifFwd`'s forwarded `Sum.inl _` samples and
+`roImpl`'s fresh `Sum.inr ()` challenges on cache misses), fixing the outer log
+uniquely determines the inner result and final simulator state. This is the
+bisimulation statement underlying `target_eq_of_mem_forkReplay`. -/
+private theorem inner_det
+    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
+    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
+    {z₁ z₂ : γ × simSt M Commit Chal}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (h₁ : (z₁, outerLog) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run))
+    (h₂ : (z₂, outerLog) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run)) :
+    z₁ = z₂ := by
+  classical
+  induction Y using OracleComp.inductionOn generalizing c₀ l₀ z₁ z₂ outerLog with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
+        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at h₁ h₂
+      obtain ⟨hz₁_eq, _⟩ := h₁
+      obtain ⟨hz₂_eq, _⟩ := h₂
+      rw [hz₁_eq, hz₂_eq]
+  | query_bind t oa ih =>
+      have hY :
+          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
+              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
+        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
+          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h₁ h₂
+      simp only [Set.mem_iUnion, support_map, Set.mem_image] at h₁ h₂
+      obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
+      obtain ⟨us_w₂, hus_w₂, pw₂, hpw₂, hz_eq₂⟩ := h₂
+      have hpw₁_split : (pw₁.1, pw₁.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w₁.1.1)).run us_w₁.1.2)).run) := by
+        change pw₁ ∈ support _
+        exact hpw₁
+      have hpw₂_split : (pw₂.1, pw₂.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w₂.1.1)).run us_w₂.1.2)).run) := by
+        change pw₂ ∈ support _
+        exact hpw₂
+      have hz_eq'₁ : (pw₁.1, us_w₁.2 ++ pw₁.2) = (z₁, outerLog) := by
+        rw [show ((pw₁.1, us_w₁.2 ++ pw₁.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w₁.2 ++ x) pw₁ from rfl]
+        exact hz_eq₁
+      have hz_eq'₂ : (pw₂.1, us_w₂.2 ++ pw₂.2) = (z₂, outerLog) := by
+        rw [show ((pw₂.1, us_w₂.2 ++ pw₂.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w₂.2 ++ x) pw₂ from rfl]
+        exact hz_eq₂
+      obtain ⟨hz_eq1₁, hz_eq2₁⟩ := Prod.mk.inj hz_eq'₁
+      obtain ⟨hz_eq1₂, hz_eq2₂⟩ := Prod.mk.inj hz_eq'₂
+      have hzeq₁ : z₁ = pw₁.1 := hz_eq1₁.symm
+      have hzeq₂ : z₂ = pw₂.1 := hz_eq1₂.symm
+      have houter_combined : us_w₁.2 ++ pw₁.2 = us_w₂.2 ++ pw₂.2 :=
+        hz_eq2₁.trans hz_eq2₂.symm
+      subst hzeq₁
+      subst hzeq₂
+      have houter₁ : us_w₁ ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₁
+      have houter₂ : us_w₂ ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₂
+      cases t with
+      | inl n =>
+          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run (c₀, l₀) =
+              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => pure (u, (c₀, l₀)) := by
+            simp [QueryImpl.add_apply_inl, unifFwd]
+          rw [hrun] at houter₁ houter₂
+          change us_w₁ ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₁
+          change us_w₂ ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₂
+          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+            (spec := wrappedSpec Chal) (Sum.inl n) (fun u => pure (u, (c₀, l₀)))] at houter₁ houter₂
+          rw [support_bind] at houter₁ houter₂
+          simp only [support_map, support_query, Set.mem_univ,
+            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+            Set.iUnion_const] at houter₁ houter₂
+          obtain ⟨_, ⟨u₁, hu₁_eq⟩, hus_w₁_in⟩ := houter₁
+          obtain ⟨_, ⟨u₂, hu₂_eq⟩, hus_w₂_in⟩ := houter₂
+          subst hu₁_eq
+          subst hu₂_eq
+          rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
+          subst hus_w₁_in
+          subst hus_w₂_in
+          simp only [List.cons_append, List.cons.injEq] at houter_combined
+          obtain ⟨hentry_eq, hpw_snd_eq⟩ := houter_combined
+          have hu_eq : u₁ = u₂ := by
+            obtain ⟨_, hheq⟩ := Sigma.mk.inj hentry_eq
+            exact eq_of_heq hheq
+          subst hu_eq
+          have hpw_snd_eq' : pw₁.2 = pw₂.2 := by
+            simpa using hpw_snd_eq
+          rw [← hpw_snd_eq'] at hpw₂_split
+          exact ih (u := u₁) (c₀ := c₀) (l₀ := l₀) (outerLog := pw₁.2)
+            hpw₁_split hpw₂_split
+      | inr mc =>
+          by_cases hcache : c₀ mc = none
+          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) =
+                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
+                StateT.run_set, hcache]
+            rw [hrun] at houter₁ houter₂
+            change us_w₁ ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter₁
+            change us_w₂ ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter₂
+            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+              (spec := wrappedSpec Chal) (Sum.inr ())
+              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter₁ houter₂
+            rw [support_bind] at houter₁ houter₂
+            simp only [support_map, support_query, Set.mem_univ,
+              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+              Set.iUnion_const] at houter₁ houter₂
+            obtain ⟨_, ⟨v₁, hv₁_eq⟩, hus_w₁_in⟩ := houter₁
+            obtain ⟨_, ⟨v₂, hv₂_eq⟩, hus_w₂_in⟩ := houter₂
+            subst hv₁_eq
+            subst hv₂_eq
+            rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
+            subst hus_w₁_in
+            subst hus_w₂_in
+            simp only [List.cons_append, List.cons.injEq] at houter_combined
+            obtain ⟨hentry_eq, hpw_snd_eq⟩ := houter_combined
+            have hv_eq : v₁ = v₂ := by
+              obtain ⟨_, hheq⟩ := Sigma.mk.inj hentry_eq
+              exact eq_of_heq hheq
+            subst hv_eq
+            have hpw_snd_eq' : pw₁.2 = pw₂.2 := by
+              simpa using hpw_snd_eq
+            rw [← hpw_snd_eq'] at hpw₂_split
+            exact ih (u := v₁) (c₀ := c₀.cacheQuery mc v₁) (l₀ := l₀ ++ [mc])
+              (outerLog := pw₁.2) hpw₁_split hpw₂_split
+          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
+            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) = pure (v, (c₀, l₀)) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
+            rw [hrun] at houter₁ houter₂
+            change us_w₁ ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₁
+            change us_w₂ ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₂
+            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter₁ houter₂
+            subst houter₁
+            subst houter₂
+            have hpw_snd_eq' : pw₁.2 = pw₂.2 := by
+              simpa using houter_combined
+            rw [← hpw_snd_eq'] at hpw₂_split
+            exact ih (u := v) (c₀ := c₀) (l₀ := l₀) (outerLog := pw₁.2)
+              hpw₁_split hpw₂_split
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Prefix monotonicity: running `(simulateQ (unifFwd + roImpl) Y).run (c₀, l₀)` produces a
+final simulator state whose `queryLog` component extends `l₀`. The resulting list always
+starts with the initial `l₀`: cache misses only append entries, and cache hits plus
+`unifFwd`-forwarded queries never touch `l₀`. Used by `inner_prefix_det` to fix the first
+`l₀.length` positions of the final `queryLog`. -/
+private theorem queryLog_extends_l₀
+    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
+    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
+    {z : γ × simSt M Commit Chal}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (h : (z, outerLog) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run)) :
+    z.2.2.take l₀.length = l₀ := by
+  classical
+  induction Y using OracleComp.inductionOn generalizing c₀ l₀ z outerLog with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
+        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at h
+      obtain ⟨hz_eq, _⟩ := h
+      rw [hz_eq]
+      exact List.take_length
+  | query_bind t oa ih =>
+      have hY :
+          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
+              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
+        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
+          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h
+      simp only [Set.mem_iUnion, support_map, Set.mem_image] at h
+      obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := h
+      have hpw_split : (pw.1, pw.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w.1.1)).run us_w.1.2)).run) := by
+        change pw ∈ support _
+        exact hpw
+      have hz_eq' : (pw.1, us_w.2 ++ pw.2) = (z, outerLog) := by
+        rw [show ((pw.1, us_w.2 ++ pw.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w.2 ++ x) pw from rfl]
+        exact hz_eq
+      obtain ⟨hz_eq1, _⟩ := Prod.mk.inj hz_eq'
+      have hzeq : z = pw.1 := hz_eq1.symm
+      subst hzeq
+      have houter : us_w ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w
+      cases t with
+      | inl n =>
+          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run
+              (c₀, l₀) =
+              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => pure (u, (c₀, l₀)) := by
+            simp [QueryImpl.add_apply_inl, unifFwd]
+          rw [hrun] at houter
+          change us_w ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter
+          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+            (spec := wrappedSpec Chal) (Sum.inl n) (fun u => pure (u, (c₀, l₀)))] at houter
+          rw [support_bind] at houter
+          simp only [support_map, support_query, Set.mem_univ,
+            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+            Set.iUnion_const] at houter
+          obtain ⟨_, ⟨u, hu_eq⟩, hus_w_in⟩ := houter
+          subst hu_eq
+          rw [Set.mem_singleton_iff] at hus_w_in
+          subst hus_w_in
+          exact ih u c₀ l₀ hpw_split
+      | inr mc =>
+          by_cases hcache : c₀ mc = none
+          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) =
+                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
+                StateT.run_set, hcache]
+            rw [hrun] at houter
+            change us_w ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter
+            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+              (spec := wrappedSpec Chal) (Sum.inr ())
+              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter
+            rw [support_bind] at houter
+            simp only [support_map, support_query, Set.mem_univ,
+              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+              Set.iUnion_const] at houter
+            obtain ⟨_, ⟨v, hv_eq⟩, hus_w_in⟩ := houter
+            subst hv_eq
+            rw [Set.mem_singleton_iff] at hus_w_in
+            subst hus_w_in
+            have hih := ih v (c₀.cacheQuery mc v) (l₀ ++ [mc]) hpw_split
+            have hlen_le : l₀.length ≤ (l₀ ++ [mc]).length := by
+              simp [List.length_append]
+            calc pw.1.2.2.take l₀.length
+                = (pw.1.2.2.take (l₀ ++ [mc]).length).take l₀.length := by
+                    rw [List.take_take, min_eq_left hlen_le]
+              _ = (l₀ ++ [mc]).take l₀.length := by rw [hih]
+              _ = l₀ := List.take_left
+          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
+            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) = pure (v, (c₀, l₀)) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
+            rw [hrun] at houter
+            change us_w ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter
+            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter
+            subst houter
+            exact ih v c₀ l₀ hpw_split
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Outer-log **prefix**-determinism for `runTrace`'s inner simulation. If the two outer
+logs share a common prefix `p` (with `#{Sum.inr ()} = j` in `p`), then the first
+`l₀.length + j` positions of the final internal `queryLog`s coincide. This is the
+bisimulation up to the fork query that powers `target_eq_of_mem_forkReplay`: a common outer
+prefix fixes the adversary's state (and hence the next cache-miss input) up through the
+fork. -/
+private theorem inner_prefix_det
+    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
+    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
+    {z₁ z₂ : γ × simSt M Commit Chal}
+    {outerLog₁ outerLog₂ : QueryLog (wrappedSpec Chal)}
+    (h₁ : (z₁, outerLog₁) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run))
+    (h₂ : (z₂, outerLog₂) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run))
+    (p suffix₁ suffix₂ : QueryLog (wrappedSpec Chal))
+    (hlog₁ : outerLog₁ = p ++ suffix₁)
+    (hlog₂ : outerLog₂ = p ++ suffix₂) :
+    z₁.2.2.take (l₀.length + p.countQ (· = Sum.inr ())) =
+      z₂.2.2.take (l₀.length + p.countQ (· = Sum.inr ())) := by
+  classical
+  induction Y using OracleComp.inductionOn generalizing
+      c₀ l₀ z₁ z₂ outerLog₁ outerLog₂ p suffix₁ suffix₂ with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
+        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at h₁ h₂
+      obtain ⟨hz₁_eq, houter₁'⟩ := h₁
+      obtain ⟨hz₂_eq, _⟩ := h₂
+      rw [houter₁'] at hlog₁
+      have hp_empty : p = [] := by
+        cases p with
+        | nil => rfl
+        | cons _ _ => simp at hlog₁
+      subst hp_empty
+      simp only [QueryLog.countQ, QueryLog.getQ_nil, List.length_nil, add_zero]
+      rw [hz₁_eq, hz₂_eq]
+  | query_bind t oa ih =>
+      have hY :
+          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
+              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
+        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
+          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h₁ h₂
+      simp only [Set.mem_iUnion, support_map, Set.mem_image] at h₁ h₂
+      obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
+      obtain ⟨us_w₂, hus_w₂, pw₂, hpw₂, hz_eq₂⟩ := h₂
+      have hpw₁_split : (pw₁.1, pw₁.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w₁.1.1)).run us_w₁.1.2)).run) := by
+        change pw₁ ∈ support _
+        exact hpw₁
+      have hpw₂_split : (pw₂.1, pw₂.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w₂.1.1)).run us_w₂.1.2)).run) := by
+        change pw₂ ∈ support _
+        exact hpw₂
+      have hz_eq'₁ : (pw₁.1, us_w₁.2 ++ pw₁.2) = (z₁, outerLog₁) := by
+        rw [show ((pw₁.1, us_w₁.2 ++ pw₁.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w₁.2 ++ x) pw₁ from rfl]
+        exact hz_eq₁
+      have hz_eq'₂ : (pw₂.1, us_w₂.2 ++ pw₂.2) = (z₂, outerLog₂) := by
+        rw [show ((pw₂.1, us_w₂.2 ++ pw₂.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w₂.2 ++ x) pw₂ from rfl]
+        exact hz_eq₂
+      obtain ⟨hz_eq1₁, hz_eq2₁⟩ := Prod.mk.inj hz_eq'₁
+      obtain ⟨hz_eq1₂, hz_eq2₂⟩ := Prod.mk.inj hz_eq'₂
+      have hzeq₁ : z₁ = pw₁.1 := hz_eq1₁.symm
+      have hzeq₂ : z₂ = pw₂.1 := hz_eq1₂.symm
+      subst hzeq₁
+      subst hzeq₂
+      have houter₁_eq : us_w₁.2 ++ pw₁.2 = p ++ suffix₁ := hz_eq2₁.trans hlog₁
+      have houter₂_eq : us_w₂.2 ++ pw₂.2 = p ++ suffix₂ := hz_eq2₂.trans hlog₂
+      have houter₁ : us_w₁ ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₁
+      have houter₂ : us_w₂ ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₂
+      cases t with
+      | inl n =>
+          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run
+              (c₀, l₀) =
+              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => pure (u, (c₀, l₀)) := by
+            simp [QueryImpl.add_apply_inl, unifFwd]
+          rw [hrun] at houter₁ houter₂
+          change us_w₁ ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₁
+          change us_w₂ ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₂
+          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+            (spec := wrappedSpec Chal) (Sum.inl n) (fun u => pure (u, (c₀, l₀)))] at houter₁ houter₂
+          rw [support_bind] at houter₁ houter₂
+          simp only [support_map, support_query, Set.mem_univ,
+            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+            Set.iUnion_const] at houter₁ houter₂
+          obtain ⟨_, ⟨u₁, hu₁_eq⟩, hus_w₁_in⟩ := houter₁
+          obtain ⟨_, ⟨u₂, hu₂_eq⟩, hus_w₂_in⟩ := houter₂
+          subst hu₁_eq
+          subst hu₂_eq
+          rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
+          subst hus_w₁_in
+          subst hus_w₂_in
+          cases p with
+          | nil =>
+              simp only [QueryLog.countQ, QueryLog.getQ_nil, List.length_nil, add_zero]
+              have h₁' : pw₁.1.2.2.take l₀.length = l₀ :=
+                queryLog_extends_l₀ (M := M) (Commit := Commit) (Chal := Chal)
+                  (oa u₁) c₀ l₀ hpw₁_split
+              have h₂' : pw₂.1.2.2.take l₀.length = l₀ :=
+                queryLog_extends_l₀ (M := M) (Commit := Commit) (Chal := Chal)
+                  (oa u₂) c₀ l₀ hpw₂_split
+              rw [h₁', h₂']
+          | cons p_head p_tail =>
+              simp only [List.cons_append, List.cons.injEq]
+                at houter₁_eq houter₂_eq
+              obtain ⟨hhead₁, htail₁⟩ := houter₁_eq
+              obtain ⟨hhead₂, htail₂⟩ := houter₂_eq
+              have hu_eq : u₁ = u₂ := by
+                have := hhead₁.trans hhead₂.symm
+                obtain ⟨_, hheq⟩ := Sigma.mk.inj this
+                exact eq_of_heq hheq
+              subst hu_eq
+              have hpH_fst : p_head.1 ≠ Sum.inr () := by
+                rw [← hhead₁]; intro h; cases h
+              have hp_count :
+                  QueryLog.countQ (spec := wrappedSpec Chal) (p_head :: p_tail)
+                      (· = Sum.inr ()) =
+                    QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ()) := by
+                simp [QueryLog.countQ, QueryLog.getQ_cons, hpH_fst]
+              rw [hp_count]
+              exact ih u₁ c₀ l₀ hpw₁_split hpw₂_split p_tail suffix₁ suffix₂ htail₁ htail₂
+      | inr mc =>
+          by_cases hcache : c₀ mc = none
+          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) =
+                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
+                StateT.run_set, hcache]
+            rw [hrun] at houter₁ houter₂
+            change us_w₁ ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter₁
+            change us_w₂ ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter₂
+            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+              (spec := wrappedSpec Chal) (Sum.inr ())
+              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter₁ houter₂
+            rw [support_bind] at houter₁ houter₂
+            simp only [support_map, support_query, Set.mem_univ,
+              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+              Set.iUnion_const] at houter₁ houter₂
+            obtain ⟨_, ⟨v₁, hv₁_eq⟩, hus_w₁_in⟩ := houter₁
+            obtain ⟨_, ⟨v₂, hv₂_eq⟩, hus_w₂_in⟩ := houter₂
+            subst hv₁_eq
+            subst hv₂_eq
+            rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
+            subst hus_w₁_in
+            subst hus_w₂_in
+            cases p with
+            | nil =>
+                simp only [QueryLog.countQ, QueryLog.getQ_nil, List.length_nil, add_zero]
+                have h₁' : pw₁.1.2.2.take l₀.length = l₀ := by
+                  have h1 := queryLog_extends_l₀ (M := M) (Commit := Commit) (Chal := Chal)
+                    (oa v₁) (c₀.cacheQuery mc v₁) (l₀ ++ [mc]) hpw₁_split
+                  have hlen_le : l₀.length ≤ (l₀ ++ [mc]).length := by
+                    simp [List.length_append]
+                  calc pw₁.1.2.2.take l₀.length
+                      = (pw₁.1.2.2.take (l₀ ++ [mc]).length).take l₀.length := by
+                          rw [List.take_take, min_eq_left hlen_le]
+                    _ = (l₀ ++ [mc]).take l₀.length := by rw [h1]
+                    _ = l₀ := List.take_left
+                have h₂' : pw₂.1.2.2.take l₀.length = l₀ := by
+                  have h2 := queryLog_extends_l₀ (M := M) (Commit := Commit) (Chal := Chal)
+                    (oa v₂) (c₀.cacheQuery mc v₂) (l₀ ++ [mc]) hpw₂_split
+                  have hlen_le : l₀.length ≤ (l₀ ++ [mc]).length := by
+                    simp [List.length_append]
+                  calc pw₂.1.2.2.take l₀.length
+                      = (pw₂.1.2.2.take (l₀ ++ [mc]).length).take l₀.length := by
+                          rw [List.take_take, min_eq_left hlen_le]
+                    _ = (l₀ ++ [mc]).take l₀.length := by rw [h2]
+                    _ = l₀ := List.take_left
+                rw [h₁', h₂']
+            | cons p_head p_tail =>
+                simp only [List.cons_append, List.cons.injEq]
+                  at houter₁_eq houter₂_eq
+                obtain ⟨hhead₁, htail₁⟩ := houter₁_eq
+                obtain ⟨hhead₂, htail₂⟩ := houter₂_eq
+                have hv_eq : v₁ = v₂ := by
+                  have := hhead₁.trans hhead₂.symm
+                  obtain ⟨_, hheq⟩ := Sigma.mk.inj this
+                  exact eq_of_heq hheq
+                subst hv_eq
+                have hpH_fst : p_head.1 = Sum.inr () := by rw [← hhead₁]
+                have hp_count :
+                    QueryLog.countQ (spec := wrappedSpec Chal) (p_head :: p_tail)
+                        (· = Sum.inr ()) =
+                      QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ()) + 1 := by
+                  simp [QueryLog.countQ, QueryLog.getQ_cons, hpH_fst]
+                rw [hp_count]
+                have hlen_eq : l₀.length +
+                      (QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ()) + 1) =
+                    (l₀ ++ [mc]).length +
+                      QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ()) := by
+                  have : (l₀ ++ [mc]).length = l₀.length + 1 := by
+                    simp [List.length_append]
+                  omega
+                rw [hlen_eq]
+                exact ih v₁ (c₀.cacheQuery mc v₁) (l₀ ++ [mc])
+                  hpw₁_split hpw₂_split p_tail suffix₁ suffix₂ htail₁ htail₂
+          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
+            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) = pure (v, (c₀, l₀)) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
+            rw [hrun] at houter₁ houter₂
+            change us_w₁ ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₁
+            change us_w₂ ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₂
+            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter₁ houter₂
+            subst houter₁
+            subst houter₂
+            exact ih v c₀ l₀ hpw₁_split hpw₂_split p suffix₁ suffix₂ houter₁_eq houter₂_eq
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- One-more-step extension of `inner_prefix_det`: if the outer logs of two runs share the
+prefix `p ++ [⟨Sum.inr (), v_i⟩]` (allowing the values `v₁, v₂` at position `|p|` to differ),
+then the internal `queryLog`s coincide for one more entry than `inner_prefix_det` guarantees,
+namely up to position `l₀.length + p.countQ(· = Sum.inr ()) + 1`. The extra entry is the
+input `mc` of the next cache-miss query issued by the adversary: its value is determined by
+the adversary's state after consuming the shared prefix `p`, which is common to both runs. -/
+private theorem inner_prefix_det_one_more_inr
+    {γ : Type} (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
+    (c₀ : (M × Commit →ₒ Chal).QueryCache) (l₀ : List (M × Commit))
+    {z₁ z₂ : γ × simSt M Commit Chal}
+    {outerLog₁ outerLog₂ : QueryLog (wrappedSpec Chal)}
+    (h₁ : (z₁, outerLog₁) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run))
+    (h₂ : (z₂, outerLog₂) ∈ support
+      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+        ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
+          (c₀, l₀))).run))
+    (p : QueryLog (wrappedSpec Chal))
+    {v₁ v₂ : Chal} {rest₁ rest₂ : QueryLog (wrappedSpec Chal)}
+    (hlog₁ : outerLog₁ = p ++ (⟨Sum.inr (), v₁⟩ :: rest₁))
+    (hlog₂ : outerLog₂ = p ++ (⟨Sum.inr (), v₂⟩ :: rest₂)) :
+    z₁.2.2.take (l₀.length + p.countQ (· = Sum.inr ()) + 1) =
+      z₂.2.2.take (l₀.length + p.countQ (· = Sum.inr ()) + 1) := by
+  classical
+  induction Y using OracleComp.inductionOn generalizing
+      c₀ l₀ z₁ z₂ outerLog₁ outerLog₂ p v₁ v₂ rest₁ rest₂ with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, simulateQ_pure, WriterT.run_pure',
+        support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at h₁
+      obtain ⟨_, houter₁'⟩ := h₁
+      rw [houter₁'] at hlog₁
+      simp at hlog₁
+  | query_bind t oa ih =>
+      have hY :
+          (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+            ((liftM (query t) : OracleComp _ _) >>= oa)).run (c₀, l₀) =
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
+              (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
+        simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
+          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+      rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h₁ h₂
+      simp only [Set.mem_iUnion, support_map, Set.mem_image] at h₁ h₂
+      obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
+      obtain ⟨us_w₂, hus_w₂, pw₂, hpw₂, hz_eq₂⟩ := h₂
+      have hpw₁_split : (pw₁.1, pw₁.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w₁.1.1)).run us_w₁.1.2)).run) := by
+        change pw₁ ∈ support _
+        exact hpw₁
+      have hpw₂_split : (pw₂.1, pw₂.2) ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
+              (oa us_w₂.1.1)).run us_w₂.1.2)).run) := by
+        change pw₂ ∈ support _
+        exact hpw₂
+      have hz_eq'₁ : (pw₁.1, us_w₁.2 ++ pw₁.2) = (z₁, outerLog₁) := by
+        rw [show ((pw₁.1, us_w₁.2 ++ pw₁.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w₁.2 ++ x) pw₁ from rfl]
+        exact hz_eq₁
+      have hz_eq'₂ : (pw₂.1, us_w₂.2 ++ pw₂.2) = (z₂, outerLog₂) := by
+        rw [show ((pw₂.1, us_w₂.2 ++ pw₂.2) : _ × QueryLog (wrappedSpec Chal)) =
+              Prod.map id (fun x => us_w₂.2 ++ x) pw₂ from rfl]
+        exact hz_eq₂
+      obtain ⟨hz_eq1₁, hz_eq2₁⟩ := Prod.mk.inj hz_eq'₁
+      obtain ⟨hz_eq1₂, hz_eq2₂⟩ := Prod.mk.inj hz_eq'₂
+      have hzeq₁ : z₁ = pw₁.1 := hz_eq1₁.symm
+      have hzeq₂ : z₂ = pw₂.1 := hz_eq1₂.symm
+      subst hzeq₁
+      subst hzeq₂
+      have houter₁_eq : us_w₁.2 ++ pw₁.2 = p ++ (⟨Sum.inr (), v₁⟩ :: rest₁) :=
+        hz_eq2₁.trans hlog₁
+      have houter₂_eq : us_w₂.2 ++ pw₂.2 = p ++ (⟨Sum.inr (), v₂⟩ :: rest₂) :=
+        hz_eq2₂.trans hlog₂
+      have houter₁ : us_w₁ ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₁
+      have houter₂ : us_w₂ ∈ support
+          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+            (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₂
+      cases t with
+      | inl n =>
+          have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run
+              (c₀, l₀) =
+              (liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => pure (u, (c₀, l₀)) := by
+            simp [QueryImpl.add_apply_inl, unifFwd]
+          rw [hrun] at houter₁ houter₂
+          change us_w₁ ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₁
+          change us_w₂ ∈ support (simulateQ loggingOracle
+              ((liftM (query (spec := wrappedSpec Chal) (Sum.inl n)) : OracleComp _ _) >>=
+                fun u => (pure (u, (c₀, l₀)) : OracleComp _ _))).run at houter₂
+          rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+            (spec := wrappedSpec Chal) (Sum.inl n)
+            (fun u => pure (u, (c₀, l₀)))] at houter₁ houter₂
+          rw [support_bind] at houter₁ houter₂
+          simp only [support_map, support_query, Set.mem_univ,
+            simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+            Set.iUnion_const] at houter₁ houter₂
+          obtain ⟨_, ⟨u₁, hu₁_eq⟩, hus_w₁_in⟩ := houter₁
+          obtain ⟨_, ⟨u₂, hu₂_eq⟩, hus_w₂_in⟩ := houter₂
+          subst hu₁_eq
+          subst hu₂_eq
+          rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
+          subst hus_w₁_in
+          subst hus_w₂_in
+          cases p with
+          | nil =>
+              simp at houter₁_eq
+          | cons p_head p_tail =>
+              simp only [List.cons_append, List.cons.injEq] at houter₁_eq houter₂_eq
+              obtain ⟨hhead₁, htail₁⟩ := houter₁_eq
+              obtain ⟨hhead₂, htail₂⟩ := houter₂_eq
+              have hu_eq : u₁ = u₂ := by
+                have := hhead₁.trans hhead₂.symm
+                obtain ⟨_, hheq⟩ := Sigma.mk.inj this
+                exact eq_of_heq hheq
+              subst hu_eq
+              have hpH_fst : p_head.1 ≠ Sum.inr () := by
+                rw [← hhead₁]; intro h; cases h
+              have hp_count :
+                  QueryLog.countQ (spec := wrappedSpec Chal) (p_head :: p_tail)
+                      (· = Sum.inr ()) =
+                    QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ()) := by
+                simp [QueryLog.countQ, QueryLog.getQ_cons, hpH_fst]
+              rw [hp_count]
+              exact ih u₁ c₀ l₀ hpw₁_split hpw₂_split p_tail htail₁ htail₂
+      | inr mc =>
+          by_cases hcache : c₀ mc = none
+          · have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) =
+                (liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get,
+                StateT.run_set, hcache]
+            rw [hrun] at houter₁ houter₂
+            change us_w₁ ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter₁
+            change us_w₂ ∈ support (simulateQ loggingOracle
+                ((liftM (query (spec := wrappedSpec Chal) (Sum.inr ())) : OracleComp _ _) >>=
+                  fun v => (pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])) :
+                    OracleComp _ _))).run at houter₂
+            rw [OracleComp.run_simulateQ_loggingOracle_query_bind
+              (spec := wrappedSpec Chal) (Sum.inr ())
+              (fun v => pure (v, (c₀.cacheQuery mc v, l₀ ++ [mc])))] at houter₁ houter₂
+            rw [support_bind] at houter₁ houter₂
+            simp only [support_map, support_query, Set.mem_univ,
+              simulateQ_pure, WriterT.run_pure', support_pure, Set.image_singleton,
+              Set.iUnion_const] at houter₁ houter₂
+            obtain ⟨_, ⟨w₁, hw₁_eq⟩, hus_w₁_in⟩ := houter₁
+            obtain ⟨_, ⟨w₂, hw₂_eq⟩, hus_w₂_in⟩ := houter₂
+            subst hw₁_eq
+            subst hw₂_eq
+            rw [Set.mem_singleton_iff] at hus_w₁_in hus_w₂_in
+            subst hus_w₁_in
+            subst hus_w₂_in
+            cases p with
+            | nil =>
+                simp only [QueryLog.countQ, QueryLog.getQ_nil, List.length_nil, add_zero]
+                have h₁' : pw₁.1.2.2.take (l₀ ++ [mc]).length = l₀ ++ [mc] :=
+                  queryLog_extends_l₀ (M := M) (Commit := Commit) (Chal := Chal)
+                    (oa w₁) (c₀.cacheQuery mc w₁) (l₀ ++ [mc]) hpw₁_split
+                have h₂' : pw₂.1.2.2.take (l₀ ++ [mc]).length = l₀ ++ [mc] :=
+                  queryLog_extends_l₀ (M := M) (Commit := Commit) (Chal := Chal)
+                    (oa w₂) (c₀.cacheQuery mc w₂) (l₀ ++ [mc]) hpw₂_split
+                have hlen : (l₀ ++ [mc]).length = l₀.length + 1 := by
+                  simp [List.length_append]
+                rw [← hlen, h₁', h₂']
+            | cons p_head p_tail =>
+                simp only [List.cons_append, List.cons.injEq] at houter₁_eq houter₂_eq
+                obtain ⟨hhead₁, htail₁⟩ := houter₁_eq
+                obtain ⟨hhead₂, htail₂⟩ := houter₂_eq
+                have hw_eq : w₁ = w₂ := by
+                  have := hhead₁.trans hhead₂.symm
+                  obtain ⟨_, hheq⟩ := Sigma.mk.inj this
+                  exact eq_of_heq hheq
+                subst hw_eq
+                have hpH_fst : p_head.1 = Sum.inr () := by rw [← hhead₁]
+                have hp_count :
+                    QueryLog.countQ (spec := wrappedSpec Chal) (p_head :: p_tail)
+                        (· = Sum.inr ()) =
+                      QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ())
+                        + 1 := by
+                  simp [QueryLog.countQ, QueryLog.getQ_cons, hpH_fst]
+                rw [hp_count]
+                have hlen_eq : l₀.length +
+                      (QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ())
+                        + 1) + 1 =
+                    (l₀ ++ [mc]).length +
+                      QueryLog.countQ (spec := wrappedSpec Chal) p_tail (· = Sum.inr ())
+                        + 1 := by
+                  have : (l₀ ++ [mc]).length = l₀.length + 1 := by
+                    simp [List.length_append]
+                  omega
+                rw [hlen_eq]
+                exact ih w₁ (c₀.cacheQuery mc w₁) (l₀ ++ [mc])
+                  hpw₁_split hpw₂_split p_tail htail₁ htail₂
+          · rcases Option.ne_none_iff_exists.mp hcache with ⟨v, hv⟩
+            have hrun : ((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run
+                (c₀, l₀) = pure (v, (c₀, l₀)) := by
+              simp [QueryImpl.add_apply_inr, roImpl, StateT.run_bind, StateT.run_get, ← hv]
+            rw [hrun] at houter₁ houter₂
+            change us_w₁ ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₁
+            change us_w₂ ∈ support (simulateQ loggingOracle
+                ((pure (v, (c₀, l₀)) : OracleComp _ _) : OracleComp _ _)).run at houter₂
+            simp only [simulateQ_pure, WriterT.run_pure', support_pure] at houter₁ houter₂
+            subst houter₁
+            subst houter₂
+            exact ih v c₀ l₀ hpw₁_split hpw₂_split p houter₁_eq houter₂_eq
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Specialization of `queryLog_length_eq_outer_inr_count` to `runTrace`'s initial state
+`(∅, [])`: the trace's `queryLog` has the same length as the count of `Sum.inr ()` outer
+queries in the recorded log. -/
+lemma runTrace_queryLog_length_eq
+    [SampleableType Chal]
+    (nmaAdv : SignatureAlg.managedRoNmaAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
+    (pk : Stmt)
+    {x : Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (hx : (x, outerLog) ∈ support (replayFirstRun (runTrace σ hr M nmaAdv pk))) :
+    x.queryLog.length = outerLog.countQ (· = Sum.inr ()) := by
+  classical
+  unfold replayFirstRun runTrace at hx
+  simp only [bind_pure_comp, simulateQ_map, WriterT.run_map', support_map] at hx
+  obtain ⟨a, ha_mem, ha_eq⟩ := hx
+  have hxqueryLog : x.queryLog = a.1.2.2 := by
+    have := congrArg Prod.fst ha_eq
+    have h2 := congrArg Trace.queryLog this
+    simpa [Prod.map_apply, Trace.queryLog] using h2.symm
+  have hlog_eq : a.2 = outerLog := by
+    have := congrArg Prod.snd ha_eq
+    simpa [Prod.map_apply] using this
+  rw [hxqueryLog, ← hlog_eq]
+  have h := queryLog_length_eq_outer_inr_count (M := M) (Commit := Commit) (Chal := Chal)
+    (γ := (M × Commit × Resp) × (unifSpec + (M × Commit →ₒ Chal)).QueryCache)
+    (nmaAdv.main pk) ∅ [] (z := a.1) (outerLog := a.2) ha_mem
+  simpa using h
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Specialization of `queryLog_cache_outer_lockstep` to `runTrace`'s initial state
+`(∅, [])`: the trace's `queryLog[i]` is cached in `x.roCache`, and the cached value matches
+the outer log's `i`-th `Sum.inr ()` response. -/
+lemma runTrace_cache_outer_lockstep
+    [SampleableType Chal] [DecidableEq Chal]
+    (nmaAdv : SignatureAlg.managedRoNmaAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
+    (pk : Stmt)
+    {x : Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (hx : (x, outerLog) ∈ support (replayFirstRun (runTrace σ hr M nmaAdv pk))) :
+    ∀ i, ∀ (h_hi : i < x.queryLog.length),
+      ∃ ω, x.roCache (x.queryLog[i]'h_hi) = some ω ∧
+        QueryLog.getQueryValue? outerLog (Sum.inr ()) i = some ω := by
+  classical
+  unfold replayFirstRun runTrace at hx
+  simp only [bind_pure_comp, simulateQ_map, WriterT.run_map', support_map] at hx
+  obtain ⟨a, ha_mem, ha_eq⟩ := hx
+  have hxqueryLog : x.queryLog = a.1.2.2 := by
+    have := congrArg Prod.fst ha_eq
+    have h2 := congrArg Trace.queryLog this
+    simpa [Prod.map_apply, Trace.queryLog] using h2.symm
+  have hxroCache : x.roCache = a.1.2.1 := by
+    have := congrArg Prod.fst ha_eq
+    have h2 := congrArg Trace.roCache this
+    simpa [Prod.map_apply, Trace.roCache] using h2.symm
+  have hlog_eq : a.2 = outerLog := by
+    have := congrArg Prod.snd ha_eq
+    simpa [Prod.map_apply] using this
+  intro i h_hi
+  have h_hi' : i < a.1.2.2.length := by rw [← hxqueryLog]; exact h_hi
+  obtain ⟨_, _, hlock⟩ :=
+    queryLog_cache_outer_lockstep (M := M) (Commit := Commit) (Chal := Chal)
+      (γ := (M × Commit × Resp) × (unifSpec + (M × Commit →ₒ Chal)).QueryCache)
+      (nmaAdv.main pk) ∅ [] (z := a.1) (outerLog := a.2) ha_mem
+  obtain ⟨ω, hcache, hlog⟩ := hlock i (Nat.zero_le _) h_hi'
+  refine ⟨ω, ?_, ?_⟩
+  · rw [hxroCache]
+    have hcongr : x.queryLog[i]'h_hi = a.1.2.2[i]'h_hi' :=
+      List.getElem_of_eq hxqueryLog _
+    rw [hcongr]
+    exact hcache
+  · rw [← hlog_eq]
+    simpa using hlog
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Decoding the `verified` flag of a trace produced by `runTrace`. If the trace's
+`verified` field is `true`, then there is a cached challenge `ω` for `x.target` and the
+corresponding `σ.verify` succeeds. Used by `forkSupportInvariant_of_mem_replayFirstRun`. -/
+lemma runTrace_verified_imp_verify
+    [SampleableType Chal]
+    (nmaAdv : SignatureAlg.managedRoNmaAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
+    (pk : Stmt)
+    {x : Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)}
+    {outerLog : QueryLog (wrappedSpec Chal)}
+    (hx : (x, outerLog) ∈ support (replayFirstRun (runTrace σ hr M nmaAdv pk)))
+    (hv : x.verified = true) :
+    ∃ ω, x.roCache x.target = some ω ∧
+      σ.verify pk x.target.2 ω x.forgery.2.2 = true := by
+  classical
+  unfold replayFirstRun runTrace at hx
+  simp only [bind_pure_comp, simulateQ_map, WriterT.run_map', support_map] at hx
+  obtain ⟨a, _, ha_eq⟩ := hx
+  obtain ⟨⟨⟨forgery, advCache⟩, ⟨roCache, queryLog⟩⟩, log_a⟩ := a
+  obtain ⟨msg, c, s⟩ := forgery
+  have hxeq : x =
+      ({ forgery := (msg, c, s),
+         advCache := advCache,
+         roCache := roCache,
+         queryLog := queryLog,
+         verified :=
+           match roCache (msg, c) with
+           | some ω => σ.verify pk c ω s
+           | none => false } :
+        Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) := by
+    have := congrArg Prod.fst ha_eq
+    simpa using this.symm
+  rw [hxeq]
+  rw [hxeq] at hv
+  simp only [Trace.target] at *
+  match hcase : roCache (msg, c), hv with
+  | none, hv => simp at hv
+  | some ω, hv =>
+      refine ⟨ω, rfl, ?_⟩
+      simpa using hv
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- The `forkPoint`-based reachability invariant for `runTrace`: whenever
+`forkPoint qH x = some s`, the outer `QueryLog` of `replayFirstRun (runTrace ...)` has a
+`Sum.inr ()` query at position `↑s`. This holds because each cache miss in `runTrace`'s
+`roImpl` issues exactly one `Sum.inr ()` query and appends one entry to the trace's
+internal `queryLog`, so the trace's logical fork index `s` (an offset into
+`trace.queryLog`) always corresponds to a real outer-log query at the same position. -/
+theorem runTrace_forkPoint_CfReachable
+    [DecidableEq Chal] [SampleableType Chal] [Inhabited Chal]
+    (nmaAdv : SignatureAlg.managedRoNmaAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
+    (qH : ℕ) (pk : Stmt) :
+    CfReachable (runTrace σ hr M nmaAdv pk)
+      (fun j : ℕ ⊕ Unit => match j with | .inl _ => 0 | .inr () => qH) (Sum.inr ())
+      (forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH) := by
+  intro x log hx s hs
+  have hlen : x.queryLog.length = log.countQ (· = Sum.inr ()) :=
+    runTrace_queryLog_length_eq σ hr M nmaAdv pk hx
+  have htarget : x.queryLog[(↑s : ℕ)]? = some x.target :=
+    forkPoint_getElem?_eq_some_target (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) hs
+  have hslt : (↑s : ℕ) < x.queryLog.length := by
+    by_contra hge
+    push Not at hge
+    have hnone : x.queryLog[(↑s : ℕ)]? = none := List.getElem?_eq_none hge
+    rw [hnone] at htarget
+    exact (Option.some_ne_none x.target htarget.symm).elim
+  have hslt' : (↑s : ℕ) < (log.getQ (· = Sum.inr ())).length := by
+    change (↑s : ℕ) < log.countQ (· = Sum.inr ())
+    rw [← hlen]
+    exact hslt
+  exact QueryLog.getQueryValue?_isSome_of_lt log (Sum.inr ()) ↑s hslt'
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- **Determinism of `runTrace`'s inner `queryLog` from the outer-log prefix.** If the outer
+logs of two runs of `runTrace` share a prefix `p` followed by a `Sum.inr ()` query (whose
+response may differ across runs), then the traces' internal `queryLog`s coincide on the first
+`p.countQ (· = Sum.inr ()) + 1` entries. This is the `runTrace` specialization of
+`inner_prefix_det_one_more_inr`, rephrased at the `replayFirstRun`-visible level. -/
+lemma runTrace_queryLog_take_eq
+    [SampleableType Chal]
+    (nmaAdv : SignatureAlg.managedRoNmaAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
+    (pk : Stmt)
+    {x₁ x₂ : Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)}
+    {outerLog₁ outerLog₂ : QueryLog (wrappedSpec Chal)}
+    (h₁ : (x₁, outerLog₁) ∈ support (replayFirstRun (runTrace σ hr M nmaAdv pk)))
+    (h₂ : (x₂, outerLog₂) ∈ support (replayFirstRun (runTrace σ hr M nmaAdv pk)))
+    (p : QueryLog (wrappedSpec Chal))
+    {v₁ v₂ : Chal} {rest₁ rest₂ : QueryLog (wrappedSpec Chal)}
+    (hlog₁ : outerLog₁ = p ++ (⟨Sum.inr (), v₁⟩ :: rest₁))
+    (hlog₂ : outerLog₂ = p ++ (⟨Sum.inr (), v₂⟩ :: rest₂)) :
+    x₁.queryLog.take (p.countQ (· = Sum.inr ()) + 1) =
+      x₂.queryLog.take (p.countQ (· = Sum.inr ()) + 1) := by
+  classical
+  unfold replayFirstRun runTrace at h₁ h₂
+  simp only [bind_pure_comp, simulateQ_map, WriterT.run_map', support_map] at h₁ h₂
+  obtain ⟨a₁, ha_mem₁, ha_eq₁⟩ := h₁
+  obtain ⟨a₂, ha_mem₂, ha_eq₂⟩ := h₂
+  have hxqL₁ : x₁.queryLog = a₁.1.2.2 := by
+    have := congrArg Prod.fst ha_eq₁
+    have h3 := congrArg Trace.queryLog this
+    simpa [Prod.map_apply, Trace.queryLog] using h3.symm
+  have hxqL₂ : x₂.queryLog = a₂.1.2.2 := by
+    have := congrArg Prod.fst ha_eq₂
+    have h3 := congrArg Trace.queryLog this
+    simpa [Prod.map_apply, Trace.queryLog] using h3.symm
+  have hlog_eq₁ : a₁.2 = outerLog₁ := by
+    have := congrArg Prod.snd ha_eq₁
+    simpa [Prod.map_apply] using this
+  have hlog_eq₂ : a₂.2 = outerLog₂ := by
+    have := congrArg Prod.snd ha_eq₂
+    simpa [Prod.map_apply] using this
+  rw [hxqL₁, hxqL₂]
+  have hdet := inner_prefix_det_one_more_inr (M := M) (Commit := Commit) (Chal := Chal)
+    (γ := (M × Commit × Resp) × (unifSpec + (M × Commit →ₒ Chal)).QueryCache)
+    (nmaAdv.main pk) ∅ []
+    (z₁ := a₁.1) (z₂ := a₂.1)
+    (outerLog₁ := a₁.2) (outerLog₂ := a₂.2)
+    ha_mem₁ ha_mem₂ p (v₁ := v₁) (v₂ := v₂)
+    (rest₁ := rest₁) (rest₂ := rest₂)
+    (hlog_eq₁.trans hlog₁) (hlog_eq₂.trans hlog₂)
+  simpa using hdet
+
+end Coupling
+
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Managed-RO replay-fork convenience theorem at a fixed public key, stated at the
 `OracleComp (unifSpec + (Unit →ₒ Chal))` level.
@@ -242,7 +1517,15 @@ Since it relies on a value-level log-prefix invariant across `replayRunWithTrace
 correspondence between the adversary's internal `queryLog` and the outer `QueryLog`, it is
 extracted through the caller-provided `P_out` transfer predicate: the caller may choose `P_out`
 so that `P_out x log` pins `x.target` to a deterministic function of `(log, cf x)`, and then
-derive target-equality from the distinct-answer disagreement on the outer log. -/
+derive target-equality from the distinct-answer disagreement on the outer log.
+
+**On the `hreach` hypothesis.** `CfReachable` ensures that whenever `forkPoint` selects an
+index `s` for a trace `x`, the outer `QueryLog` actually has an `i = Sum.inr ()` query at
+position `↑s`. For the FiatShamir setting this follows from the correspondence between the
+trace's internal `queryLog : List (M × Commit)` and the outer `QueryLog` of `Sum.inr ()`
+queries: each cache miss in `roImpl` appends to both simultaneously, so a logical index `s`
+into the trace's list corresponds to the same physical position in the outer log. Callers
+discharge `hreach` by establishing this correspondence at the level of `runTrace`. -/
 theorem replayForkingBound
     [DecidableEq M] [DecidableEq Commit]
     [DecidableEq Chal] [SampleableType Chal] [Fintype Chal] [Inhabited Chal]
@@ -253,7 +1536,10 @@ theorem replayForkingBound
       QueryLog (unifSpec + (Unit →ₒ Chal)) → Prop)
     (hP : ∀ {x log},
       (x, log) ∈ support (replayFirstRun (runTrace σ hr M nmaAdv pk)) →
-      P_out x log) :
+      P_out x log)
+    (hreach : CfReachable (runTrace σ hr M nmaAdv pk)
+      (fun j : ℕ ⊕ Unit => match j with | .inl _ => 0 | .inr () => qH) (Sum.inr ())
+      (forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH)) :
     let wrappedMain := runTrace σ hr M nmaAdv pk
     let cf := forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH
     let qb : ℕ ⊕ Unit → ℕ := fun j => match j with | .inl _ => 0 | .inr () => qH
@@ -306,7 +1592,7 @@ theorem replayForkingBound
               Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) =>
               r.isSome | forkReplay wrappedMain qb (Sum.inr ()) cf] := by
         have hbound := le_probEvent_isSome_forkReplay
-          (main := wrappedMain) (qb := qb) (i := Sum.inr ()) (cf := cf)
+          (main := wrappedMain) (qb := qb) (i := Sum.inr ()) (cf := cf) hreach
         simp only at hbound
         rw [hH_inv] at hbound
         exact hbound

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -1416,7 +1416,7 @@ omit [SampleableType Stmt] [SampleableType Wit] in
 internal `queryLog`, so the trace's logical fork index `s` (an offset into
 `trace.queryLog`) always corresponds to a real outer-log query at the same position. -/
 theorem runTrace_forkPoint_CfReachable
-    [DecidableEq Chal] [SampleableType Chal] [Inhabited Chal]
+    [DecidableEq Chal] [SampleableType Chal]
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qH : ℕ) (pk : Stmt) :

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -799,16 +799,14 @@ private theorem target_eq_of_mem_forkReplay
     push Not at hge
     rw [List.getElem?_eq_none hge] at htgt₂
     exact (Option.some_ne_none _ htgt₂.symm).elim
-  have hgetElem₁ : (x₁.queryLog.take ((↑s : ℕ) + 1))[(↑s : ℕ)]? = x₁.queryLog[(↑s : ℕ)]? := by
-    rw [List.getElem?_take]
-    split_ifs with h; · rfl
-    · exact absurd (Nat.lt_succ_self _) h
-  have hgetElem₂ : (x₂.queryLog.take ((↑s : ℕ) + 1))[(↑s : ℕ)]? = x₂.queryLog[(↑s : ℕ)]? := by
+  have hgetElem_take :
+      ∀ l : List (M × Commit),
+        (l.take ((↑s : ℕ) + 1))[(↑s : ℕ)]? = l[(↑s : ℕ)]? := fun l => by
     rw [List.getElem?_take]
     split_ifs with h; · rfl
     · exact absurd (Nat.lt_succ_self _) h
   have : some x₁.target = some x₂.target := by
-    rw [← htgt₁, ← htgt₂, ← hgetElem₁, ← hgetElem₂, htakeEq]
+    rw [← htgt₁, ← htgt₂, ← hgetElem_take x₁.queryLog, ← hgetElem_take x₂.queryLog, htakeEq]
   exact Option.some.inj this
 
 /-- **Per-pk extraction bound.** Given the structural forking event on `pk` (two fork

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -811,6 +811,7 @@ private theorem target_eq_of_mem_forkReplay
     rw [← htgt₁, ← htgt₂, ← hgetElem₁, ← hgetElem₂, htakeEq]
   exact Option.some.inj this
 
+omit [SampleableType Stmt] in
 /-- **Per-pk extraction bound.** Given the structural forking event on `pk` (two fork
 runs selecting the same index, with distinct counted-oracle responses, both satisfying
 `forkSupportInvariant`), the NMA reduction recovers a valid witness with probability at
@@ -958,6 +959,7 @@ private theorem perPk_extraction_bound
 
 end eufNmaHelpers
 
+omit [SampleableType Stmt] in
 /-- **NMA-to-extraction via the forking lemma and special soundness.**
 
 For any managed-RO NMA adversary `B` making at most `qH` random-oracle queries, there

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -561,51 +561,255 @@ private noncomputable def eufNmaReduction
   simulateQ (QueryImpl.ofLift unifSpec ProbComp +
     (uniformSampleImpl (spec := (Unit →ₒ Chal)))) (eufNmaForkExtract σ hr M nmaAdv qH pk)
 
-omit [Fintype Chal] in
+omit [SampleableType Stmt] [SampleableType Wit] [Inhabited Chal] [Fintype Chal] in
 /-- **Support invariant of the replay-fork first run.**
 
 Every `(x, log)` in the support of `replayFirstRun (Fork.runTrace σ hr M nmaAdv pk)`
 satisfies the per-run invariant `forkSupportInvariant`: at a valid fork point, the cached
-RO challenge matches the outer log entry and the forgery verifies.
-
-TODO(p6-support-invariant): prove by induction on `Fork.runTrace` — each counted-oracle
-query updates `roCache` and the external log in lockstep, so their corresponding entries
-match, and `verified` guarantees `σ.verify pk` succeeds at the cached challenge. -/
+RO challenge matches the outer log entry and the forgery verifies. -/
 private theorem forkSupportInvariant_of_mem_replayFirstRun
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qH : ℕ) (pk : Stmt)
     {x : Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)}
     {log : QueryLog (unifSpec + (Unit →ₒ Chal))}
-    (_h : (x, log) ∈ support (replayFirstRun (Fork.runTrace σ hr M nmaAdv pk))) :
+    (h : (x, log) ∈ support (replayFirstRun (Fork.runTrace σ hr M nmaAdv pk))) :
     forkSupportInvariant σ M qH pk x log := by
-  sorry
+  classical
+  intro s hs
+  have htarget : x.queryLog[(↑s : ℕ)]? = some x.target :=
+    Fork.forkPoint_getElem?_eq_some_target (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) hs
+  have hverified : x.verified = true :=
+    Fork.forkPoint_some_imp_verified (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) hs
+  have hslt : (↑s : ℕ) < x.queryLog.length := by
+    by_contra hge
+    push Not at hge
+    have hnone : x.queryLog[(↑s : ℕ)]? = none := List.getElem?_eq_none hge
+    rw [hnone] at htarget
+    exact (Option.some_ne_none x.target htarget.symm).elim
+  obtain ⟨ω, hcache_idx, hlog⟩ :=
+    Fork.runTrace_cache_outer_lockstep σ hr M nmaAdv pk h (↑s : ℕ) hslt
+  have htgt_eq : x.queryLog[(↑s : ℕ)]'hslt = x.target := by
+    have h1 : x.queryLog[(↑s : ℕ)]? = some (x.queryLog[(↑s : ℕ)]'hslt) :=
+      List.getElem?_eq_getElem hslt
+    rw [h1] at htarget
+    exact Option.some.inj htarget
+  rw [htgt_eq] at hcache_idx
+  obtain ⟨ω', hcache', hverify⟩ :=
+    Fork.runTrace_verified_imp_verify σ hr M nmaAdv pk h hverified
+  have hωeq : ω = ω' := by
+    rw [hcache_idx] at hcache'
+    exact Option.some.inj hcache'
+  refine ⟨ω, hlog, hcache_idx, ?_⟩
+  rw [hωeq]
+  exact hverify
 
-omit [Fintype Chal] in
+omit [SampleableType Stmt] [SampleableType Wit] in
 /-- **Target equality across two successful fork runs** sharing the same fork index.
 
 If both runs of `forkReplay (Fork.runTrace σ hr M nmaAdv pk)` select fork point `s`,
-their forgery targets agree, because the two runs share all counted-oracle responses
-strictly before `s` and the `Fork.runTrace` invariant forces `queryLog[n]` to be
-determined by the first `n` counted-oracle responses.
-
-TODO(p6-target-equality): derive from `forkReplay_success_log_props` together with the
-`Fork.runTrace` determinism invariant. -/
+their forgery targets agree. The two runs share all counted-oracle responses strictly
+before the fork index, and the replay-determinism lemma `Fork.runTrace_queryLog_take_eq`
+then forces their internal `queryLog`s to coincide on the first `s + 1` entries, so
+`forkPoint_getElem?_eq_some_target` pins both targets to the same value. -/
 private theorem target_eq_of_mem_forkReplay
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qH : ℕ) (pk : Stmt)
     (x₁ x₂ : Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal))
     (s : Fin (qH + 1))
-    (_hsup : some (x₁, x₂) ∈ support (forkReplay (Fork.runTrace σ hr M nmaAdv pk)
+    (hsup : some (x₁, x₂) ∈ support (forkReplay (Fork.runTrace σ hr M nmaAdv pk)
       (nmaForkBudget qH) (Sum.inr ())
       (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH)))
-    (_h₁ : Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)
+    (h₁ : Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)
       qH x₁ = some s)
-    (_h₂ : Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)
+    (h₂ : Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)
       qH x₂ = some s) :
     x₁.target = x₂.target := by
-  sorry
+  classical
+  -- Unpack the replay-fork success structure.
+  obtain ⟨log₁, log₂, s', hx₁, hx₂, hcf₁, hcf₂, _hneq, replacement, st, hz, hlog₂, _hmismatch,
+    hfork, _hprefix⟩ := forkReplay_success_log_props
+      (main := Fork.runTrace σ hr M nmaAdv pk)
+      (qb := nmaForkBudget qH) (i := Sum.inr ())
+      (cf := Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH)
+      hsup
+  -- `s = s'` via `hcf₁` and `h₁`.
+  have hs_eq : s' = s := by rw [hcf₁] at h₁; exact Option.some.inj h₁
+  cases hs_eq
+  -- Abbreviations for readability.
+  set main : OracleComp (Fork.wrappedSpec Chal)
+      (Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) :=
+    Fork.runTrace σ hr M nmaAdv pk with hmain
+  -- Immutable replay parameters.
+  have htrace_eq : st.trace = log₁ :=
+    replayRunWithTraceValue_trace_eq
+      (main := main) (i := Sum.inr ())
+      (trace := log₁) (forkQuery := (↑s : ℕ)) (replacement := replacement) hz
+  have hforkq : st.forkQuery = (↑s : ℕ) :=
+    replayRunWithTraceValue_forkQuery_eq
+      (main := main) (i := Sum.inr ())
+      (trace := log₁) (forkQuery := (↑s : ℕ)) (replacement := replacement) hz
+  -- Key facts about `st.cursor`.
+  obtain ⟨hcur_pos, htrace_in, hobs_in⟩ :=
+    replayRunWithTraceValue_forkConsumed_imp_last_input
+      (main := main) (i := Sum.inr ())
+      (trace := log₁) (forkQuery := (↑s : ℕ)) (replacement := replacement) hz hfork
+  change 0 < st.cursor at hcur_pos
+  change QueryLog.inputAt? st.trace (st.cursor - 1) = some (Sum.inr ()) at htrace_in
+  change QueryLog.inputAt? st.observed (st.cursor - 1) = some (Sum.inr ()) at hobs_in
+  rw [htrace_eq] at htrace_in
+  rw [hlog₂] at hobs_in
+  have hInv := replayRunWithTraceValue_preservesPrefixInvariant
+    (main := main) (i := Sum.inr ())
+    (trace := log₁) (forkQuery := (↑s : ℕ)) (replacement := replacement) hz
+  have hcur_trace : st.cursor ≤ log₁.length := by rw [← htrace_eq]; exact hInv.1
+  have hcur_obs : st.cursor ≤ log₂.length := by rw [← hlog₂]; exact hInv.2.1
+  have hc1_lt_t : st.cursor - 1 < log₁.length := by omega
+  have hc1_lt_o : st.cursor - 1 < log₂.length := by omega
+  -- Count identity: `(log₂.take (c-1)).getQ (· = Sum.inr ()).length = s`.
+  have hcount_obs :=
+    replayRunWithTraceValue_forkConsumed_imp_prefix_count
+      (main := main) (i := Sum.inr ())
+      (trace := log₁) (forkQuery := (↑s : ℕ)) (replacement := replacement) hz hfork
+  change (QueryLog.getQ (st.observed.take (st.cursor - 1))
+    (· = Sum.inr ())).length = st.forkQuery at hcount_obs
+  rw [hforkq, hlog₂] at hcount_obs
+  -- Value-level prefix equality `log₁.take (c-1) = log₂.take (c-1)`.
+  have htake_len₁ : (log₁.take (st.cursor - 1)).length = st.cursor - 1 :=
+    List.length_take_of_le (by omega)
+  have htake_len₂ : (log₂.take (st.cursor - 1)).length = st.cursor - 1 :=
+    List.length_take_of_le (by omega)
+  have hprefix_val : log₁.take (st.cursor - 1) = log₂.take (st.cursor - 1) := by
+    apply List.ext_getElem?
+    intro n
+    by_cases hn : n < st.cursor - 1
+    · have hgetEq : st.observed[n]? = st.trace[n]? :=
+        replayRunWithTraceValue_prefix_getElem?_eq
+          (main := main) (i := Sum.inr ())
+          (trace := log₁) (forkQuery := (↑s : ℕ)) (replacement := replacement) hz
+          (n := n) (by rw [if_pos hfork]; exact hn)
+      rw [hlog₂, htrace_eq] at hgetEq
+      have hn_t : n < log₁.length := by omega
+      have hn_o : n < log₂.length := by omega
+      have hlen₁ : n < (log₁.take (st.cursor - 1)).length := by rw [htake_len₁]; exact hn
+      have hlen₂ : n < (log₂.take (st.cursor - 1)).length := by rw [htake_len₂]; exact hn
+      rw [List.getElem?_eq_getElem hlen₁, List.getElem?_eq_getElem hlen₂,
+        List.getElem_take, List.getElem_take,
+        ← List.getElem?_eq_getElem hn_t, ← List.getElem?_eq_getElem hn_o]
+      exact hgetEq.symm
+    · push Not at hn
+      have hlen₁ : (log₁.take (st.cursor - 1)).length ≤ n := by rw [htake_len₁]; exact hn
+      have hlen₂ : (log₂.take (st.cursor - 1)).length ≤ n := by rw [htake_len₂]; exact hn
+      rw [List.getElem?_eq_none hlen₁, List.getElem?_eq_none hlen₂]
+  -- Extract the distinguished entries at position `c-1` as `⟨Sum.inr (), v_i⟩`.
+  have hget₁ : log₁[st.cursor - 1]? = some (log₁[st.cursor - 1]'hc1_lt_t) :=
+    List.getElem?_eq_getElem hc1_lt_t
+  have hget₂ : log₂[st.cursor - 1]? = some (log₂[st.cursor - 1]'hc1_lt_o) :=
+    List.getElem?_eq_getElem hc1_lt_o
+  have hfst₁ : (log₁[st.cursor - 1]'hc1_lt_t).1 = Sum.inr () := by
+    have := htrace_in
+    unfold QueryLog.inputAt? at this
+    rw [hget₁] at this
+    simpa using this
+  have hfst₂ : (log₂[st.cursor - 1]'hc1_lt_o).1 = Sum.inr () := by
+    have := hobs_in
+    unfold QueryLog.inputAt? at this
+    rw [hget₂] at this
+    simpa using this
+  -- Destructure `log_i[c-1]` as `⟨Sum.inr (), v_i⟩` for some `v_i : Chal`.
+  obtain ⟨v₁, hv₁⟩ : ∃ v : Chal, log₁[st.cursor - 1]'hc1_lt_t =
+      (⟨Sum.inr (), v⟩ : (i : ℕ ⊕ Unit) × (Fork.wrappedSpec Chal).Range i) := by
+    rcases hsig : log₁[st.cursor - 1]'hc1_lt_t with ⟨i, v⟩
+    rw [hsig] at hfst₁
+    cases i with
+    | inl n => cases hfst₁
+    | inr u => cases u; exact ⟨v, rfl⟩
+  obtain ⟨v₂, hv₂⟩ : ∃ v : Chal, log₂[st.cursor - 1]'hc1_lt_o =
+      (⟨Sum.inr (), v⟩ : (i : ℕ ⊕ Unit) × (Fork.wrappedSpec Chal).Range i) := by
+    rcases hsig : log₂[st.cursor - 1]'hc1_lt_o with ⟨i, v⟩
+    rw [hsig] at hfst₂
+    cases i with
+    | inl n => cases hfst₂
+    | inr u => cases u; exact ⟨v, rfl⟩
+  -- `c - 1 + 1 = c` using `0 < c`.
+  have hcsub : st.cursor - 1 + 1 = st.cursor := by omega
+  -- Decompose `log_i = log_i.take (c-1) ++ ⟨Sum.inr (), v_i⟩ :: log_i.drop c`.
+  have hdec₁ : log₁ = log₁.take (st.cursor - 1) ++
+      ((⟨Sum.inr (), v₁⟩ : (i : ℕ ⊕ Unit) × (Fork.wrappedSpec Chal).Range i) ::
+        log₁.drop st.cursor) := by
+    have hdrop :
+        log₁.drop (st.cursor - 1) =
+          (log₁[st.cursor - 1]'hc1_lt_t) :: log₁.drop (st.cursor - 1 + 1) :=
+      List.drop_eq_getElem_cons hc1_lt_t
+    rw [hcsub] at hdrop
+    rw [hv₁] at hdrop
+    calc log₁ = log₁.take (st.cursor - 1) ++ log₁.drop (st.cursor - 1) :=
+        (List.take_append_drop _ _).symm
+      _ = log₁.take (st.cursor - 1) ++
+          ((⟨Sum.inr (), v₁⟩ : (i : ℕ ⊕ Unit) × (Fork.wrappedSpec Chal).Range i) ::
+            log₁.drop st.cursor) := by rw [hdrop]
+  have hdec₂ : log₂ = log₁.take (st.cursor - 1) ++
+      ((⟨Sum.inr (), v₂⟩ : (i : ℕ ⊕ Unit) × (Fork.wrappedSpec Chal).Range i) ::
+        log₂.drop st.cursor) := by
+    have hdrop :
+        log₂.drop (st.cursor - 1) =
+          (log₂[st.cursor - 1]'hc1_lt_o) :: log₂.drop (st.cursor - 1 + 1) :=
+      List.drop_eq_getElem_cons hc1_lt_o
+    rw [hcsub] at hdrop
+    rw [hv₂] at hdrop
+    calc log₂ = log₂.take (st.cursor - 1) ++ log₂.drop (st.cursor - 1) :=
+        (List.take_append_drop _ _).symm
+      _ = log₁.take (st.cursor - 1) ++ log₂.drop (st.cursor - 1) := by rw [hprefix_val]
+      _ = log₁.take (st.cursor - 1) ++
+          ((⟨Sum.inr (), v₂⟩ : (i : ℕ ⊕ Unit) × (Fork.wrappedSpec Chal).Range i) ::
+            log₂.drop st.cursor) := by rw [hdrop]
+  -- Count: the common prefix `p = log₁.take (c-1)` has exactly `s` `Sum.inr ()` entries.
+  have hpref_count :
+      QueryLog.countQ (log₁.take (st.cursor - 1)) (· = Sum.inr ()) = (↑s : ℕ) := by
+    unfold QueryLog.countQ
+    rw [hprefix_val]
+    exact hcount_obs
+  -- Apply `runTrace_queryLog_take_eq` to get `x₁.queryLog.take (s+1) = x₂.queryLog.take (s+1)`.
+  have htakeEq :
+      x₁.queryLog.take (QueryLog.countQ (log₁.take (st.cursor - 1)) (· = Sum.inr ()) + 1) =
+        x₂.queryLog.take
+          (QueryLog.countQ (log₁.take (st.cursor - 1)) (· = Sum.inr ()) + 1) :=
+    Fork.runTrace_queryLog_take_eq σ hr M (Resp := Resp) nmaAdv pk
+      (x₁ := x₁) (x₂ := x₂) (outerLog₁ := log₁) (outerLog₂ := log₂) hx₁ hx₂
+      (p := log₁.take (st.cursor - 1)) (v₁ := v₁) (v₂ := v₂)
+      (rest₁ := log₁.drop st.cursor) (rest₂ := log₂.drop st.cursor) hdec₁ hdec₂
+  rw [hpref_count] at htakeEq
+  -- Both sides yield `x_i.queryLog[s]? = some x_i.target`; thus targets agree.
+  have htgt₁ : x₁.queryLog[(↑s : ℕ)]? = some x₁.target :=
+    Fork.forkPoint_getElem?_eq_some_target (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) h₁
+  have htgt₂ : x₂.queryLog[(↑s : ℕ)]? = some x₂.target :=
+    Fork.forkPoint_getElem?_eq_some_target (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) h₂
+  have hs_lt₁ : (↑s : ℕ) < x₁.queryLog.length := by
+    by_contra hge
+    push Not at hge
+    rw [List.getElem?_eq_none hge] at htgt₁
+    exact (Option.some_ne_none _ htgt₁.symm).elim
+  have hs_lt₂ : (↑s : ℕ) < x₂.queryLog.length := by
+    by_contra hge
+    push Not at hge
+    rw [List.getElem?_eq_none hge] at htgt₂
+    exact (Option.some_ne_none _ htgt₂.symm).elim
+  have hgetElem₁ : (x₁.queryLog.take ((↑s : ℕ) + 1))[(↑s : ℕ)]? = x₁.queryLog[(↑s : ℕ)]? := by
+    rw [List.getElem?_take]
+    split_ifs with h; · rfl
+    · exact absurd (Nat.lt_succ_self _) h
+  have hgetElem₂ : (x₂.queryLog.take ((↑s : ℕ) + 1))[(↑s : ℕ)]? = x₂.queryLog[(↑s : ℕ)]? := by
+    rw [List.getElem?_take]
+    split_ifs with h; · rfl
+    · exact absurd (Nat.lt_succ_self _) h
+  have : some x₁.target = some x₂.target := by
+    rw [← htgt₁, ← htgt₂, ← hgetElem₁, ← hgetElem₂, htakeEq]
+  exact Option.some.inj this
 
 /-- **Per-pk extraction bound.** Given the structural forking event on `pk` (two fork
 runs selecting the same index, with distinct counted-oracle responses, both satisfying
@@ -856,6 +1060,8 @@ theorem euf_nma_bound
     Fork.replayForkingBound (σ := σ) (hr := hr) (M := M) nmaAdv qH pk
       (P_out := forkSupportInvariant σ M qH pk)
       (hP := fun h => forkSupportInvariant_of_mem_replayFirstRun σ hr M nmaAdv qH pk h)
+      (hreach := Fork.runTrace_forkPoint_CfReachable
+        (σ := σ) (hr := hr) (M := M) nmaAdv qH pk)
   -- ── Step (d): compose (c) with `perPk_extraction_bound`, then integrate over keygen
   -- via `jensen_keygen_forking_bound`.
   have hPerPkFinal : ∀ pk : Stmt,

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -606,7 +606,7 @@ private theorem forkSupportInvariant_of_mem_replayFirstRun
   rw [hωeq]
   exact hverify
 
-omit [SampleableType Stmt] [SampleableType Wit] in
+omit [SampleableType Stmt] [SampleableType Wit] [Fintype Chal] [Inhabited Chal] in
 /-- **Target equality across two successful fork runs** sharing the same fork index.
 
 If both runs of `forkReplay (Fork.runTrace σ hr M nmaAdv pk)` select fork point `s`,
@@ -809,6 +809,7 @@ private theorem target_eq_of_mem_forkReplay
     rw [← htgt₁, ← htgt₂, ← hgetElem_take x₁.queryLog, ← hgetElem_take x₂.queryLog, htakeEq]
   exact Option.some.inj this
 
+omit [SampleableType Stmt] in
 /-- **Per-pk extraction bound.** Given the structural forking event on `pk` (two fork
 runs selecting the same index, with distinct counted-oracle responses, both satisfying
 `forkSupportInvariant`), the NMA reduction recovers a valid witness with probability at
@@ -956,6 +957,7 @@ private theorem perPk_extraction_bound
 
 end eufNmaHelpers
 
+omit [SampleableType Stmt] in
 /-- **NMA-to-extraction via the forking lemma and special soundness.**
 
 For any managed-RO NMA adversary `B` making at most `qH` random-oracle queries, there
@@ -982,7 +984,11 @@ This matches Firsov-Janku's `schnorr_koa_secure` at
 with the single-run postcondition `verify` plus the extractor correctness lemma
 `extractor_corr` at [fsec/proof/Schnorr.ec:87](../../../fsec/proof/Schnorr.ec). Our version
 uses `Fork.replayForkingBound` for the RO-level packaging and `_hss` for special
-soundness, with `σ.extract` playing the role of EC's `extractor`. -/
+soundness, with `σ.extract` playing the role of EC's `extractor`.
+
+**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`**
+(ReplayFork.lean): the Jensen/Cauchy-Schwarz step that powers `Fork.replayForkingBound`
+is still a `sorry`, so this theorem is not yet unconditionally proved end-to-end. -/
 theorem euf_nma_bound
     [DecidableEq M] [DecidableEq Commit]
     [SampleableType Chal]
@@ -1095,7 +1101,13 @@ The combined bound is:
       ≤ Pr[extraction succeeds]`
 
 where `ε = Adv^{EUF-CMA}(A)`. The ENNReal subtraction truncates at zero, so
-the bound is trivially satisfied when the simulation loss exceeds the advantage. -/
+the bound is trivially satisfied when the simulation loss exceeds the advantage.
+
+**Currently conditional on two open obligations**:
+1. `euf_cma_to_nma` (this file, still `sorry`): CMA-to-NMA reduction via HVZK simulator.
+2. `sq_probOutput_main_le_noGuardReplayComp` (ReplayFork.lean, still `sorry`):
+   Jensen/Cauchy-Schwarz step inside `Fork.replayForkingBound`, transitively inherited
+   from `euf_nma_bound`. -/
 theorem euf_cma_bound
     [SampleableType Chal]
     (hss : σ.SpeciallySound)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -986,9 +986,10 @@ with the single-run postcondition `verify` plus the extractor correctness lemma
 uses `Fork.replayForkingBound` for the RO-level packaging and `_hss` for special
 soundness, with `σ.extract` playing the role of EC's `extractor`.
 
-**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`**
-(ReplayFork.lean): the Jensen/Cauchy-Schwarz step that powers `Fork.replayForkingBound`
-is still a `sorry`, so this theorem is not yet unconditionally proved end-to-end. -/
+**Currently conditional on the two B1 prefix-faithfulness `sorry`s**
+(`evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt` and
+`tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt` in ReplayFork.lean),
+which feed the Jensen/Cauchy-Schwarz step that powers `Fork.replayForkingBound`. -/
 theorem euf_nma_bound
     [DecidableEq M] [DecidableEq Commit]
     [SampleableType Chal]
@@ -1105,8 +1106,10 @@ the bound is trivially satisfied when the simulation loss exceeds the advantage.
 
 **Currently conditional on two open obligations**:
 1. `euf_cma_to_nma` (this file, still `sorry`): CMA-to-NMA reduction via HVZK simulator.
-2. `sq_probOutput_main_le_noGuardReplayComp` (ReplayFork.lean, still `sorry`):
-   Jensen/Cauchy-Schwarz step inside `Fork.replayForkingBound`, transitively inherited
+2. The two B1 prefix-faithfulness `sorry`s in ReplayFork.lean
+   (`evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt` and
+   `tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt`), which feed the
+   Jensen/Cauchy-Schwarz step inside `Fork.replayForkingBound`; transitively inherited
    from `euf_nma_bound`. -/
 theorem euf_cma_bound
     [SampleableType Chal]

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -642,7 +642,7 @@ private theorem target_eq_of_mem_forkReplay
   -- Abbreviations for readability.
   set main : OracleComp (Fork.wrappedSpec Chal)
       (Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) :=
-    Fork.runTrace σ hr M nmaAdv pk with hmain
+    Fork.runTrace σ hr M nmaAdv pk
   -- Immutable replay parameters.
   have htrace_eq : st.trace = log₁ :=
     replayRunWithTraceValue_trace_eq
@@ -915,12 +915,12 @@ private theorem perPk_extraction_bound
   -- Targets coincide by the shared-prefix property of `forkReplay`.
   have htarget : x₁.target = x₂.target :=
     target_eq_of_mem_forkReplay σ hr M nmaAdv qH pk x₁ x₂ s (hreq ▸ hsupp) hcf₁ hcf₂
-  set m₁ := x₁.forgery.1 with hm₁_def
-  set c₁ := x₁.forgery.2.1 with hc₁_def
-  set sr₁ := x₁.forgery.2.2 with hsr₁_def
-  set m₂ := x₂.forgery.1 with hm₂_def
-  set c₂ := x₂.forgery.2.1 with hc₂_def
-  set sr₂ := x₂.forgery.2.2 with hsr₂_def
+  set m₁ := x₁.forgery.1
+  set c₁ := x₁.forgery.2.1
+  set sr₁ := x₁.forgery.2.2
+  set m₂ := x₂.forgery.1
+  set c₂ := x₂.forgery.2.1
+  set sr₂ := x₂.forgery.2.2
   have htgt₁ : x₁.target = (m₁, c₁) := rfl
   have htgt₂ : x₂.target = (m₂, c₂) := rfl
   have htarget_eq : (m₁, c₁) = (m₂, c₂) := by rw [← htgt₁, ← htgt₂]; exact htarget

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -268,6 +268,35 @@ lemma getQueryValue?_takeBeforeForkAt_self [spec.DecidableEq]
     exact h
   rw [hnone]
 
+/-- If `log` has at most `s` entries of type `i`, then truncating `log` at position `s`
+leaves it unchanged: there is no `s`-th `i`-entry to truncate before. -/
+lemma takeBeforeForkAt_of_getQ_length_le [spec.DecidableEq]
+    (log : QueryLog spec) (i : ι) (s : ℕ)
+    (h : (log.getQ (· = i)).length ≤ s) :
+    takeBeforeForkAt log i s = log := by
+  induction log generalizing s with
+  | nil => simp
+  | cons entry tl ih =>
+      obtain ⟨t, u⟩ := entry
+      by_cases ht : t = i
+      · subst ht
+        cases s with
+        | zero =>
+            simp only [QueryLog.getQ_cons, ↓reduceIte, List.length_cons, Nat.le_zero] at h
+            omega
+        | succ s =>
+            rw [takeBeforeForkAt_cons_self_succ]
+            have h' : (QueryLog.getQ tl (· = t)).length ≤ s := by
+              simp only [QueryLog.getQ_cons, ↓reduceIte, List.length_cons] at h
+              omega
+            rw [ih s h']
+      · rw [takeBeforeForkAt_cons_of_ne _ _ _ _ _ ht]
+        have h' : (QueryLog.getQ tl (· = i)).length ≤ s := by
+          simp only [QueryLog.getQ_cons] at h
+          rw [if_neg ht] at h
+          exact h
+        rw [ih s h']
+
 end QueryLog
 
 namespace OracleComp

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -1464,23 +1464,73 @@ variable [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
 variable [∀ i, SampleableType (spec.Range i)] [unifSpec ⊂ₒ spec]
 variable [OracleSpec.LawfulSubSpec unifSpec spec]
 
-/-- Replay does not increase the total number of oracle queries. This is the runtime-control
-placeholder needed before the full quantitative replay forking argument.
+omit [spec.Fintype] [spec.Inhabited] [∀ i, SampleableType (spec.Range i)]
+    [unifSpec ⊂ₒ spec] [OracleSpec.LawfulSubSpec unifSpec spec] in
+/-- Each step of `replayOracle` makes at most one oracle query. Either the oracle returns
+pure (matched-consumption or fork substitution), or it invokes `liftM (query t)` exactly
+once (live post-fork, mismatch, missing-entry, or mismatched-type fallback). -/
+private lemma replayOracle_step_isTotalQueryBound
+    (i : ι) (t : ι) (st : ReplayForkState spec i) :
+    IsTotalQueryBound (((replayOracle (spec := spec) i) t).run st) 1 := by
+  classical
+  -- 1-query block: `liftM (query t) >>= (fun u => pure (u, upd u))`.
+  have hquery : ∀ (upd : spec.Range t → ReplayForkState spec i),
+      IsTotalQueryBound (liftM (query (spec := spec) t) >>= fun u =>
+        (pure (u, upd u) : OracleComp spec (spec.Range t × ReplayForkState spec i))) 1 := by
+    intro upd
+    rw [isTotalQueryBound_query_bind_iff]
+    exact ⟨Nat.one_pos, fun _ => trivial⟩
+  unfold replayOracle
+  simp only [StateT.run_bind, StateT.run_get, pure_bind]
+  by_cases hlive : st.forkConsumed || st.mismatch
+  · -- Live branch: 1 query.
+    simp only [hlive, ↓reduceIte, bind_pure_comp, StateT.run_bind, StateT.run_monadLift,
+      monadLift_eq_self, StateT.run_map, StateT.run_set, map_pure, Functor.map_map]
+    exact hquery (fun u => st.noteObserved t u)
+  · simp only [hlive, Bool.false_eq_true, ↓reduceIte, bind_pure_comp, dite_eq_ite]
+    cases hnext : st.nextEntry? with
+    | none =>
+        simp only [StateT.run_bind, StateT.run_monadLift, monadLift_eq_self,
+          bind_pure_comp, StateT.run_map, StateT.run_set, map_pure, Functor.map_map]
+        exact hquery (fun u => (st.markMismatch).noteObserved t u)
+    | some entry =>
+        rcases entry with ⟨t', u'⟩
+        by_cases hsame : t = t'
+        · cases hsame
+          by_cases hti : t = i
+          · cases hti
+            by_cases hfork : st.distinguishedCount = st.forkQuery
+            · -- Fork substitution: 0 queries.
+              simp only [↓reduceDIte, hfork, ↓reduceIte, StateT.run_map, StateT.run_set,
+                map_pure]
+              exact trivial
+            · simp only [↓reduceDIte, hfork, ↓reduceIte, StateT.run_map, StateT.run_set,
+                map_pure]
+              exact trivial
+          · simp only [↓reduceDIte, hti, StateT.run_map, StateT.run_set, map_pure]
+            exact trivial
+        · -- Mismatched type: 1 query.
+          simp only [↓reduceDIte, hsame, StateT.run_bind, StateT.run_monadLift,
+            monadLift_eq_self, bind_pure_comp, StateT.run_map, StateT.run_set, map_pure,
+            Functor.map_map]
+          exact hquery (fun u => (st.markMismatch).noteObserved t u)
 
-This runtime bound is off the critical path for the quantitative forking bound and has no direct
-counterpart in Firsov-Janku's `fsec`. It is deferred until downstream users actually need an
-expected-cost or pathwise bound on replay forks.
+omit [spec.Fintype] [spec.Inhabited] [∀ i, SampleableType (spec.Range i)]
+    [unifSpec ⊂ₒ spec] [OracleSpec.LawfulSubSpec unifSpec spec] in
+/-- Replay does not increase the total number of oracle queries. If `main` makes at most
+`n` queries, then `replayRunWithTraceValue main i trace forkQuery replacement` also makes
+at most `n` queries.
 
-Proof plan (deferred): each step of `replayOracle` performs at most one oracle query. In
-the live/mismatch branch and the non-matching-type fallback it does exactly one live query
-(`liftM (query t)`); in the matched-consumption and fork-substitution branches it does
-zero. Reduce to `IsTotalQueryBound.simulateQ_run_of_step` with the per-step 1-bound. -/
+Reduces to `IsTotalQueryBound.simulateQ_run_of_step` with
+`replayOracle_step_isTotalQueryBound` supplying the per-step bound of `1`. -/
 theorem isTotalQueryBound_replayRunWithTraceValue
     (main : OracleComp spec α) (n : ℕ)
     (hmain : IsTotalQueryBound main n)
     (i : ι) (trace : QueryLog spec) (forkQuery : Nat) (replacement : spec.Range i) :
     IsTotalQueryBound (replayRunWithTraceValue main i trace forkQuery replacement) n := by
-  sorry
+  unfold replayRunWithTraceValue
+  exact IsTotalQueryBound.simulateQ_run_of_step (impl := replayOracle i) hmain
+    (fun t s => replayOracle_step_isTotalQueryBound i t s) _
 
 omit [spec.Fintype] [spec.Inhabited] [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- If `forkReplay` succeeds, both runs agree on the selected fork index. -/

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -494,6 +494,97 @@ lemma forkReplayWithTraceValue_eq_none_of_cf_none
     forkReplayWithTraceValue main qb i cf first u = pure none := by
   simp [forkReplayWithTraceValue, h]
 
+/-!
+### Live-mode α-marginal
+
+Once the replay oracle has transitioned into "live mode" (either `forkConsumed = true`
+after the fork fired, or `mismatch = true` after a trace mismatch or exhaustion), every
+subsequent query simply falls through to the ambient `query t` and records the answer in
+`observed`. In particular, the α-component of the simulated computation coincides with
+`main` itself: the state only records observations and does not influence the output.
+
+These lemmas are used in the B1 faithfulness proofs (`evalDist_uniform_bind_fst_replay
+RunWithTraceValue_takeBeforeForkAt` and `tsum_probOutput_replayFirstRun_weight_take
+BeforeForkAt`): after the fork point on either side (full log vs. truncated log), both
+computations enter live mode, and the α-marginal collapses to `evalDist main`.
+-/
+
+/-- Live mode is preserved by `noteObserved`: neither `forkConsumed` nor `mismatch` is
+touched by recording an observation. -/
+lemma ReplayForkState.noteObserved_live_iff {i : ι}
+    (st : ReplayForkState spec i) (t : ι) (u : spec.Range t) :
+    (st.noteObserved t u).forkConsumed = st.forkConsumed ∧
+      (st.noteObserved t u).mismatch = st.mismatch := by
+  simp [ReplayForkState.noteObserved]
+
+/-- **Live-mode α-marginal.** Starting from a replay state in live mode
+(`forkConsumed = true` or `mismatch = true`), the α-component of running the replay
+oracle on `main` equals `main` itself. The state only accumulates observations; it has
+no effect on the α-distribution. -/
+lemma fst_map_simulateQ_replayOracle_of_live [spec.DecidableEq]
+    (i : ι) (main : OracleComp spec α) :
+    ∀ (st : ReplayForkState spec i),
+      (st.forkConsumed = true ∨ st.mismatch = true) →
+      (Prod.fst <$> (simulateQ (replayOracle i) main).run st :
+        OracleComp spec α) = main := by
+  induction main using OracleComp.inductionOn with
+  | pure x => intro st _; simp
+  | query_bind t oa ih =>
+    intro st hst
+    have hlive : (st.forkConsumed || st.mismatch) = true := by
+      rcases hst with h | h <;> simp [h]
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.cont_query,
+      OracleQuery.input_query, id_map, StateT.run_bind]
+    -- Unfold the oracle at `t` using the live branch.
+    have hstep : (replayOracle (spec := spec) i t).run st =
+        (do
+          let u : spec.Range t ← monadLift (query t : OracleComp spec (spec.Range t))
+          pure (u, st.noteObserved t u)) := by
+      unfold replayOracle
+      simp only [StateT.run_bind, StateT.run_get, pure_bind, hlive, if_true,
+        bind_pure_comp, StateT.run_monadLift, monadLift_eq_self, StateT.run_map,
+        StateT.run_set, map_pure]
+      rfl
+    rw [hstep]
+    simp only [bind_pure_comp, map_bind, monadLift_eq_self, bind_map_left]
+    -- `Prod.fst <$> (do u ← query t; let st' := noteObserved; (simulateQ ...).run st')`
+    --   = `do u ← query t; Prod.fst <$> (simulateQ ...).run (noteObserved st u)`
+    -- By IH applied to `noteObserved st u` (still in live mode), the inner
+    -- `Prod.fst <$> ...` equals `oa u`.
+    have hst' : ∀ u : spec.Range t,
+        (st.noteObserved t u).forkConsumed = true ∨
+          (st.noteObserved t u).mismatch = true := by
+      intro u
+      rcases hst with h | h
+      · left; simpa [ReplayForkState.noteObserved] using h
+      · right; simpa [ReplayForkState.noteObserved] using h
+    calc (Prod.fst <$> (do
+            let u : spec.Range t ← monadLift (query t : OracleComp spec (spec.Range t))
+            (simulateQ (replayOracle i) (oa u)).run (st.noteObserved t u))
+            : OracleComp spec α)
+        = (do
+            let u : spec.Range t ← monadLift (query t : OracleComp spec (spec.Range t))
+            Prod.fst <$> (simulateQ (replayOracle i) (oa u)).run
+              (st.noteObserved t u)) := by
+          simp [map_bind]
+      _ = (do
+            let u : spec.Range t ← monadLift (query t : OracleComp spec (spec.Range t))
+            oa u) := by
+          refine bind_congr fun u => ?_
+          exact ih u (st.noteObserved t u) (hst' u)
+      _ = (liftM (query t) >>= fun u => oa u : OracleComp spec α) := rfl
+
+/-- α-marginal form of `fst_map_simulateQ_replayOracle_of_live`, specialized to the
+`evalDist` level. Once in live mode, the α-output distribution of the replay run is
+`evalDist main`. -/
+lemma evalDist_fst_map_simulateQ_replayOracle_of_live [spec.DecidableEq]
+    [spec.Fintype] [spec.Inhabited]
+    (i : ι) (main : OracleComp spec α) (st : ReplayForkState spec i)
+    (hst : st.forkConsumed = true ∨ st.mismatch = true) :
+    evalDist (Prod.fst <$> (simulateQ (replayOracle i) main).run st :
+      OracleComp spec α) = evalDist main := by
+  rw [fst_map_simulateQ_replayOracle_of_live i main st hst]
+
 section support
 
 /-- Prefix-style replay invariant: the consumed prefix of `observed` matches the consumed prefix of

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -2062,21 +2062,58 @@ private lemma probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeFork
   rw [hcomm₁, hcomm₂]
   exact congrFun (congrArg DFunLike.coe h) x
 
+/-- **Weighted replay prefix-faithfulness (second key distributional claim for B1).**
+
+Averaging the first-run output `p = (x₁, log)` with any `h`-weight depending only on
+the truncated log `QueryLog.takeBeforeForkAt log i s`, the indicator that the
+first-run output satisfies `f x₁ = y` may be replaced with the replay-marginal
+probability that the *second run* satisfies `f x₂ = y`, without changing the total.
+
+This is the replay analogue of `tsum_probOutput_generateSeed_weight_takeAtIndex`:
+a joint-distribution identity stating that, conditional on the truncated log, the
+first- and second-run outputs are exchangeable with identical marginals given by the
+replay computation `replayRunWithTraceValue main i (takeBeforeForkAt ..) s u` on a
+fresh uniform `u`.
+
+Proof sketch (deferred): induction on `main`, jointly tracking the logging oracle
+(that feeds `replayFirstRun`) and the replay-with-truncated-log oracle on the RHS.
+At each query step, both sides consume the matching log entry or fall through to a
+live sample in synchronized fashion; at the `(s+1)`-th `i`-query, both sides go
+live, delivering the same conditional marginal. -/
+private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
+    {β : Type} (main : OracleComp spec α) (i : ι) (s : ℕ)
+    (f : α → β) (y : β) (h : QueryLog spec → ℝ≥0∞) :
+    ∑' p, Pr[= p | replayFirstRun main] *
+      (h (QueryLog.takeBeforeForkAt p.2 i s) *
+        Pr[= y | (f <$> (pure p.1 : OracleComp spec α) : OracleComp spec β)]) =
+    ∑' p, Pr[= p | replayFirstRun main] *
+      (h (QueryLog.takeBeforeForkAt p.2 i s) *
+        Pr[= y | f <$> Prod.fst <$> (do
+          let u ← liftComp ($ᵗ spec.Range i) spec
+          replayRunWithTraceValue main i
+            (QueryLog.takeBeforeForkAt p.2 i s) s u :
+              OracleComp spec (α × _))]) := by
+  sorry
+
 /-- Replay-side Jensen / Cauchy-Schwarz step. Squaring the probability that the first
 run satisfies `cf x₁ = some s` is bounded by the joint probability that *both* the
 first run and the second (substituted) run satisfy `cf · = some s`.
 
-This is the replay analogue of `sq_probOutput_main_le_noGuardComp`. The proof reduces
-to two replay-specific ingredients:
+This is the replay analogue of `sq_probOutput_main_le_noGuardComp`. The proof has the
+same structure as the seeded version, relying on two replay-specific distributional
+identities:
 
-* Pointwise prefix-faithfulness
+* **Pointwise prefix-faithfulness**
   (`evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt`): the
   second-run output distribution, averaged over `u`, depends on the log only through
   its prefix `takeBeforeForkAt log i s`.
-* A Jensen / change-of-variable step over the `τ`-marginal that derives
-  `(Pr[cf main = s])² ≤ Pr[z | noGuardReplayComp]` from the pointwise faithfulness.
+* **Weighted prefix-faithfulness**
+  (`tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt`): averaging the
+  first-run output `p` with an `h`-weight depending on the truncated log, the
+  indicator `[cf x₁ = y]` may be replaced by the replay marginal with the same
+  truncated log.
 
-Given these, the identification with `noGuardReplayComp` is straightforward. -/
+With these, the Cauchy-Schwarz chain runs exactly as in the seeded case. -/
 private lemma sq_probOutput_main_le_noGuardReplayComp
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
@@ -2084,7 +2121,166 @@ private lemma sq_probOutput_main_le_noGuardReplayComp
       Pr[= (some (some s, some s) : Option
             (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1)))) |
           noGuardReplayComp main qb i cf s] := by
-  sorry
+  classical
+  set y : Option (Fin (qb i + 1)) := some s with hy_def
+  set z : Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1))) := some (y, y) with hz_def
+  -- Shorthand for the replay-marginal probability as a function of a log prefix.
+  let Q : QueryLog spec → ℝ≥0∞ := fun τ =>
+    Pr[= y | cf <$> Prod.fst <$> (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      replayRunWithTraceValue main i τ ↑s u : OracleComp spec (α × _))]
+  -- Shorthand for the indicator-as-probOutput and the first-run marginal.
+  let I : α → ℝ≥0∞ := fun x =>
+    Pr[= y | (cf <$> (pure x : OracleComp spec α) :
+      OracleComp spec (Option (Fin (qb i + 1))))]
+  let w : α × QueryLog spec → ℝ≥0∞ := fun p => Pr[= p | replayFirstRun main]
+  have hw_le_one : ∑' p, w p ≤ 1 := tsum_probOutput_le_one
+  -- `hMain`: expand `Pr[= y | cf <$> main]` as an expectation over `p`.
+  have hMain : (Pr[= y | cf <$> main] : ℝ≥0∞) = ∑' p, w p * I p.1 := by
+    have h1 : (cf <$> main : OracleComp spec (Option (Fin (qb i + 1)))) =
+        (fun p : α × QueryLog spec => cf p.1) <$> replayFirstRun main := by
+      conv_lhs => rw [show main = Prod.fst <$> replayFirstRun main from
+        (fst_map_replayFirstRun main).symm]
+      simp only [Functor.map_map]
+    rw [h1, probOutput_map_eq_tsum]
+    refine tsum_congr fun p => ?_
+    simp only [w, I, map_pure]
+  -- `hMainTake`: the same expectation with `Q(trunc_p)` instead of the indicator.
+  have hMainTake : (Pr[= y | cf <$> main] : ℝ≥0∞) =
+      ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) := by
+    have hB1h := tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
+      (main := main) (i := i) (s := (↑s : ℕ)) (f := cf) (y := y) (h := fun _ => (1 : ℝ≥0∞))
+    simp only [one_mul] at hB1h
+    calc (Pr[= y | cf <$> main] : ℝ≥0∞)
+        = ∑' p, w p * I p.1 := hMain
+      _ = ∑' p, Pr[= p | replayFirstRun main] *
+            Pr[= y | (cf <$> (pure p.1 : OracleComp spec α) :
+              OracleComp spec (Option (Fin (qb i + 1))))] := by
+              refine tsum_congr fun p => ?_; rfl
+      _ = ∑' p, Pr[= p | replayFirstRun main] *
+            Pr[= y | cf <$> Prod.fst <$> (do
+              let u ← liftComp ($ᵗ spec.Range i) spec
+              replayRunWithTraceValue main i
+                (QueryLog.takeBeforeForkAt p.2 i ↑s) ↑s u :
+                  OracleComp spec (α × _))] := hB1h
+      _ = ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) := by
+              refine tsum_congr fun p => ?_; rfl
+  -- `hEq`: the two expansions of `Pr[= y | cf <$> main]` coincide.
+  have hEq : ∑' p, w p * I p.1 =
+      ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) := hMain.symm.trans hMainTake
+  -- `hJensen`: Cauchy-Schwarz with weights `w`.
+  have hJensen :
+      (∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s)) ^ 2 ≤
+      ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) ^ 2 :=
+    ENNReal.sq_tsum_le_tsum_sq w (fun p => Q (QueryLog.takeBeforeForkAt p.2 i ↑s)) hw_le_one
+  -- `hEq2`: `E[Q²] = E[Q * I]` via weighted faithfulness with `h = Q`.
+  have hEq2 :
+      ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) ^ 2 =
+      ∑' p, w p * (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) * I p.1) := by
+    have hB1h := tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
+      (main := main) (i := i) (s := (↑s : ℕ)) (f := cf) (y := y) (h := Q)
+    -- `hB1h`: ∑ w p * (Q(trunc) * I p.1) = ∑ w p * (Q(trunc) * Q(trunc))
+    -- So `hB1h.symm`: ∑ w p * (Q(trunc) * Q(trunc)) = ∑ w p * (Q(trunc) * I p.1).
+    -- Rewrite `Q(trunc)^2 = Q(trunc) * Q(trunc)` to match, then apply hB1h.symm.
+    have hsq_eq : ∀ p : α × QueryLog spec,
+        w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) ^ 2 =
+        Pr[= p | replayFirstRun main] *
+          (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) *
+            Pr[= y | cf <$> Prod.fst <$> (do
+              let u ← liftComp ($ᵗ spec.Range i) spec
+              replayRunWithTraceValue main i
+                (QueryLog.takeBeforeForkAt p.2 i ↑s) ↑s u :
+                  OracleComp spec (α × _))]) := fun p => by
+      simp only [sq, w, Q]
+    calc ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) ^ 2
+        = ∑' p, Pr[= p | replayFirstRun main] *
+            (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) *
+              Pr[= y | cf <$> Prod.fst <$> (do
+                let u ← liftComp ($ᵗ spec.Range i) spec
+                replayRunWithTraceValue main i
+                  (QueryLog.takeBeforeForkAt p.2 i ↑s) ↑s u :
+                    OracleComp spec (α × _))]) := by
+            refine tsum_congr fun p => ?_; exact hsq_eq p
+      _ = ∑' p, Pr[= p | replayFirstRun main] *
+            (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) *
+              Pr[= y | (cf <$> (pure p.1 : OracleComp spec α) :
+                OracleComp spec (Option (Fin (qb i + 1))))]) := hB1h.symm
+      _ = ∑' p, w p * (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) * I p.1) := by
+            refine tsum_congr fun p => ?_; rfl
+  -- `hFactor`: expand `Pr[= z | noGuardReplayComp]` as `E[I p.1 * Q(p.2)]`.
+  have hFactor : Pr[= z | noGuardReplayComp main qb i cf s] =
+      ∑' p, w p * (I p.1 * Q p.2) := by
+    simp only [noGuardReplayComp, z, hz_def, y]
+    rw [probOutput_bind_eq_tsum]
+    refine tsum_congr fun p => ?_
+    -- Show: Pr[= some (some s, some s) | (do u; q; return some (cf p.1, cf q.1))]
+    --       = I p.1 * Q p.2
+    congr 1
+    -- Rewrite the inner computation.
+    have hinner :
+        (do
+          let u ← liftComp ($ᵗ spec.Range i) spec
+          let q ← replayRunWithTraceValue main i p.2 ↑s u
+          return some (cf p.1, cf q.1) :
+            OracleComp spec (Option (Option (Fin (qb i + 1)) ×
+              Option (Fin (qb i + 1))))) =
+        some <$> ((cf p.1, ·) <$> (cf <$> Prod.fst <$> (do
+          let u ← liftComp ($ᵗ spec.Range i) spec
+          replayRunWithTraceValue main i p.2 ↑s u))) := by
+      simp [map_eq_bind_pure_comp, Function.comp]
+    rw [hinner, probOutput_some_map_some, probOutput_prod_mk_snd_map]
+    -- Goal: (if (some s, some s).1 = cf p.1 then Pr[= (some s, some s).2 | ...] else 0)
+    --       = I p.1 * Q p.2
+    change (if (some s, some s).1 = cf p.1 then
+        Pr[= (some s, some s).2 | (cf <$> Prod.fst <$> (do
+          let u ← liftComp ($ᵗ spec.Range i) spec
+          replayRunWithTraceValue main i p.2 ↑s u) :
+            OracleComp spec (Option (Fin (qb i + 1))))] else 0) =
+      I p.1 * Q p.2
+    classical
+    by_cases hp : cf p.1 = y
+    · have h_eq : y = cf p.1 := hp.symm
+      rw [if_pos h_eq]
+      have hI : I p.1 = 1 := by
+        simp only [I, map_pure, probOutput_pure]
+        rw [if_pos hp.symm]
+      rw [hI, one_mul]
+    · have h_ne : y ≠ cf p.1 := fun h => hp h.symm
+      rw [if_neg h_ne]
+      have hI : I p.1 = 0 := by
+        simp only [I, map_pure, probOutput_pure]
+        rw [if_neg (fun h => hp h.symm)]
+      rw [hI, zero_mul]
+  -- `hFactorTrunc`: use B1a to replace `Q p.2` by `Q (trunc p.2)`.
+  have hFactorTrunc : Pr[= z | noGuardReplayComp main qb i cf s] =
+      ∑' p, w p * (I p.1 * Q (QueryLog.takeBeforeForkAt p.2 i ↑s)) := by
+    rw [hFactor]
+    refine tsum_congr fun p => ?_
+    congr 1
+    congr 1
+    -- `Q p.2 = Q (trunc p.2)` by B1a (probOutput form, composed with cf).
+    simp only [Q]
+    have hB1a := probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
+      (main := main) (i := i) (log := p.2) (s := (↑s : ℕ))
+    rw [probOutput_map_eq_tsum, probOutput_map_eq_tsum]
+    refine tsum_congr fun a => ?_
+    rw [hB1a]
+  -- Chain the inequalities.
+  have hfinal : (Pr[= y | cf <$> main] : ℝ≥0∞) ^ 2 ≤
+      Pr[= z | noGuardReplayComp main qb i cf s] := by
+    calc (Pr[= y | cf <$> main] : ℝ≥0∞) ^ 2
+        = (∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s)) ^ 2 := by rw [hMainTake]
+      _ ≤ ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) ^ 2 := hJensen
+      _ = ∑' p, w p * (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) * I p.1) := hEq2
+      _ = ∑' p, w p * (I p.1 * Q (QueryLog.takeBeforeForkAt p.2 i ↑s)) := by
+            refine tsum_congr fun p => ?_
+            ring
+      _ = Pr[= z | noGuardReplayComp main qb i cf s] := hFactorTrunc.symm
+  change (Pr[= s | cf <$> main] : ℝ≥0∞) ^ 2 ≤ Pr[= z | noGuardReplayComp main qb i cf s]
+  have : (Pr[= s | cf <$> main] : ℝ≥0∞) = Pr[= y | cf <$> main] := by
+    simp [y]
+  rw [this]
+  exact hfinal
 
 omit [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- Structural replay inequality: the no-guard composition's joint success event is

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -1998,41 +1998,85 @@ private lemma probOutput_collisionReplay_le_main_div
           ↑(Fintype.card (spec.Range i)) := by
             rw [div_eq_mul_inv]
 
+/-- **Replay-side prefix-faithfulness (key distributional claim for B1).**
+
+Averaging the uniform substitution `u`, the second run's output distribution depends on
+the trace `log` only through its prefix `QueryLog.takeBeforeForkAt log i s`.
+
+Operationally: the replay oracle consumes `log` entry by entry until the fork fires at
+the `s`-th `i`-query (substituting `u`), after which it goes live. If we truncate `log`
+to `QueryLog.takeBeforeForkAt log i s` (which has at most `s` `i`-entries), the replay
+instead hits `nextEntry? = none` at the fork position and falls through to a live
+sample, which is uniform, just like averaging over `u`.
+
+This lemma encodes that operational equivalence as a distributional equality. It is
+the replay analogue of `evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue`.
+
+Proof sketch (deferred): induction on `main`, tracking the replay-oracle state, case
+splitting on whether the current query's index matches `i`, is a non-fork consumer,
+or is the fork query. The pre-fork portion matches the prefix so both sides trace the
+same path; at the fork, both sides produce a uniform sample (substituted `u` on the
+left, live on the right). Post-fork, both sides are fully live. -/
+private lemma evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
+    [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
+    (main : OracleComp spec α) (i : ι) (log : QueryLog spec) (s : ℕ) :
+    evalDist (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      Prod.fst <$> replayRunWithTraceValue main i log s u : OracleComp spec α) =
+    evalDist (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      Prod.fst <$> replayRunWithTraceValue main i (QueryLog.takeBeforeForkAt log i s) s u) := by
+  sorry
+
+/-- Probability form of the prefix-faithfulness claim: averaging over `u`, the probability
+that the second run produces any fixed output `x` depends on the trace only through its
+prefix `QueryLog.takeBeforeForkAt log i s`.
+
+This is the direct consequence of
+`evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt`, restated at the
+`probOutput` level for convenient use in tsum manipulations. -/
+private lemma probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
+    (main : OracleComp spec α) (i : ι) (log : QueryLog spec) (s : ℕ) (x : α) :
+    Pr[= x | Prod.fst <$> (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      replayRunWithTraceValue main i log s u : OracleComp spec (α × _))] =
+    Pr[= x | Prod.fst <$> (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      replayRunWithTraceValue main i (QueryLog.takeBeforeForkAt log i s) s u)] := by
+  have h := evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
+    main i log s
+  have hcomm₁ : (Prod.fst <$> (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      replayRunWithTraceValue main i log s u) : OracleComp spec α) =
+      (do let u ← liftComp ($ᵗ spec.Range i) spec
+          Prod.fst <$> replayRunWithTraceValue main i log s u) := by
+    simp only [map_bind]
+  have hcomm₂ : (Prod.fst <$> (do
+      let u ← liftComp ($ᵗ spec.Range i) spec
+      replayRunWithTraceValue main i (QueryLog.takeBeforeForkAt log i s) s u) :
+        OracleComp spec α) =
+      (do let u ← liftComp ($ᵗ spec.Range i) spec
+          Prod.fst <$> replayRunWithTraceValue main i
+            (QueryLog.takeBeforeForkAt log i s) s u) := by
+    simp only [map_bind]
+  rw [hcomm₁, hcomm₂]
+  exact congrFun (congrArg DFunLike.coe h) x
+
 /-- Replay-side Jensen / Cauchy-Schwarz step. Squaring the probability that the first
 run satisfies `cf x₁ = some s` is bounded by the joint probability that *both* the
 first run and the second (substituted) run satisfy `cf · = some s`.
 
-This is the replay analogue of `sq_probOutput_main_le_noGuardComp` for the seeded fork.
-The seeded version factors `noGuardComp`'s success probability as
-`∑_seed P(seed) · P(cf x₁ = s | seed) · P(cf x₂ = s | seed.takeAtIndex i s)` and applies
-ENNReal Cauchy-Schwarz `(∑ w·a)² ≤ (∑ w) · (∑ w·a²) ≤ ∑ w·a²` (since ∑ w ≤ 1) after
-showing the cross term equals `Pr[cf <$> main = s]²` via a `takeAtIndex` rewrite.
+This is the replay analogue of `sq_probOutput_main_le_noGuardComp`. The proof reduces
+to two replay-specific ingredients:
 
-The seeded factorization relies on two structural lemmas about `generateSeed` /
-`takeAtIndex`:
+* Pointwise prefix-faithfulness
+  (`evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt`): the
+  second-run output distribution, averaged over `u`, depends on the log only through
+  its prefix `takeBeforeForkAt log i s`.
+* A Jensen / change-of-variable step over the `τ`-marginal that derives
+  `(Pr[cf main = s])² ≤ Pr[z | noGuardReplayComp]` from the pointwise faithfulness.
 
-* `evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue`: averaging the
-  appended value `u` makes a truncated-then-extended seed equivalent to the truncated
-  seed alone.
-* `tsum_probOutput_generateSeed_weight_takeAtIndex`: weighting by an arbitrary
-  function of the truncated seed, the full-seed and truncated-seed simulations have
-  the same distribution.
-
-**Replay-side gap.** The replay analogue requires the same conceptual decomposition
-but operates on `replayFirstRun main` (a logged run) instead of `generateSeed`. It
-needs:
-
-* A truncation operator `QueryLog.takeBeforeForkAt log i s` returning the prefix of
-  `log` up to (but not including) the `s`-th `i`-query.
-* A "run-from-prefix" operator that runs `main` against the prefix replay trace
-  followed by live oracle answers, and a lemma relating it to `replayRunWithTraceValue`
-  averaged over the substituted `u`.
-* A weighted averaging lemma analogous to
-  `tsum_probOutput_generateSeed_weight_takeAtIndex` saying that averaging
-  `Pr[= log | replayFirstRun main]` against any function of the truncated log equals
-  averaging the same function against the truncated-log distribution.
-
-These ingredients are deferred. -/
+Given these, the identification with `noGuardReplayComp` is straightforward. -/
 private lemma sq_probOutput_main_le_noGuardReplayComp
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -1469,7 +1469,12 @@ placeholder needed before the full quantitative replay forking argument.
 
 This runtime bound is off the critical path for the quantitative forking bound and has no direct
 counterpart in Firsov-Janku's `fsec`. It is deferred until downstream users actually need an
-expected-cost or pathwise bound on replay forks. -/
+expected-cost or pathwise bound on replay forks.
+
+Proof plan (deferred): each step of `replayOracle` performs at most one oracle query. In
+the live/mismatch branch and the non-matching-type fallback it does exactly one live query
+(`liftM (query t)`); in the matched-consumption and fork-substitution branches it does
+zero. Reduce to `IsTotalQueryBound.simulateQ_run_of_step` with the per-step 1-bound. -/
 theorem isTotalQueryBound_replayRunWithTraceValue
     (main : OracleComp spec α) (n : ℕ)
     (hmain : IsTotalQueryBound main n)

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -88,6 +88,65 @@ lemma getQueryValue?_eq_some_of_getQ_getElem? [spec.DecidableEq]
   rw [h]
   simp
 
+/-- Every entry of `log.getQ (· = t)` has its first component equal to `t`. -/
+lemma getQ_eq_mem [spec.DecidableEq] (log : QueryLog spec) (t : ι)
+    {entry : (t' : ι) × spec.Range t'} (h : entry ∈ log.getQ (· = t)) :
+    entry.1 = t := by
+  induction log with
+  | nil => simp [QueryLog.getQ] at h
+  | cons hd tl ih =>
+      simp only [QueryLog.getQ_cons] at h
+      by_cases hh : hd.1 = t
+      · simp only [hh, ↓reduceIte, List.mem_cons] at h
+        rcases h with rfl | h
+        · exact hh
+        · exact ih h
+      · simp only [hh, ↓reduceIte] at h
+        exact ih h
+
+/-- If the `t`-filtered log has at least `n + 1` entries, then `getQueryValue? log t n`
+is `some _`. -/
+lemma getQueryValue?_isSome_of_lt [spec.DecidableEq] (log : QueryLog spec) (t : ι) (n : Nat)
+    (h : n < (log.getQ (· = t)).length) :
+    (getQueryValue? log t n).isSome := by
+  unfold getQueryValue?
+  have hopt : (log.getQ (· = t))[n]? = some ((log.getQ (· = t))[n]'h) :=
+    List.getElem?_eq_getElem h
+  have hentry := List.getElem_mem h (l := log.getQ (· = t))
+  have ht' : ((log.getQ (· = t))[n]'h).1 = t := getQ_eq_mem log t hentry
+  rw [hopt]
+  set entry := (log.getQ (· = t))[n]'h with hentry_def
+  obtain ⟨t', u'⟩ := entry
+  simp only at ht'
+  subst ht'
+  simp
+
+/-- Prepending an entry whose oracle index does not match `t` leaves the `t`-indexed
+view of the log unchanged. -/
+lemma getQueryValue?_cons_of_ne [spec.DecidableEq]
+    (entry : (t' : ι) × spec.Range t') (log : QueryLog spec) (t : ι) (n : Nat)
+    (h : entry.1 ≠ t) :
+    getQueryValue? (entry :: log) t n = getQueryValue? log t n := by
+  unfold getQueryValue?
+  rw [QueryLog.getQ_cons]
+  simp [h]
+
+/-- The first entry of `getQueryValue? (⟨t, u⟩ :: log) t 0` is the prepended value. -/
+lemma getQueryValue?_cons_self_zero [spec.DecidableEq]
+    (t : ι) (u : spec.Range t) (log : QueryLog spec) :
+    getQueryValue? (⟨t, u⟩ :: log) t 0 = some u := by
+  apply getQueryValue?_eq_some_of_getQ_getElem?
+  rw [QueryLog.getQ_cons]
+  simp
+
+/-- Prepending a matching `⟨t, _⟩` entry shifts later `t`-indexed lookups by one. -/
+lemma getQueryValue?_cons_self_succ [spec.DecidableEq]
+    (t : ι) (u : spec.Range t) (log : QueryLog spec) (n : Nat) :
+    getQueryValue? (⟨t, u⟩ :: log) t (n + 1) = getQueryValue? log t n := by
+  unfold getQueryValue?
+  rw [QueryLog.getQ_cons]
+  simp
+
 end QueryLog
 
 namespace OracleComp
@@ -289,27 +348,50 @@ section support
 
 /-- Prefix-style replay invariant: the consumed prefix of `observed` matches the consumed prefix of
 `trace` at the level of query inputs, and if the fork has not fired yet then `observed` has no
-extra suffix beyond that prefix. -/
-def ReplayPrefixInvariant (i : ι) (st : ReplayForkState spec i) : Prop :=
+extra suffix beyond that prefix.
+
+The `values` clause additionally pins down values on the non-fork positions: for every position
+`n` strictly before the fork (or every position `< cursor` when the fork has not yet fired),
+`observed[n]? = trace[n]?`, i.e., both the input oracle and the stored response agree. At the
+fork position itself the value in `observed` is the replacement, so only the input agrees.
+
+The `distinguishedCount_eq` and `fork_position` clauses pin down the position of the fork entry
+in the filtered `i`-log: while pre-fork with no mismatch, `distinguishedCount` counts the number
+of `i`-type entries in `observed`; once the fork has fired, the entry at position `cursor - 1`
+in `observed` is exactly the `forkQuery`-th (0-indexed) `i`-type entry, i.e., the prefix
+`observed.take (cursor - 1)` contains exactly `forkQuery` entries of type `i`. -/
+def ReplayPrefixInvariant [spec.DecidableEq] (i : ι) (st : ReplayForkState spec i) : Prop :=
   st.cursor ≤ st.trace.length ∧
   st.cursor ≤ st.observed.length ∧
   (∀ n, n < st.cursor →
     QueryLog.inputAt? st.observed n = QueryLog.inputAt? st.trace n) ∧
   (st.forkConsumed = false → st.mismatch = false → st.observed.length = st.cursor) ∧
   (st.forkConsumed = true →
-    0 < st.cursor ∧ QueryLog.inputAt? st.trace (st.cursor - 1) = some i)
+    0 < st.cursor ∧ QueryLog.inputAt? st.trace (st.cursor - 1) = some i) ∧
+  (∀ n, n < (if st.forkConsumed then st.cursor - 1 else st.cursor) →
+    st.observed[n]? = st.trace[n]?) ∧
+  (st.forkConsumed = false → st.mismatch = false →
+    st.distinguishedCount = (st.observed.getQ (· = i)).length) ∧
+  (st.forkConsumed = true →
+    (QueryLog.getQ (st.observed.take (st.cursor - 1)) (· = i)).length = st.forkQuery)
 
 namespace ReplayPrefixInvariant
 
-variable {i : ι}
+variable [spec.DecidableEq] {i : ι}
 
 lemma init (trace : QueryLog spec) (forkQuery : Nat) (replacement : spec.Range i) :
     ReplayPrefixInvariant i (ReplayForkState.init trace forkQuery replacement) := by
-  refine ⟨by simp [ReplayForkState.init], by simp [ReplayForkState.init], ?_, ?_, ?_⟩
+  refine ⟨by simp [ReplayForkState.init], by simp [ReplayForkState.init], ?_, ?_, ?_, ?_, ?_, ?_⟩
   · intro n hn
     exact (Nat.not_lt_zero n hn).elim
   · intro hfork hmismatch
     simp [ReplayForkState.init]
+  · intro hfork
+    simp [ReplayForkState.init] at hfork
+  · intro n hn
+    simp [ReplayForkState.init] at hn
+  · intro _ _
+    simp [ReplayForkState.init, QueryLog.getQ]
   · intro hfork
     simp [ReplayForkState.init] at hfork
 
@@ -321,7 +403,7 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
     (hInv : ReplayPrefixInvariant i st)
     (hz : z ∈ support ((replayOracle i t).run st)) :
     ReplayPrefixInvariant i z.2 := by
-  rcases hInv with ⟨hcursorTrace, hcursorObs, hprefix, hlen, hforked⟩
+  rcases hInv with ⟨hcursorTrace, hcursorObs, hprefix, hlen, hforked, hvalues, hdcount, hforkpos⟩
   unfold replayOracle at hz
   simp only [StateT.run_bind, StateT.run_get, pure_bind] at hz
   by_cases hlive : st.forkConsumed || st.mismatch
@@ -330,7 +412,7 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
       support_liftM, OracleQuery.input_query, OracleQuery.cont_query, Set.range_id,
       Set.image_univ, Set.mem_range] at hz
     rcases hz with ⟨u, hu, rfl⟩
-    refine ⟨?_, ?_, ?_, ?_, ?_⟩
+    refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
     · exact hcursorTrace
     · exact Nat.le_trans hcursorObs <|
         by simp [ReplayForkState.noteObserved, QueryLog.logQuery, QueryLog.singleton]
@@ -352,6 +434,34 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
       simp [hfc', hm'] at hlive
     · intro hfc
       simpa [ReplayForkState.noteObserved] using hforked hfc
+    · intro n hn
+      have hn' : n < (if st.forkConsumed then st.cursor - 1 else st.cursor) := by
+        simpa [ReplayForkState.noteObserved] using hn
+      have hn_cur : n < st.cursor := by
+        split_ifs at hn' with hfc
+        · exact Nat.lt_of_lt_of_le hn' (Nat.sub_le _ _)
+        · exact hn'
+      have hnobs : n < st.observed.length := Nat.lt_of_lt_of_le hn_cur hcursorObs
+      change (st.observed.logQuery t u)[n]? = st.trace[n]?
+      rw [QueryLog.logQuery, QueryLog.singleton, List.getElem?_append_left hnobs]
+      exact hvalues n hn'
+    · intro hfc hm
+      exfalso
+      have hfc' : st.forkConsumed = false := by
+        simpa [ReplayForkState.noteObserved] using hfc
+      have hm' : st.mismatch = false := by
+        simpa [ReplayForkState.noteObserved] using hm
+      simp [hfc', hm'] at hlive
+    · intro hfc
+      have hfc' : st.forkConsumed = true := by
+        simpa [ReplayForkState.noteObserved] using hfc
+      -- new observed = st.observed ++ [⟨t, u⟩], cursor unchanged.
+      have hsub : st.cursor - 1 ≤ st.observed.length :=
+        Nat.le_trans (Nat.sub_le _ _) hcursorObs
+      change (QueryLog.getQ
+        ((st.observed.logQuery t u).take (st.cursor - 1)) (· = i)).length = st.forkQuery
+      rw [QueryLog.logQuery, QueryLog.singleton, List.take_append_of_le_length hsub]
+      simpa using hforkpos hfc'
   · simp only [hlive, Bool.false_eq_true, ↓reduceIte, bind_pure_comp, dite_eq_ite] at hz
     cases hnext : st.nextEntry? with
     | none =>
@@ -360,7 +470,13 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
             support_map, support_liftM, OracleQuery.input_query, OracleQuery.cont_query,
             Set.range_id, Set.image_univ, Set.mem_range] at hz
         rcases hz with ⟨u, hu, rfl⟩
-        refine ⟨?_, ?_, ?_, ?_, ?_⟩
+        have hflags : st.forkConsumed = false ∧ st.mismatch = false := by
+          cases hfc0 : st.forkConsumed <;> cases hm0 : st.mismatch
+          · constructor <;> simp
+          · simp [hfc0, hm0] at hlive
+          · simp [hfc0, hm0] at hlive
+          · simp [hfc0, hm0] at hlive
+        refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
         · exact hcursorTrace
         · simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch,
             QueryLog.logQuery, QueryLog.singleton] using
@@ -381,12 +497,24 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
           exfalso
           have hfc' : st.forkConsumed = true := by
             simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch] using hfc
-          have hflags : st.forkConsumed = false ∧ st.mismatch = false := by
-            cases hfc0 : st.forkConsumed <;> cases hm0 : st.mismatch
-            · constructor <;> simp
-            · simp [hfc0, hm0] at hlive
-            · simp [hfc0, hm0] at hlive
-            · simp [hfc0, hm0] at hlive
+          simp [hflags.1] at hfc'
+        · intro n hn
+          have hn' : n < st.cursor := by
+            simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch, hflags.1]
+              using hn
+          have hnobs : n < st.observed.length := Nat.lt_of_lt_of_le hn' hcursorObs
+          change (st.observed.logQuery t u)[n]? = st.trace[n]?
+          rw [QueryLog.logQuery, QueryLog.singleton, List.getElem?_append_left hnobs]
+          have : n < (if st.forkConsumed then st.cursor - 1 else st.cursor) := by
+            rw [hflags.1]; simpa using hn'
+          exact hvalues n this
+        · intro hfc hm
+          exfalso
+          simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch] at hm
+        · intro hfc
+          exfalso
+          have hfc' : st.forkConsumed = true := by
+            simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch] using hfc
           simp [hflags.1] at hfc'
     | some entry =>
         rcases entry with ⟨t', u'⟩
@@ -411,7 +539,7 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
                 have hsome : st.trace[st.cursor]? = some ⟨i, u'⟩ := by
                   simpa [ReplayForkState.nextEntry?] using hnext
                 exact (List.getElem?_eq_some_iff).1 hsome |>.1
-              refine ⟨Nat.succ_le_of_lt hlt, ?_, ?_, ?_, ?_⟩
+              refine ⟨Nat.succ_le_of_lt hlt, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
               · simp [QueryLog.logQuery, QueryLog.singleton, hObsEq]
               · intro n hn
                 by_cases hEq : n = st.cursor
@@ -457,6 +585,27 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
                 · have hsome : st.trace[st.cursor]? = some ⟨i, u'⟩ := by
                     simpa [ReplayForkState.nextEntry?] using hnext
                   simp [QueryLog.inputAt?, hsome]
+              · intro n hn
+                have hn' : n < st.cursor := by
+                  simpa [Nat.add_sub_cancel] using hn
+                have hnobs : n < st.observed.length := by simpa [hObsEq] using hn'
+                change (st.observed.logQuery i st.replacement)[n]? = st.trace[n]?
+                rw [QueryLog.logQuery, QueryLog.singleton, List.getElem?_append_left hnobs]
+                have : n < (if st.forkConsumed then st.cursor - 1 else st.cursor) := by
+                  rw [hflags.1]; simpa using hn'
+                exact hvalues n this
+              · intro hfc hm
+                simp at hfc
+              · intro _
+                have hdc_old : st.distinguishedCount =
+                    (st.observed.getQ (· = i)).length := hdcount hflags.1 hflags.2
+                have hdc_fq : st.distinguishedCount = st.forkQuery := hfork
+                change (QueryLog.getQ ((st.observed.logQuery i st.replacement).take
+                    (st.cursor + 1 - 1)) (· = i)).length = st.forkQuery
+                simp only [Nat.add_sub_cancel]
+                rw [QueryLog.logQuery, QueryLog.singleton]
+                rw [show st.cursor = st.observed.length from hObsEq.symm, List.take_left]
+                exact hdc_old.symm.trans hdc_fq
             · simp only [hnext, ↓reduceDIte, hfork, ↓reduceIte, StateT.run_map, StateT.run_set,
                 map_pure, support_pure, Set.mem_singleton_iff] at hz
               rcases hz with rfl
@@ -464,7 +613,7 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
                 have hsome : st.trace[st.cursor]? = some ⟨i, u'⟩ := by
                   simpa [ReplayForkState.nextEntry?] using hnext
                 exact (List.getElem?_eq_some_iff).1 hsome |>.1
-              refine ⟨Nat.succ_le_of_lt hlt, ?_, ?_, ?_, ?_⟩
+              refine ⟨Nat.succ_le_of_lt hlt, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
               · simp [QueryLog.logQuery, QueryLog.singleton, hObsEq]
               · intro n hn
                 by_cases hEq : n = st.cursor
@@ -492,6 +641,37 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
                 simp [hflags.1, hflags.2, QueryLog.logQuery, QueryLog.singleton, hObsEq] at hfc hm ⊢
               · intro hfc
                 simp [hflags.1] at hfc
+              · intro n hn
+                have hn' : n < st.cursor + 1 := by
+                  simpa [hflags.1] using hn
+                change (st.observed.logQuery i u')[n]? = st.trace[n]?
+                by_cases hEq : n = st.cursor
+                · subst hEq
+                  have hsome : st.trace[st.cursor]? = some ⟨i, u'⟩ := by
+                    simpa [ReplayForkState.nextEntry?] using hnext
+                  rw [QueryLog.logQuery, QueryLog.singleton,
+                    List.getElem?_append_right (by simp [hObsEq])]
+                  simp [hObsEq, hsome]
+                · have hn'' : n < st.cursor := by
+                    rcases Nat.lt_succ_iff_lt_or_eq.mp hn' with hn'' | hn''
+                    · exact hn''
+                    · exact (hEq hn'').elim
+                  have hnobs : n < st.observed.length := by simpa [hObsEq] using hn''
+                  rw [QueryLog.logQuery, QueryLog.singleton, List.getElem?_append_left hnobs]
+                  have : n < (if st.forkConsumed then st.cursor - 1 else st.cursor) := by
+                    rw [hflags.1]; simpa using hn''
+                  exact hvalues n this
+              · intro _ _
+                -- non-fork i-query: dc +=1, observed ++=[⟨i, u'⟩], getQ-length gains 1.
+                have hdc_old := hdcount hflags.1 hflags.2
+                change st.distinguishedCount + 1 =
+                    ((st.observed.logQuery i u').getQ (· = i)).length
+                rw [QueryLog.getQ_logQuery]
+                simp only [↓reduceIte, List.length_append, List.length_cons, List.length_nil,
+                  zero_add, Nat.add_right_cancel_iff]
+                exact hdc_old
+              · intro hfc
+                simp [hflags.1] at hfc
           · simp only [hnext, ↓reduceDIte, hti, StateT.run_map, StateT.run_set, map_pure,
               support_pure, Set.mem_singleton_iff] at hz
             rcases hz with rfl
@@ -499,7 +679,7 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
               have hsome : st.trace[st.cursor]? = some ⟨t, u'⟩ := by
                 simpa [ReplayForkState.nextEntry?] using hnext
               exact (List.getElem?_eq_some_iff).1 hsome |>.1
-            refine ⟨Nat.succ_le_of_lt hlt, ?_, ?_, ?_, ?_⟩
+            refine ⟨Nat.succ_le_of_lt hlt, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
             · simp [QueryLog.logQuery, QueryLog.singleton, hObsEq]
             · intro n hn
               by_cases hEq : n = st.cursor
@@ -526,12 +706,40 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
               simp [hflags.1, hflags.2, QueryLog.logQuery, QueryLog.singleton, hObsEq] at hfc hm ⊢
             · intro hfc
               simp [hflags.1] at hfc
+            · intro n hn
+              have hn' : n < st.cursor + 1 := by
+                simpa [hflags.1] using hn
+              change (st.observed.logQuery t u')[n]? = st.trace[n]?
+              by_cases hEq : n = st.cursor
+              · subst hEq
+                have hsome : st.trace[st.cursor]? = some ⟨t, u'⟩ := by
+                  simpa [ReplayForkState.nextEntry?] using hnext
+                rw [QueryLog.logQuery, QueryLog.singleton,
+                  List.getElem?_append_right (by simp [hObsEq])]
+                simp [hObsEq, hsome]
+              · have hn'' : n < st.cursor := by
+                  rcases Nat.lt_succ_iff_lt_or_eq.mp hn' with hn'' | hn''
+                  · exact hn''
+                  · exact (hEq hn'').elim
+                have hnobs : n < st.observed.length := by simpa [hObsEq] using hn''
+                rw [QueryLog.logQuery, QueryLog.singleton, List.getElem?_append_left hnobs]
+                have : n < (if st.forkConsumed then st.cursor - 1 else st.cursor) := by
+                  rw [hflags.1]; simpa using hn''
+                exact hvalues n this
+            · intro _ _
+              -- non-i, non-fork query: dc unchanged, observed gains a non-i entry.
+              have hdc_old := hdcount hflags.1 hflags.2
+              change st.distinguishedCount = ((st.observed.logQuery t u').getQ (· = i)).length
+              rw [QueryLog.getQ_logQuery, if_neg hti]
+              simpa using hdc_old
+            · intro hfc
+              simp [hflags.1] at hfc
         · simp only [hnext, hsame, ↓reduceDIte, StateT.run_bind, StateT.run_monadLift,
             monadLift_eq_self, bind_pure_comp, StateT.run_map, StateT.run_set, map_pure,
             Functor.map_map, support_map, support_liftM, OracleQuery.input_query,
             OracleQuery.cont_query, Set.range_id, Set.image_univ, Set.mem_range] at hz
           rcases hz with ⟨u, hu, rfl⟩
-          refine ⟨?_, ?_, ?_, ?_, ?_⟩
+          refine ⟨?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
           · exact hcursorTrace
           · simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch,
               QueryLog.logQuery, QueryLog.singleton] using
@@ -545,6 +753,24 @@ private lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
                       (QueryLog.inputAt?_logQuery_of_lt (log := st.observed) (t := t) (u := u)
                         (n := n) hnobs)
               _ = QueryLog.inputAt? st.trace n := hprefix n hn
+          · intro hfc hm
+            exfalso
+            simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch] at hm
+          · intro hfc
+            exfalso
+            have hfc' : st.forkConsumed = true := by
+              simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch] using hfc
+            simp [hflags.1] at hfc'
+          · intro n hn
+            have hn' : n < st.cursor := by
+              simpa [ReplayForkState.noteObserved, ReplayForkState.markMismatch, hflags.1]
+                using hn
+            have hnobs : n < st.observed.length := Nat.lt_of_lt_of_le hn' hcursorObs
+            change (st.observed.logQuery t u)[n]? = st.trace[n]?
+            rw [QueryLog.logQuery, QueryLog.singleton, List.getElem?_append_left hnobs]
+            have : n < (if st.forkConsumed then st.cursor - 1 else st.cursor) := by
+              rw [hflags.1]; simpa using hn'
+            exact hvalues n this
           · intro hfc hm
             exfalso
             simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch] at hm
@@ -599,6 +825,38 @@ lemma replayRunWithTraceValue_prefix_input_eq [spec.DecidableEq]
     (main := main) (i := i) (trace := trace) (forkQuery := forkQuery)
     (replacement := replacement) hz).2.2.1 n hn
 
+/-- Support-level value-agreement lemma: before the effective fork position (i.e., before
+`cursor - 1` once the fork has fired, or before `cursor` while it has not), the second-run
+`observed` log agrees with the first-run `trace` log on both the query input and the stored
+response. This strengthens `replayRunWithTraceValue_prefix_input_eq` and is the key lemma
+for arguing that the adversary's query transcript prior to the fork is identical across
+the two runs. -/
+lemma replayRunWithTraceValue_prefix_getElem?_eq [spec.DecidableEq]
+    (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
+    (forkQuery : Nat) (replacement : spec.Range i)
+    {z : α × ReplayForkState spec i}
+    (hz : z ∈ support (replayRunWithTraceValue main i trace forkQuery replacement))
+    {n : Nat}
+    (hn : n < (if z.2.forkConsumed then z.2.cursor - 1 else z.2.cursor)) :
+    z.2.observed[n]? = z.2.trace[n]? :=
+  (replayRunWithTraceValue_preservesPrefixInvariant
+    (main := main) (i := i) (trace := trace) (forkQuery := forkQuery)
+    (replacement := replacement) hz).2.2.2.2.2.1 n hn
+
+/-- Extract the "fork-position count" invariant: once the fork has fired, the prefix of `observed`
+up to the fork position contains exactly `st.forkQuery` entries of type `i`. This pins down where
+the replacement entry sits in the filtered `i`-log. -/
+lemma replayRunWithTraceValue_forkConsumed_imp_prefix_count [spec.DecidableEq]
+    (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
+    (forkQuery : Nat) (replacement : spec.Range i)
+    {z : α × ReplayForkState spec i}
+    (hz : z ∈ support (replayRunWithTraceValue main i trace forkQuery replacement))
+    (hfork : z.2.forkConsumed = true) :
+    (QueryLog.getQ (z.2.observed.take (z.2.cursor - 1)) (· = i)).length = z.2.forkQuery :=
+  (replayRunWithTraceValue_preservesPrefixInvariant
+    (main := main) (i := i) (trace := trace) (forkQuery := forkQuery)
+    (replacement := replacement) hz).2.2.2.2.2.2.2 hfork
+
 /-- If replay has consumed the fork point, the last consumed log entry is the distinguished query
 input `i`. This is the pathwise "same target" fact used downstream. -/
 lemma replayRunWithTraceValue_forkConsumed_imp_last_input [spec.DecidableEq]
@@ -613,7 +871,7 @@ lemma replayRunWithTraceValue_forkConsumed_imp_last_input [spec.DecidableEq]
   have hInv := replayRunWithTraceValue_preservesPrefixInvariant
     (main := main) (i := i) (trace := trace) (forkQuery := forkQuery)
     (replacement := replacement) hz
-  rcases hInv.2.2.2.2 hfork with ⟨hpos, htrace⟩
+  rcases hInv.2.2.2.2.1 hfork with ⟨hpos, htrace⟩
   refine ⟨hpos, htrace, ?_⟩
   exact (replayRunWithTraceValue_prefix_input_eq
     (main := main) (i := i) (trace := trace) (forkQuery := forkQuery)
@@ -1054,6 +1312,7 @@ section quantitative
 
 variable [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
 variable [∀ i, SampleableType (spec.Range i)] [unifSpec ⊂ₒ spec]
+variable [OracleSpec.LawfulSubSpec unifSpec spec]
 
 /-- Replay does not increase the total number of oracle queries. This is the runtime-control
 placeholder needed before the full quantitative replay forking argument.
@@ -1068,7 +1327,7 @@ theorem isTotalQueryBound_replayRunWithTraceValue
     IsTotalQueryBound (replayRunWithTraceValue main i trace forkQuery replacement) n := by
   sorry
 
-omit [spec.Fintype] [spec.Inhabited] in
+omit [spec.Fintype] [spec.Inhabited] [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- If `forkReplay` succeeds, both runs agree on the selected fork index. -/
 theorem cf_eq_of_mem_support_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
@@ -1099,6 +1358,7 @@ theorem cf_eq_of_mem_support_forkReplay
           exact ⟨s, hcf, hcf₂⟩
         · simp at h
 
+omit [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- On `forkReplay` support, first-projection success equals the pair-style success event.
 This mirrors `probEvent_seededFork_fst_eq_probEvent_pair` for the replay fork. -/
 theorem probEvent_forkReplay_fst_eq_probEvent_pair
@@ -1117,6 +1377,715 @@ theorem probEvent_forkReplay_fst_eq_probEvent_pair
       (main := main) (qb := qb) (i := i) (cf := cf) x₁ x₂ hmem with ⟨t, h₁, h₂⟩
     simp [h₁, h₂]
 
+/-! ### Helper lemmas for `le_probOutput_forkReplay`
+
+The pointwise replay bound is proved by the same three-step decomposition used for
+`le_probOutput_seededFork`:
+
+1. `probOutput_collisionReplay_le_main_div` (replay analogue of
+   `probOutput_collision_le_main_div`): bounds the probability that the uniformly
+   sampled replacement `u` collides with the logged answer at the `s`-th `i`-query of
+   the first run. The bound is `Pr[cf <$> main = some s] / h` where
+   `h = |spec.Range i|`. Proof is purely about the `replayFirstRun` marginal: for any
+   fixed `v`, `Pr[u = v | u ← uniform] = 1/h`.
+
+2. `noGuardReplayComp_le_forkReplay_add_collisionReplay` (replay analogue of
+   `hNoGuardLeAdd`): a structural inequality saying that the unrestricted "no-guard"
+   composition (which always runs the second pass and inspects both projections of
+   `cf`) is dominated by the genuine `forkReplay` success event plus the collision
+   event. Proof is pointwise on `(x₁, log)`-pairs from `replayFirstRun`.
+
+3. `sq_probOutput_main_le_noGuardReplayComp` (replay analogue of
+   `sq_probOutput_main_le_noGuardComp`): the Jensen / Cauchy-Schwarz step. Squares
+   the probability that the first run satisfies `cf x₁ = some s` and bounds it by the
+   no-guard joint success probability. This is the deepest piece: it requires a
+   replay-side analogue of `seededOracle.tsum_probOutput_generateSeed_weight_takeAtIndex`,
+   stating that averaging over the full first-run log is equal to averaging over the
+   "log truncated at the `s`-th `i`-query, then completed with a fresh uniform answer
+   plus live tail samples". -/
+
+/-- Reachability hypothesis on the fork-index selector `cf`: whenever the first run
+of `main` outputs `x` and the recorded log is `log`, every selected fork index
+`s = cf x` actually corresponds to an `i`-query in `log` (i.e. the `s`-th `i`-query
+exists in the log). This is needed for the replay forking lemma because, unlike
+the seeded variant, `forkReplay`'s second run cannot fork at a position the first
+run never reached. In FiatShamir-style applications `cf` extracts the index of a
+recorded query, so this property holds by construction. -/
+def CfReachable [spec.DecidableEq] (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1))) : Prop :=
+  ∀ {x : α} {log : QueryLog spec},
+    (x, log) ∈ support (replayFirstRun main) →
+    ∀ s : Fin (qb i + 1), cf x = some s →
+      (QueryLog.getQueryValue? log i ↑s).isSome
+
+/-! ### Replay state-correctness invariant
+
+The next group of lemmas establishes that when `main` is replayed against a log it
+itself produced and the fork index is reachable in that log, the second run reaches
+the fork query without mismatching the prefix. The proof has three parts:
+
+1. `replayOracle_preservesConsumed` (per-step) and `replayRun_preservesConsumed`
+   (full simulation): once `forkConsumed = true ∧ mismatch = false` holds at some
+   point, both flags stay set for the remainder of the run.
+2. `replayRun_state_correct_aux`: a coupled inductive invariant over `main` showing
+   that, starting from a state coupled to a partial first run with enough remaining
+   `i`-queries to hit the fork, the simulation reaches `forkConsumed = true` with
+   `mismatch = false`.
+3. `replayRunWithTraceValue_state_correct`: the user-facing corollary obtained by
+   instantiating the auxiliary invariant at the initial replay state. -/
+
+omit [spec.Fintype] [spec.Inhabited]
+  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+  [OracleSpec.LawfulSubSpec unifSpec spec] in
+private lemma replayOracle_preservesConsumed
+    (i t : ι) {st : ReplayForkState spec i}
+    (h_consumed : st.forkConsumed = true) (h_mismatch : st.mismatch = false)
+    {z : spec.Range t × ReplayForkState spec i}
+    (hz : z ∈ support ((replayOracle i t).run st)) :
+    z.2.forkConsumed = true ∧ z.2.mismatch = false := by
+  unfold replayOracle at hz
+  simp only [StateT.run_bind, StateT.run_get, pure_bind] at hz
+  have hlive : (st.forkConsumed || st.mismatch) = true := by simp [h_consumed]
+  simp only [hlive, ↓reduceIte, bind_pure_comp, StateT.run_bind, StateT.run_monadLift,
+    monadLift_eq_self, StateT.run_map, StateT.run_set, map_pure, Functor.map_map,
+    support_map, support_liftM, OracleQuery.input_query, OracleQuery.cont_query,
+    Set.range_id, Set.image_univ, Set.mem_range] at hz
+  rcases hz with ⟨_, _, rfl⟩
+  refine ⟨?_, ?_⟩
+  · simpa [ReplayForkState.noteObserved] using h_consumed
+  · simpa [ReplayForkState.noteObserved] using h_mismatch
+
+omit [spec.Fintype] [spec.Inhabited]
+  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+  [OracleSpec.LawfulSubSpec unifSpec spec] in
+private theorem replayRun_preservesConsumed
+    (main : OracleComp spec α) (idx : ι) {st₀ : ReplayForkState spec idx}
+    (h_consumed : st₀.forkConsumed = true) (h_mismatch : st₀.mismatch = false)
+    {z : α × ReplayForkState spec idx}
+    (hz : z ∈ support (((simulateQ (replayOracle idx) main).run st₀) :
+      OracleComp spec (α × ReplayForkState spec idx))) :
+    z.2.forkConsumed = true ∧ z.2.mismatch = false := by
+  induction main using OracleComp.inductionOn generalizing st₀ z with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hz
+      obtain ⟨rfl, rfl⟩ := Prod.mk.inj hz
+      exact ⟨h_consumed, h_mismatch⟩
+  | query_bind t oa ih =>
+      rw [simulateQ_query_bind, StateT.run_bind] at hz
+      rw [support_bind] at hz
+      simp only [Set.mem_iUnion] at hz
+      obtain ⟨us, hus, hzcont⟩ := hz
+      have hus' : us ∈ support (((replayOracle idx) t).run st₀ :
+          OracleComp spec (spec.Range t × ReplayForkState spec idx)) := by
+        simpa [simulateQ_query, OracleQuery.query_def] using hus
+      have ⟨h_consumed', h_mismatch'⟩ :=
+        replayOracle_preservesConsumed (i := idx) (t := t) h_consumed h_mismatch hus'
+      exact ih (u := us.1) (st₀ := us.2) h_consumed' h_mismatch' hzcont
+
+omit [spec.Fintype] [spec.Inhabited]
+  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+  [OracleSpec.LawfulSubSpec unifSpec spec] in
+/-- Coupled invariant for the replay simulation: starting from a state whose remaining
+trace coincides with a continuation produced by some first run of `main`, and which
+still has enough `idx`-queries left to reach the fork query, every reachable end state
+of the second run satisfies `mismatch = false ∧ forkConsumed = true`.
+
+This is the workhorse inductive lemma behind `replayRunWithTraceValue_state_correct`.
+The induction is on `main`; the pure case is impossible (no remaining queries to
+reach the fork) and the query/bind case dispatches on whether the fork is consumed
+in this step (delegating to `replayRun_preservesConsumed`) or postponed (recursing
+via the inductive hypothesis with an updated coupled state). -/
+private theorem replayRun_state_correct_aux
+    (main : OracleComp spec α) (idx : ι) {st₀ : ReplayForkState spec idx}
+    {x_first : α} {log_cont : QueryLog spec}
+    (h_first : (x_first, log_cont) ∈ support (replayFirstRun main))
+    (h_mismatch : st₀.mismatch = false)
+    (h_obs_len : st₀.observed.length = st₀.cursor)
+    (h_trace_drop : st₀.trace.drop st₀.cursor = log_cont)
+    (h_forkConsumed : st₀.forkConsumed = false)
+    (h_dlt : st₀.distinguishedCount ≤ st₀.forkQuery)
+    (h_can_reach : st₀.forkQuery + 1 - st₀.distinguishedCount
+      ≤ log_cont.countQ (· = idx))
+    {z : α × ReplayForkState spec idx}
+    (hz : z ∈ support (((simulateQ (replayOracle idx) main).run st₀) :
+      OracleComp spec (α × ReplayForkState spec idx))) :
+    z.2.mismatch = false ∧ z.2.forkConsumed = true := by
+  induction main using OracleComp.inductionOn generalizing st₀ x_first log_cont z with
+  | pure x =>
+      have hlog_nil : log_cont = [] := by
+        simp only [replayFirstRun, simulateQ_pure, WriterT.run_pure,
+          support_pure, Set.mem_singleton_iff, Prod.mk.injEq] at h_first
+        exact h_first.2
+      subst hlog_nil
+      simp only [QueryLog.countQ, QueryLog.getQ_nil, List.length_nil,
+        Nat.le_zero] at h_can_reach
+      omega
+  | query_bind t oa ih =>
+      -- Decompose the first-run support to expose `log_cont = ⟨t, u_first⟩ :: log_cont'`.
+      rw [replayFirstRun, OracleComp.run_simulateQ_loggingOracle_query_bind,
+        support_bind] at h_first
+      simp only [Set.mem_iUnion, support_map, exists_prop] at h_first
+      obtain ⟨u_first, _, p_first, hp_first, hp_eq⟩ := h_first
+      obtain ⟨hx_eq, hlog_eq⟩ := Prod.mk.inj hp_eq
+      set log_cont' := p_first.2 with hlog_cont'_def
+      have hlog_cont_eq : log_cont = ⟨t, u_first⟩ :: log_cont' := hlog_eq.symm
+      have hp_first' : (p_first.1, log_cont') ∈ support (replayFirstRun (oa u_first)) := by
+        change p_first ∈ support (replayFirstRun (oa u_first))
+        exact hp_first
+      -- The trace exposes the same head `⟨t, u_first⟩` at position `cursor`.
+      have h_trace_drop' : st₀.trace.drop st₀.cursor = ⟨t, u_first⟩ :: log_cont' := by
+        rw [h_trace_drop, hlog_cont_eq]
+      have hcursor_lt : st₀.cursor < st₀.trace.length := by
+        have hlen : (st₀.trace.drop st₀.cursor).length =
+            st₀.trace.length - st₀.cursor := List.length_drop
+        rw [h_trace_drop'] at hlen
+        simp at hlen
+        omega
+      have h_next_entry : st₀.trace[st₀.cursor]? = some ⟨t, u_first⟩ := by
+        have h0 : (st₀.trace.drop st₀.cursor)[0]? = some ⟨t, u_first⟩ := by
+          rw [h_trace_drop']; rfl
+        rwa [List.getElem?_drop, Nat.add_zero] at h0
+      have h_nextEntry_eq : st₀.nextEntry? = some ⟨t, u_first⟩ := by
+        unfold ReplayForkState.nextEntry?; exact h_next_entry
+      -- Helper: dropping one more step trims the head.
+      have hdrop_succ : st₀.trace.drop (st₀.cursor + 1) = log_cont' := by
+        have hd : st₀.trace.drop (st₀.cursor + 1) =
+            (st₀.trace.drop st₀.cursor).drop 1 := by
+          rw [List.drop_drop, Nat.add_comm]
+        rw [hd, h_trace_drop']
+        rfl
+      -- Decompose the second-run support: (us : range × state) is the next step.
+      rw [simulateQ_query_bind, StateT.run_bind, support_bind] at hz
+      simp only [Set.mem_iUnion] at hz
+      obtain ⟨us, hus, hzcont⟩ := hz
+      have hus' : us ∈ support (((replayOracle idx) t).run st₀ :
+          OracleComp spec (spec.Range t × ReplayForkState spec idx)) := by
+        simpa [simulateQ_query, OracleQuery.query_def] using hus
+      -- Analyze the per-step semantics of `replayOracle` at this state.
+      unfold replayOracle at hus'
+      simp only [StateT.run_bind, StateT.run_get, pure_bind] at hus'
+      have hlive_false : (st₀.forkConsumed || st₀.mismatch) = false := by
+        simp [h_forkConsumed, h_mismatch]
+      simp only [hlive_false, Bool.false_eq_true, ↓reduceIte, bind_pure_comp,
+        dite_eq_ite, h_nextEntry_eq, ↓reduceDIte] at hus'
+      -- Subcase split: t = idx with distinguishedCount = forkQuery vs. otherwise.
+      by_cases hti : t = idx
+      · subst hti
+        by_cases hfork : st₀.distinguishedCount = st₀.forkQuery
+        · -- Subcase A: fork query consumed in this step.
+          set st₁ : ReplayForkState spec t :=
+            { st₀ with cursor := st₀.cursor + 1
+                       distinguishedCount := st₀.forkQuery + 1
+                       forkConsumed := true
+                       observed := st₀.observed.logQuery t st₀.replacement } with hst₁
+          have hus_eq : us = (st₀.replacement, st₁) := by
+            simp only [hfork, ↓reduceDIte] at hus'
+            simpa using hus'
+          rw [hus_eq] at hzcont
+          have h_consumed_new : st₁.forkConsumed = true := rfl
+          have h_mismatch_new : st₁.mismatch = false := h_mismatch
+          exact (replayRun_preservesConsumed (oa _) t (st₀ := st₁)
+            h_consumed_new h_mismatch_new hzcont).symm
+        · -- Subcase B: idx-query but not the fork.
+          set st₁ : ReplayForkState spec t :=
+            { st₀ with cursor := st₀.cursor + 1
+                       distinguishedCount := st₀.distinguishedCount + 1
+                       observed := st₀.observed.logQuery t u_first } with hst₁
+          have hus_eq : us = (u_first, st₁) := by
+            simp only [hfork, ↓reduceDIte] at hus'
+            simpa using hus'
+          rw [hus_eq] at hzcont
+          have h_st₁_mismatch : st₁.mismatch = false := h_mismatch
+          have h_st₁_obs_len : st₁.observed.length = st₁.cursor := by
+            simp [st₁, QueryLog.logQuery, QueryLog.singleton, h_obs_len]
+          have h_st₁_trace_drop : st₁.trace.drop st₁.cursor = log_cont' := hdrop_succ
+          have h_st₁_forkConsumed : st₁.forkConsumed = false := h_forkConsumed
+          have h_st₁_dlt : st₁.distinguishedCount ≤ st₁.forkQuery := by
+            simp only [st₁]; omega
+          have hcount_cons :
+              QueryLog.countQ (⟨t, u_first⟩ :: log_cont') (· = t) =
+                log_cont'.countQ (· = t) + 1 := by
+            unfold QueryLog.countQ
+            rw [QueryLog.getQ_cons]
+            simp
+          have h_can_reach' : st₁.forkQuery + 1 - st₁.distinguishedCount
+              ≤ log_cont'.countQ (· = t) := by
+            rw [hlog_cont_eq, hcount_cons] at h_can_reach
+            simp only [st₁]; omega
+          have hzcont' : z ∈ support (((simulateQ (replayOracle t) (oa u_first)).run st₁) :
+              OracleComp spec (α × ReplayForkState spec t)) := by simpa using hzcont
+          exact ih u_first hp_first' h_st₁_mismatch h_st₁_obs_len
+            h_st₁_trace_drop h_st₁_forkConsumed h_st₁_dlt h_can_reach' hzcont'
+      · -- Subcase C: non-idx query.
+        set st₁ : ReplayForkState spec idx :=
+          { st₀ with cursor := st₀.cursor + 1
+                     observed := st₀.observed.logQuery t u_first } with hst₁
+        have hus_eq : us = (u_first, st₁) := by
+          simp only [hti, ↓reduceDIte] at hus'
+          simpa using hus'
+        rw [hus_eq] at hzcont
+        have h_st₁_mismatch : st₁.mismatch = false := h_mismatch
+        have h_st₁_obs_len : st₁.observed.length = st₁.cursor := by
+          simp [st₁, QueryLog.logQuery, QueryLog.singleton, h_obs_len]
+        have h_st₁_trace_drop : st₁.trace.drop st₁.cursor = log_cont' := hdrop_succ
+        have h_st₁_forkConsumed : st₁.forkConsumed = false := h_forkConsumed
+        have h_st₁_dlt : st₁.distinguishedCount ≤ st₁.forkQuery := h_dlt
+        have hcount_cons :
+            QueryLog.countQ (⟨t, u_first⟩ :: log_cont') (· = idx) =
+              log_cont'.countQ (· = idx) := by
+          unfold QueryLog.countQ
+          rw [QueryLog.getQ_cons]
+          simp [hti]
+        have h_can_reach' : st₁.forkQuery + 1 - st₁.distinguishedCount
+            ≤ log_cont'.countQ (· = idx) := by
+          rw [hlog_cont_eq, hcount_cons] at h_can_reach
+          exact h_can_reach
+        have hzcont' : z ∈ support (((simulateQ (replayOracle idx) (oa u_first)).run st₁) :
+            OracleComp spec (α × ReplayForkState spec idx)) := by simpa using hzcont
+        exact ih u_first hp_first' h_st₁_mismatch h_st₁_obs_len
+          h_st₁_trace_drop h_st₁_forkConsumed h_st₁_dlt h_can_reach' hzcont'
+
+omit [spec.Fintype] [spec.Inhabited]
+  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+  [OracleSpec.LawfulSubSpec unifSpec spec] in
+/-- Replay correctness invariant: starting from a logged first run of `main` whose
+log already records an `i`-query at position `↑s`, replaying `main` against that log
+with substitution at the fork query always reaches the fork (so `forkConsumed = true`
+and `mismatch = false` on every output state).
+
+This is the user-facing corollary of `replayRun_state_correct_aux`, instantiated at
+the initial replay state produced by `ReplayForkState.init`. The invariant is used in
+the replay forking lemma to argue that the no-guard composition cannot succeed via a
+state-failure path that `forkReplay` would reject. -/
+theorem replayRunWithTraceValue_state_correct
+    (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1)))
+    {x₁ : α} {log : QueryLog spec}
+    (hlog : (x₁, log) ∈ support (replayFirstRun main))
+    {s : Fin (qb i + 1)} (hcf : cf x₁ = some s)
+    (hreach : CfReachable main qb i cf)
+    (u : spec.Range i)
+    {q : α × ReplayForkState spec i}
+    (hq : q ∈ support (replayRunWithTraceValue main i log ↑s u)) :
+    q.2.mismatch = false ∧ q.2.forkConsumed = true := by
+  -- Build the coupling hypotheses for `init log s u`.
+  set st₀ := ReplayForkState.init log (forkQuery := ↑s) (replacement := u) with hst₀_def
+  have h_mismatch : st₀.mismatch = false := by simp [st₀, ReplayForkState.init]
+  have h_obs_len : st₀.observed.length = st₀.cursor := by
+    simp [st₀, ReplayForkState.init]
+  have h_trace_drop : st₀.trace.drop st₀.cursor = log := by
+    simp [st₀, ReplayForkState.init]
+  have h_forkConsumed : st₀.forkConsumed = false := by
+    simp [st₀, ReplayForkState.init]
+  have h_dlt : st₀.distinguishedCount ≤ st₀.forkQuery := by
+    simp [st₀, ReplayForkState.init]
+  -- Reachability gives us the i-query count bound.
+  have hreach' := hreach hlog s hcf
+  obtain ⟨logged, hlogged⟩ := Option.isSome_iff_exists.mp hreach'
+  have h_count : (s : ℕ) + 1 ≤ log.countQ (· = i) := by
+    have hgetQ : (log.getQ (· = i))[(s : ℕ)]? = some ⟨i, logged⟩ :=
+      QueryLog.getQ_getElem?_eq_of_getQueryValue?_eq_some _ _ _ _ hlogged
+    have hlt : (s : ℕ) < (log.getQ (· = i)).length :=
+      (List.getElem?_eq_some_iff.1 hgetQ).1
+    simpa [QueryLog.countQ] using Nat.succ_le_of_lt hlt
+  have h_can_reach : st₀.forkQuery + 1 - st₀.distinguishedCount
+      ≤ log.countQ (· = i) := by
+    simp only [st₀, ReplayForkState.init, Nat.sub_zero]
+    exact h_count
+  -- Apply the auxiliary invariant.
+  have hq' : q ∈ support (((simulateQ (replayOracle i) main).run st₀) :
+      OracleComp spec (α × ReplayForkState spec i)) := by
+    simpa [replayRunWithTraceValue, st₀] using hq
+  exact replayRun_state_correct_aux (idx := i) (st₀ := st₀) (x_first := x₁)
+    (log_cont := log) main hlog h_mismatch h_obs_len h_trace_drop
+    h_forkConsumed h_dlt h_can_reach hq'
+
+/-- The "no-guard" replay composition: run `main` with logging, sample `u`, then run
+`main` a second time with the replay oracle (replaying log up to the `s`-th `i`-query
+and substituting `u` there). Always returns the pair of `cf`-projections, with no
+guards. This is the replay analogue of the `noGuardComp` used in
+`sq_probOutput_main_le_noGuardComp` for the seeded fork. -/
+noncomputable def noGuardReplayComp
+    (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
+    OracleComp spec (Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1)))) := do
+  let p ← replayFirstRun main
+  let u ← liftComp ($ᵗ spec.Range i) spec
+  let q ← replayRunWithTraceValue main i p.2 ↑s u
+  return some (cf p.1, cf q.1)
+
+/-- The "collision" replay composition: run `main` with logging, sample `u`, and
+return `cf x₁` only when `u` coincides with the logged answer at the `s`-th `i`-query.
+This is the replay analogue of `collisionComp` used in the seeded forking proof. -/
+noncomputable def collisionReplayComp
+    (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
+    OracleComp spec (Option (Fin (qb i + 1))) := do
+  let p ← replayFirstRun main
+  let u ← liftComp ($ᵗ spec.Range i) spec
+  if QueryLog.getQueryValue? p.2 i ↑s = some u then return cf p.1 else return none
+
+/-- Replay-side collision bound: the probability that the second-run replacement `u`
+coincides with the logged answer at the `s`-th `i`-query of the first run, restricted
+to the event `cf x₁ = some s`, is at most `Pr[cf <$> main = some s] / |spec.Range i|`.
+This is the replay analogue of `probOutput_collision_le_main_div`.
+
+Proof idea: for any fixed `v`, `Pr[u = v | u ← uniform] = 1/h`, so the conditional
+`Pr[ getQueryValue? log i s = some u | u uniform ]` is at most `1/h` regardless of
+the log. Averaging over `(x₁, log)` and using `probOutput_fst_map_replayFirstRun`
+to drop the log marginal yields the bound. -/
+private lemma probOutput_collisionReplay_le_main_div
+    (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
+    Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s] ≤
+      Pr[= (some s : Option (Fin (qb i + 1))) | cf <$> main] /
+        ↑(Fintype.card (spec.Range i)) := by
+  classical
+  set h : ℝ≥0∞ := ↑(Fintype.card (spec.Range i))
+  have hcard_pos : (0 : ℝ≥0∞) < (↑(Fintype.card (spec.Range i)) : ℝ≥0∞) := by
+    exact_mod_cast (Fintype.card_pos (α := spec.Range i))
+  have hcard_ne_zero : (↑(Fintype.card (spec.Range i)) : ℝ≥0∞) ≠ 0 := hcard_pos.ne'
+  have hcard_ne_top : (↑(Fintype.card (spec.Range i)) : ℝ≥0∞) ≠ ⊤ :=
+    ENNReal.natCast_ne_top _
+  -- Bound the inner conditional `Pr[u : getQ log i s = some u]` by `1/h`.
+  -- Generalize the lookup so that subsequent `cases` does not substitute back into the goal.
+  have h_inner :
+      ∀ (x₁ : α) (log : QueryLog spec),
+        Pr[= (some s : Option (Fin (qb i + 1))) | do
+          let u ← liftComp ($ᵗ spec.Range i) spec
+          if QueryLog.getQueryValue? log i ↑s = some u then
+            return cf x₁ else (return none : OracleComp spec _)] ≤
+        (if cf x₁ = some s then (1 : ℝ≥0∞) else 0) * h⁻¹ := by
+    intro x₁ log
+    -- Generalize the lookup once, then prove the abstracted bound.
+    have h_pointwise :
+        ∀ (lookup : Option (spec.Range i)),
+          Pr[= (some s : Option (Fin (qb i + 1))) | do
+            let u ← liftComp ($ᵗ spec.Range i) spec
+            if lookup = some u then
+              return cf x₁ else (return none : OracleComp spec _)] ≤
+          (if cf x₁ = some s then (1 : ℝ≥0∞) else 0) * h⁻¹ := by
+      intro lookup
+      by_cases hcfs : cf x₁ = some s
+      · rcases lookup with _ | v
+        · have hzero :
+              Pr[= (some s : Option (Fin (qb i + 1))) | do
+                let u ← liftComp ($ᵗ spec.Range i) spec
+                if (none : Option (spec.Range i)) = some u then
+                  return cf x₁ else (return none : OracleComp spec _)] = 0 := by
+            rw [probOutput_bind_eq_tsum]
+            refine ENNReal.tsum_eq_zero.mpr fun u => ?_
+            simp
+          rw [hzero]; simp [hcfs]
+        · -- `lookup = some v`. Only `u = v` triggers the success branch.
+          have hcomp :
+              Pr[= (some s : Option (Fin (qb i + 1))) | do
+                let u ← liftComp ($ᵗ spec.Range i) spec
+                if (some v : Option (spec.Range i)) = some u then
+                  return cf x₁ else (return none : OracleComp spec _)]
+              = Pr[= v | liftComp ($ᵗ spec.Range i) spec] := by
+            rw [probOutput_bind_eq_tsum]
+            calc
+              ∑' u, Pr[= u | liftComp ($ᵗ spec.Range i) spec] *
+                  Pr[= (some s : Option (Fin (qb i + 1))) |
+                    if (some v : Option (spec.Range i)) = some u then
+                      return cf x₁ else (return none : OracleComp spec _)]
+                  = ∑' u, if u = v then Pr[= u | liftComp ($ᵗ spec.Range i) spec] else 0 := by
+                    refine tsum_congr fun u => ?_
+                    by_cases hu : u = v
+                    · subst hu; simp [hcfs]
+                    · have hne : (some v : Option (spec.Range i)) ≠ some u := by
+                        intro habs; exact hu (Option.some.inj habs).symm
+                      simp [hne, hu]
+              _ = Pr[= v | liftComp ($ᵗ spec.Range i) spec] := by
+                    rw [tsum_eq_single v]
+                    · simp
+                    · intro b hb
+                      have : ¬ (b = v) := hb
+                      rw [if_neg this]
+          rw [hcomp, probOutput_liftComp, probOutput_uniformSample]
+          simp [hcfs, h]
+      · -- `cf x₁ ≠ some s`: the success branch never produces `some s`.
+        have hzero :
+            Pr[= (some s : Option (Fin (qb i + 1))) | do
+              let u ← liftComp ($ᵗ spec.Range i) spec
+              if lookup = some u then
+                return cf x₁ else (return none : OracleComp spec _)] = 0 := by
+          rw [probOutput_bind_eq_tsum]
+          refine ENNReal.tsum_eq_zero.mpr fun u => ?_
+          rw [mul_eq_zero]; right
+          by_cases hu : lookup = some u
+          · rw [if_pos hu]
+            simp only [probOutput_pure_eq_indicator, Set.indicator_apply,
+              Set.mem_singleton_iff, Function.const_apply]
+            split_ifs with hcf
+            · exact (hcfs hcf.symm).elim
+            · rfl
+          · rw [if_neg hu]; simp
+        rw [hzero]; simp [hcfs]
+    exact h_pointwise (QueryLog.getQueryValue? log i ↑s)
+  -- Average the pointwise bound over `(x₁, log) ~ replayFirstRun`.
+  have hexpand :
+      Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s] =
+      ∑' (p : α × QueryLog spec),
+        Pr[= p | replayFirstRun main] *
+          Pr[= (some s : Option (Fin (qb i + 1))) | do
+            let u ← liftComp ($ᵗ spec.Range i) spec
+            if QueryLog.getQueryValue? p.2 i ↑s = some u then
+              return cf p.1 else (return none : OracleComp spec _)] := by
+    simp only [collisionReplayComp]
+    rw [probOutput_bind_eq_tsum]
+  rw [hexpand]
+  calc
+    ∑' (p : α × QueryLog spec),
+        Pr[= p | replayFirstRun main] *
+          Pr[= (some s : Option (Fin (qb i + 1))) | do
+            let u ← liftComp ($ᵗ spec.Range i) spec
+            if QueryLog.getQueryValue? p.2 i ↑s = some u then
+              return cf p.1 else (return none : OracleComp spec _)]
+      ≤ ∑' (p : α × QueryLog spec),
+          Pr[= p | replayFirstRun main] *
+            ((if cf p.1 = some s then (1 : ℝ≥0∞) else 0) * h⁻¹) := by
+            refine ENNReal.tsum_le_tsum fun p => ?_
+            exact mul_le_mul' le_rfl (h_inner p.1 p.2)
+    _ = (∑' (p : α × QueryLog spec),
+          Pr[= p | replayFirstRun main] *
+            (if cf p.1 = some s then (1 : ℝ≥0∞) else 0)) * h⁻¹ := by
+            rw [← ENNReal.tsum_mul_right]
+            refine tsum_congr fun p => ?_
+            ring
+    _ = Pr[ fun p : α × QueryLog spec => cf p.1 = some s | replayFirstRun main] * h⁻¹ := by
+            rw [probEvent_eq_tsum_ite]
+            congr 1
+            refine tsum_congr fun p => ?_
+            by_cases hp : cf p.1 = some s <;> simp [hp]
+    _ = Pr[= (some s : Option (Fin (qb i + 1))) | cf <$> main] * h⁻¹ := by
+            congr 1
+            calc
+              Pr[ fun p : α × QueryLog spec => cf p.1 = some s | replayFirstRun main]
+                  = Pr[ fun x : α => cf x = some s | main] := by
+                    simpa using probEvent_fst_replayFirstRun (main := main)
+                      (p := fun x : α => cf x = some s)
+              _ = Pr[ fun y : Option (Fin (qb i + 1)) => y = some s | cf <$> main] := by
+                    simpa [Function.comp] using
+                      (probEvent_map (mx := main) (f := cf)
+                        (q := fun y : Option (Fin (qb i + 1)) => y = some s)).symm
+              _ = Pr[= (some s : Option (Fin (qb i + 1))) | cf <$> main] := by
+                    simp [probEvent_eq_eq_probOutput
+                      (mx := cf <$> main) (x := (some s : Option (Fin (qb i + 1))))]
+    _ = Pr[= (some s : Option (Fin (qb i + 1))) | cf <$> main] /
+          ↑(Fintype.card (spec.Range i)) := by
+            rw [div_eq_mul_inv]
+
+/-- Replay-side Jensen / Cauchy-Schwarz step. Squaring the probability that the first
+run satisfies `cf x₁ = some s` is bounded by the joint probability that *both* the
+first run and the second (substituted) run satisfy `cf · = some s`.
+
+This is the replay analogue of `sq_probOutput_main_le_noGuardComp` for the seeded fork.
+The seeded version factors `noGuardComp`'s success probability as
+`∑_seed P(seed) · P(cf x₁ = s | seed) · P(cf x₂ = s | seed.takeAtIndex i s)` and applies
+ENNReal Cauchy-Schwarz `(∑ w·a)² ≤ (∑ w) · (∑ w·a²) ≤ ∑ w·a²` (since ∑ w ≤ 1) after
+showing the cross term equals `Pr[cf <$> main = s]²` via a `takeAtIndex` rewrite.
+
+The seeded factorization relies on two structural lemmas about `generateSeed` /
+`takeAtIndex`:
+
+* `evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue`: averaging the
+  appended value `u` makes a truncated-then-extended seed equivalent to the truncated
+  seed alone.
+* `tsum_probOutput_generateSeed_weight_takeAtIndex`: weighting by an arbitrary
+  function of the truncated seed, the full-seed and truncated-seed simulations have
+  the same distribution.
+
+**Replay-side gap.** The replay analogue requires the same conceptual decomposition
+but operates on `replayFirstRun main` (a logged run) instead of `generateSeed`. It
+needs:
+
+* A truncation operator `QueryLog.takeBeforeForkAt log i s` returning the prefix of
+  `log` up to (but not including) the `s`-th `i`-query.
+* A "run-from-prefix" operator that runs `main` against the prefix replay trace
+  followed by live oracle answers, and a lemma relating it to `replayRunWithTraceValue`
+  averaged over the substituted `u`.
+* A weighted averaging lemma analogous to
+  `tsum_probOutput_generateSeed_weight_takeAtIndex` saying that averaging
+  `Pr[= log | replayFirstRun main]` against any function of the truncated log equals
+  averaging the same function against the truncated-log distribution.
+
+These ingredients are deferred. -/
+private lemma sq_probOutput_main_le_noGuardReplayComp
+    (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
+    Pr[= s | cf <$> main] ^ 2 ≤
+      Pr[= (some (some s, some s) : Option
+            (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1)))) |
+          noGuardReplayComp main qb i cf s] := by
+  sorry
+
+omit [OracleSpec.LawfulSubSpec unifSpec spec] in
+/-- Structural replay inequality: the no-guard composition's joint success event is
+dominated by the genuine `forkReplay` success event plus the collision event. This is
+the replay analogue of the structural inequality `hNoGuardLeAdd` used in
+`le_probOutput_seededFork`.
+
+The proof mirrors the seeded version: bind on `replayFirstRun main`, case-split on
+`cf x₁`, and reduce the `some s` branch to a per-`u` comparison of the three
+computations. Two additional ingredients enter the replay version:
+
+* **`hreach : CfReachable main qb i cf`** ensures the fork query is reachable from
+  the first run: whenever `cf x₁ = some s`, the recorded log has an `i`-query at
+  position `↑s`. Without this assumption, `forkReplay` returns `pure none`
+  unconditionally on the substantive branch and the inequality fails.
+* **`replayRunWithTraceValue_state_correct`** ensures the second run always reaches
+  the fork without mismatching the prefix, so the state-flag check in
+  `forkReplayWithTraceValue` is vacuous on the relevant support. -/
+private lemma noGuardReplayComp_le_forkReplay_add_collisionReplay
+    (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1)))
+    (hreach : CfReachable main qb i cf) (s : Fin (qb i + 1)) :
+    Pr[= (some (some s, some s) : Option
+            (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1)))) |
+          noGuardReplayComp main qb i cf s] ≤
+      Pr[= (some (some s, some s) : Option
+            (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1)))) |
+          (fun r : Option (α × α) => r.map (Prod.map cf cf)) <$>
+            forkReplay main qb i cf] +
+      Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s] := by
+  classical
+  set z : Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1))) := some (some s, some s)
+  set f : Option (α × α) → Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1))) :=
+    fun r => r.map (Prod.map cf cf)
+  -- All three computations start with `replayFirstRun main`. Apply the bind
+  -- congruence and reduce to a per-`(x₁, log₁)` inequality.
+  show Pr[= z | noGuardReplayComp main qb i cf s] ≤
+    Pr[= z | f <$> forkReplay main qb i cf] +
+      Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s]
+  simp only [noGuardReplayComp, collisionReplayComp, forkReplay, map_bind]
+  refine (probOutput_bind_congr_le_add
+    (mx := (replayFirstRun main : OracleComp spec (α × QueryLog spec)))
+    (y := z) (z₁ := z) (z₂ := (some s : Option (Fin (qb i + 1))))) ?_
+  intro p hp
+  -- Single case-split on whether `cf p.1 = some s`. The non-substantive branch
+  -- collapses to `LHS = 0`.
+  by_cases hcf_s : cf p.1 = some s
+  · -- Substantive case: `cf p.1 = some s`.
+    -- Reachability gives a logged value at the fork query.
+    have hreach' := hreach hp s hcf_s
+    obtain ⟨logged, hlogged⟩ := Option.isSome_iff_exists.mp hreach'
+    -- Reduce both sides to per-`u` quantities by binding on `u`.
+    simp only [hcf_s, map_bind]
+    refine (probOutput_bind_congr_le_add
+      (mx := (liftComp ($ᵗ spec.Range i) spec : OracleComp spec (spec.Range i)))
+      (y := z) (z₁ := z) (z₂ := (some s : Option (Fin (qb i + 1))))) ?_
+    intro u _hu
+    -- Helper: rewrite `forkReplayWithTraceValue main qb i cf p u`-mapped using `hcf_s`,`hlogged`.
+    have hforkUnfold :
+        (fun r : Option (α × α) => r.map (Prod.map cf cf)) <$>
+          forkReplayWithTraceValue main qb i cf p u =
+        (if logged = u then
+            (pure none : OracleComp spec (Option (Option (Fin (qb i + 1)) ×
+              Option (Fin (qb i + 1)))))
+          else
+            replayRunWithTraceValue main i p.2 ↑s u >>= fun q =>
+              if q.2.mismatch || !q.2.forkConsumed then pure none
+              else if cf q.1 = some s then pure (some (some s, cf q.1))
+              else pure none) := by
+      unfold forkReplayWithTraceValue
+      simp only [hcf_s, hlogged]
+      split_ifs with hcoll
+      · simp [map_pure]
+      · rw [map_bind]
+        congr 1
+        ext q
+        split_ifs with _ _ <;> simp [hcf_s]
+    have hcollUnfold :
+        (if QueryLog.getQueryValue? p.2 i ↑s = some u then
+            (return (some s : Option (Fin (qb i + 1))) : OracleComp spec _)
+          else return none) =
+        (if logged = u then
+            (return (some s : Option (Fin (qb i + 1))) : OracleComp spec _)
+          else return none) := by
+      by_cases hcoll : logged = u
+      · simp [hlogged, hcoll]
+      · have hne : QueryLog.getQueryValue? p.2 i ↑s ≠ some u := by
+          rw [hlogged]; intro habs; exact hcoll (Option.some_inj.mp habs)
+        simp [hne, hcoll]
+    rw [hforkUnfold, hcollUnfold]
+    by_cases hcoll : logged = u
+    · -- Collision case: bound by 1 ≤ 0 + 1.
+      rw [if_pos hcoll, if_pos hcoll]
+      calc Pr[= z | do
+            let _q ← replayRunWithTraceValue main i p.2 ↑s u
+            (pure (some (some s, cf _q.1)) : OracleComp spec _)]
+          ≤ 1 := probOutput_le_one
+        _ = 0 + 1 := by ring
+        _ = Pr[= z | (pure none :
+                OracleComp spec (Option (Option (Fin (qb i + 1)) ×
+                  Option (Fin (qb i + 1)))))] +
+            Pr[= (some s : Option (Fin (qb i + 1))) |
+              (return some s : OracleComp spec _)] := by
+          simp [z]
+    · -- No-collision case: use replay correctness.
+      rw [if_neg hcoll, if_neg hcoll]
+      have hstate : ∀ {q : α × ReplayForkState spec i},
+          q ∈ support (replayRunWithTraceValue main i p.2 ↑s u) →
+          q.2.mismatch = false ∧ q.2.forkConsumed = true :=
+        fun hq => replayRunWithTraceValue_state_correct main qb i cf hp hcf_s hreach u hq
+      have hL_eq :
+          Pr[= z | do
+            let q ← replayRunWithTraceValue main i p.2 ↑s u
+            (pure (some (some s, cf q.1)) : OracleComp spec _)] =
+          Pr[ fun q : α × ReplayForkState spec i => cf q.1 = some s |
+                replayRunWithTraceValue main i p.2 ↑s u] := by
+        rw [probEvent_eq_tsum_ite, probOutput_bind_eq_tsum]
+        refine tsum_congr fun q => ?_
+        simp only [probOutput_pure_eq_indicator, Set.indicator_apply,
+          Set.mem_singleton_iff, Function.const_apply, z]
+        by_cases hq : cf q.1 = some s
+        · simp [hq]
+        · have hq_symm : ¬ some s = cf q.1 := fun h => hq h.symm
+          simp [hq, hq_symm]
+      have hR_eq :
+          Pr[= z |
+            (replayRunWithTraceValue main i p.2 ↑s u >>= fun q =>
+              if q.2.mismatch || !q.2.forkConsumed then
+                (pure none : OracleComp spec (Option (Option (Fin (qb i + 1)) ×
+                  Option (Fin (qb i + 1)))))
+              else if cf q.1 = some s then pure (some (some s, cf q.1))
+              else pure none)] =
+          Pr[ fun q : α × ReplayForkState spec i => cf q.1 = some s |
+                replayRunWithTraceValue main i p.2 ↑s u] := by
+        rw [probEvent_eq_tsum_ite, probOutput_bind_eq_tsum]
+        refine tsum_congr fun q => ?_
+        by_cases hqmem : q ∈ support (replayRunWithTraceValue main i p.2 ↑s u)
+        · obtain ⟨hmm, hfc⟩ := hstate hqmem
+          simp only [hmm, hfc, Bool.or_false, Bool.not_true]
+          by_cases hq : cf q.1 = some s
+          · simp [hq, z]
+          · simp [hq, z]
+        · have hzero : Pr[= q | replayRunWithTraceValue main i p.2 ↑s u] = 0 :=
+            probOutput_eq_zero_of_not_mem_support hqmem
+          rw [hzero]
+          split_ifs <;> simp
+      rw [hL_eq, hR_eq]
+      exact le_add_of_nonneg_right (zero_le _)
+  · -- Non-substantive case: `cf p.1 ≠ some s`.
+    -- LHS noGuard returns `some (cf p.1, _)` ≠ `some (some s, some s)` since
+    -- `cf p.1 ≠ some s`. So Pr[LHS = z] = 0.
+    have hL :
+        Pr[= z | do
+          let _u ← liftComp ($ᵗ spec.Range i) spec
+          let q ← replayRunWithTraceValue main i p.2 ↑s _u
+          (pure (some (cf p.1, cf q.1)) : OracleComp spec _)] = 0 := by
+      rw [probOutput_eq_zero_iff]
+      intro hmem
+      simp only [support_bind, support_pure, Set.mem_iUnion, Set.mem_singleton_iff,
+        z] at hmem
+      obtain ⟨_, _, _, _, hh⟩ := hmem
+      have h1 := (Prod.mk.inj (Option.some.inj hh)).1
+      exact hcf_s h1.symm
+    rw [hL]
+    exact zero_le _
+
 /-- Key pointwise replay lower bound. This is the replay analogue of
 `le_probOutput_seededFork`.
 
@@ -1133,15 +2102,70 @@ In Lean the analogous pointwise bound corresponds to step (3) combined with (1) 
 structurally similar to the seed-based `le_probOutput_seededFork` proof in
 `VCVio/CryptoFoundations/SeededFork.lean`, with `replayFirstRun`/`replayRunWithTraceValue` playing
 the role of `generateSeed`/`seededOracle` and `QueryLog.takeBeforeFork`-style slicing replacing
-`QuerySeed.takeAtIndex`. -/
+`QuerySeed.takeAtIndex`.
+
+The proof reduces to three helper lemmas:
+`probOutput_collisionReplay_le_main_div`,
+`sq_probOutput_main_le_noGuardReplayComp`, and
+`noGuardReplayComp_le_forkReplay_add_collisionReplay`.
+
+The `hreach` hypothesis (`CfReachable`) is needed because, unlike the seed-based version
+(where `cf x = some s` always implies the `s`-th query value is well-defined in the seed),
+in the replay setting, `cf` is computed from `x` independently from the actual queries
+made by the run that produced it. The hypothesis captures the natural condition that the
+fork point `s` chosen by `cf` always corresponds to a query that was actually issued. -/
 theorem le_probOutput_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
-    (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
+    (cf : α → Option (Fin (qb i + 1)))
+    (hreach : CfReachable main qb i cf) (s : Fin (qb i + 1)) :
     let h : ℝ≥0∞ := ↑(Fintype.card (spec.Range i))
     Pr[= s | cf <$> main] ^ 2 - Pr[= s | cf <$> main] / h
       ≤ Pr[ fun r => r.map (cf ∘ Prod.fst) = some (some s) |
           forkReplay main qb i cf] := by
-  sorry
+  set h : ℝ≥0∞ := ↑(Fintype.card (spec.Range i))
+  -- Rewrite the RHS as a `probOutput` over the pair-style success event after `cf` mapping.
+  rw [probEvent_forkReplay_fst_eq_probEvent_pair
+        (main := main) (qb := qb) (i := i) (cf := cf)]
+  let f : Option (α × α) → Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1))) :=
+    fun r => r.map (Prod.map cf cf)
+  let z : Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1))) := some (some s, some s)
+  have hRhsEq :
+      Pr[ fun r => r.map (Prod.map cf cf) = some (some s, some s) | forkReplay main qb i cf] =
+        Pr[= z | f <$> forkReplay main qb i cf] := by
+    calc
+      Pr[ fun r => r.map (Prod.map cf cf) = some (some s, some s) | forkReplay main qb i cf]
+          = Pr[ fun r => f r = z | forkReplay main qb i cf] := by simp [f, z]
+      _ = Pr[ fun x => x = z | f <$> forkReplay main qb i cf] := by
+            simpa [Function.comp] using
+              (probEvent_map (mx := forkReplay main qb i cf) (f := f)
+                (q := fun x : Option (Option (Fin (qb i + 1)) × Option (Fin (qb i + 1))) =>
+                  x = z)).symm
+      _ = Pr[= z | f <$> forkReplay main qb i cf] := by
+            simp [probEvent_eq_eq_probOutput
+              (mx := f <$> forkReplay main qb i cf) (x := z)]
+  rw [hRhsEq]
+  have hCollision := probOutput_collisionReplay_le_main_div
+    (main := main) (qb := qb) (i := i) (cf := cf) s
+  have hLhsCollision :
+      Pr[= s | cf <$> main] ^ 2 - Pr[= s | cf <$> main] / h ≤
+        Pr[= s | cf <$> main] ^ 2 -
+          Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s] :=
+    tsub_le_tsub_left (by simpa [h] using hCollision) (Pr[= s | cf <$> main] ^ 2)
+  refine le_trans hLhsCollision ?_
+  -- noGuard bound from Cauchy-Schwarz, plus the structural inequality.
+  have hNoGuardGeSquare := sq_probOutput_main_le_noGuardReplayComp
+    (main := main) (qb := qb) (i := i) (cf := cf) s
+  have hNoGuardLeAdd := noGuardReplayComp_le_forkReplay_add_collisionReplay
+    (main := main) (qb := qb) (i := i) (cf := cf) hreach s
+  have hNoGuardMinusLeRhs :
+      Pr[= z | noGuardReplayComp main qb i cf s] -
+          Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s] ≤
+        Pr[= z | f <$> forkReplay main qb i cf] :=
+    (tsub_le_iff_right).2 (by simpa [z, f] using hNoGuardLeAdd)
+  exact le_trans
+    (tsub_le_tsub_right (by simpa [z] using hNoGuardGeSquare)
+      (Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s]))
+    hNoGuardMinusLeRhs
 
 omit [spec.DecidableEq] [∀ i, SampleableType (spec.Range i)] [unifSpec ⊂ₒ spec] in
 /-- The replay-fork precondition is itself bounded by `1`. This mirrors
@@ -1155,6 +2179,7 @@ theorem forkReplay_precondition_le_one
      acc * (acc / q - h⁻¹)) ≤ 1 :=
   seededFork_precondition_le_one (main := main) (qb := qb) (i := i) (cf := cf)
 
+omit [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- Sum of disjoint replay-fork success events is at most the total `some` probability.
 This mirrors `sum_probEvent_fork_le_tsum_some` in `Fork.lean`; the proof is purely
 algebraic on the underlying distribution and does not depend on the fork mechanism. -/
@@ -1190,10 +2215,11 @@ private lemma sum_probEvent_forkReplay_le_tsum_some
 
 /-- Replay fork failure probability bound. This mirrors `probOutput_none_seededFork_le`;
 the proof structure is identical, substituting the pointwise replay lower bound
-`le_probOutput_forkReplay` for its seed-based analogue. -/
+`le_probOutput_forkReplay` for its seed-based analogue. The `hreach` hypothesis is
+threaded through from `le_probOutput_forkReplay`. -/
 theorem probOutput_none_forkReplay_le
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
-    (cf : α → Option (Fin (qb i + 1))) :
+    (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
     let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
     let h : ℝ≥0∞ := Fintype.card (spec.Range i)
     let q := qb i + 1
@@ -1219,7 +2245,7 @@ theorem probOutput_none_forkReplay_le
         tsub_le_tsub_left (sum_probEvent_forkReplay_le_tsum_some main qb i cf) 1
     _ ≤ 1 - ∑ s, (ps s ^ 2 - ps s / h) :=
         tsub_le_tsub_left (Finset.sum_le_sum fun s _ =>
-          le_probOutput_forkReplay main qb i cf s) 1
+          le_probOutput_forkReplay main qb i cf hreach s) 1
     _ ≤ 1 - acc * (acc / ↑(qb i + 1) - h⁻¹) := by
         apply tsub_le_tsub_left _ 1
         have hcs := ENNReal.sq_sum_le_card_mul_sum_sq
@@ -1251,10 +2277,10 @@ theorem probOutput_none_forkReplay_le
 /-- Packaged replay forking theorem. This is the replay analogue of
 `le_probEvent_isSome_seededFork`, derived from `probOutput_none_forkReplay_le` and
 `forkReplay_precondition_le_one` by the same `1 - ·` conversion used in
-`le_probEvent_isSome_seededFork`. -/
+`le_probEvent_isSome_seededFork`. The `hreach` hypothesis is threaded through. -/
 theorem le_probEvent_isSome_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
-    (cf : α → Option (Fin (qb i + 1))) :
+    (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
     (let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
      let h : ℝ≥0∞ := Fintype.card (spec.Range i)
      let q := qb i + 1
@@ -1278,10 +2304,11 @@ theorem le_probEvent_isSome_forkReplay
            let q := qb i + 1
            acc * (acc / q - h⁻¹)) ≤ 1 :=
     (ENNReal.le_sub_iff_add_le_right hpre_ne_top hpre_le_one).1
-      (probOutput_none_forkReplay_le (main := main) (qb := qb) (i := i) (cf := cf))
+      (probOutput_none_forkReplay_le (main := main) (qb := qb) (i := i) (cf := cf) hreach)
   exact (ENNReal.le_sub_iff_add_le_right hnone_ne_top probOutput_le_one).2
     (by simpa [add_comm] using hfork)
 
+omit [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- Structural success facts for `forkReplay`: both outputs come from logged runs of `main`,
 share the same selected fork index, differ at the selected distinguished-oracle answer, and the
 second run is witnessed by a replay state whose observed log agrees with the first-run log on the
@@ -1372,6 +2399,7 @@ theorem forkReplay_success_log_props
             exact this
         · simp at h
 
+omit [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- Replay property transfer: any postcondition that holds for every logged run of `main`
 holds for both outputs of a successful replay fork, together with the common selected fork index
 and the fact that the distinguished answers differ at that index.

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -115,7 +115,7 @@ lemma getQueryValue?_isSome_of_lt [spec.DecidableEq] (log : QueryLog spec) (t : 
   have hentry := List.getElem_mem h (l := log.getQ (· = t))
   have ht' : ((log.getQ (· = t))[n]'h).1 = t := getQ_eq_mem log t hentry
   rw [hopt]
-  set entry := (log.getQ (· = t))[n]'h with hentry_def
+  set entry := (log.getQ (· = t))[n]'h
   obtain ⟨t', u'⟩ := entry
   simp only at ht'
   subst ht'

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -931,7 +931,6 @@ private lemma replayOracle_immutable_params [spec.DecidableEq]
           simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch]
 
 private theorem replayRun_immutable_params [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) {st₀ : ReplayForkState spec i}
     {z : α × ReplayForkState spec i}
     (hz : z ∈ support (((simulateQ (replayOracle i) main).run st₀) :
@@ -953,7 +952,6 @@ private theorem replayRun_immutable_params [spec.DecidableEq]
       exact ⟨h₂.1.trans h₁.1, h₂.2.1.trans h₁.2.1, h₂.2.2.trans h₁.2.2⟩
 
 lemma replayRunWithTraceValue_forkQuery_eq [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -965,7 +963,6 @@ lemma replayRunWithTraceValue_forkQuery_eq [spec.DecidableEq]
       (st₀ := ReplayForkState.init trace forkQuery replacement) hz).1
 
 lemma replayRunWithTraceValue_replacement_eq [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -977,7 +974,6 @@ lemma replayRunWithTraceValue_replacement_eq [spec.DecidableEq]
       (st₀ := ReplayForkState.init trace forkQuery replacement) hz).2.1
 
 lemma replayRunWithTraceValue_trace_eq [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1139,7 +1135,6 @@ private lemma replayOracle_preservesReplacementInvariant [spec.DecidableEq]
             simp [ReplayForkState.markMismatch, ReplayForkState.noteObserved, hflags.1] at hfc
 
 private theorem replayRun_preservesReplacementInvariant [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) {st₀ : ReplayForkState spec i}
     (hInv : ReplayReplacementInvariant i st₀)
     {z : α × ReplayForkState spec i}
@@ -1161,7 +1156,6 @@ private theorem replayRun_preservesReplacementInvariant [spec.DecidableEq]
 
 /-- Every reachable replay state preserves the replacement invariant. -/
 theorem replayRunWithTraceValue_preservesReplacementInvariant [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1175,7 +1169,6 @@ theorem replayRunWithTraceValue_preservesReplacementInvariant [spec.DecidableEq]
 /-- If the replay has consumed the fork and the fork point is `forkQuery`, then the
 `forkQuery`-th distinguished-oracle entry in the observed log is exactly the replacement. -/
 lemma replayRunWithTraceValue_getQueryValue?_observed_eq_replacement [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1202,7 +1195,6 @@ lemma replayRunWithTraceValue_getQueryValue?_observed_eq_replacement [spec.Decid
   exact QueryLog.getQueryValue?_eq_some_of_getQ_getElem? _ _ _ _ hPostApp
 
 private lemma replayOracle_observed_eq_logQuery [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (i : ι) (t : ι) {st : ReplayForkState spec i}
     {z : spec.Range t × ReplayForkState spec i}
     (hz : z ∈ support (((replayOracle i) t).run st :
@@ -1253,7 +1245,6 @@ private lemma replayOracle_observed_eq_logQuery [spec.DecidableEq]
           simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch]
 
 private theorem replayRun_mem_support_replayFirstRun_append [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) {st₀ : ReplayForkState spec i}
     {z : α × ReplayForkState spec i}
     (hz : z ∈ support (((simulateQ (replayOracle i) main).run st₀) :
@@ -1292,7 +1283,6 @@ private theorem replayRun_mem_support_replayFirstRun_append [spec.DecidableEq]
 
 /-- Every replay run can be realized as a logged run with the same observed transcript. -/
 theorem replayRunWithTraceValue_mem_support_replayFirstRun [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -2113,7 +2103,13 @@ The `hreach` hypothesis (`CfReachable`) is needed because, unlike the seed-based
 (where `cf x = some s` always implies the `s`-th query value is well-defined in the seed),
 in the replay setting, `cf` is computed from `x` independently from the actual queries
 made by the run that produced it. The hypothesis captures the natural condition that the
-fork point `s` chosen by `cf` always corresponds to a query that was actually issued. -/
+fork point `s` chosen by `cf` always corresponds to a query that was actually issued.
+
+**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`**: this theorem
+invokes the Jensen/Cauchy-Schwarz step as a helper, and that helper is still a `sorry`.
+Downstream consumers (`probOutput_none_forkReplay_le`, `le_probEvent_isSome_forkReplay`,
+`Fork.replayForkingBound`, `euf_nma_bound`, `euf_cma_bound`) inherit this conditionality
+until the step is discharged. -/
 theorem le_probOutput_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
@@ -2216,7 +2212,10 @@ private lemma sum_probEvent_forkReplay_le_tsum_some
 /-- Replay fork failure probability bound. This mirrors `probOutput_none_seededFork_le`;
 the proof structure is identical, substituting the pointwise replay lower bound
 `le_probOutput_forkReplay` for its seed-based analogue. The `hreach` hypothesis is
-threaded through from `le_probOutput_forkReplay`. -/
+threaded through from `le_probOutput_forkReplay`.
+
+**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`** (transitively via
+`le_probOutput_forkReplay`). -/
 theorem probOutput_none_forkReplay_le
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
@@ -2277,7 +2276,10 @@ theorem probOutput_none_forkReplay_le
 /-- Packaged replay forking theorem. This is the replay analogue of
 `le_probEvent_isSome_seededFork`, derived from `probOutput_none_forkReplay_le` and
 `forkReplay_precondition_le_one` by the same `1 - ·` conversion used in
-`le_probEvent_isSome_seededFork`. The `hreach` hypothesis is threaded through. -/
+`le_probEvent_isSome_seededFork`. The `hreach` hypothesis is threaded through.
+
+**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`** (transitively via
+`probOutput_none_forkReplay_le`). -/
 theorem le_probEvent_isSome_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
@@ -2308,7 +2310,7 @@ theorem le_probEvent_isSome_forkReplay
   exact (ENNReal.le_sub_iff_add_le_right hnone_ne_top probOutput_le_one).2
     (by simpa [add_comm] using hfork)
 
-omit [OracleSpec.LawfulSubSpec unifSpec spec] in
+omit [spec.Fintype] [spec.Inhabited] [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- Structural success facts for `forkReplay`: both outputs come from logged runs of `main`,
 share the same selected fork index, differ at the selected distinguished-oracle answer, and the
 second run is witnessed by a replay state whose observed log agrees with the first-run log on the
@@ -2399,7 +2401,7 @@ theorem forkReplay_success_log_props
             exact this
         · simp at h
 
-omit [OracleSpec.LawfulSubSpec unifSpec spec] in
+omit [spec.Fintype] [spec.Inhabited] [OracleSpec.LawfulSubSpec unifSpec spec] in
 /-- Replay property transfer: any postcondition that holds for every logged run of `main`
 holds for both outputs of a successful replay fork, together with the common selected fork index
 and the fact that the distinguished answers differ at that index.

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -2041,11 +2041,16 @@ sample, which is uniform, just like averaging over `u`.
 This lemma encodes that operational equivalence as a distributional equality. It is
 the replay analogue of `evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue`.
 
-Proof sketch (deferred): induction on `main`, tracking the replay-oracle state, case
-splitting on whether the current query's index matches `i`, is a non-fork consumer,
-or is the fork query. The pre-fork portion matches the prefix so both sides trace the
-same path; at the fork, both sides produce a uniform sample (substituted `u` on the
-left, live on the right). Post-fork, both sides are fully live. -/
+Proof structure:
+- **Trivial case** (`(log.getQ (· = i)).length ≤ s`): the fork never fires on either side
+  because `log` has fewer than `s + 1` `i`-entries, so `takeBeforeForkAt log i s = log`
+  (`takeBeforeForkAt_of_getQ_length_le`) and the equality is immediate.
+- **Nontrivial case** (`s < (log.getQ (· = i)).length`): fork fires on the left at the
+  `s`-th `i`-entry (substituting `u`), and on the right the prefix is exhausted right
+  before that entry, so `nextEntry? = none` triggers `markMismatch` and a live sample.
+  Both sides trace identical pre-fork behaviour, produce a uniform sample at the fork
+  position, and then continue in live (mismatch) mode. Proved by induction on `main`
+  tracking the replay-oracle state. -/
 private lemma evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
     [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
     (main : OracleComp spec α) (i : ι) (log : QueryLog spec) (s : ℕ) :
@@ -2055,7 +2060,12 @@ private lemma evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
     evalDist (do
       let u ← liftComp ($ᵗ spec.Range i) spec
       Prod.fst <$> replayRunWithTraceValue main i (QueryLog.takeBeforeForkAt log i s) s u) := by
-  sorry
+  classical
+  by_cases hlen : (log.getQ (· = i)).length ≤ s
+  · rw [QueryLog.takeBeforeForkAt_of_getQ_length_le log i s hlen]
+  · -- Nontrivial case: `s < (log.getQ (· = i)).length`. Proof deferred to induction on `main`.
+    push Not at hlen
+    sorry
 
 /-- Probability form of the prefix-faithfulness claim: averaging over `u`, the probability
 that the second run produces any fixed output `x` depends on the trace only through its
@@ -2104,11 +2114,25 @@ first- and second-run outputs are exchangeable with identical marginals given by
 replay computation `replayRunWithTraceValue main i (takeBeforeForkAt ..) s u` on a
 fresh uniform `u`.
 
-Proof sketch (deferred): induction on `main`, jointly tracking the logging oracle
-(that feeds `replayFirstRun`) and the replay-with-truncated-log oracle on the RHS.
-At each query step, both sides consume the matching log entry or fall through to a
-live sample in synchronized fashion; at the `(s+1)`-th `i`-query, both sides go
-live, delivering the same conditional marginal. -/
+Proof plan:
+1. Rewrite both sides as tsums over the truncated log `τ` by pushing the
+   `trunc p.2`-dependence through with `tsum_congr` and the `takeBeforeForkAt`
+   "equal or short" characterisation of the fibres of
+   `p ↦ takeBeforeForkAt p.2 i s`.
+2. For each fixed `τ`, the two inner tsums over `p` with `takeBeforeForkAt p.2 i s = τ`
+   have a joint-marginal interpretation: they average `[cf p.1 = y]` vs. the replay
+   marginal over the remaining (post-`τ`) randomness of `main`.
+3. Proceed by induction on `main`, mirroring the seeded analogue structurally.
+   The logging-oracle on the LHS extends the log with whatever `main` produces;
+   the replay-oracle on the RHS starts from the truncated prefix.  Pre-fork, both
+   sides consume matching entries; at the truncation boundary both go live with a
+   fresh uniform (this is what `B1a`, encoded as
+   `probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt`,
+   captures); post-fork, both sides are in live mode and the two marginal distributions
+   coincide.
+
+Deferred as a large structural induction (cf. the ~150-line seeded
+`tsum_probOutput_generateSeed_weight_takeAtIndex`). -/
 private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
     {β : Type} (main : OracleComp spec α) (i : ι) (s : ℕ)
     (f : α → β) (y : β) (h : QueryLog spec → ℝ≥0∞) :

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -2574,11 +2574,13 @@ in the replay setting, `cf` is computed from `x` independently from the actual q
 made by the run that produced it. The hypothesis captures the natural condition that the
 fork point `s` chosen by `cf` always corresponds to a query that was actually issued.
 
-**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`**: this theorem
-invokes the Jensen/Cauchy-Schwarz step as a helper, and that helper is still a `sorry`.
+**Currently conditional on the two prefix-faithfulness `sorry`s** feeding
+`sq_probOutput_main_le_noGuardReplayComp`:
+`evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt` (induction on `main`)
+and `tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt` (weighted-averaging induction).
 Downstream consumers (`probOutput_none_forkReplay_le`, `le_probEvent_isSome_forkReplay`,
 `Fork.replayForkingBound`, `euf_nma_bound`, `euf_cma_bound`) inherit this conditionality
-until the step is discharged. -/
+until both faithfulness lemmas are discharged. -/
 theorem le_probOutput_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
@@ -2683,8 +2685,8 @@ the proof structure is identical, substituting the pointwise replay lower bound
 `le_probOutput_forkReplay` for its seed-based analogue. The `hreach` hypothesis is
 threaded through from `le_probOutput_forkReplay`.
 
-**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`** (transitively via
-`le_probOutput_forkReplay`). -/
+**Currently conditional on the two B1 prefix-faithfulness `sorry`s** (transitively via
+`le_probOutput_forkReplay` → `sq_probOutput_main_le_noGuardReplayComp`). -/
 theorem probOutput_none_forkReplay_le
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
@@ -2747,8 +2749,9 @@ theorem probOutput_none_forkReplay_le
 `forkReplay_precondition_le_one` by the same `1 - ·` conversion used in
 `le_probEvent_isSome_seededFork`. The `hreach` hypothesis is threaded through.
 
-**Currently conditional on `sq_probOutput_main_le_noGuardReplayComp`** (transitively via
-`probOutput_none_forkReplay_le`). -/
+**Currently conditional on the two B1 prefix-faithfulness `sorry`s** (transitively via
+`probOutput_none_forkReplay_le` → `le_probOutput_forkReplay`
+→ `sq_probOutput_main_le_noGuardReplayComp`). -/
 theorem le_probEvent_isSome_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -147,6 +147,127 @@ lemma getQueryValue?_cons_self_succ [spec.DecidableEq]
   rw [QueryLog.getQ_cons]
   simp
 
+/-- The prefix of `log` up to (but not including) the `s`-th `i`-query.
+
+If `log` has fewer than `s + 1` queries to `i`, this returns the entire `log`. This is
+the replay analogue of `QuerySeed.takeAtIndex` and is the key slicing operator used in
+the Cauchy-Schwarz step of the replay forking bound. -/
+def takeBeforeForkAt [spec.DecidableEq] :
+    QueryLog spec → ι → ℕ → QueryLog spec
+  | [], _, _ => []
+  | ⟨t, u⟩ :: tl, i, 0 =>
+      if t = i then [] else ⟨t, u⟩ :: takeBeforeForkAt tl i 0
+  | ⟨t, u⟩ :: tl, i, s + 1 =>
+      if t = i then ⟨t, u⟩ :: takeBeforeForkAt tl i s
+      else ⟨t, u⟩ :: takeBeforeForkAt tl i (s + 1)
+
+@[simp]
+lemma takeBeforeForkAt_nil [spec.DecidableEq] (i : ι) (s : ℕ) :
+    takeBeforeForkAt ([] : QueryLog spec) i s = [] := rfl
+
+lemma takeBeforeForkAt_cons_of_ne [spec.DecidableEq]
+    (t : ι) (u : spec.Range t) (tl : QueryLog spec) (i : ι) (s : ℕ) (h : t ≠ i) :
+    takeBeforeForkAt (⟨t, u⟩ :: tl) i s = ⟨t, u⟩ :: takeBeforeForkAt tl i s := by
+  cases s with
+  | zero => simp [takeBeforeForkAt, h]
+  | succ s => simp [takeBeforeForkAt, h]
+
+lemma takeBeforeForkAt_cons_self_zero [spec.DecidableEq]
+    (t : ι) (u : spec.Range t) (tl : QueryLog spec) :
+    takeBeforeForkAt (⟨t, u⟩ :: tl) t 0 = [] := by
+  simp [takeBeforeForkAt]
+
+lemma takeBeforeForkAt_cons_self_succ [spec.DecidableEq]
+    (t : ι) (u : spec.Range t) (tl : QueryLog spec) (s : ℕ) :
+    takeBeforeForkAt (⟨t, u⟩ :: tl) t (s + 1) = ⟨t, u⟩ :: takeBeforeForkAt tl t s := by
+  simp [takeBeforeForkAt]
+
+/-- The prefix `takeBeforeForkAt log i s` has at most `s` queries to `i`. -/
+lemma countQ_takeBeforeForkAt_le [spec.DecidableEq]
+    (log : QueryLog spec) (i : ι) (s : ℕ) :
+    (takeBeforeForkAt log i s).countQ (· = i) ≤ s := by
+  induction log generalizing s with
+  | nil => simp [QueryLog.countQ]
+  | cons entry tl ih =>
+      obtain ⟨t, u⟩ := entry
+      by_cases h : t = i
+      · subst h
+        cases s with
+        | zero => rw [takeBeforeForkAt_cons_self_zero]; simp [QueryLog.countQ]
+        | succ s =>
+            rw [takeBeforeForkAt_cons_self_succ]
+            simp only [QueryLog.countQ, QueryLog.getQ_cons, ↓reduceIte, List.length_cons]
+            have := ih s
+            simp only [QueryLog.countQ] at this
+            omega
+      · rw [takeBeforeForkAt_cons_of_ne _ _ _ _ _ h]
+        simp only [QueryLog.countQ, QueryLog.getQ_cons]
+        rw [if_neg h]
+        simpa [QueryLog.countQ] using ih s
+
+/-- If `log` contains at least `s + 1` queries to `i`, then `takeBeforeForkAt log i s` has
+exactly `s` queries to `i`. -/
+lemma countQ_takeBeforeForkAt_eq [spec.DecidableEq]
+    (log : QueryLog spec) (i : ι) (s : ℕ)
+    (h : s < (log.getQ (· = i)).length) :
+    (takeBeforeForkAt log i s).countQ (· = i) = s := by
+  induction log generalizing s with
+  | nil => simp [QueryLog.getQ] at h
+  | cons entry tl ih =>
+      obtain ⟨t, u⟩ := entry
+      by_cases ht : t = i
+      · subst ht
+        cases s with
+        | zero => rw [takeBeforeForkAt_cons_self_zero]; simp [QueryLog.countQ, QueryLog.getQ]
+        | succ s =>
+            rw [takeBeforeForkAt_cons_self_succ]
+            simp only [QueryLog.countQ, QueryLog.getQ_cons, ↓reduceIte, List.length_cons]
+            have h' : s < (QueryLog.getQ tl (· = t)).length := by
+              simp only [QueryLog.getQ_cons, ↓reduceIte, List.length_cons] at h
+              omega
+            have := ih s h'
+            simp only [QueryLog.countQ] at this
+            omega
+      · rw [takeBeforeForkAt_cons_of_ne _ _ _ _ _ ht]
+        simp only [QueryLog.countQ, QueryLog.getQ_cons]
+        rw [if_neg ht]
+        simp only [QueryLog.getQ_cons] at h
+        rw [if_neg ht] at h
+        simpa [QueryLog.countQ] using ih s h
+
+/-- `takeBeforeForkAt log i s` is a prefix of `log`. -/
+lemma takeBeforeForkAt_prefix [spec.DecidableEq]
+    (log : QueryLog spec) (i : ι) (s : ℕ) :
+    (takeBeforeForkAt log i s) <+: log := by
+  induction log generalizing s with
+  | nil => simp
+  | cons entry tl ih =>
+      obtain ⟨t, u⟩ := entry
+      by_cases h : t = i
+      · subst h
+        cases s with
+        | zero =>
+            rw [takeBeforeForkAt_cons_self_zero]
+            exact List.nil_prefix
+        | succ s =>
+            rw [takeBeforeForkAt_cons_self_succ]
+            exact List.cons_prefix_cons.mpr ⟨rfl, ih s⟩
+      · rw [takeBeforeForkAt_cons_of_ne _ _ _ _ _ h]
+        exact List.cons_prefix_cons.mpr ⟨rfl, ih s⟩
+
+/-- `getQueryValue?` on the truncation at index `i` position `s` is `none`: the prefix
+has fewer than `s + 1` entries at oracle `i`. -/
+lemma getQueryValue?_takeBeforeForkAt_self [spec.DecidableEq]
+    (log : QueryLog spec) (i : ι) (s : ℕ) :
+    getQueryValue? (takeBeforeForkAt log i s) i s = none := by
+  unfold getQueryValue?
+  have h := countQ_takeBeforeForkAt_le log i s
+  simp only [QueryLog.countQ] at h
+  have hnone : ((takeBeforeForkAt log i s).getQ (· = i))[s]? = none := by
+    rw [List.getElem?_eq_none_iff]
+    exact h
+  rw [hnone]
+
 end QueryLog
 
 namespace OracleComp


### PR DESCRIPTION
## Summary

Builds out the foundation, scaffolding, and first reductions for B1 (`sq_probOutput_main_le_noGuardReplayComp`), the Cauchy-Schwarz / Jensen step in the replay forking bound.

## Commits

1. **`feat(crypto): add QueryLog.takeBeforeForkAt truncation operator`** — Defines the prefix `QueryLog.takeBeforeForkAt log i s` (replay analogue of `QuerySeed.takeAtIndex`) along with its basic properties (`countQ_*`, `takeBeforeForkAt_prefix`, `getQueryValue?_takeBeforeForkAt_self`).

2. **`feat(crypto): factor B1 into replay prefix-faithfulness claim`** — Introduces the key distributional claim: averaging the uniform substitution `u`, the replay second-run distribution depends on `log` only through `takeBeforeForkAt log i s`.  Adds both `evalDist` and `probOutput` forms.

3. **`feat(crypto): complete sq_probOutput_main_le_noGuardReplayComp`** — **Fully proves B1** modulo the two faithfulness claims above.  Uses `ENNReal.sq_tsum_le_tsum_sq` (Cauchy-Schwarz on a sub-probability weight), the weighted faithfulness claim, the basic faithfulness claim, and careful expansion of `Pr[= z | noGuardReplayComp ..]` via `probOutput_prod_mk_snd_map` and `probOutput_some_map_some`.  Mirrors the structure of the seeded analogue `sq_probOutput_main_le_noGuardComp`.

4. **`feat(crypto): add takeBeforeForkAt_of_getQ_length_le trivial case`** — When `log` has at most `s` entries of type `i`, truncation is a no-op: `takeBeforeForkAt log i s = log`.

5. **`refactor(crypto): dispatch trivial case of B1a via length helper`** — Splits the basic faithfulness claim into trivial (log short, proved via #4) and nontrivial (log long, fork fires) cases, so the remaining `sorry` is only the nontrivial branch.  Also expands the weighted-faithfulness docstring with a concrete three-step proof plan.

## Remaining sorries after this PR

In `VCVio/CryptoFoundations/ReplayFork.lean`:

* `isTotalQueryBound_replayRunWithTraceValue` (~L1473) — pre-existing, query-budget bookkeeping, unrelated to the distributional bound.
* `evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt` (~L2054) — **nontrivial case only.** Fork fires on the left with substituted `u`, falls through to live sample on the right; distributions coincide.  Proof deferred to induction on `main` tracking replay-oracle state (~200-line structural analogue of the seeded `evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue`).
* `tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt` (~L2136) — weighted replay prefix-faithfulness.  Joint-distribution identity replacing the first-run success indicator with the replay-marginal probability, averaged over logs.  Proof deferred (~150-line analogue of the seeded `tsum_probOutput_generateSeed_weight_takeAtIndex`).

## Stacking

Stacks on top of #290 (Group A structural lemmas).

## Test plan

- [x] `lake build VCVio.CryptoFoundations.ReplayFork` succeeds.
- [x] Full `lake build` succeeds (just the three documented sorries + pre-existing unrelated warnings).
- [ ] CI to confirm no regressions.

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user (Quang Dao) with approval.