### PR TITLE
refactor(uc): naming cleanup + MachineId identity layer

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -115,6 +115,7 @@ import VCVio.Interaction.TwoParty.Swap
 import VCVio.Interaction.UC.Computational
 import VCVio.Interaction.UC.Emulates
 import VCVio.Interaction.UC.Interface
+import VCVio.Interaction.UC.MachineId
 import VCVio.Interaction.UC.Notation
 import VCVio.Interaction.UC.OpenProcess
 import VCVio.Interaction.UC.OpenProcessModel

--- a/VCVio/Interaction/UC/Computational.lean
+++ b/VCVio/Interaction/UC/Computational.lean
@@ -11,9 +11,16 @@ import VCVio.CryptoFoundations.Asymptotics.Security
 /-!
 # Computational observation layer for UC security
 
-This file bridges the abstract UC judgments (`Emulates`, `UCSecure`) to
-concrete computational indistinguishability by instantiating the `ObsEq`
-parameter with distributional advantage bounds.
+This file gives a concrete computational reading of the abstract UC
+judgments (`Emulates`, `UCSecure`) in terms of distributional
+distinguishing advantage. It deliberately keeps the fixed-`ε` notion
+`CompEmulates` separate from the abstract `Emulates`-as-equivalence
+judgment, because the relation
+`fun c₁ c₂ => distAdvantage (sem c₁) (sem c₂) ≤ ε` is not transitive at
+fixed `ε` (the triangle inequality only gives `2ε`) and therefore cannot
+be packaged as `Observation T`. The principled bridge to abstract
+`Emulates` lives at the asymptotic level (`AsympCompEmulates`), where
+sums of negligibles are still negligible.
 
 ## Main definitions
 
@@ -39,8 +46,6 @@ parameter with distributional advantage bounds.
 * `CompEmulates.map_invariance`: boundary adaptation preserves the bound.
 * `CompEmulates.par_compose`, `wire_compose`, `plug_compose`:
   advantages add under parallel, wired, and plugged composition.
-* `CompEmulates.toEmulates`: every `CompEmulates` yields an abstract
-  `Emulates` for the induced observation relation.
 * `CompUCSecure.toCompEmulates`: simulator-based security implies
   computational emulation when the simulator is the identity.
 * `AsympCompEmulates.par_compose`, `wire_compose`, `plug_compose`:
@@ -84,25 +89,7 @@ def CompEmulates (sem : Semantics T) (ε : ℝ)
   ∀ K : T.Plug Δ,
     (sem.run (T.close real K)).distAdvantage (sem.run (T.close ideal K)) ≤ ε
 
-/--
-The observation relation on closed systems induced by a semantics and
-an advantage bound: two closed systems are related when their
-distinguishing advantage is at most `ε`.
--/
-def compObsEq (sem : Semantics T) (ε : ℝ) : T.Closed → T.Closed → Prop :=
-  fun c₁ c₂ => (sem.run c₁).distAdvantage (sem.run c₂) ≤ ε
-
 namespace CompEmulates
-
-/--
-`CompEmulates` is an instance of abstract `Emulates` for the observation
-relation `compObsEq sem ε`.
--/
-theorem toEmulates {sem : Semantics T} {ε : ℝ}
-    {Δ : PortBoundary} {real ideal : T.Obj Δ}
-    (h : CompEmulates sem ε real ideal) :
-    Emulates real ideal (compObsEq sem ε) :=
-  ⟨h⟩
 
 /--
 Every system computationally emulates itself with advantage zero.

--- a/VCVio/Interaction/UC/Emulates.lean
+++ b/VCVio/Interaction/UC/Emulates.lean
@@ -13,27 +13,36 @@ at the abstract `OpenTheory` level.
 
 ## Main definitions
 
-* `Emulates T real ideal ObsEq` says that the open system `real` *emulates*
-  `ideal` in theory `T` whenever, for every valid plug (context), the
-  resulting closed systems are observationally equivalent.
+* `Observation T` bundles a binary relation on closed systems together with a
+  proof that it is an equivalence relation. UC judgments are parameterized
+  uniformly over `Observation T` so that reflexivity, symmetry, and
+  transitivity are always available without per-call hypotheses.
 
-* `UCSecure T protocol ideal ObsEq SimSpace simulate` is the existential
-  simulator variant: there exists a simulator that transforms any context so
-  that the closed ideal system (with the simulated context) is observationally
-  equivalent to the closed real system.
+* `Emulates real ideal Obs` says that the open system `real` *emulates*
+  `ideal` whenever, for every valid plug (context), the resulting closed
+  systems are related by `Obs.rel`.
+
+* `UCSecure protocol ideal Obs SimSpace simulate` is the existential simulator
+  variant: there exists a simulator that transforms any context so that the
+  closed ideal system (with the simulated context) is `Obs.rel`-related to
+  the closed real system.
+
+The canonical `Observation.eq T` instantiates the framework with perfect
+syntactic equality on closed systems; downstream layers (e.g. open process
+isos, asymptotic computational indistinguishability) supply their own
+`Observation` constructors.
 
 ## Basic properties
 
-* `Emulates.refl` and `Emulates.trans` follow immediately from the
-  corresponding properties of the observation relation `ObsEq`.
+* `Emulates.refl` and `Emulates.trans` are immediate consequences of the
+  bundled `Equivalence` proof in `Observation`.
 
 * `Emulates.map_invariance` shows that adapting both sides of an emulation
   along the same boundary morphism preserves the emulation (requires a
   lawful theory).
 
 * `Emulates.plug_invariance` shows that plugging both sides of an emulation
-  with the same additional context preserves the emulation (requires a
-  lawful theory).
+  with the same additional context preserves the emulation.
 
 ## UC composition theorems
 
@@ -46,6 +55,20 @@ These rely on structural factorization lemmas
 (`close_par_left`, `close_par_right`, `close_wire_left`,
 `close_wire_right`, `plug_comm`) that capture monoidal coherence
 identities, derived from the `CompactClosed` axioms.
+
+## Design note: why `Observation` requires a full `Equivalence`
+
+Bundling the equivalence proof into `Observation` lets every UC theorem
+quantify over a single parameter `Obs : Observation T` rather than threading
+a relation plus separate `hRefl`/`hTrans`/`hSymm` hypotheses. The cost is
+that observation relations which are *not* equivalences (e.g. the fixed-`ε`
+computational distinguishability relation
+`fun c₁ c₂ => distAdvantage (sem c₁) (sem c₂) ≤ ε`, which fails transitivity
+because the triangle inequality only gives `2ε`) cannot be packaged as
+`Observation T`. The intended bridge from computational security to abstract
+`Emulates` therefore lives at the asymptotic level (where negligible
+distance is closed under sums and is a genuine equivalence), not at the
+fixed-`ε` level.
 -/
 
 universe u
@@ -56,48 +79,77 @@ namespace UC
 variable {T : OpenTheory.{u}}
 
 /--
-`Emulates T real ideal ObsEq` asserts that `real` contextually emulates
-`ideal` in the open-composition theory `T`.
+`Observation T` bundles a binary relation on the closed systems of an open
+theory `T` together with a proof that it is an equivalence relation.
+
+This is the parameter slot through which different security flavors
+(perfect, statistical, asymptotic computational) plug into the abstract UC
+judgments `Emulates` and `UCSecure`.
+-/
+structure Observation (T : OpenTheory.{u}) where
+  /-- The underlying binary relation on closed systems. -/
+  rel : T.Closed → T.Closed → Prop
+  /-- The relation is an equivalence (reflexive, symmetric, transitive). -/
+  equiv : Equivalence rel
+
+namespace Observation
+
+/-- Perfect syntactic equality on closed systems is an observation relation. -/
+def eq (T : OpenTheory.{u}) : Observation T where
+  rel := Eq
+  equiv := ⟨fun _ => rfl, Eq.symm, Eq.trans⟩
+
+@[simp]
+theorem eq_rel {T : OpenTheory.{u}} {c₁ c₂ : T.Closed} :
+    (Observation.eq T).rel c₁ c₂ ↔ c₁ = c₂ := Iff.rfl
+
+end Observation
+
+/--
+`Emulates real ideal Obs` asserts that `real` contextually emulates
+`ideal` in the open-composition theory `T`, judged by the observation
+relation `Obs : Observation T`.
 
 For every plug `K : T.Plug Δ`, the closed compositions `T.close real K`
-and `T.close ideal K` are related by `ObsEq`.
+and `T.close ideal K` are related by `Obs.rel`.
 
 This is the definitional core of UC security: no environment can
-distinguish `real` from `ideal`.
+distinguish `real` from `ideal` under the chosen observation.
 -/
 structure Emulates
     {Δ : PortBoundary}
     (real ideal : T.Obj Δ)
-    (ObsEq : T.Closed → T.Closed → Prop) : Prop where
-  compare : ∀ K : T.Plug Δ, ObsEq (T.close real K) (T.close ideal K)
+    (Obs : Observation T) : Prop where
+  compare : ∀ K : T.Plug Δ, Obs.rel (T.close real K) (T.close ideal K)
 
 namespace Emulates
 
-/--
-Every open system emulates itself, provided the observation relation is
-reflexive.
--/
+/-- Every open system emulates itself. -/
 theorem refl
     {Δ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (hRefl : ∀ c, ObsEq c c)
+    (Obs : Observation T)
     (W : T.Obj Δ) :
-    Emulates W W ObsEq :=
-  ⟨fun _ => hRefl _⟩
+    Emulates W W Obs :=
+  ⟨fun _ => Obs.equiv.refl _⟩
 
-/--
-Emulation composes transitively, provided the observation relation is
-transitive.
--/
+/-- Emulation is symmetric. -/
+theorem symm
+    {Δ : PortBoundary}
+    {Obs : Observation T}
+    {W₁ W₂ : T.Obj Δ}
+    (h : Emulates W₁ W₂ Obs) :
+    Emulates W₂ W₁ Obs :=
+  ⟨fun K => Obs.equiv.symm (h.compare K)⟩
+
+/-- Emulation composes transitively. -/
 theorem trans
     {Δ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (hTrans : ∀ a b c, ObsEq a b → ObsEq b c → ObsEq a c)
+    {Obs : Observation T}
     {W₁ W₂ W₃ : T.Obj Δ}
-    (h₁₂ : Emulates W₁ W₂ ObsEq)
-    (h₂₃ : Emulates W₂ W₃ ObsEq) :
-    Emulates W₁ W₃ ObsEq :=
-  ⟨fun K => hTrans _ _ _ (h₁₂.compare K) (h₂₃.compare K)⟩
+    (h₁₂ : Emulates W₁ W₂ Obs)
+    (h₂₃ : Emulates W₂ W₃ Obs) :
+    Emulates W₁ W₃ Obs :=
+  ⟨fun K => Obs.equiv.trans (h₁₂.compare K) (h₂₃.compare K)⟩
 
 /--
 Adapting both sides of an emulation along the same boundary morphism
@@ -109,11 +161,11 @@ which is the `map_plug` naturality law.
 theorem map_invariance
     [OpenTheory.IsLawfulPlug T]
     {Δ₁ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     (f : PortBoundary.Hom Δ₁ Δ₂)
     {real ideal : T.Obj Δ₁}
-    (h : Emulates real ideal ObsEq) :
-    Emulates (T.map f real) (T.map f ideal) ObsEq :=
+    (h : Emulates real ideal Obs) :
+    Emulates (T.map f real) (T.map f ideal) Obs :=
   ⟨fun K => by
     simp only [OpenTheory.close,
       OpenTheory.map_plug f real K, OpenTheory.map_plug f ideal K]
@@ -129,11 +181,11 @@ immediate from the definition.
 -/
 theorem plug_invariance
     {Δ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     {real ideal : T.Obj Δ}
-    (h : Emulates real ideal ObsEq)
+    (h : Emulates real ideal Obs)
     (K : T.Plug Δ) :
-    ObsEq (T.close real K) (T.close ideal K) :=
+    Obs.rel (T.close real K) (T.close ideal K) :=
   h.compare K
 
 end Emulates
@@ -324,11 +376,11 @@ variable [OpenTheory.CompactClosed T]
 emulation, with the right component and environment held fixed. -/
 theorem par_left
     {Δ₁ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     {real₁ ideal₁ : T.Obj Δ₁}
-    (h₁ : Emulates real₁ ideal₁ ObsEq)
+    (h₁ : Emulates real₁ ideal₁ Obs)
     (W₂ : T.Obj Δ₂) :
-    Emulates (T.par real₁ W₂) (T.par ideal₁ W₂) ObsEq :=
+    Emulates (T.par real₁ W₂) (T.par ideal₁ W₂) Obs :=
   ⟨fun K => by
     rw [OpenTheory.close_par_left real₁ W₂ K,
         OpenTheory.close_par_left ideal₁ W₂ K]
@@ -338,11 +390,11 @@ theorem par_left
 emulation, with the left component and environment held fixed. -/
 theorem par_right
     {Δ₁ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     (W₁ : T.Obj Δ₁)
     {real₂ ideal₂ : T.Obj Δ₂}
-    (h₂ : Emulates real₂ ideal₂ ObsEq) :
-    Emulates (T.par W₁ real₂) (T.par W₁ ideal₂) ObsEq :=
+    (h₂ : Emulates real₂ ideal₂ Obs) :
+    Emulates (T.par W₁ real₂) (T.par W₁ ideal₂) Obs :=
   ⟨fun K => by
     rw [OpenTheory.close_par_right W₁ real₂ K,
         OpenTheory.close_par_right W₁ ideal₂ K]
@@ -357,22 +409,21 @@ each step reducing to emulation of a single component via
 `close_par_left` / `close_par_right`. -/
 theorem par_compose
     {Δ₁ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (hTrans : ∀ a b c, ObsEq a b → ObsEq b c → ObsEq a c)
+    {Obs : Observation T}
     {real₁ ideal₁ : T.Obj Δ₁} {real₂ ideal₂ : T.Obj Δ₂}
-    (h₁ : Emulates real₁ ideal₁ ObsEq)
-    (h₂ : Emulates real₂ ideal₂ ObsEq) :
-    Emulates (T.par real₁ real₂) (T.par ideal₁ ideal₂) ObsEq :=
-  Emulates.trans hTrans (par_left h₁ real₂) (par_right ideal₁ h₂)
+    (h₁ : Emulates real₁ ideal₁ Obs)
+    (h₂ : Emulates real₂ ideal₂ Obs) :
+    Emulates (T.par real₁ real₂) (T.par ideal₁ ideal₂) Obs :=
+  Emulates.trans (par_left h₁ real₂) (par_right ideal₁ h₂)
 
 /-- Replacing the left factor of a wiring preserves emulation. -/
 theorem wire_left
     {Δ₁ Γ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     {real₁ ideal₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)}
-    (h₁ : Emulates real₁ ideal₁ ObsEq)
+    (h₁ : Emulates real₁ ideal₁ Obs)
     (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)) :
-    Emulates (T.wire real₁ W₂) (T.wire ideal₁ W₂) ObsEq :=
+    Emulates (T.wire real₁ W₂) (T.wire ideal₁ W₂) Obs :=
   ⟨fun K => by
     rw [OpenTheory.close_wire_left real₁ W₂ K,
         OpenTheory.close_wire_left ideal₁ W₂ K]
@@ -381,11 +432,11 @@ theorem wire_left
 /-- Replacing the right factor of a wiring preserves emulation. -/
 theorem wire_right
     {Δ₁ Γ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ))
     {real₂ ideal₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)}
-    (h₂ : Emulates real₂ ideal₂ ObsEq) :
-    Emulates (T.wire W₁ real₂) (T.wire W₁ ideal₂) ObsEq :=
+    (h₂ : Emulates real₂ ideal₂ Obs) :
+    Emulates (T.wire W₁ real₂) (T.wire W₁ ideal₂) Obs :=
   ⟨fun K => by
     rw [OpenTheory.close_wire_right W₁ real₂ K,
         OpenTheory.close_wire_right W₁ ideal₂ K]
@@ -395,25 +446,24 @@ theorem wire_right
 ideal, then their wired composition emulates the wired ideal. -/
 theorem wire_compose
     {Δ₁ Γ Δ₂ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (hTrans : ∀ a b c, ObsEq a b → ObsEq b c → ObsEq a c)
+    {Obs : Observation T}
     {real₁ ideal₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)}
     {real₂ ideal₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)}
-    (h₁ : Emulates real₁ ideal₁ ObsEq)
-    (h₂ : Emulates real₂ ideal₂ ObsEq) :
-    Emulates (T.wire real₁ real₂) (T.wire ideal₁ ideal₂) ObsEq :=
-  Emulates.trans hTrans (wire_left h₁ real₂) (wire_right ideal₁ h₂)
+    (h₁ : Emulates real₁ ideal₁ Obs)
+    (h₂ : Emulates real₂ ideal₂ Obs) :
+    Emulates (T.wire real₁ real₂) (T.wire ideal₁ ideal₂) Obs :=
+  Emulates.trans (wire_left h₁ real₂) (wire_right ideal₁ h₂)
 
 /-- Replacing the plug (environment) while keeping the protocol fixed
 preserves observational equivalence, using `plug_comm` to swap
 the protocol/environment roles. -/
 theorem plug_right
     {Δ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
+    {Obs : Observation T}
     (W : T.Obj Δ)
     {K₁ K₂ : T.Obj (PortBoundary.swap Δ)}
-    (hK : Emulates K₁ K₂ ObsEq) :
-    ObsEq (T.close W K₁) (T.close W K₂) := by
+    (hK : Emulates K₁ K₂ Obs) :
+    Obs.rel (T.close W K₁) (T.close W K₂) := by
   simp only [OpenTheory.close, OpenTheory.plug_comm W K₁,
     OpenTheory.plug_comm W K₂]
   exact hK.compare W
@@ -428,26 +478,25 @@ step 1 is `plug_invariance` (same environment, different protocol) and
 step 2 is `plug_right` (same protocol, different environment). -/
 theorem plug_compose
     {Δ : PortBoundary}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (hTrans : ∀ a b c, ObsEq a b → ObsEq b c → ObsEq a c)
+    {Obs : Observation T}
     {real ideal : T.Obj Δ}
     {K_real K_ideal : T.Obj (PortBoundary.swap Δ)}
-    (hProt : Emulates real ideal ObsEq)
-    (hEnv : Emulates K_real K_ideal ObsEq) :
-    ObsEq (T.close real K_real) (T.close ideal K_ideal) :=
-  hTrans _ _ _
+    (hProt : Emulates real ideal Obs)
+    (hEnv : Emulates K_real K_ideal Obs) :
+    Obs.rel (T.close real K_real) (T.close ideal K_ideal) :=
+  Obs.equiv.trans
     (hProt.plug_invariance K_real)
     (plug_right ideal hEnv)
 
 end Emulates
 
 /--
-`UCSecure T protocol ideal ObsEq SimSpace simulate` is the UC security
-statement with an existential simulator.
+`UCSecure protocol ideal Obs SimSpace simulate` is the UC security statement
+with an existential simulator.
 
 There exists a simulator parameter `s : SimSpace` such that for every
 context `K`, the closed real-world execution `T.close protocol K` is
-observationally equivalent to the closed ideal-world execution
+related (under `Obs.rel`) to the closed ideal-world execution
 `T.close ideal (simulate s K)`.
 
 The simulator `simulate s` transforms the context rather than the ideal
@@ -458,10 +507,10 @@ real world.
 def UCSecure
     {Δ : PortBoundary}
     (protocol ideal : T.Obj Δ)
-    (ObsEq : T.Closed → T.Closed → Prop)
+    (Obs : Observation T)
     (SimSpace : Type*) (simulate : SimSpace → T.Plug Δ → T.Plug Δ) : Prop :=
   ∃ s : SimSpace, ∀ K : T.Plug Δ,
-    ObsEq (T.close protocol K) (T.close ideal (simulate s K))
+    Obs.rel (T.close protocol K) (T.close ideal (simulate s K))
 
 /--
 Emulation implies UC security with the trivial (identity) simulator.
@@ -469,9 +518,9 @@ Emulation implies UC security with the trivial (identity) simulator.
 theorem Emulates.toUCSecure
     {Δ : PortBoundary}
     {protocol ideal : T.Obj Δ}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (h : Emulates protocol ideal ObsEq) :
-    UCSecure protocol ideal ObsEq PUnit (fun _ K => K) :=
+    {Obs : Observation T}
+    (h : Emulates protocol ideal Obs) :
+    UCSecure protocol ideal Obs PUnit (fun _ K => K) :=
   ⟨⟨⟩, h.compare⟩
 
 /--
@@ -480,9 +529,9 @@ UC security with identity simulation recovers emulation.
 theorem UCSecure.toEmulates_id
     {Δ : PortBoundary}
     {protocol ideal : T.Obj Δ}
-    {ObsEq : T.Closed → T.Closed → Prop}
-    (hSec : UCSecure protocol ideal ObsEq PUnit (fun _ K => K)) :
-    Emulates protocol ideal ObsEq :=
+    {Obs : Observation T}
+    (hSec : UCSecure protocol ideal Obs PUnit (fun _ K => K)) :
+    Emulates protocol ideal Obs :=
   let ⟨_, h⟩ := hSec; ⟨h⟩
 
 end UC

--- a/VCVio/Interaction/UC/MachineId.lean
+++ b/VCVio/Interaction/UC/MachineId.lean
@@ -1,0 +1,140 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.UC.OpenProcess
+
+/-!
+# Machine identity for UC composition
+
+This file introduces `MachineId Sid Pid`, the `(sid, pid)` machine identity
+used to address protocol participants in CJSV22-style universal composition
+(Canetti, Jain, Swanberg, Varia, *Universally Composable End-to-End Secure
+Messaging*, CRYPTO 2022). A machine is identified by a session identifier
+`sid : Sid` and a party identifier `pid : Pid`. Within a single instantiated
+session, party identifiers distinguish participants; across sessions, the
+session identifier scopes who is allowed to talk to whom.
+
+The framework's `OpenProcess Party Δ` is generic in its participant type
+`Party`. Specializing `Party := MachineId Sid Pid` recovers the CJSV22 surface
+where every protocol input and output is keyed by a `(sid, pid)` pair. The
+abbreviation `MachineProcess Sid Pid Δ` names that specialization.
+
+`MachineId` is intentionally additive: nothing in the existing UC layer
+mentions it, and protocols that already use a flat `Party` continue to work
+unchanged. New work that needs session-aware identity (forward security,
+post-compromise security, multi-session composition) instantiates
+`Party := MachineId Sid Pid` and uses the helpers below.
+
+## Status of related layers (deferred follow-ups)
+
+The full CJSV22 access-control story requires three additional pieces that are
+deliberately *not* introduced here, because each one carries a non-trivial
+cross-cutting design choice and they ship together as a coherent unit:
+
+* **`Interface.Packet.sender : MachineId`.** A packet currently carries only a
+  recipient port. Adding a sender field is invasive (every existing packet
+  construction site needs updating). Without it, the framework cannot tell
+  which machine sent an inbound packet, so any access-control predicate has
+  nothing concrete to inspect.
+* **`HasAccessControl` typeclass.** Per-process predicate
+  `allowed : MachineId → Packet → Bool` consulted by
+  `BoundaryAction.inputDecode` to drop ill-addressed packets. Depends on
+  `Packet.sender` to be expressible.
+* **`subroutineRespecting : MachineProcess Sid Pid Δ → Prop`.** A decidable,
+  structural predicate that recovers what an explicit scope policy would
+  otherwise enforce: a machine `(s, p)` only emits to and accepts packets
+  tagged with session `s`. Defining it cleanly requires `Packet.sender` so
+  the predicate has something concrete to read off the boundary action.
+
+These three are tracked together as the next slice of the F1 plan; see
+`Notes/vcvio-signal-uc-foundation-cjsv22.md` §6.10.1 and the F1 phase
+description for the proposed naming and the broader composition story.
+-/
+
+universe u v w
+
+namespace Interaction
+namespace UC
+
+/--
+`MachineId Sid Pid` is the standard `(sid, pid)` machine identity from
+CJSV22's universal composition with global subroutines.
+
+Two machines are equal iff both their session identifier and party identifier
+agree. Decidable equality is derived from decidable equality on `Sid` and
+`Pid`.
+
+The session identifier `Sid` is left abstract so users can pick the structure
+that fits their composition style: a flat `Nat` or `String` for single-level
+sessions, or a `List String` / prefix tree when nested subsessions need to
+be addressed by hierarchical paths (the standard CJSV22 idiom for spawned
+subprotocols).
+-/
+structure MachineId (Sid : Type u) (Pid : Type u) where
+  sid : Sid
+  pid : Pid
+deriving DecidableEq
+
+namespace MachineId
+
+variable {Sid Pid : Type u}
+
+theorem ext_iff {m₁ m₂ : MachineId Sid Pid} :
+    m₁ = m₂ ↔ m₁.sid = m₂.sid ∧ m₁.pid = m₂.pid := by
+  cases m₁; cases m₂; simp
+
+@[ext]
+theorem ext {m₁ m₂ : MachineId Sid Pid}
+    (hsid : m₁.sid = m₂.sid) (hpid : m₁.pid = m₂.pid) : m₁ = m₂ := by
+  rw [ext_iff]; exact ⟨hsid, hpid⟩
+
+/--
+Two machines belong to the same protocol session iff their session identifiers
+agree.
+
+This is the syntactic ingredient of CJSV22's "subroutine respecting" check:
+within a subroutine respecting protocol, a machine routes inbound and outbound
+messages only between machines sharing its `sid`.
+-/
+def sameSession [DecidableEq Sid] (m₁ m₂ : MachineId Sid Pid) : Bool :=
+  decide (m₁.sid = m₂.sid)
+
+@[simp]
+theorem sameSession_self [DecidableEq Sid] (m : MachineId Sid Pid) :
+    m.sameSession m = true := by
+  simp [sameSession]
+
+theorem sameSession_iff [DecidableEq Sid] (m₁ m₂ : MachineId Sid Pid) :
+    m₁.sameSession m₂ = true ↔ m₁.sid = m₂.sid := by
+  simp [sameSession]
+
+theorem sameSession_comm [DecidableEq Sid] (m₁ m₂ : MachineId Sid Pid) :
+    m₁.sameSession m₂ = m₂.sameSession m₁ := by
+  simp [sameSession, eq_comm]
+
+theorem sameSession_trans [DecidableEq Sid] {m₁ m₂ m₃ : MachineId Sid Pid}
+    (h₁₂ : m₁.sameSession m₂ = true) (h₂₃ : m₂.sameSession m₃ = true) :
+    m₁.sameSession m₃ = true := by
+  rw [sameSession_iff] at h₁₂ h₂₃ ⊢
+  exact h₁₂.trans h₂₃
+
+end MachineId
+
+/--
+`MachineProcess Sid Pid Δ` is the specialization of `OpenProcess` to processes
+whose participants are identified by `(sid, pid)` machine identities.
+
+This is the canonical type for protocols written in the CJSV22 idiom: every
+input and output packet is keyed by a `MachineId Sid Pid`, and session-scoped
+composition operates uniformly over this type.
+
+Existing examples that use a flat `Party` are unaffected; only protocols that
+need session-aware identity instantiate this abbreviation.
+-/
+abbrev MachineProcess (Sid Pid : Type u) (Δ : PortBoundary) :=
+  OpenProcess.{u, v, w} (MachineId Sid Pid) Δ
+
+end UC
+end Interaction

--- a/VCVio/Interaction/UC/OpenProcess.lean
+++ b/VCVio/Interaction/UC/OpenProcess.lean
@@ -25,11 +25,11 @@ The design follows the layered approach from the UC design notes:
   chosen move contributes.
 * `OpenNodeSemantics Party Δ X` extends the existing `NodeSemantics Party X`
   by one `BoundaryAction` field.
-* `OpenStepContext Party Δ` is the resulting realized node context.
+* `OpenNodeContext Party Δ` is the resulting realized node context.
 * `OpenProcess Party Δ` specializes `ProcessOver` to that open context.
 
 The closed-world layer is recovered by the canonical forgetful projection
-`openStepContextForget`, which drops the boundary action and retains only
+`OpenNodeContext.forget`, which drops the boundary action and retains only
 the `NodeSemantics`. This means every `OpenProcess` can be viewed as a plain
 closed `Process` by `ProcessOver.mapContext`.
 
@@ -307,10 +307,10 @@ At a node with move space `X`, the context value is
 `OpenNodeSemantics Party Δ X`: the usual controller-path and local-view data,
 plus a `BoundaryAction` describing the node's external traffic.
 -/
-abbrev OpenStepContext (Party : Type u) (Δ : PortBoundary) :=
+abbrev OpenNodeContext (Party : Type u) (Δ : PortBoundary) :=
   fun (X : Type w) => OpenNodeSemantics Party Δ X
 
-namespace OpenStepContext
+namespace OpenNodeContext
 
 /--
 The forgetful map from the open-world context to the closed-world context.
@@ -320,7 +320,7 @@ This drops the `BoundaryAction` and retains only the `NodeSemantics`
 -/
 def forget (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.ContextHom
-      (OpenStepContext Party Δ : Spec.Node.Context.{w})
+      (OpenNodeContext Party Δ : Spec.Node.Context.{w})
       (StepContext Party) :=
   fun _ ons => ons.toNodeSemantics
 
@@ -332,7 +332,7 @@ This marks every node as purely internal (no boundary traffic).
 def embed (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.ContextHom
       (StepContext Party)
-      (OpenStepContext Party Δ : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party Δ : Spec.Node.Context.{w}) :=
   fun _ ns => .ofClosed ns
 
 /--
@@ -344,13 +344,13 @@ the closed-world node semantics.
 def map (Party : Type u) {Δ₁ Δ₂ : PortBoundary}
     (φ : PortBoundary.Hom Δ₁ Δ₂) :
     Spec.Node.ContextHom
-      (OpenStepContext Party Δ₁ : Spec.Node.Context.{w})
-      (OpenStepContext Party Δ₂ : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party Δ₁ : Spec.Node.Context.{w})
+      (OpenNodeContext Party Δ₂ : Spec.Node.Context.{w}) :=
   fun _ ons => ons.mapBoundary φ
 
 @[simp]
 theorem map_id (Party : Type u) (Δ : PortBoundary) :
-    OpenStepContext.map.{u, w} Party (PortBoundary.Hom.id Δ) =
+    OpenNodeContext.map.{u, w} Party (PortBoundary.Hom.id Δ) =
       Spec.Node.ContextHom.id _ := by
   funext X ons; simp [map, Spec.Node.ContextHom.id]
 
@@ -358,8 +358,8 @@ theorem map_comp (Party : Type u)
     {Δ₁ Δ₂ Δ₃ : PortBoundary}
     (g : PortBoundary.Hom Δ₂ Δ₃) (f : PortBoundary.Hom Δ₁ Δ₂) :
     Spec.Node.ContextHom.comp
-      (OpenStepContext.map.{u, w} Party g) (OpenStepContext.map Party f) =
-      OpenStepContext.map Party (PortBoundary.Hom.comp g f) := by
+      (OpenNodeContext.map.{u, w} Party g) (OpenNodeContext.map Party f) =
+      OpenNodeContext.map Party (PortBoundary.Hom.comp g f) := by
   funext X ons; simp [map, Spec.Node.ContextHom.comp,
     OpenNodeSemantics.mapBoundary_comp]
 
@@ -372,8 +372,8 @@ interface while preserving the closed-world node semantics.
 def inlTensor (Party : Type u)
     (Δ₁ : PortBoundary) (Δ₂ : PortBoundary) :
     Spec.Node.ContextHom
-      (OpenStepContext Party Δ₁ : Spec.Node.Context.{w})
-      (OpenStepContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party Δ₁ : Spec.Node.Context.{w})
+      (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
     toNodeSemantics := ons.toNodeSemantics
     boundary := ons.boundary.embedInlTensor Δ₂
@@ -388,23 +388,23 @@ interface while preserving the closed-world node semantics.
 def inrTensor (Party : Type u)
     (Δ₁ : PortBoundary) (Δ₂ : PortBoundary) :
     Spec.Node.ContextHom
-      (OpenStepContext Party Δ₂ : Spec.Node.Context.{w})
-      (OpenStepContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party Δ₂ : Spec.Node.Context.{w})
+      (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
     toNodeSemantics := ons.toNodeSemantics
     boundary := ons.boundary.embedInrTensor Δ₁
   }
 
 /--
-Wire the left factor: transform `OpenStepContext Party (tensor Δ₁ Γ)` into
-`OpenStepContext Party (tensor Δ₁ Δ₂)` by filtering out internal (Γ) packets
+Wire the left factor: transform `OpenNodeContext Party (tensor Δ₁ Γ)` into
+`OpenNodeContext Party (tensor Δ₁ Δ₂)` by filtering out internal (Γ) packets
 and keeping only external (Δ₁) packets.
 -/
 def wireLeft (Party : Type u)
     (Δ₁ Γ Δ₂ : PortBoundary) :
     Spec.Node.ContextHom
-      (OpenStepContext Party (PortBoundary.tensor Δ₁ Γ) : Spec.Node.Context.{w})
-      (OpenStepContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party (PortBoundary.tensor Δ₁ Γ) : Spec.Node.Context.{w})
+      (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
     toNodeSemantics := ons.toNodeSemantics
     boundary := ons.boundary.wireLeft Δ₂
@@ -412,30 +412,30 @@ def wireLeft (Party : Type u)
 
 /--
 Wire the right factor: transform
-`OpenStepContext Party (tensor (swap Γ) Δ₂)` into
-`OpenStepContext Party (tensor Δ₁ Δ₂)` by filtering out internal
+`OpenNodeContext Party (tensor (swap Γ) Δ₂)` into
+`OpenNodeContext Party (tensor Δ₁ Δ₂)` by filtering out internal
 (swap Γ) packets and keeping only external (Δ₂) packets.
 -/
 def wireRight (Party : Type u)
     (Δ₁ Γ Δ₂ : PortBoundary) :
     Spec.Node.ContextHom
-      (OpenStepContext Party (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂) :
+      (OpenNodeContext Party (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂) :
         Spec.Node.Context.{w})
-      (OpenStepContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
     toNodeSemantics := ons.toNodeSemantics
     boundary := ons.boundary.wireRight Δ₁
   }
 
 /--
-Close the boundary: transform `OpenStepContext Party Δ` into
-`OpenStepContext Party empty` by dropping all boundary traffic.
+Close the boundary: transform `OpenNodeContext Party Δ` into
+`OpenNodeContext Party empty` by dropping all boundary traffic.
 Used by `plug` to internalize all external interactions.
 -/
 def close (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.ContextHom
-      (OpenStepContext Party Δ : Spec.Node.Context.{w})
-      (OpenStepContext Party PortBoundary.empty : Spec.Node.Context.{w}) :=
+      (OpenNodeContext Party Δ : Spec.Node.Context.{w})
+      (OpenNodeContext Party PortBoundary.empty : Spec.Node.Context.{w}) :=
   fun _ ons => {
     toNodeSemantics := ons.toNodeSemantics
     boundary := ons.boundary.closed
@@ -505,7 +505,7 @@ theorem map_tensor_comp_wireRight (Party : Type u)
   simp [map, wireRight, Spec.Node.ContextHom.comp,
     OpenNodeSemantics.mapBoundary]
 
-end OpenStepContext
+end OpenNodeContext
 
 /--
 The open-world specialization of `StepOver`.
@@ -515,7 +515,7 @@ records both the usual controller/view data and its boundary traffic against
 `Δ`.
 -/
 abbrev OpenStep (Party : Type u) (Δ : PortBoundary) (P : Type v) :=
-  StepOver (OpenStepContext Party Δ : Spec.Node.Context.{w}) P
+  StepOver (OpenNodeContext Party Δ : Spec.Node.Context.{w}) P
 
 /--
 The open-world specialization of `ProcessOver`.
@@ -525,10 +525,10 @@ decorated by `OpenNodeSemantics Party Δ`. It exposes the directed boundary
 `Δ` to an external context.
 
 The closed-world `Process Party` is recovered by
-`ProcessOver.mapContext (OpenStepContext.forget Party Δ)`.
+`ProcessOver.mapContext (OpenNodeContext.forget Party Δ)`.
 -/
 abbrev OpenProcess (Party : Type u) (Δ : PortBoundary) :=
-  ProcessOver (OpenStepContext Party Δ : Spec.Node.Context.{w})
+  ProcessOver (OpenNodeContext Party Δ : Spec.Node.Context.{w})
 
 namespace OpenProcess
 
@@ -542,7 +542,7 @@ local views.
 -/
 def toClosed {Party : Type u} {Δ : PortBoundary}
     (op : OpenProcess.{u, v, w} Party Δ) : Process Party :=
-  op.mapContext (OpenStepContext.forget Party Δ)
+  op.mapContext (OpenNodeContext.forget Party Δ)
 
 /--
 Embed a closed-world process as an open process with no boundary traffic.
@@ -552,7 +552,7 @@ produces no packets.
 -/
 def ofClosed {Party : Type u} {Δ : PortBoundary}
     (p : Process.{u, v, w} Party) : OpenProcess Party Δ :=
-  p.mapContext (OpenStepContext.embed Party Δ)
+  p.mapContext (OpenNodeContext.embed Party Δ)
 
 /--
 Adapt the exposed boundary of an open process along a structural boundary
@@ -565,7 +565,7 @@ and closed-world node semantics unchanged.
 def mapBoundary {Party : Type u} {Δ₁ Δ₂ : PortBoundary}
     (φ : PortBoundary.Hom Δ₁ Δ₂) (op : OpenProcess.{u, v, w} Party Δ₁) :
     OpenProcess Party Δ₂ :=
-  op.mapContext (OpenStepContext.map Party φ)
+  op.mapContext (OpenNodeContext.map Party φ)
 
 end OpenProcess
 
@@ -574,7 +574,7 @@ end OpenProcess
 predicates used throughout VCVio.
 -/
 abbrev OpenProcess.System (Party : Type u) (Δ : PortBoundary) :=
-  ProcessOver.System (OpenStepContext Party Δ : Spec.Node.Context.{w})
+  ProcessOver.System (OpenNodeContext Party Δ : Spec.Node.Context.{w})
 
 -- ============================================================================
 -- § Silent steps and weak bisimulation
@@ -588,7 +588,7 @@ ensures the predicate is invariant under *all* context morphisms, including
 `List.filterMap`. -/
 def IsSilentDecoration {Party : Type u} {Δ : PortBoundary} :
     {spec : Interaction.Spec.{w}} →
-    Interaction.Spec.Decoration (OpenStepContext.{u, w} Party Δ) spec →
+    Interaction.Spec.Decoration (OpenNodeContext.{u, w} Party Δ) spec →
     spec.Transcript → Prop
   | .done, _, _ => True
   | .node _ _, ⟨ons, drest⟩, ⟨x, tr⟩ =>
@@ -606,11 +606,11 @@ def IsSilentStep {Party : Type u} {Δ : PortBoundary}
 `mapBoundary`, `embedInlTensor`, `embedInrTensor`, `wireLeft`, `wireRight`,
 and `closed`) preserve `isActivated`. -/
 theorem isSilentDecoration_iff_map {Party : Type u} {Δ₁ Δ₂ : PortBoundary}
-    (f : Spec.Node.ContextHom (OpenStepContext.{u, w} Party Δ₁)
-      (OpenStepContext.{u, w} Party Δ₂))
-    (hAct : ∀ (X : Type w) (ons : OpenStepContext Party Δ₁ X),
+    (f : Spec.Node.ContextHom (OpenNodeContext.{u, w} Party Δ₁)
+      (OpenNodeContext.{u, w} Party Δ₂))
+    (hAct : ∀ (X : Type w) (ons : OpenNodeContext Party Δ₁ X),
       (f X ons).boundary.isActivated = ons.boundary.isActivated) :
-    {spec : Spec.{w}} → (d : Spec.Decoration (OpenStepContext Party Δ₁) spec) →
+    {spec : Spec.{w}} → (d : Spec.Decoration (OpenNodeContext Party Δ₁) spec) →
     (tr : spec.Transcript) →
     IsSilentDecoration (Spec.Decoration.map f spec d) tr ↔ IsSilentDecoration d tr
   | .done, _, _ => Iff.rfl
@@ -634,7 +634,7 @@ theorem isSilentStep_mapBoundary_iff {Party : Type u} {Δ₁ Δ₂ : PortBoundar
     IsSilentStep (p.mapBoundary φ) s tr ↔ IsSilentStep p s tr := by
   apply isSilentDecoration_iff_map
   intro X ons
-  simp [OpenStepContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+  simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
 
 -- ============================================================================
 -- § OpenProcessIso: weak bisimulation equivalence for open processes

--- a/VCVio/Interaction/UC/OpenProcessModel.lean
+++ b/VCVio/Interaction/UC/OpenProcessModel.lean
@@ -63,25 +63,25 @@ def openTheory : OpenTheory.{max (v + 1) u (w + 1)} where
   map φ p := p.mapBoundary φ
   par {Δ₁} {Δ₂} p₁ p₂ :=
     p₁.interleave p₂
-      (OpenStepContext.inlTensor Party Δ₁ Δ₂)
-      (OpenStepContext.inrTensor Party Δ₁ Δ₂)
+      (OpenNodeContext.inlTensor Party Δ₁ Δ₂)
+      (OpenNodeContext.inrTensor Party Δ₁ Δ₂)
       (schedulerNode Party (PortBoundary.tensor Δ₁ Δ₂))
   wire {Δ₁} {Γ} {Δ₂} p₁ p₂ :=
     p₁.interleave p₂
-      (OpenStepContext.wireLeft Party Δ₁ Γ Δ₂)
-      (OpenStepContext.wireRight Party Δ₁ Γ Δ₂)
+      (OpenNodeContext.wireLeft Party Δ₁ Γ Δ₂)
+      (OpenNodeContext.wireRight Party Δ₁ Γ Δ₂)
       (schedulerNode Party (PortBoundary.tensor Δ₁ Δ₂))
   plug {Δ} p k :=
     p.interleave k
-      (OpenStepContext.close Party Δ)
-      (OpenStepContext.close Party (PortBoundary.swap Δ))
+      (OpenNodeContext.close Party Δ)
+      (OpenNodeContext.close Party (PortBoundary.swap Δ))
       (schedulerNode Party PortBoundary.empty)
 
 instance : OpenTheory.IsLawfulMap (openTheory.{u, v, w} Party) where
   map_id {Δ} W := by
     change W.mapBoundary (PortBoundary.Hom.id Δ) = W
     simp only [OpenProcess.mapBoundary]
-    rw [OpenStepContext.map_id]
+    rw [OpenNodeContext.map_id]
     cases W with | mk Proc step =>
     simp only [ProcessOver.mapContext, StepOver.mapContext]
     congr 1; funext p
@@ -91,7 +91,7 @@ instance : OpenTheory.IsLawfulMap (openTheory.{u, v, w} Party) where
     change W.mapBoundary (PortBoundary.Hom.comp g f) =
       (W.mapBoundary f).mapBoundary g
     simp only [OpenProcess.mapBoundary]
-    rw [← OpenStepContext.map_comp]
+    rw [← OpenNodeContext.map_comp]
     cases W with | mk Proc step =>
     simp only [ProcessOver.mapContext, StepOver.mapContext]
     congr 1; funext p
@@ -115,8 +115,8 @@ instance : OpenTheory.IsLawfulPar (openTheory.{u, v, w} Party) where
     simp only [OpenProcess.mapBoundary]
     rw [ProcessOver.mapContext_interleave, ProcessOver.interleave_mapContext]
     congr 1
-    · exact OpenStepContext.map_tensor_comp_inlTensor Party f₁ f₂
-    · exact OpenStepContext.map_tensor_comp_inrTensor Party f₁ f₂
+    · exact OpenNodeContext.map_tensor_comp_inlTensor Party f₁ f₂
+    · exact OpenNodeContext.map_tensor_comp_inrTensor Party f₁ f₂
 
 instance : OpenTheory.IsLawfulWire (openTheory.{u, v, w} Party) where
   map_wire {Δ₁} {Δ₁'} {Γ} {Δ₂} {Δ₂'} f₁ f₂ W₁ W₂ := by
@@ -129,8 +129,8 @@ instance : OpenTheory.IsLawfulWire (openTheory.{u, v, w} Party) where
     simp only [OpenProcess.mapBoundary]
     rw [ProcessOver.mapContext_interleave, ProcessOver.interleave_mapContext]
     congr 1
-    · exact OpenStepContext.map_tensor_comp_wireLeft Party f₁ f₂
-    · exact OpenStepContext.map_tensor_comp_wireRight Party f₁ f₂
+    · exact OpenNodeContext.map_tensor_comp_wireLeft Party f₁ f₂
+    · exact OpenNodeContext.map_tensor_comp_wireRight Party f₁ f₂
 
 instance : OpenTheory.IsLawfulPlug (openTheory.{u, v, w} Party) where
   map_plug {Δ₁} {Δ₂} f W K := by
@@ -188,7 +188,7 @@ theorem openTheory_par_assoc_iso
           ((isSilentDecoration_iff_map _ ?_ _ _).mpr
             ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
         all_goals intro X ons
-        all_goals simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
+        all_goals simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
       | false =>
         refine ⟨⟨⟨false⟩, ⟨⟨true⟩, rest'⟩⟩, fun h => hvisible ?_, rfl, rfl, rfl⟩
         simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration, Spec.Decoration.map]
@@ -199,10 +199,10 @@ theorem openTheory_par_assoc_iso
             ((isSilentDecoration_iff_map _ ?_ _ _).mp
               ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2.2)))⟩
         all_goals intro X ons
-        · simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
-        · simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
-        · simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
-        · simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
+        · simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
+        · simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
+        · simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
+        · simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
     | false =>
       refine ⟨⟨⟨false⟩, ⟨⟨false⟩, rest⟩⟩, fun h => hvisible ?_, rfl, rfl, rfl⟩
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration, Spec.Decoration.map]
@@ -212,7 +212,7 @@ theorem openTheory_par_assoc_iso
         ((isSilentDecoration_iff_map _ ?_ _ _).mp
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2.2))⟩
       all_goals intro X ons
-      all_goals simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
+      all_goals simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
   · intro ⟨⟨b⟩, rest⟩ _
     match b with
     | true => exact .inl ⟨⟨⟨true⟩, ⟨⟨true⟩, rest⟩⟩, rfl, rfl, rfl⟩
@@ -233,7 +233,7 @@ theorem openTheory_par_assoc_iso
         ((isSilentDecoration_iff_map _ ?_ _ _).mp
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2.2))⟩
       all_goals intro X ons
-      all_goals simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
+      all_goals simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
     | false =>
       obtain ⟨⟨b'⟩, rest'⟩ := rest
       match b' with
@@ -248,10 +248,10 @@ theorem openTheory_par_assoc_iso
             ((isSilentDecoration_iff_map _ ?_ _ _).mp
               ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2.2)))⟩
         all_goals intro X ons
-        · simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
-        · simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
-        · simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
-        · simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
+        · simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
+        · simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
+        · simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
+        · simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
       | false =>
         refine ⟨⟨⟨false⟩, rest'⟩, fun h => hvisible ?_, rfl, rfl, rfl⟩
         rw [isSilentStep_mapBoundary_iff] at h
@@ -262,7 +262,7 @@ theorem openTheory_par_assoc_iso
           ((isSilentDecoration_iff_map _ ?_ _ _).mpr
             ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
         all_goals intro X ons
-        all_goals simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
+        all_goals simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
 
 /-- Parallel composition of open processes is commutative up to bisimilarity. -/
 theorem openTheory_par_comm_iso
@@ -292,17 +292,17 @@ theorem openTheory_par_comm_iso
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration]
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration] at h
       exact ⟨rfl, (isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mpr
+          simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mpr
         ((isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mp h.2)⟩
+          simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mp h.2)⟩
     | false =>
       refine ⟨⟨⟨true⟩, rest⟩, fun h => hvisible ?_, rfl, rfl⟩
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration]
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration] at h
       exact ⟨rfl, (isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mpr
+          simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mpr
         ((isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mp h.2)⟩
+          simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mp h.2)⟩
   · intro ⟨⟨b⟩, rest⟩ _
     match b with
     | true => exact .inl ⟨⟨⟨false⟩, rest⟩, rfl, rfl⟩
@@ -315,18 +315,18 @@ theorem openTheory_par_comm_iso
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration]
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration] at h
       exact ⟨rfl, (isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mpr
+          simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mpr
         ((isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mp h.2)⟩
+          simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mp h.2)⟩
     | false =>
       refine ⟨⟨⟨true⟩, rest⟩, fun h => hvisible ?_, rfl, rfl⟩
       rw [isSilentStep_mapBoundary_iff] at h
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration]
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration] at h
       exact ⟨rfl, (isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mpr
+          simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]) _ _).mpr
         ((isSilentDecoration_iff_map _ (fun X ons => by
-          simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mp h.2)⟩
+          simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]) _ _).mp h.2)⟩
 
 /-- The unit for parallel composition is the trivial process with no boundary
 and `PUnit` state. -/
@@ -368,7 +368,7 @@ theorem openTheory_par_leftUnit_iso
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration, Spec.Decoration.map]
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr h⟩
       intro X ons
-      simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
+      simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
   · intro tr₂ _
     exact .inl ⟨⟨⟨false⟩, tr₂⟩, rfl⟩
   · intro tr₂ hvisible
@@ -378,7 +378,7 @@ theorem openTheory_par_leftUnit_iso
       Spec.Decoration.map] at h
     refine (isSilentDecoration_iff_map _ ?_ _ _).mp h.2
     intro X ons
-    simp [OpenStepContext.inrTensor, BoundaryAction.embedInrTensor]
+    simp [OpenNodeContext.inrTensor, BoundaryAction.embedInrTensor]
 
 /-- The monoidal unit is a right identity for parallel composition up to
 bisimilarity. -/
@@ -407,7 +407,7 @@ theorem openTheory_par_rightUnit_iso
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration, Spec.Decoration.map]
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr h⟩
       intro X ons
-      simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
+      simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
     | false =>
       exact absurd (by simp [IsSilentStep, ProcessOver.interleave,
         IsSilentDecoration, Spec.Decoration.map, schedulerNode,
@@ -421,7 +421,7 @@ theorem openTheory_par_rightUnit_iso
       Spec.Decoration.map] at h
     refine (isSilentDecoration_iff_map _ ?_ _ _).mp h.2
     intro X ons
-    simp [OpenStepContext.inlTensor, BoundaryAction.embedInlTensor]
+    simp [OpenNodeContext.inlTensor, BoundaryAction.embedInlTensor]
 
 /-- The identity wire (coevaluation) on boundary `Γ`: relays messages
 bidirectionally between `swap Γ` and `Γ`. -/
@@ -464,7 +464,7 @@ theorem openTheory_wire_idWire_iso
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration, Spec.Decoration.map]
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr h⟩
       intro X ons
-      simp [OpenStepContext.wireRight, BoundaryAction.wireRight]
+      simp [OpenNodeContext.wireRight, BoundaryAction.wireRight]
   · intro tr₂ _
     exact .inl ⟨⟨⟨false⟩, tr₂⟩, rfl⟩
   · intro tr₂ hvisible
@@ -473,7 +473,7 @@ theorem openTheory_wire_idWire_iso
       Spec.Decoration.map] at h
     refine (isSilentDecoration_iff_map _ ?_ _ _).mp h.2
     intro X ons
-    simp [OpenStepContext.wireRight, BoundaryAction.wireRight]
+    simp [OpenNodeContext.wireRight, BoundaryAction.wireRight]
 
 /-- Right zig-zag: wiring the identity wire on the right is a no-op up to
 bisimilarity. -/
@@ -501,7 +501,7 @@ theorem openTheory_wire_idWire_right_iso
       simp only [IsSilentStep, ProcessOver.interleave, IsSilentDecoration, Spec.Decoration.map]
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr h⟩
       intro X ons
-      simp [OpenStepContext.wireLeft, BoundaryAction.wireLeft]
+      simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
     | false =>
       exact absurd (by simp [IsSilentStep, ProcessOver.interleave,
         IsSilentDecoration, Spec.Decoration.map, schedulerNode,
@@ -514,7 +514,7 @@ theorem openTheory_wire_idWire_right_iso
       Spec.Decoration.map] at h
     refine (isSilentDecoration_iff_map _ ?_ _ _).mp h.2
     intro X ons
-    simp [OpenStepContext.wireLeft, BoundaryAction.wireLeft]
+    simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
 
 /-- `plug` is derivable from `wire` plus boundary reshaping, up to
 bisimilarity. -/
@@ -549,20 +549,20 @@ theorem openTheory_plug_eq_wire_iso
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr
         ((isSilentDecoration_iff_map _ ?_ _ _).mp
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
-      · intro X ons; simp [OpenStepContext.close, BoundaryAction.closed]
+      · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
       · intro X ons
-        simp [OpenStepContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
-      · intro X ons; simp [OpenStepContext.wireLeft, BoundaryAction.wireLeft]
+        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+      · intro X ons; simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
     | false =>
       refine ⟨⟨⟨false⟩, rest⟩, fun h => hvisible ?_, rfl⟩
       rw [isSilentStep_mapBoundary_iff] at h
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr
         ((isSilentDecoration_iff_map _ ?_ _ _).mp
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
-      · intro X ons; simp [OpenStepContext.close, BoundaryAction.closed]
+      · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
       · intro X ons
-        simp [OpenStepContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
-      · intro X ons; simp [OpenStepContext.wireRight, BoundaryAction.wireRight]
+        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+      · intro X ons; simp [OpenNodeContext.wireRight, BoundaryAction.wireRight]
   · intro ⟨⟨b⟩, rest⟩ _
     match b with
     | true => exact .inl ⟨⟨⟨true⟩, rest⟩, rfl⟩
@@ -575,19 +575,19 @@ theorem openTheory_plug_eq_wire_iso
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr
         ((isSilentDecoration_iff_map _ ?_ _ _).mpr
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
-      · intro X ons; simp [OpenStepContext.wireLeft, BoundaryAction.wireLeft]
+      · intro X ons; simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
       · intro X ons
-        simp [OpenStepContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
-      · intro X ons; simp [OpenStepContext.close, BoundaryAction.closed]
+        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+      · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
     | false =>
       refine ⟨⟨⟨false⟩, rest⟩, fun h => hvisible ?_, rfl⟩
       refine ⟨rfl, (isSilentDecoration_iff_map _ ?_ _ _).mpr
         ((isSilentDecoration_iff_map _ ?_ _ _).mpr
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
-      · intro X ons; simp [OpenStepContext.wireRight, BoundaryAction.wireRight]
+      · intro X ons; simp [OpenNodeContext.wireRight, BoundaryAction.wireRight]
       · intro X ons
-        simp [OpenStepContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
-      · intro X ons; simp [OpenStepContext.close, BoundaryAction.closed]
+        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+      · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
 
 /-- The monoidal unit equals the coevaluation at the trivial boundary,
 up to bisimilarity. -/


### PR DESCRIPTION
## Summary

Three small, layered changes to the UC layer that improve naming
coherence and add the first piece of the CJSV22 (sid, pid) identity
story in a fully additive way.

1. **`OpenStepContext` → `OpenNodeContext`** (`7085519`).
   Pure rename across `VCVio/Interaction/UC/OpenProcess.lean` and
   `VCVio/Interaction/UC/OpenProcessModel.lean`. Aligns the UC node
   context name with the existing `NodeSemantics` / `NodeContext`
   vocabulary in the concurrent layer (no more `Step` / `Node`
   inconsistency at the same level of abstraction).

2. **Bundle the observation relation as `Observation T`** (`9ab0c55`).
   `Emulates` and `UCSecure` previously took a bare relation
   `obsEq : T.Closed → T.Closed → Prop` plus separate `hRefl` and
   `hTrans` hypotheses on every composition theorem. This commit
   introduces

   ```
   structure Observation (T : OpenTheory.{u}) where
     rel : T.Closed → T.Closed → Prop
     equiv : Equivalence rel
   ```

   along with `Observation.eq` (perfect syntactic equality), and
   migrates `Emulates`, `UCSecure`, and all composition theorems
   (`refl`, `trans`, `symm`, `map_invariance`, `plug_invariance`,
   `par_left/right/compose`, `wire_left/right/compose`,
   `plug_right/compose`, `toUCSecure`, `UCSecure.toEmulates_id`) to
   take a single `Obs : Observation T` parameter. `Emulates.symm` is
   now available for free.

   `compObsEq` and `CompEmulates.toEmulates` are removed from
   `VCVio/Interaction/UC/Computational.lean`. Fixed-`ε` distinguishing
   advantage is *not* transitive (the triangle inequality yields `2ε`,
   not `ε`), so it cannot honestly be packaged as `Observation T`. The
   principled bridge to abstract `Emulates` lives at the asymptotic
   level via `AsympCompEmulates` (where sums of negligible functions
   are still negligible). `Computational.lean`'s module docstring
   records this design boundary.

3. **`UC/MachineId.lean`** (`dab7c33`). New file (~140 lines)
   introducing the additive identity layer:

   - `structure MachineId (Sid Pid : Type u)` with `deriving DecidableEq`,
     `ext`, `ext_iff`.
   - `MachineId.sameSession` boolean predicate plus standard equivalence
     lemmas (`_self`, `_iff`, `_comm`, `_trans`).
   - `abbrev MachineProcess Sid Pid Δ := OpenProcess (MachineId Sid Pid) Δ`
     as the canonical CJSV22-shaped specialization.

   Existing protocols that use a flat `Party` continue to work
   unchanged. The module docstring records the three follow-ups
   (`Packet.sender`, `HasAccessControl`, `subroutineRespecting`) that
   ship together as the next slice of the F1 plan; see
   `Notes/vcvio-signal-uc-foundation-cjsv22.md` §6.10.1.

## Verification

* `lake build VCVio` succeeds with no new warnings (the existing
  `sorry` warnings in `GPVHashAndSign`, `DiffieHellman`, `KEMDEM`,
  `RenyiDivergence` are pre-existing and unrelated).
* `#print axioms` over every new declaration in `MachineId.lean`
  reports only `propext` (or no axioms at all). No `Classical.choice`
  or `sorryAx` introduced.
* `Emulates.lean`, `UCSecure.lean`, `Computational.lean`,
  `OpenProcess.lean`, `OpenProcessModel.lean` all replay cleanly.

## Test plan

- [ ] CI green
- [ ] Reviewer sanity-checks the `Observation T` API (especially that
      removing `compObsEq` is the right call given the non-transitivity
      argument)

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the
user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)