### PR TITLE
feat(uc): F1 Slice 2 + F2 Slice 1 + style: access control vocabulary, EnvAction Event X, corruption vocabulary, no banners

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for the repo's explicit attribution 
 - Preserve existing headers on routine edits.
 - Only rewrite attribution when a file is genuinely new or materially replaced.
 - Do not add a separate AI-attribution line.
+- For inline section breaks within a Lean file, use Mathlib-style doc-comment headers `/-! ## Title -/` (or the multi-line `/-! ## Title \n\n explanation -/` form). **Do not use ASCII banners** such as `-- ====...===` flanking a `-- § Title` line. The `/-!` form is rendered by `doc-gen4`; ASCII banners are not, and they make the file feel artificially partitioned. If a section is large enough to want a loud header, it is usually large enough to want its own `namespace` or its own file. See *Section Headers Within A File* in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## What This Project Is
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,42 @@ When in doubt, prefer:
   5. module docstring
   Keep exactly one blank line between these blocks.
 
+### Section Headers Within A File
+
+Use Mathlib-style doc-comment section headers, **not** ASCII banners.
+
+For an inline section break inside a Lean file, use a one-line docstring header that doc-gen will render in the generated documentation:
+
+```lean
+/-! ## Section title -/
+```
+
+Or, for a section with its own paragraph of explanation:
+
+```lean
+/-!
+## Section title
+
+Optional paragraph describing what the section contains.
+-/
+```
+
+Do **not** use ASCII banners such as:
+
+```lean
+-- ============================================================================
+-- § Section title
+-- ============================================================================
+```
+
+ASCII banners are visually loud, do not appear in the generated documentation, and make the file feel partitioned in a way that the type system does not enforce. Prefer the `/-!` form, which both reads as natural prose and surfaces in `doc-gen4` output. If a section is large enough to warrant its own banner, it is usually large enough to warrant its own `namespace` or its own file.
+
 ## Style Notes
 
 - Keep imports at the top of the file.
 - Follow Mathlib naming conventions where possible.
 - Respect the module layering documented in [`AGENTS.md`](AGENTS.md).
+- Use `/-! ## Title -/` doc-headers, not ASCII banners, for inline section breaks (see *Documentation Expectations* above).
 
 ## Licensing
 

--- a/Examples/CompositionDiagram.lean
+++ b/Examples/CompositionDiagram.lean
@@ -78,9 +78,7 @@ private def renderDHAtom : ∀ {Δ : PortBoundary}, DHAtom Δ → String
   | _, .simulator => "Simulator"
   | _, .dummyChannel => "Dummy Channel"
 
--- ============================================================================
--- § Communication infrastructure
--- ============================================================================
+/-! ## Communication infrastructure -/
 
 /-- Two directional channels running in parallel: Alice→Bob ∥ Bob→Alice. -/
 @[show_composition]
@@ -99,9 +97,7 @@ wire(par(Channel A→B, Channel B→A), Adversary)
 def insecureNetwork : Raw DHAtom bd2 :=
   channels ⊞ .atom .adversary
 
--- ============================================================================
--- § Real world
--- ============================================================================
+/-! ## Real world -/
 
 /-- Protocol parties: Alice ∥ Bob. -/
 @[show_composition]
@@ -133,9 +129,7 @@ plug(wire(par(Alice, Bob), insecureNetwork), Environment)
 def realWorld : Raw DHAtom PortBoundary.empty :=
   protocolExecution ⊠ .atom .environment
 
--- ============================================================================
--- § Ideal world
--- ============================================================================
+/-! ## Ideal world -/
 
 /-- Ideal parties: the ideal key-exchange functionality ∥ the UC simulator. -/
 @[show_composition]
@@ -157,9 +151,7 @@ plug(wire(par(Ideal KE, Simulator), Dummy Channel), Environment)
 def idealWorld : Raw DHAtom PortBoundary.empty :=
   idealParties ⊞ .atom .dummyChannel ⊠ .atom .environment
 
--- ============================================================================
--- § DOT output
--- ============================================================================
+/-! ## DOT output -/
 
 #eval IO.println "=== Real World ==="
 #eval IO.println (Raw.toDot renderDHAtom realWorld)

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -113,7 +113,9 @@ import VCVio.Interaction.TwoParty.Role
 import VCVio.Interaction.TwoParty.Strategy
 import VCVio.Interaction.TwoParty.Swap
 import VCVio.Interaction.UC.Computational
+import VCVio.Interaction.UC.Corruption
 import VCVio.Interaction.UC.Emulates
+import VCVio.Interaction.UC.EnvAction
 import VCVio.Interaction.UC.Interface
 import VCVio.Interaction.UC.MachineId
 import VCVio.Interaction.UC.Notation

--- a/VCVio/Interaction/UC/Corruption.lean
+++ b/VCVio/Interaction/UC/Corruption.lean
@@ -69,7 +69,7 @@ from `[DecidableEq Sid] [DecidableEq Pid]`) and over `Epoch = ℕ`.
 provides decidable equality on the identity type parameters.
 -/
 
-universe w
+universe w w₂
 
 namespace Interaction
 namespace UC
@@ -391,13 +391,13 @@ constrains which step transcripts (which carry the env event in their
 data) the environment is allowed to schedule.
 -/
 abbrev CorruptionPolicy
-    {Γ : Interaction.Spec.Node.Context.{w, w}}
+    {Γ : Interaction.Spec.Node.Context.{w, w₂}}
     (process : ProcessOver Γ) :=
   ProcessOver.StepPolicy process
 
 namespace CorruptionPolicy
 
-variable {Γ : Interaction.Spec.Node.Context.{w, w}} {process : ProcessOver Γ}
+variable {Γ : Interaction.Spec.Node.Context.{w, w₂}} {process : ProcessOver Γ}
 
 /-- Allow every step transcript: the unconstrained baseline. -/
 abbrev top : CorruptionPolicy process :=

--- a/VCVio/Interaction/UC/Corruption.lean
+++ b/VCVio/Interaction/UC/Corruption.lean
@@ -74,9 +74,7 @@ universe w w₂
 namespace Interaction
 namespace UC
 
--- ============================================================================
--- § Corruption alphabet and epoch
--- ============================================================================
+/-! ## Corruption alphabet and epoch -/
 
 /--
 The standard CJSV22 corruption alphabet for a fixed `(Sid, Pid)`
@@ -134,9 +132,7 @@ own `Epoch`-isomorphic type; the framework only requires
 -/
 abbrev Epoch : Type := ℕ
 
--- ============================================================================
--- § Corruption state
--- ============================================================================
+/-! ## Corruption state -/
 
 /--
 `CorruptionState Sid Pid` packages the two-flag corruption tracking
@@ -321,9 +317,7 @@ theorem compromised_applyCompromise_of_compromised
 
 end CorruptionState
 
--- ============================================================================
--- § Leakable state (equivocability obligation)
--- ============================================================================
+/-! ## Leakable state (equivocability obligation) -/
 
 /--
 `LeakableState State Leakage` exposes an extraction function that
@@ -356,9 +350,7 @@ class LeakableState
     (Leakage : outParam Type) where
   leak : State → MachineId Sid Pid → Leakage
 
--- ============================================================================
--- § Corruption policy
--- ============================================================================
+/-! ## Corruption policy -/
 
 open Interaction.Concurrent
 

--- a/VCVio/Interaction/UC/Corruption.lean
+++ b/VCVio/Interaction/UC/Corruption.lean
@@ -1,0 +1,414 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.UC.EnvAction
+import VCVio.Interaction.UC.MachineId
+import VCVio.Interaction.Concurrent.Policy
+
+/-!
+# Adaptive momentary corruption vocabulary
+
+This file introduces the standalone vocabulary for CJSV22-style adaptive
+momentary corruption (Canetti, Jain, Swanberg, Varia, *Universally
+Composable End-to-End Secure Messaging*, CRYPTO 2022 §3.2):
+
+* **`CorruptionAlphabet Sid Pid`** — the inductive event alphabet
+  `compromise(m)` and `refresh(m)`, indexed by `MachineId Sid Pid`.
+* **`Epoch`** — the per-machine refresh counter, defined as `ℕ` (the
+  simplest concrete choice; richer protocols like asymmetric ratchets
+  can wrap this in their own `Epoch`-isomorphic type).
+* **`CorruptionState Sid Pid`** — the two-flag corruption tracking:
+  `corrupted` (current snapshot in adversary view) and `compromised`
+  (per-`(machine, epoch)` historical view), plus the per-machine
+  `epoch` counter.
+* **`CorruptionState.applyCompromise` / `applyRefresh`** — the
+  canonical deterministic updates triggered by the alphabet events.
+* **`CorruptionState.envActionBase`** — the canonical `EnvAction`
+  built from those updates, the baseline that every protocol opting
+  in to adaptive momentary corruption inherits.
+* **`LeakableState`** — the typeclass that surfaces the equivocability
+  obligation as a missing instance. Real protocols supply the natural
+  state projection; simulators supply a fabrication that is
+  consistent with all prior leakages and the current trace.
+* **`CorruptionPolicy`** — a `StepPolicy` specialization keyed on the
+  corruption alphabet, reusing the existing `inter` / `top` /
+  `byController` combinators from `Interaction.Concurrent.Policy`.
+
+## Universe constraint
+
+`Sid` and `Pid` live in `Type` (i.e. `Type 0`) because
+`CorruptionState` participates in `ProbComp`-valued reactions and
+`ProbComp : Type → Type`. This matches the universe convention used
+in `VCVio/Interaction/UC/Runtime.lean`. Concrete protocol identity
+types (`ℕ`, `String`, etc.) all satisfy this bound.
+
+## Additive design
+
+Like `EnvAction`, `CorruptionState` is **standalone**: it is *not*
+threaded into `OpenNodeSemantics` here. Existing `OpenProcess`
+constructions are untouched. The corruption-aware composition wrapper
+that pairs a `MachineProcess` with a state-indexed `EnvAction` (and
+hosts the four `*.corrupt` forwarding lemmas) is a follow-up slice.
+
+## Why `LeakableState` is a typeclass
+
+Forcing every protocol that participates in adaptive corruption to
+declare what it leaks turns the equivocability obligation into a
+mechanically checkable instance hole. A simulator that cannot
+fabricate consistent state cannot supply an instance and cannot be
+plugged into the security definition; the obligation is enforced at
+compile time rather than via meta-theoretic side conditions.
+
+## Decidability
+
+All comparisons are over `MachineId` (which derives `DecidableEq`
+from `[DecidableEq Sid] [DecidableEq Pid]`) and over `Epoch = ℕ`.
+`CorruptionState` operations are computable as long as the user
+provides decidable equality on the identity type parameters.
+-/
+
+universe w
+
+namespace Interaction
+namespace UC
+
+-- ============================================================================
+-- § Corruption alphabet and epoch
+-- ============================================================================
+
+/--
+The standard CJSV22 corruption alphabet for a fixed `(Sid, Pid)`
+identity space.
+
+* `compromise m` snapshots the current state of machine `m` into the
+  adversary's view: the leakage function fires, and the current epoch
+  of `m` is marked compromised.
+* `refresh m` advances the epoch counter for `m`. After a refresh,
+  future epochs of `m` are not (yet) compromised; the protocol's
+  forward-secrecy mechanism gets a chance to heal.
+
+The pair `(compromise, refresh)` is the alphabet underlying the
+*momentary* part of "adaptive momentary corruption": at any point the
+environment may compromise a machine, and a subsequent refresh
+recovers post-compromise security for future epochs.
+
+`CorruptionAlphabet Sid Pid` is the canonical instantiation of
+`EnvAction.alphabet` for adaptive momentary corruption. The
+`EnvAction` paired with this alphabet is built from
+`CorruptionState.envActionBase`.
+-/
+inductive CorruptionAlphabet (Sid Pid : Type) where
+  /-- Snapshot the current state of `m` into the adversary's view. -/
+  | compromise (m : MachineId Sid Pid) : CorruptionAlphabet Sid Pid
+  /-- Advance the epoch counter of `m`, enabling forward healing. -/
+  | refresh    (m : MachineId Sid Pid) : CorruptionAlphabet Sid Pid
+deriving DecidableEq
+
+namespace CorruptionAlphabet
+
+variable {Sid Pid : Type}
+
+/-- The machine targeted by a corruption event. -/
+def target : CorruptionAlphabet Sid Pid → MachineId Sid Pid
+  | .compromise m => m
+  | .refresh m    => m
+
+@[simp] theorem target_compromise (m : MachineId Sid Pid) :
+    (compromise m).target = m := rfl
+
+@[simp] theorem target_refresh (m : MachineId Sid Pid) :
+    (refresh m).target = m := rfl
+
+end CorruptionAlphabet
+
+/--
+`Epoch` indexes the per-machine refresh cycles.
+
+A flat `ℕ` is the simplest concrete choice: refresh counts as
+`epoch m += 1`. Richer protocols (e.g. Signal's asymmetric ratchet
+with separate sending and receiving counters) can wrap this in their
+own `Epoch`-isomorphic type; the framework only requires
+`DecidableEq` and a way to advance.
+-/
+abbrev Epoch : Type := ℕ
+
+-- ============================================================================
+-- § Corruption state
+-- ============================================================================
+
+/--
+`CorruptionState Sid Pid` packages the two-flag corruption tracking
+that an environment-driven step carries between events.
+
+* `corrupted m = true` iff the current state of `m` has been
+  snapshotted by the adversary at least once and not refreshed
+  since. Mutated by `compromise m` (sets `true`) and `refresh m`
+  (sets `false`).
+* `compromised m e = true` iff the secrets for epoch `e` of `m`
+  are in the adversary's view. Strictly accumulating: a compromise
+  event sets `compromised m (current_epoch m)`; epochs once
+  compromised stay compromised forever.
+* `epoch m` is `m`'s current refresh counter. Mutated by
+  `refresh m` (increments by one).
+
+The two flags `corrupted` and `compromised` are deliberately
+independent:
+
+* `corrupted m` may be `false` while `compromised m e` holds for
+  some past `e`: the adversary saw that epoch's secret, but the
+  machine has since refreshed and now has a fresh secret.
+* `corrupted m` may be `true` while `compromised m e'` is `false`
+  for some future `e'`: a forward-secret key schedule may
+  forward-decrypt only a bounded window from a current compromise.
+
+Two flags, two distinct purposes. The naming deliberately avoids
+the ambiguous "exposed", which would collide with `OpenTheory`'s
+boundary-exposure terminology.
+-/
+@[ext]
+structure CorruptionState (Sid Pid : Type) where
+  /-- Per-machine snapshot flag, mutated by `compromise` and `refresh`. -/
+  corrupted : MachineId Sid Pid → Bool := fun _ => false
+  /-- Per-(machine, epoch) leak flag, monotonically accumulating. -/
+  compromised : MachineId Sid Pid → Epoch → Bool := fun _ _ => false
+  /-- Per-machine refresh counter, advanced by `refresh`. -/
+  epoch : MachineId Sid Pid → Epoch := fun _ => 0
+
+namespace CorruptionState
+
+variable {Sid Pid : Type}
+
+/-- The fully-honest initial state: nothing corrupted, nothing
+compromised, every machine at epoch zero. -/
+def init : CorruptionState Sid Pid := {}
+
+instance : Inhabited (CorruptionState Sid Pid) := ⟨init⟩
+
+@[simp] theorem corrupted_init (m : MachineId Sid Pid) :
+    (init : CorruptionState Sid Pid).corrupted m = false := rfl
+
+@[simp] theorem compromised_init (m : MachineId Sid Pid) (e : Epoch) :
+    (init : CorruptionState Sid Pid).compromised m e = false := rfl
+
+@[simp] theorem epoch_init (m : MachineId Sid Pid) :
+    (init : CorruptionState Sid Pid).epoch m = 0 := rfl
+
+variable [DecidableEq Sid] [DecidableEq Pid]
+
+/--
+Apply `compromise m` to the corruption state: set `corrupted m` and
+mark the current epoch of `m` as compromised. The epoch counter is
+not advanced.
+
+This is a deterministic update, so the value lives in the underlying
+`CorruptionState`; the canonical `EnvAction` reaction wraps it via
+`pure`.
+-/
+def applyCompromise
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    CorruptionState Sid Pid where
+  corrupted := Function.update cs.corrupted m true
+  compromised := fun m' e' =>
+    cs.compromised m' e' || (decide (m = m') && decide (e' = cs.epoch m))
+  epoch := cs.epoch
+
+/--
+Apply `refresh m` to the corruption state: clear `corrupted m` and
+advance the epoch counter of `m` by one. Past `compromised` flags are
+preserved (they are historical and accumulate).
+
+After a refresh, future events on `m` write into the new epoch; this
+is the structural ingredient that lets the framework derive PCS
+(post-compromise security) as a healing theorem rather than as an
+axiom.
+-/
+def applyRefresh
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    CorruptionState Sid Pid where
+  corrupted := Function.update cs.corrupted m false
+  compromised := cs.compromised
+  epoch := Function.update cs.epoch m (cs.epoch m + 1)
+
+/--
+The canonical `EnvAction` reaction for the corruption alphabet:
+`compromise` snapshots, `refresh` advances the epoch.
+
+This is the baseline used by every protocol that opts in to
+adaptive momentary corruption. Protocols that need richer
+per-event behaviour (e.g. simulator-controlled randomization on
+`compromise`, or a non-trivial leakage function) override the
+relevant branch in their bespoke `EnvAction` rather than touching
+the alphabet itself.
+-/
+def reactBase
+    (s : CorruptionAlphabet Sid Pid) (cs : CorruptionState Sid Pid) :
+    ProbComp (CorruptionState Sid Pid) :=
+  match s with
+  | .compromise m => pure (applyCompromise m cs)
+  | .refresh m    => pure (applyRefresh m cs)
+
+/-- The canonical corruption-aware `EnvAction`. -/
+def envActionBase :
+    EnvAction (CorruptionAlphabet Sid Pid) (CorruptionState Sid Pid) where
+  react := reactBase
+
+@[simp] theorem reactBase_compromise
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    reactBase (.compromise m) cs = pure (applyCompromise m cs) := rfl
+
+@[simp] theorem reactBase_refresh
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    reactBase (.refresh m) cs = pure (applyRefresh m cs) := rfl
+
+@[simp] theorem corrupted_applyCompromise_self
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).corrupted m = true := by
+  simp [applyCompromise]
+
+theorem corrupted_applyCompromise_of_ne
+    {m m' : MachineId Sid Pid} (h : m' ≠ m) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).corrupted m' = cs.corrupted m' := by
+  simp [applyCompromise, Function.update_of_ne h]
+
+@[simp] theorem corrupted_applyRefresh_self
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).corrupted m = false := by
+  simp [applyRefresh]
+
+theorem corrupted_applyRefresh_of_ne
+    {m m' : MachineId Sid Pid} (h : m' ≠ m) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).corrupted m' = cs.corrupted m' := by
+  simp [applyRefresh, Function.update_of_ne h]
+
+@[simp] theorem epoch_applyCompromise
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).epoch = cs.epoch := rfl
+
+@[simp] theorem epoch_applyRefresh_self
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).epoch m = cs.epoch m + 1 := by
+  simp [applyRefresh]
+
+theorem epoch_applyRefresh_of_ne
+    {m m' : MachineId Sid Pid} (h : m' ≠ m) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).epoch m' = cs.epoch m' := by
+  simp [applyRefresh, Function.update_of_ne h]
+
+theorem compromised_applyCompromise_self_currentEpoch
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).compromised m (cs.epoch m) = true := by
+  simp [applyCompromise]
+
+/--
+`compromise` is monotone: once an epoch is in the adversary's view, it
+stays in the adversary's view. This is the structural fact that makes
+PCS (post-compromise security) about *future* epochs rather than
+about un-leaking past ones.
+-/
+theorem compromised_applyCompromise_of_compromised
+    {cs : CorruptionState Sid Pid} {m : MachineId Sid Pid}
+    {m' : MachineId Sid Pid} {e : Epoch}
+    (h : cs.compromised m' e = true) :
+    (applyCompromise m cs).compromised m' e = true := by
+  simp [applyCompromise, h]
+
+/-- `refresh` preserves all past compromise flags. -/
+@[simp] theorem compromised_applyRefresh
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).compromised = cs.compromised := rfl
+
+end CorruptionState
+
+-- ============================================================================
+-- § Leakable state (equivocability obligation)
+-- ============================================================================
+
+/--
+`LeakableState State Leakage` exposes an extraction function that
+projects a per-machine snapshot from `State`.
+
+The intended use is on `MachineProcess`-shaped state types: a real
+protocol supplies the natural projection (e.g. "current long-term
+secret + ratchet root for machine `m`"); a simulator supplies a
+fabrication consistent with all prior leakages and the current
+adversary trace.
+
+This is the typed form of the **equivocability obligation** from
+CJSV22 §4.1. By exposing it as a typeclass, the framework forces the
+following invariant at compile time: a simulator that cannot
+fabricate consistent state cannot supply an instance, and cannot be
+used to discharge UC security. The obligation becomes a *missing
+instance* error rather than a meta-theoretic gap in the proof.
+
+`Leakage` is an `outParam` because each `State` functionally
+determines its leakage type: there is one canonical projection per
+protocol, and ambiguity should not arise during instance synthesis.
+
+There is **no default instance**. Forcing every protocol to declare
+what it leaks is intentional: an automatic default would either leak
+too much (the entire `State`, breaking forward-secrecy proofs) or
+too little (nothing, vacuously satisfying the typeclass).
+-/
+class LeakableState
+    {Sid Pid : Type} (State : Type)
+    (Leakage : outParam Type) where
+  leak : State → MachineId Sid Pid → Leakage
+
+-- ============================================================================
+-- § Corruption policy
+-- ============================================================================
+
+open Interaction.Concurrent
+
+/--
+`CorruptionPolicy process` is a `StepPolicy` specialization that
+constrains the environment's corruption capabilities at each
+process step.
+
+Concretely: a corruption policy is given the concrete step transcript
+of a process and decides whether the step is admissible. Reuses the
+existing `Concurrent.ProcessOver.StepPolicy` machinery
+(`Interaction/Concurrent/Policy.lean`) verbatim, so the standard
+`top` / `inter` / `byController` / `byPath` / `byEvent` / `byTicket`
+combinators apply unchanged.
+
+Common downstream policies (none specialized here yet — they live with
+their pilot protocols):
+
+* `static` — only allow `compromise` events before any `send`-class
+  event has fired.
+* `momentary` — allow at most one `compromise(m)` per epoch per
+  machine (the CJSV22 default).
+* `bounded n` — allow at most `n` compromises across the whole
+  trace.
+
+These are **policies on the underlying step transcripts**, not on the
+corruption alphabet directly. The corruption alphabet flows through
+the `EnvAction` channel of a corruption-aware process; the policy
+constrains which step transcripts (which carry the env event in their
+data) the environment is allowed to schedule.
+-/
+abbrev CorruptionPolicy
+    {Γ : Interaction.Spec.Node.Context.{w, w}}
+    (process : ProcessOver Γ) :=
+  ProcessOver.StepPolicy process
+
+namespace CorruptionPolicy
+
+variable {Γ : Interaction.Spec.Node.Context.{w, w}} {process : ProcessOver Γ}
+
+/-- Allow every step transcript: the unconstrained baseline. -/
+abbrev top : CorruptionPolicy process :=
+  ProcessOver.StepPolicy.top
+
+/-- Conjunction of two corruption policies: both must allow. -/
+abbrev inter (left right : CorruptionPolicy process) :
+    CorruptionPolicy process :=
+  ProcessOver.StepPolicy.inter left right
+
+end CorruptionPolicy
+
+end UC
+end Interaction

--- a/VCVio/Interaction/UC/Emulates.lean
+++ b/VCVio/Interaction/UC/Emulates.lean
@@ -190,9 +190,7 @@ theorem plug_invariance
 
 end Emulates
 
--- ============================================================================
--- § Structural factorization of `close` under composition
--- ============================================================================
+/-! ## Structural factorization of `close` under composition -/
 
 section Factorization
 
@@ -364,9 +362,7 @@ theorem OpenTheory.plug_comm
 
 end Factorization
 
--- ============================================================================
--- § UC composition theorems
--- ============================================================================
+/-! ## UC composition theorems -/
 
 namespace Emulates
 

--- a/VCVio/Interaction/UC/EnvAction.lean
+++ b/VCVio/Interaction/UC/EnvAction.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.OracleComp.ProbComp
+
+/-!
+# Environment-driven action alphabets
+
+This file introduces `EnvAction Sym X`, a standalone alphabet of
+environment-driven events that may act on a per-step state of type `X`.
+The alphabet `Sym` is the user-supplied symbol set (typically a sum
+type with one constructor per environment event: `compromise`,
+`refresh`, `setEpochParam`, etc.); the `react` function specifies how
+the state evolves on each event.
+
+This vocabulary is the foundation for CJSV22-style adaptive momentary
+corruption (Canetti, Jain, Swanberg, Varia, *Universally Composable
+End-to-End Secure Messaging*, CRYPTO 2022 §3.2). In CJSV22 the
+environment is the privileged source of `Corrupt`-type events, distinct
+from the adversary boundary (which carries port traffic). `EnvAction`
+gives the same separation a typed home in VCVio: corruption events flow
+through `EnvAction`, port traffic flows through `BoundaryAction`, and
+the two channels are kept structurally orthogonal.
+
+The alphabet parameter is named `Sym` rather than the CJSV22-style
+`Σ` because `Σ` is a reserved Lean keyword (sigma types).
+
+## Additive design
+
+`EnvAction` is intentionally **standalone**: it is *not* threaded into
+`OpenNodeSemantics` in this slice. Existing `OpenProcess Party Δ`
+constructions are unaffected, and protocols that do not need
+environment-driven events incur zero cost. A subsequent slice will
+build a corruption-aware wrapper that pairs an `OpenProcess` with a
+state-indexed `EnvAction`; the four `*.corrupt` forwarding lemmas
+(CJSV22 §4.2) live on that wrapper.
+
+## Probabilistic reactions
+
+`react` is `ProbComp`-valued, so corruption-driven state transitions
+can themselves be probabilistic (e.g. simulator-controlled
+randomization on `compromise`). Deterministic events use
+`pure ∘ update` and pay no extra cost.
+-/
+
+/-
+The state type `X` is constrained to `Type 0` because `ProbComp : Type → Type`
+lives in `Type`. This matches the universe convention in
+`VCVio/Interaction/UC/Runtime.lean`, where the runtime layer requires move
+and state types to live in `Type 0` for the same reason.
+-/
+universe u
+
+namespace Interaction
+namespace UC
+
+/--
+`EnvAction Sym X` is the per-event reaction of a per-step state
+`x : X` to environment events drawn from the alphabet `Sym`.
+
+`react : Sym → X → ProbComp X` specifies how each event transforms
+the state. The default `react` is `fun _ x => pure x` (every event is
+a no-op), which keeps the empty alphabet `Sym := Empty` trivially
+satisfiable.
+
+Two concrete instantiations matter here:
+
+* `EnvAction Empty X` — the trivial alphabet, used by every protocol
+  that doesn't participate in environment-driven corruption. Costs
+  nothing; the canonical inhabitant is `EnvAction.empty`.
+* `EnvAction (CorruptionAlphabet Sid Pid) (CorruptionState Sid Pid)` —
+  the canonical CJSV22 instantiation. See
+  `VCVio.Interaction.UC.Corruption` for the alphabet and state
+  definitions.
+
+The structure is independent of the boundary `Δ` so that environment
+events are *not* keyed by port: an environment event acts on whatever
+`X`-typed slice of state the protocol exposes, with no dependence on
+which ports happen to be in scope.
+-/
+@[ext]
+structure EnvAction (Sym : Type u) (X : Type) where
+  /-- The state transition triggered by each event. -/
+  react : Sym → X → ProbComp X := fun _ x => pure x
+
+namespace EnvAction
+
+variable {Sym : Type u} {X : Type}
+
+/--
+The trivial environment-action over the empty alphabet: no events
+ever fire.
+
+Useful as the default for processes that do not care about
+environment-driven dynamics.
+-/
+def empty (X : Type) : EnvAction Empty X where
+  react e _ := e.elim
+
+/--
+The constant environment-action: every event leaves the state
+unchanged.
+
+This is the canonical "passive observer" reaction, useful when a
+process participates in an alphabet (so its `EnvAction` slot is
+non-trivially typed) but its state has no per-event update.
+-/
+def passive (Sym : Type u) (X : Type) : EnvAction Sym X where
+  react _ x := pure x
+
+/--
+Adapt the alphabet of an environment-action along a function
+`g : Sym → Sym'`.
+
+The new alphabet is `Sym`; an event `s : Sym` is reacted to by routing
+it through `g` to obtain `s' : Sym'` and applying the original
+reaction. This is the contravariant action on the alphabet that lets
+coarser alphabets be embedded into finer ones.
+-/
+def comap {Sym Sym' : Type u} {X : Type}
+    (g : Sym → Sym') (e : EnvAction Sym' X) : EnvAction Sym X where
+  react s x := e.react (g s) x
+
+/--
+Adapt the state of an environment-action along a state-projection.
+
+Given `e : EnvAction Sym X` and a projection `π : Y → X` together with
+a re-installation `ι : X → Y → Y` that re-installs the updated `X`
+slice into a larger state `Y`, the lifted action operates on `Y` by
+reacting on the `X`-slice and re-installing the result.
+
+This is the structural lift used when corruption-aware reactions need
+to thread through richer per-step states; the `Corruption` layer uses
+it to lift the canonical `CorruptionState.react` over state-bundled
+`MachineProcess`es.
+-/
+def liftState {Sym : Type u} {X Y : Type}
+    (π : Y → X) (ι : X → Y → Y) (e : EnvAction Sym X) :
+    EnvAction Sym Y where
+  react s y := do
+    let x' ← e.react s (π y)
+    return ι x' y
+
+@[simp]
+theorem comap_id (e : EnvAction Sym X) :
+    comap (id : Sym → Sym) e = e := by
+  ext s x; rfl
+
+@[simp]
+theorem comap_comap {Sym Sym' Sym'' : Type u} {X : Type}
+    (h : Sym → Sym') (g : Sym' → Sym'') (e : EnvAction Sym'' X) :
+    comap h (comap g e) = comap (g ∘ h) e := by
+  ext s x; rfl
+
+@[simp]
+theorem passive_react (Sym : Type u) (X : Type) (s : Sym) (x : X) :
+    (passive Sym X).react s x = pure x := rfl
+
+@[simp]
+theorem empty_react (X : Type) (e : Empty) (x : X) :
+    (empty X).react e x = e.elim := rfl
+
+end EnvAction
+
+end UC
+end Interaction

--- a/VCVio/Interaction/UC/EnvAction.lean
+++ b/VCVio/Interaction/UC/EnvAction.lean
@@ -8,9 +8,9 @@ import VCVio.OracleComp.ProbComp
 /-!
 # Environment-driven action alphabets
 
-This file introduces `EnvAction Sym X`, a standalone alphabet of
+This file introduces `EnvAction Event X`, a standalone alphabet of
 environment-driven events that may act on a per-step state of type `X`.
-The alphabet `Sym` is the user-supplied symbol set (typically a sum
+The alphabet `Event` is the user-supplied event set (typically a sum
 type with one constructor per environment event: `compromise`,
 `refresh`, `setEpochParam`, etc.); the `react` function specifies how
 the state evolves on each event.
@@ -24,8 +24,10 @@ gives the same separation a typed home in VCVio: corruption events flow
 through `EnvAction`, port traffic flows through `BoundaryAction`, and
 the two channels are kept structurally orthogonal.
 
-The alphabet parameter is named `Sym` rather than the CJSV22-style
-`Σ` because `Σ` is a reserved Lean keyword (sigma types).
+The alphabet parameter is named `Event` rather than the CJSV22-style
+`Σ` because `Σ` is a reserved Lean keyword (sigma types). The CSP /
+π-calculus convention "events" is also a more literal description of
+what the alphabet contains than the bare letter `Σ`.
 
 ## Additive design
 
@@ -57,12 +59,12 @@ namespace Interaction
 namespace UC
 
 /--
-`EnvAction Sym X` is the per-event reaction of a per-step state
-`x : X` to environment events drawn from the alphabet `Sym`.
+`EnvAction Event X` is the per-event reaction of a per-step state
+`x : X` to environment events drawn from the alphabet `Event`.
 
-`react : Sym → X → ProbComp X` specifies how each event transforms
+`react : Event → X → ProbComp X` specifies how each event transforms
 the state. The default `react` is `fun _ x => pure x` (every event is
-a no-op), which keeps the empty alphabet `Sym := Empty` trivially
+a no-op), which keeps the empty alphabet `Event := Empty` trivially
 satisfiable.
 
 Two concrete instantiations matter here:
@@ -81,13 +83,13 @@ events are *not* keyed by port: an environment event acts on whatever
 which ports happen to be in scope.
 -/
 @[ext]
-structure EnvAction (Sym : Type u) (X : Type) where
+structure EnvAction (Event : Type u) (X : Type) where
   /-- The state transition triggered by each event. -/
-  react : Sym → X → ProbComp X := fun _ x => pure x
+  react : Event → X → ProbComp X := fun _ x => pure x
 
 namespace EnvAction
 
-variable {Sym : Type u} {X : Type}
+variable {Event : Type u} {X : Type}
 
 /--
 The trivial environment-action over the empty alphabet: no events
@@ -107,56 +109,56 @@ This is the canonical "passive observer" reaction, useful when a
 process participates in an alphabet (so its `EnvAction` slot is
 non-trivially typed) but its state has no per-event update.
 -/
-def passive (Sym : Type u) (X : Type) : EnvAction Sym X where
+def passive (Event : Type u) (X : Type) : EnvAction Event X where
   react _ x := pure x
 
 /--
 Adapt the alphabet of an environment-action along a function
-`g : Sym → Sym'`.
+`g : Event → Event'`.
 
-The new alphabet is `Sym`; an event `s : Sym` is reacted to by routing
-it through `g` to obtain `s' : Sym'` and applying the original
-reaction. This is the contravariant action on the alphabet that lets
-coarser alphabets be embedded into finer ones.
+The new alphabet is `Event`; an event `s : Event` is reacted to by
+routing it through `g` to obtain `s' : Event'` and applying the
+original reaction. This is the contravariant action on the alphabet
+that lets coarser alphabets be embedded into finer ones.
 -/
-def comap {Sym Sym' : Type u} {X : Type}
-    (g : Sym → Sym') (e : EnvAction Sym' X) : EnvAction Sym X where
+def comap {Event Event' : Type u} {X : Type}
+    (g : Event → Event') (e : EnvAction Event' X) : EnvAction Event X where
   react s x := e.react (g s) x
 
 /--
 Adapt the state of an environment-action along a state-projection.
 
-Given `e : EnvAction Sym X` and a projection `π : Y → X` together with
-a re-installation `ι : X → Y → Y` that re-installs the updated `X`
-slice into a larger state `Y`, the lifted action operates on `Y` by
-reacting on the `X`-slice and re-installing the result.
+Given `e : EnvAction Event X` and a projection `π : Y → X` together
+with a re-installation `ι : X → Y → Y` that re-installs the updated
+`X` slice into a larger state `Y`, the lifted action operates on `Y`
+by reacting on the `X`-slice and re-installing the result.
 
 This is the structural lift used when corruption-aware reactions need
 to thread through richer per-step states; the `Corruption` layer uses
 it to lift the canonical `CorruptionState.react` over state-bundled
 `MachineProcess`es.
 -/
-def liftState {Sym : Type u} {X Y : Type}
-    (π : Y → X) (ι : X → Y → Y) (e : EnvAction Sym X) :
-    EnvAction Sym Y where
+def liftState {Event : Type u} {X Y : Type}
+    (π : Y → X) (ι : X → Y → Y) (e : EnvAction Event X) :
+    EnvAction Event Y where
   react s y := do
     let x' ← e.react s (π y)
     return ι x' y
 
 @[simp]
-theorem comap_id (e : EnvAction Sym X) :
-    comap (id : Sym → Sym) e = e := by
+theorem comap_id (e : EnvAction Event X) :
+    comap (id : Event → Event) e = e := by
   ext s x; rfl
 
 @[simp]
-theorem comap_comap {Sym Sym' Sym'' : Type u} {X : Type}
-    (h : Sym → Sym') (g : Sym' → Sym'') (e : EnvAction Sym'' X) :
+theorem comap_comap {Event Event' Event'' : Type u} {X : Type}
+    (h : Event → Event') (g : Event' → Event'') (e : EnvAction Event'' X) :
     comap h (comap g e) = comap (g ∘ h) e := by
   ext s x; rfl
 
 @[simp]
-theorem passive_react (Sym : Type u) (X : Type) (s : Sym) (x : X) :
-    (passive Sym X).react s x = pure x := rfl
+theorem passive_react (Event : Type u) (X : Type) (s : Event) (x : X) :
+    (passive Event X).react s x = pure x := rfl
 
 @[simp]
 theorem empty_react (X : Type) (e : Empty) (x : X) :

--- a/VCVio/Interaction/UC/Interface.lean
+++ b/VCVio/Interaction/UC/Interface.lean
@@ -293,6 +293,118 @@ theorem mapPacket_comp
 
 end Hom
 
+/--
+`RoutedPacket I M` is an `Interface.Packet I` together with the identity
+`M` of the machine that emitted it.
+
+`RoutedPacket` is the standard wire-level vocabulary for traffic that
+needs to remember its origin while flowing through composition operators.
+The sender type `M` is left abstract: the canonical instantiation is
+`M := MachineId Sid Pid` (CJSV22 §2.1), but the same wrapper supports
+other identity schemes (`Unit` for purely internal traffic, or any future
+protocol-descriptor variant).
+
+For a packet that has just been produced by a single machine, `sender` is
+that machine's identity. After the packet has been routed through several
+composition layers, `sender` still refers to the *original* emitter, not
+to whichever intermediate node the packet most recently passed through.
+
+`RoutedPacket` is purely additive over the existing `Packet` definition:
+all framework primitives that already operate on `Packet I` continue to
+do so. Only consumers that need access control or sender-aware dispatch
+opt into `RoutedPacket I M`.
+-/
+structure RoutedPacket (I : Interface.{uA, uB}) (M : Type wA) :
+    Type (max uA uB wA) where
+  sender : M
+  packet : Packet I
+
+namespace RoutedPacket
+
+@[ext]
+theorem ext
+    {I : Interface.{uA, uB}} {M : Type wA}
+    {rp₁ rp₂ : RoutedPacket I M}
+    (hsender : rp₁.sender = rp₂.sender)
+    (hpacket : rp₁.packet = rp₂.packet) :
+    rp₁ = rp₂ := by
+  cases rp₁; cases rp₂; congr
+
+/--
+Translate the packet component along an interface morphism, leaving the
+sender identity untouched.
+
+This is the routed analogue of `Hom.mapPacket`: the sender's identity
+survives interface adaptation because composition operators only ever
+relabel ports, never re-attribute origin.
+-/
+def mapPacket
+    {I : Interface.{uA, uB}} {J : Interface.{vA, vB}} {M : Type wA}
+    (f : Hom I J) (rp : RoutedPacket I M) : RoutedPacket J M where
+  sender := rp.sender
+  packet := Hom.mapPacket f rp.packet
+
+/--
+Translate the sender identity along a function, leaving the packet
+untouched.
+
+This is the routed analogue of pushing the packet through an identity
+relabelling on senders. The two transformations commute, see
+`mapPacket_mapSender`.
+-/
+def mapSender
+    {I : Interface.{uA, uB}} {M N : Type wA}
+    (g : M → N) (rp : RoutedPacket I M) : RoutedPacket I N where
+  sender := g rp.sender
+  packet := rp.packet
+
+@[simp]
+theorem mapPacket_id
+    {I : Interface.{uA, uB}} {M : Type wA}
+    (rp : RoutedPacket I M) :
+    mapPacket (Hom.id I) rp = rp := by
+  cases rp
+  simp [mapPacket]
+
+@[simp]
+theorem mapPacket_comp
+    {I : Interface.{uA, uB}}
+    {J : Interface.{vA, vB}}
+    {K : Interface.{wA, wB}}
+    {M : Type wA}
+    (g : Hom J K) (f : Hom I J) (rp : RoutedPacket I M) :
+    mapPacket g (mapPacket f rp) = mapPacket (Hom.comp g f) rp := by
+  cases rp
+  simp [mapPacket, Hom.mapPacket_comp]
+
+@[simp]
+theorem mapSender_id
+    {I : Interface.{uA, uB}} {M : Type wA}
+    (rp : RoutedPacket I M) :
+    mapSender (id : M → M) rp = rp := by
+  cases rp; rfl
+
+@[simp]
+theorem mapSender_comp
+    {I : Interface.{uA, uB}} {M N O : Type wA}
+    (h : N → O) (g : M → N) (rp : RoutedPacket I M) :
+    mapSender h (mapSender g rp) = mapSender (h ∘ g) rp := by
+  cases rp; rfl
+
+theorem mapPacket_mapSender
+    {I : Interface.{uA, uB}} {J : Interface.{vA, vB}} {M N : Type wA}
+    (f : Hom I J) (g : M → N) (rp : RoutedPacket I M) :
+    mapPacket f (mapSender g rp) = mapSender g (mapPacket f rp) := by
+  cases rp; rfl
+
+theorem mapSender_mapPacket
+    {I : Interface.{uA, uB}} {J : Interface.{vA, vB}} {M N : Type wA}
+    (g : M → N) (f : Hom I J) (rp : RoutedPacket I M) :
+    mapSender g (mapPacket f rp) = mapPacket f (mapSender g rp) := by
+  cases rp; rfl
+
+end RoutedPacket
+
 namespace QueryHom
 
 /--

--- a/VCVio/Interaction/UC/MachineId.lean
+++ b/VCVio/Interaction/UC/MachineId.lean
@@ -145,9 +145,7 @@ need session-aware identity instantiate this abbreviation.
 abbrev MachineProcess (Sid Pid : Type u) (Δ : PortBoundary) :=
   OpenProcess.{u, v, w} (MachineId Sid Pid) Δ
 
--- ============================================================================
--- § Per-process access control
--- ============================================================================
+/-! ## Per-process access control -/
 
 /--
 `HasAccessControl P` is the per-process predicate deciding which routed
@@ -227,9 +225,7 @@ theorem MachineProcess.allowed_allowSameSession
     (MachineProcess.allowSameSession owner P).allowed rp =
       rp.sender.sameSession owner := rfl
 
--- ============================================================================
--- § Subroutine respecting predicate
--- ============================================================================
+/-! ## Subroutine respecting predicate -/
 
 /--
 A node semantics is **session-coherent at** `sid` for a chosen move `x`

--- a/VCVio/Interaction/UC/MachineId.lean
+++ b/VCVio/Interaction/UC/MachineId.lean
@@ -136,5 +136,170 @@ need session-aware identity instantiate this abbreviation.
 abbrev MachineProcess (Sid Pid : Type u) (Δ : PortBoundary) :=
   OpenProcess.{u, v, w} (MachineId Sid Pid) Δ
 
+-- ============================================================================
+-- § Per-process access control
+-- ============================================================================
+
+/--
+`HasAccessControl P` is the per-process predicate deciding which routed
+inbound packets are admissible to the open process `P`.
+
+For an open process `P : OpenProcess Party Δ`, an instance supplies
+`allowed : Interface.RoutedPacket Δ.In Party → Bool`. The runtime layer
+consults this typeclass when delivering inbound packets: a packet is
+forwarded to `P` only when `allowed rp = true`.
+
+The default for new instances is **allow everything** (`HasAccessControl.allowAll`).
+Protocols that need sender-aware filtering provide a more restrictive
+instance. The canonical CJSV22-style filter
+(`MachineProcess.allowSameSession`) admits a packet iff its sender shares a
+session with the process owner, recovering the access-control fragment of
+the subroutine respecting condition (CJSV22 §2.3).
+
+The runtime integration into `BoundaryAction.inputDecode` is deliberately
+**not** wired up in this slice: the typeclass exists as a forward-compatible
+vocabulary that downstream layers (notably the F2 corruption work) consume.
+Until that integration lands, `HasAccessControl` is a *declarative* contract
+that downstream constructions must thread by hand.
+-/
+class HasAccessControl
+    {Party : Type u} {Δ : PortBoundary}
+    (P : OpenProcess.{u, v, w} Party Δ) where
+  allowed : Interface.RoutedPacket Δ.In Party → Bool
+
+namespace HasAccessControl
+
+variable {Party : Type u} {Δ : PortBoundary}
+
+/--
+The trivial **allow-all** access control: every routed packet is admissible.
+
+Useful for protocols whose security does not depend on per-machine input
+filtering, and as the canonical baseline against which more restrictive
+instances are compared.
+-/
+@[reducible]
+def allowAll (P : OpenProcess.{u, v, w} Party Δ) : HasAccessControl P where
+  allowed _ := true
+
+@[simp]
+theorem allowed_allowAll
+    (P : OpenProcess.{u, v, w} Party Δ)
+    (rp : Interface.RoutedPacket Δ.In Party) :
+    (HasAccessControl.allowAll P).allowed rp = true := rfl
+
+end HasAccessControl
+
+/--
+The canonical CJSV22 same-session access control on a `MachineProcess`.
+
+`MachineProcess.allowSameSession owner P` admits a routed packet iff its
+sender shares a session with `owner` (per `MachineId.sameSession`).
+
+This is the access-control fragment of the **subroutine respecting**
+condition (CJSV22 §2.3): a machine `(s, p)` only accepts inputs from
+senders whose session identifier is also `s`. Combined with a sender-aware
+emit (delivered by F2), this recovers the full structural same-session
+discipline.
+-/
+@[reducible]
+def MachineProcess.allowSameSession
+    {Sid Pid : Type u} {Δ : PortBoundary} [DecidableEq Sid]
+    (owner : MachineId Sid Pid)
+    (P : MachineProcess.{u, v, w} Sid Pid Δ) : HasAccessControl P where
+  allowed rp := rp.sender.sameSession owner
+
+@[simp]
+theorem MachineProcess.allowed_allowSameSession
+    {Sid Pid : Type u} {Δ : PortBoundary} [DecidableEq Sid]
+    (owner : MachineId Sid Pid)
+    (P : MachineProcess.{u, v, w} Sid Pid Δ)
+    (rp : Interface.RoutedPacket Δ.In (MachineId Sid Pid)) :
+    (MachineProcess.allowSameSession owner P).allowed rp =
+      rp.sender.sameSession owner := rfl
+
+-- ============================================================================
+-- § Subroutine respecting predicate
+-- ============================================================================
+
+/--
+A node semantics is **session-coherent at** `sid` for a chosen move `x`
+iff every controller listed by the node for that move resides in
+session `sid`.
+
+This is the per-move check used by `DecorationSessionCoherentAt`: at the
+node where `x` is chosen, every machine credited as a controller of `x`
+must share the protocol's session identifier.
+-/
+def OpenNodeSemantics.SessionCoherentAtMove
+    {Sid Pid : Type u} {Δ : PortBoundary} {X : Type w}
+    (sid : Sid) (ons : OpenNodeSemantics (MachineId Sid Pid) Δ X)
+    (x : X) : Prop :=
+  ∀ m ∈ ons.controllers x, m.sid = sid
+
+/--
+A spec decoration is **session-coherent at** `sid` along a chosen
+transcript iff every visited node attributes only controllers in
+session `sid`.
+
+This is the recursive companion to
+`OpenNodeSemantics.SessionCoherentAtMove`, modeled directly on
+`IsSilentDecoration`: the predicate walks the same transcript path
+through the decoration tree and accumulates the per-node coherence
+checks.
+-/
+def DecorationSessionCoherentAt
+    {Sid Pid : Type u} {Δ : PortBoundary} (sid : Sid) :
+    {spec : Interaction.Spec.{w}} →
+    Interaction.Spec.Decoration
+      (OpenNodeContext.{u, w} (MachineId Sid Pid) Δ) spec →
+    spec.Transcript → Prop
+  | .done, _, _ => True
+  | .node _ _, ⟨ons, drest⟩, ⟨x, tr⟩ =>
+      ons.SessionCoherentAtMove sid x ∧
+      DecorationSessionCoherentAt sid (drest x) tr
+
+/--
+A `MachineProcess` is **subroutine respecting at** `sid` iff every step
+from every reachable state, along every transcript path, only attributes
+controllers in session `sid`.
+
+This is the **controller-side** fragment of CJSV22's subroutine
+respecting condition. The sender-side fragment (every emitted /
+accepted `RoutedPacket` has sender in session `sid`) lives at the
+`BoundaryAction` integration layer and is enforced by future
+`HasAccessControl` instances installed via
+`MachineProcess.allowSameSession`.
+-/
+def MachineProcess.SubroutineRespectingAt
+    {Sid Pid : Type u} {Δ : PortBoundary}
+    (sid : Sid) (P : MachineProcess.{u, v, w} Sid Pid Δ) : Prop :=
+  ∀ (s : P.Proc) (tr : (P.step s).spec.Transcript),
+    DecorationSessionCoherentAt sid (P.step s).semantics tr
+
+@[simp]
+theorem DecorationSessionCoherentAt_done
+    {Sid Pid : Type u} {Δ : PortBoundary} (sid : Sid)
+    (d : Interaction.Spec.Decoration
+      (OpenNodeContext.{u, w} (MachineId Sid Pid) Δ) .done)
+    (tr : (Interaction.Spec.done : Interaction.Spec.{w}).Transcript) :
+    DecorationSessionCoherentAt sid d tr := by
+  trivial
+
+@[simp]
+theorem DecorationSessionCoherentAt_node
+    {Sid Pid : Type u} {Δ : PortBoundary} (sid : Sid)
+    {Moves : Type w} {residual : Moves → Interaction.Spec.{w}}
+    (d : Interaction.Spec.Decoration
+      (OpenNodeContext.{u, w} (MachineId Sid Pid) Δ)
+      (.node Moves residual))
+    (x : Moves)
+    (tr : (residual x).Transcript) :
+    DecorationSessionCoherentAt sid d ⟨x, tr⟩ ↔
+      d.1.SessionCoherentAtMove sid x ∧
+      DecorationSessionCoherentAt sid (d.2 x) tr := by
+  rcases d with ⟨ons, drest⟩
+  rfl
+
 end UC
 end Interaction

--- a/VCVio/Interaction/UC/MachineId.lean
+++ b/VCVio/Interaction/UC/MachineId.lean
@@ -27,30 +27,39 @@ unchanged. New work that needs session-aware identity (forward security,
 post-compromise security, multi-session composition) instantiates
 `Party := MachineId Sid Pid` and uses the helpers below.
 
-## Status of related layers (deferred follow-ups)
+## Per-process access control and subroutine respecting
 
-The full CJSV22 access-control story requires three additional pieces that are
-deliberately *not* introduced here, because each one carries a non-trivial
-cross-cutting design choice and they ship together as a coherent unit:
+This file also introduces the access-control vocabulary required by the
+CJSV22 *subroutine respecting* condition:
 
-* **`Interface.Packet.sender : MachineId`.** A packet currently carries only a
-  recipient port. Adding a sender field is invasive (every existing packet
-  construction site needs updating). Without it, the framework cannot tell
-  which machine sent an inbound packet, so any access-control predicate has
-  nothing concrete to inspect.
-* **`HasAccessControl` typeclass.** Per-process predicate
-  `allowed : MachineId → Packet → Bool` consulted by
-  `BoundaryAction.inputDecode` to drop ill-addressed packets. Depends on
-  `Packet.sender` to be expressible.
-* **`subroutineRespecting : MachineProcess Sid Pid Δ → Prop`.** A decidable,
-  structural predicate that recovers what an explicit scope policy would
-  otherwise enforce: a machine `(s, p)` only emits to and accepts packets
-  tagged with session `s`. Defining it cleanly requires `Packet.sender` so
-  the predicate has something concrete to read off the boundary action.
+* **`HasAccessControl P`.** A typeclass over `OpenProcess Party Δ`
+  carrying `allowed : Interface.RoutedPacket Δ.In Party → Bool`. The
+  default-open instance `HasAccessControl.allowAll` is provided for
+  protocols whose security is not sensitive to per-machine input
+  filtering.
+* **`MachineProcess.allowSameSession owner P`.** The canonical CJSV22
+  filter on a `MachineProcess`: admit a routed packet iff its sender
+  shares a session with `owner` (per `MachineId.sameSession`).
+* **`MachineProcess.SubroutineRespectingAt sid P`.** A `Prop`-valued
+  property saying every reachable step's decoration only attributes
+  controllers in session `sid`. Built recursively over `Spec.Decoration`
+  via `OpenNodeSemantics.SessionCoherentAtMove` and
+  `DecorationSessionCoherentAt`.
 
-These three are tracked together as the next slice of the F1 plan; see
-`Notes/vcvio-signal-uc-foundation-cjsv22.md` §6.10.1 and the F1 phase
-description for the proposed naming and the broader composition story.
+These three pieces are *additive* on top of the existing `OpenProcess`
+surface: no existing construction site is touched, and the predicate
+`SubroutineRespectingAt` reads off the controller annotations already
+carried by `OpenNodeContext`.
+
+## Deferred follow-up
+
+The runtime integration that consults `HasAccessControl` from
+`BoundaryAction.inputDecode` is deliberately deferred to the F2
+corruption layer, which already needs to touch the boundary surface for
+`EnvAction` dispatch. Until that integration lands, `HasAccessControl`
+is a *declarative* contract that downstream constructions thread by
+hand. See `Notes/vcvio-signal-uc-foundation-cjsv22.md` §6.10.1 and the
+F2 design memo for the integration plan.
 -/
 
 universe u v w

--- a/VCVio/Interaction/UC/OpenProcess.lean
+++ b/VCVio/Interaction/UC/OpenProcess.lean
@@ -576,9 +576,7 @@ predicates used throughout VCVio.
 abbrev OpenProcess.System (Party : Type u) (Δ : PortBoundary) :=
   ProcessOver.System (OpenNodeContext Party Δ : Spec.Node.Context.{w})
 
--- ============================================================================
--- § Silent steps and weak bisimulation
--- ============================================================================
+/-! ## Silent steps and weak bisimulation -/
 
 /-- A transcript path through a decorated open-process spec is **silent** when
 every visited node is not externally activated (`isActivated = false`).
@@ -636,9 +634,7 @@ theorem isSilentStep_mapBoundary_iff {Party : Type u} {Δ₁ Δ₂ : PortBoundar
   intro X ons
   simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
 
--- ============================================================================
--- § OpenProcessIso: weak bisimulation equivalence for open processes
--- ============================================================================
+/-! ## OpenProcessIso: weak bisimulation equivalence for open processes -/
 
 /--
 Two open processes with the same boundary are **weakly bisimilar** when there

--- a/VCVio/Interaction/UC/OpenProcessModel.lean
+++ b/VCVio/Interaction/UC/OpenProcessModel.lean
@@ -142,9 +142,7 @@ instance : OpenTheory.IsLawfulPlug (openTheory.{u, v, w} Party) where
 
 instance : OpenTheory.IsLawful (openTheory.{u, v, w} Party) where
 
--- ============================================================================
--- § Monoidal and compact closed laws up to bisimilarity
--- ============================================================================
+/-! ## Monoidal and compact closed laws up to bisimilarity -/
 
 /-- Parallel composition of open processes is associative up to bisimilarity:
 reassociating the internal scheduler nesting does not change the observable

--- a/VCVio/Interaction/UC/OpenSyntax/Expr.lean
+++ b/VCVio/Interaction/UC/OpenSyntax/Expr.lean
@@ -223,9 +223,7 @@ theorem interpret_unit {Atom : PortBoundary → Type u}
   simp only [Expr.unit, interpret_map]
   exact OpenTheory.unit_eq.symm
 
--- ============================================================================
--- § Lawful OpenTheory instance
--- ============================================================================
+/-! ## Lawful OpenTheory instance -/
 
 /--
 The free lawful `OpenTheory` whose objects are quotiented expressions over
@@ -314,9 +312,7 @@ instance compactClosed (Atom : PortBoundary → Type u) :
     Quotient.inductionOn₃ W₁ W₂ K fun _ _ _ =>
       Quotient.sound Raw.Equiv.plug_wire_left
 
--- ============================================================================
--- § Bridge: Expr → Interp
--- ============================================================================
+/-! ## Bridge: Expr → Interp -/
 
 /--
 Embed a quotiented expression into the tagless-final representation.

--- a/VCVioWidgets/OpenSyntax/Panel.lean
+++ b/VCVioWidgets/OpenSyntax/Panel.lean
@@ -34,9 +34,7 @@ the panel with
 to see the composition diagram.
 -/
 
--- ============================================================================
--- § Intermediate tree representation
--- ============================================================================
+/-! ## Intermediate tree representation -/
 
 inductive CompTree where
   | atom (label : String)
@@ -47,9 +45,7 @@ inductive CompTree where
   | opaque (label : String)
   deriving Inhabited
 
--- ============================================================================
--- § Meta-level expression extraction
--- ============================================================================
+/-! ## Meta-level expression extraction -/
 
 private def rawPrefix : Name := `Interaction.UC.OpenSyntax.Raw
 
@@ -112,9 +108,7 @@ where
         let fmt ← ppExpr e
         return .opaque fmt.pretty
 
--- ============================================================================
--- § Graph rendering (D3 force-directed via GraphDisplay)
--- ============================================================================
+/-! ## Graph rendering (D3 force-directed via GraphDisplay) -/
 
 private structure GraphState where
   vertices : Array GraphDisplay.Vertex
@@ -285,9 +279,7 @@ private def compTreeToGraph (tree : CompTree) : GraphDisplay.Props :=
     showDetails := true
   }
 
--- ============================================================================
--- § Attribute registry
--- ============================================================================
+/-! ## Attribute registry -/
 
 structure RegisteredComp where
   modName : Name
@@ -323,9 +315,7 @@ def getRegisteredCompositions (modName : Name) : CoreM (Array Name) := do
     | some names => names
     | none => #[]
 
--- ============================================================================
--- § Panel widget
--- ============================================================================
+/-! ## Panel widget -/
 
 private def css (entries : List (String × String)) : Json :=
   Json.mkObj <| entries.map fun (k, v) => (k, Json.str v)

--- a/VCVioWidgets/OpenSyntax/TreePanel.lean
+++ b/VCVioWidgets/OpenSyntax/TreePanel.lean
@@ -29,9 +29,7 @@ top-down tree layout algorithm. No physics simulation; the diagram is
 stable and hierarchical.
 -/
 
--- ============================================================================
--- § Tree layout computation
--- ============================================================================
+/-! ## Tree layout computation -/
 
 private structure LayoutNode where
   id : Nat
@@ -129,9 +127,7 @@ private partial def layoutTree (tree : CompTree) (depth : Float) (st : LayoutSta
         nodes := st.nodes.push node
         edges := st.edges.push edge })
 
--- ============================================================================
--- § SVG rendering via Html.element
--- ============================================================================
+/-! ## SVG rendering via Html.element -/
 
 private def findNode (nodes : Array LayoutNode) (id : Nat) : Option LayoutNode :=
   nodes.find? (·.id == id)
@@ -242,9 +238,7 @@ private def renderTreeSvg (tree : CompTree) : Html :=
     ("height", Json.str svgH)]
     (#[defs] ++ edgeElems ++ nodeElems)
 
--- ============================================================================
--- § Panel widget
--- ============================================================================
+/-! ## Panel widget -/
 
 private def css (entries : List (String × String)) : Json :=
   Json.mkObj <| entries.map fun (k, v) => (k, Json.str v)


### PR DESCRIPTION
## Summary

Combined PR carrying **F1 Slice 2** (CJSV22 machine-identity layer, follow-up to #296), **F2 Slice 1** (the standalone vocabulary for adaptive momentary corruption), and the **no-ASCII-banners style cleanup**. Originally landed as separate stacked PRs #297, #300, #301; consolidated here per request so review can iterate on a single thread.

All additions are **purely additive** to runtime semantics: no existing call site is modified, and `BoundaryAction` keeps its current signature.

Eight commits, each axiom-clean (where applicable):

## F1 Slice 2 — access control vocabulary

### 1. `RoutedPacket I M` (`VCVio/Interaction/UC/Interface.lean`)

Wire-level packet tagged with the identity of its emitter, parameterised over an abstract sender type `M`. Comes with `ext`, functoriality lemmas (`mapPacket_id`, `mapPacket_comp`, `mapSender_id`, `mapSender_comp`) and the commutation `mapPacket_mapSender`. The canonical instantiation is `M := MachineId Sid Pid`, but `Unit` (purely internal traffic) and other identity schemes work unchanged.

### 2. `HasAccessControl` + `SubroutineRespectingAt` (`VCVio/Interaction/UC/MachineId.lean`)

* `HasAccessControl P` — typeclass over `OpenProcess Party Δ` carrying `allowed : Interface.RoutedPacket Δ.In Party → Bool`. Default-open via `HasAccessControl.allowAll`.
* `MachineProcess.allowSameSession owner P` — canonical CJSV22 filter admitting a packet iff sender shares a session with `owner`. Marked `@[reducible]` so it unfolds during typeclass synthesis.
* `MachineProcess.SubroutineRespectingAt sid P` — `Prop` saying every reachable step's decoration only attributes controllers in session `sid`. Built recursively via `OpenNodeSemantics.SessionCoherentAtMove` and `DecorationSessionCoherentAt`.

### 3. Module docstring refresh

Replaces the previous "deferred follow-ups" block with a current "Per-process access control and subroutine respecting" section.

## F2 Slice 1 — corruption vocabulary

### 4. `EnvAction Event X` (`VCVio/Interaction/UC/EnvAction.lean`)

Per-event reaction of a per-step state to environment-driven events. Single field `react : Event → X → ProbComp X`. Companion API: `empty`, `passive`, `comap`, `liftState`, plus `comap_id`, `comap_comap`, `passive_react`, `empty_react` simp lemmas. Alphabet parameter named `Event` (CSP / π-calculus convention) rather than CJSV22's `Σ` (reserved Lean keyword).

### 5. `Corruption.lean` (`VCVio/Interaction/UC/Corruption.lean`)

- **`CorruptionAlphabet Sid Pid`** — inductive `compromise(m)` and `refresh(m)`, indexed by `MachineId`. `deriving DecidableEq`.
- **`Epoch := ℕ`** — per-machine refresh counter.
- **`CorruptionState Sid Pid`** — three-field record (`corrupted`, `compromised`, `epoch`); `init`, `Inhabited`, `@[ext]`. The two flags are deliberately independent: one tracks the current adversary view, the other the per-epoch leak history.
- **`applyCompromise` / `applyRefresh`** — deterministic state updates. `compromise` snapshots the current epoch as compromised and sets `corrupted m`; `refresh` clears `corrupted m` and increments `epoch m`. Past `compromised` flags are preserved (monotonicity, the structural ingredient for PCS).
- **`reactBase` / `envActionBase`** — the canonical `EnvAction` baseline that every protocol opting in to adaptive momentary corruption inherits.
- 11 simp / theorem lemmas covering per-flag, per-epoch behaviour including monotonicity (`compromised_applyCompromise_of_compromised`).
- **`LeakableState State Leakage`** typeclass — exposes `leak : State → MachineId → Leakage`. **No default instance**: surfaces the equivocability obligation as a missing-instance error.
- **`CorruptionPolicy process`** — `StepPolicy` specialization, reusing `top` / `inter` from `Interaction.Concurrent.Policy`.

### 6. `EnvAction` rename `Sym → Event`

Mechanical rename of the alphabet parameter: CSP / π-calculus convention, more literal than `Sym`, no collision with `Symmetric` / `SymmEnc`.

### 7. `CorruptionPolicy` universe generalisation

Fixes the universe binder from `Context.{w, w}` to `Context.{w, w₂}`, matching the actual signature of `ProcessOver.StepPolicy`. Resolves the Codex bot's review comment: collapsing the two universe parameters to one would have made the alias unusable for any mixed-universe `OpenNodeContext`.

## Style — no ASCII section banners

### 8. Mechanical scrub

25 ASCII section banners removed across 9 files, replaced with one-line Mathlib-style doc-headers `/-! ## Title -/` (rendered by `doc-gen4`):

| File                                          | Banners |
| --------------------------------------------- | ------- |
| `VCVioWidgets/OpenSyntax/Panel.lean`          | 5       |
| `Examples/CompositionDiagram.lean`            | 4       |
| `VCVio/Interaction/UC/Corruption.lean`        | 4       |
| `VCVioWidgets/OpenSyntax/TreePanel.lean`      | 3       |
| `VCVio/Interaction/UC/Emulates.lean`          | 2       |
| `VCVio/Interaction/UC/MachineId.lean`         | 2       |
| `VCVio/Interaction/UC/OpenProcess.lean`       | 2       |
| `VCVio/Interaction/UC/OpenSyntax/Expr.lean`   | 2       |
| `VCVio/Interaction/UC/OpenProcessModel.lean`  | 1       |

### 9. New rule

- `CONTRIBUTING.md` — new *Section Headers Within A File* subsection under *Documentation Expectations*, plus a one-line entry in *Style Notes*.
- `AGENTS.md` — one-line entry in *Attribution, Headers, And Docstrings* pointing at the CONTRIBUTING.md section. (`CLAUDE.md` is a symlink.)

The rule: use `/-! ## Title -/` (one-line) or `/-! ## Title \n explanation -/` (multi-line). Don't use ASCII banners. If a section is large enough to want a loud header, it's usually large enough to want its own `namespace` or its own file.

## Universe constraint

`Sid Pid : Type` (i.e. `Type 0`) in the `Corruption` layer because `CorruptionState` participates in `ProbComp`-valued reactions and `ProbComp : Type → Type`. Concrete identity types (`ℕ`, `String`) all satisfy this bound; matches the convention in `Runtime.lean`.

## Additive design

- No file outside `VCVio/Interaction/UC/{Interface,MachineId,EnvAction,Corruption}.lean`, the section-banner-touched files (style-only), and the auto-generated `VCVio.lean` import list is touched.
- Nothing here is threaded into `OpenNodeSemantics` in this slice.
- Existing `OpenProcess` / `MachineProcess` constructions are unaffected.
- The corruption-aware composition wrapper (`MachineProcessC`) that pairs `MachineProcess` with a state-indexed `EnvAction` and hosts the four `*.corrupt` forwarding lemmas is **F2 Slice 2**.
- `F_AKE`, `F_E2E`, and the healing theorem are **F2 Slice 3**.

## Axiom hygiene

`#print axioms` over all new declarations:

- F1 Slice 2 declarations: 18 zero-axiom; `RoutedPacket.mapPacket_{id,comp}` only `propext` + `Quot.sound`.
- `EnvAction` declarations: `Quot.sound` only (from `@[ext]`).
- `CorruptionAlphabet` / `CorruptionState` core constructors and definitions: zero axioms.
- `CorruptionState` reaction lemmas: at most `propext`.
- `LeakableState`, `CorruptionPolicy.{top,inter}`: zero axioms.

No `Classical.choice`, no new axioms introduced.

## Test plan

- [x] `lake build` (full repo, 3572/3572)
- [x] `#print axioms` audit on all new declarations
- [x] Smoke tests on `HasAccessControl` instances
- [x] `rg '^-- =' VCVio/ Examples/ VCVioWidgets/` empty (no banners remain)
- [x] Codex bot fix verified (`CorruptionPolicy` universes generalised)
- [ ] (next slice) corruption-aware composition wrapper `MachineProcessC` + four `*.corrupt` forwarding lemmas

## Predecessors (folded in)

- ~~#300~~ (F2 Slice 1: corruption vocabulary) — folded
- ~~#301~~ (style: forbid ASCII section banners) — folded

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)