### PR TITLE
feat(uc): F2 Slice 1 — corruption vocabulary (EnvAction + CorruptionState + LeakableState + CorruptionPolicy)

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -113,7 +113,9 @@ import VCVio.Interaction.TwoParty.Role
 import VCVio.Interaction.TwoParty.Strategy
 import VCVio.Interaction.TwoParty.Swap
 import VCVio.Interaction.UC.Computational
+import VCVio.Interaction.UC.Corruption
 import VCVio.Interaction.UC.Emulates
+import VCVio.Interaction.UC.EnvAction
 import VCVio.Interaction.UC.Interface
 import VCVio.Interaction.UC.MachineId
 import VCVio.Interaction.UC.Notation

--- a/VCVio/Interaction/UC/Corruption.lean
+++ b/VCVio/Interaction/UC/Corruption.lean
@@ -1,0 +1,414 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.UC.EnvAction
+import VCVio.Interaction.UC.MachineId
+import VCVio.Interaction.Concurrent.Policy
+
+/-!
+# Adaptive momentary corruption vocabulary
+
+This file introduces the standalone vocabulary for CJSV22-style adaptive
+momentary corruption (Canetti, Jain, Swanberg, Varia, *Universally
+Composable End-to-End Secure Messaging*, CRYPTO 2022 §3.2):
+
+* **`CorruptionAlphabet Sid Pid`** — the inductive event alphabet
+  `compromise(m)` and `refresh(m)`, indexed by `MachineId Sid Pid`.
+* **`Epoch`** — the per-machine refresh counter, defined as `ℕ` (the
+  simplest concrete choice; richer protocols like asymmetric ratchets
+  can wrap this in their own `Epoch`-isomorphic type).
+* **`CorruptionState Sid Pid`** — the two-flag corruption tracking:
+  `corrupted` (current snapshot in adversary view) and `compromised`
+  (per-`(machine, epoch)` historical view), plus the per-machine
+  `epoch` counter.
+* **`CorruptionState.applyCompromise` / `applyRefresh`** — the
+  canonical deterministic updates triggered by the alphabet events.
+* **`CorruptionState.envActionBase`** — the canonical `EnvAction`
+  built from those updates, the baseline that every protocol opting
+  in to adaptive momentary corruption inherits.
+* **`LeakableState`** — the typeclass that surfaces the equivocability
+  obligation as a missing instance. Real protocols supply the natural
+  state projection; simulators supply a fabrication that is
+  consistent with all prior leakages and the current trace.
+* **`CorruptionPolicy`** — a `StepPolicy` specialization keyed on the
+  corruption alphabet, reusing the existing `inter` / `top` /
+  `byController` combinators from `Interaction.Concurrent.Policy`.
+
+## Universe constraint
+
+`Sid` and `Pid` live in `Type` (i.e. `Type 0`) because
+`CorruptionState` participates in `ProbComp`-valued reactions and
+`ProbComp : Type → Type`. This matches the universe convention used
+in `VCVio/Interaction/UC/Runtime.lean`. Concrete protocol identity
+types (`ℕ`, `String`, etc.) all satisfy this bound.
+
+## Additive design
+
+Like `EnvAction`, `CorruptionState` is **standalone**: it is *not*
+threaded into `OpenNodeSemantics` here. Existing `OpenProcess`
+constructions are untouched. The corruption-aware composition wrapper
+that pairs a `MachineProcess` with a state-indexed `EnvAction` (and
+hosts the four `*.corrupt` forwarding lemmas) is a follow-up slice.
+
+## Why `LeakableState` is a typeclass
+
+Forcing every protocol that participates in adaptive corruption to
+declare what it leaks turns the equivocability obligation into a
+mechanically checkable instance hole. A simulator that cannot
+fabricate consistent state cannot supply an instance and cannot be
+plugged into the security definition; the obligation is enforced at
+compile time rather than via meta-theoretic side conditions.
+
+## Decidability
+
+All comparisons are over `MachineId` (which derives `DecidableEq`
+from `[DecidableEq Sid] [DecidableEq Pid]`) and over `Epoch = ℕ`.
+`CorruptionState` operations are computable as long as the user
+provides decidable equality on the identity type parameters.
+-/
+
+universe w
+
+namespace Interaction
+namespace UC
+
+-- ============================================================================
+-- § Corruption alphabet and epoch
+-- ============================================================================
+
+/--
+The standard CJSV22 corruption alphabet for a fixed `(Sid, Pid)`
+identity space.
+
+* `compromise m` snapshots the current state of machine `m` into the
+  adversary's view: the leakage function fires, and the current epoch
+  of `m` is marked compromised.
+* `refresh m` advances the epoch counter for `m`. After a refresh,
+  future epochs of `m` are not (yet) compromised; the protocol's
+  forward-secrecy mechanism gets a chance to heal.
+
+The pair `(compromise, refresh)` is the alphabet underlying the
+*momentary* part of "adaptive momentary corruption": at any point the
+environment may compromise a machine, and a subsequent refresh
+recovers post-compromise security for future epochs.
+
+`CorruptionAlphabet Sid Pid` is the canonical instantiation of
+`EnvAction.alphabet` for adaptive momentary corruption. The
+`EnvAction` paired with this alphabet is built from
+`CorruptionState.envActionBase`.
+-/
+inductive CorruptionAlphabet (Sid Pid : Type) where
+  /-- Snapshot the current state of `m` into the adversary's view. -/
+  | compromise (m : MachineId Sid Pid) : CorruptionAlphabet Sid Pid
+  /-- Advance the epoch counter of `m`, enabling forward healing. -/
+  | refresh    (m : MachineId Sid Pid) : CorruptionAlphabet Sid Pid
+deriving DecidableEq
+
+namespace CorruptionAlphabet
+
+variable {Sid Pid : Type}
+
+/-- The machine targeted by a corruption event. -/
+def target : CorruptionAlphabet Sid Pid → MachineId Sid Pid
+  | .compromise m => m
+  | .refresh m    => m
+
+@[simp] theorem target_compromise (m : MachineId Sid Pid) :
+    (compromise m).target = m := rfl
+
+@[simp] theorem target_refresh (m : MachineId Sid Pid) :
+    (refresh m).target = m := rfl
+
+end CorruptionAlphabet
+
+/--
+`Epoch` indexes the per-machine refresh cycles.
+
+A flat `ℕ` is the simplest concrete choice: refresh counts as
+`epoch m += 1`. Richer protocols (e.g. Signal's asymmetric ratchet
+with separate sending and receiving counters) can wrap this in their
+own `Epoch`-isomorphic type; the framework only requires
+`DecidableEq` and a way to advance.
+-/
+abbrev Epoch : Type := ℕ
+
+-- ============================================================================
+-- § Corruption state
+-- ============================================================================
+
+/--
+`CorruptionState Sid Pid` packages the two-flag corruption tracking
+that an environment-driven step carries between events.
+
+* `corrupted m = true` iff the current state of `m` has been
+  snapshotted by the adversary at least once and not refreshed
+  since. Mutated by `compromise m` (sets `true`) and `refresh m`
+  (sets `false`).
+* `compromised m e = true` iff the secrets for epoch `e` of `m`
+  are in the adversary's view. Strictly accumulating: a compromise
+  event sets `compromised m (current_epoch m)`; epochs once
+  compromised stay compromised forever.
+* `epoch m` is `m`'s current refresh counter. Mutated by
+  `refresh m` (increments by one).
+
+The two flags `corrupted` and `compromised` are deliberately
+independent:
+
+* `corrupted m` may be `false` while `compromised m e` holds for
+  some past `e`: the adversary saw that epoch's secret, but the
+  machine has since refreshed and now has a fresh secret.
+* `corrupted m` may be `true` while `compromised m e'` is `false`
+  for some future `e'`: a forward-secret key schedule may
+  forward-decrypt only a bounded window from a current compromise.
+
+Two flags, two distinct purposes. The naming deliberately avoids
+the ambiguous "exposed", which would collide with `OpenTheory`'s
+boundary-exposure terminology.
+-/
+@[ext]
+structure CorruptionState (Sid Pid : Type) where
+  /-- Per-machine snapshot flag, mutated by `compromise` and `refresh`. -/
+  corrupted : MachineId Sid Pid → Bool := fun _ => false
+  /-- Per-(machine, epoch) leak flag, monotonically accumulating. -/
+  compromised : MachineId Sid Pid → Epoch → Bool := fun _ _ => false
+  /-- Per-machine refresh counter, advanced by `refresh`. -/
+  epoch : MachineId Sid Pid → Epoch := fun _ => 0
+
+namespace CorruptionState
+
+variable {Sid Pid : Type}
+
+/-- The fully-honest initial state: nothing corrupted, nothing
+compromised, every machine at epoch zero. -/
+def init : CorruptionState Sid Pid := {}
+
+instance : Inhabited (CorruptionState Sid Pid) := ⟨init⟩
+
+@[simp] theorem corrupted_init (m : MachineId Sid Pid) :
+    (init : CorruptionState Sid Pid).corrupted m = false := rfl
+
+@[simp] theorem compromised_init (m : MachineId Sid Pid) (e : Epoch) :
+    (init : CorruptionState Sid Pid).compromised m e = false := rfl
+
+@[simp] theorem epoch_init (m : MachineId Sid Pid) :
+    (init : CorruptionState Sid Pid).epoch m = 0 := rfl
+
+variable [DecidableEq Sid] [DecidableEq Pid]
+
+/--
+Apply `compromise m` to the corruption state: set `corrupted m` and
+mark the current epoch of `m` as compromised. The epoch counter is
+not advanced.
+
+This is a deterministic update, so the value lives in the underlying
+`CorruptionState`; the canonical `EnvAction` reaction wraps it via
+`pure`.
+-/
+def applyCompromise
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    CorruptionState Sid Pid where
+  corrupted := Function.update cs.corrupted m true
+  compromised := fun m' e' =>
+    cs.compromised m' e' || (decide (m = m') && decide (e' = cs.epoch m))
+  epoch := cs.epoch
+
+/--
+Apply `refresh m` to the corruption state: clear `corrupted m` and
+advance the epoch counter of `m` by one. Past `compromised` flags are
+preserved (they are historical and accumulate).
+
+After a refresh, future events on `m` write into the new epoch; this
+is the structural ingredient that lets the framework derive PCS
+(post-compromise security) as a healing theorem rather than as an
+axiom.
+-/
+def applyRefresh
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    CorruptionState Sid Pid where
+  corrupted := Function.update cs.corrupted m false
+  compromised := cs.compromised
+  epoch := Function.update cs.epoch m (cs.epoch m + 1)
+
+/--
+The canonical `EnvAction` reaction for the corruption alphabet:
+`compromise` snapshots, `refresh` advances the epoch.
+
+This is the baseline used by every protocol that opts in to
+adaptive momentary corruption. Protocols that need richer
+per-event behaviour (e.g. simulator-controlled randomization on
+`compromise`, or a non-trivial leakage function) override the
+relevant branch in their bespoke `EnvAction` rather than touching
+the alphabet itself.
+-/
+def reactBase
+    (s : CorruptionAlphabet Sid Pid) (cs : CorruptionState Sid Pid) :
+    ProbComp (CorruptionState Sid Pid) :=
+  match s with
+  | .compromise m => pure (applyCompromise m cs)
+  | .refresh m    => pure (applyRefresh m cs)
+
+/-- The canonical corruption-aware `EnvAction`. -/
+def envActionBase :
+    EnvAction (CorruptionAlphabet Sid Pid) (CorruptionState Sid Pid) where
+  react := reactBase
+
+@[simp] theorem reactBase_compromise
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    reactBase (.compromise m) cs = pure (applyCompromise m cs) := rfl
+
+@[simp] theorem reactBase_refresh
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    reactBase (.refresh m) cs = pure (applyRefresh m cs) := rfl
+
+@[simp] theorem corrupted_applyCompromise_self
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).corrupted m = true := by
+  simp [applyCompromise]
+
+theorem corrupted_applyCompromise_of_ne
+    {m m' : MachineId Sid Pid} (h : m' ≠ m) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).corrupted m' = cs.corrupted m' := by
+  simp [applyCompromise, Function.update_of_ne h]
+
+@[simp] theorem corrupted_applyRefresh_self
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).corrupted m = false := by
+  simp [applyRefresh]
+
+theorem corrupted_applyRefresh_of_ne
+    {m m' : MachineId Sid Pid} (h : m' ≠ m) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).corrupted m' = cs.corrupted m' := by
+  simp [applyRefresh, Function.update_of_ne h]
+
+@[simp] theorem epoch_applyCompromise
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).epoch = cs.epoch := rfl
+
+@[simp] theorem epoch_applyRefresh_self
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).epoch m = cs.epoch m + 1 := by
+  simp [applyRefresh]
+
+theorem epoch_applyRefresh_of_ne
+    {m m' : MachineId Sid Pid} (h : m' ≠ m) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).epoch m' = cs.epoch m' := by
+  simp [applyRefresh, Function.update_of_ne h]
+
+theorem compromised_applyCompromise_self_currentEpoch
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyCompromise m cs).compromised m (cs.epoch m) = true := by
+  simp [applyCompromise]
+
+/--
+`compromise` is monotone: once an epoch is in the adversary's view, it
+stays in the adversary's view. This is the structural fact that makes
+PCS (post-compromise security) about *future* epochs rather than
+about un-leaking past ones.
+-/
+theorem compromised_applyCompromise_of_compromised
+    {cs : CorruptionState Sid Pid} {m : MachineId Sid Pid}
+    {m' : MachineId Sid Pid} {e : Epoch}
+    (h : cs.compromised m' e = true) :
+    (applyCompromise m cs).compromised m' e = true := by
+  simp [applyCompromise, h]
+
+/-- `refresh` preserves all past compromise flags. -/
+@[simp] theorem compromised_applyRefresh
+    (m : MachineId Sid Pid) (cs : CorruptionState Sid Pid) :
+    (applyRefresh m cs).compromised = cs.compromised := rfl
+
+end CorruptionState
+
+-- ============================================================================
+-- § Leakable state (equivocability obligation)
+-- ============================================================================
+
+/--
+`LeakableState State Leakage` exposes an extraction function that
+projects a per-machine snapshot from `State`.
+
+The intended use is on `MachineProcess`-shaped state types: a real
+protocol supplies the natural projection (e.g. "current long-term
+secret + ratchet root for machine `m`"); a simulator supplies a
+fabrication consistent with all prior leakages and the current
+adversary trace.
+
+This is the typed form of the **equivocability obligation** from
+CJSV22 §4.1. By exposing it as a typeclass, the framework forces the
+following invariant at compile time: a simulator that cannot
+fabricate consistent state cannot supply an instance, and cannot be
+used to discharge UC security. The obligation becomes a *missing
+instance* error rather than a meta-theoretic gap in the proof.
+
+`Leakage` is an `outParam` because each `State` functionally
+determines its leakage type: there is one canonical projection per
+protocol, and ambiguity should not arise during instance synthesis.
+
+There is **no default instance**. Forcing every protocol to declare
+what it leaks is intentional: an automatic default would either leak
+too much (the entire `State`, breaking forward-secrecy proofs) or
+too little (nothing, vacuously satisfying the typeclass).
+-/
+class LeakableState
+    {Sid Pid : Type} (State : Type)
+    (Leakage : outParam Type) where
+  leak : State → MachineId Sid Pid → Leakage
+
+-- ============================================================================
+-- § Corruption policy
+-- ============================================================================
+
+open Interaction.Concurrent
+
+/--
+`CorruptionPolicy process` is a `StepPolicy` specialization that
+constrains the environment's corruption capabilities at each
+process step.
+
+Concretely: a corruption policy is given the concrete step transcript
+of a process and decides whether the step is admissible. Reuses the
+existing `Concurrent.ProcessOver.StepPolicy` machinery
+(`Interaction/Concurrent/Policy.lean`) verbatim, so the standard
+`top` / `inter` / `byController` / `byPath` / `byEvent` / `byTicket`
+combinators apply unchanged.
+
+Common downstream policies (none specialized here yet — they live with
+their pilot protocols):
+
+* `static` — only allow `compromise` events before any `send`-class
+  event has fired.
+* `momentary` — allow at most one `compromise(m)` per epoch per
+  machine (the CJSV22 default).
+* `bounded n` — allow at most `n` compromises across the whole
+  trace.
+
+These are **policies on the underlying step transcripts**, not on the
+corruption alphabet directly. The corruption alphabet flows through
+the `EnvAction` channel of a corruption-aware process; the policy
+constrains which step transcripts (which carry the env event in their
+data) the environment is allowed to schedule.
+-/
+abbrev CorruptionPolicy
+    {Γ : Interaction.Spec.Node.Context.{w, w}}
+    (process : ProcessOver Γ) :=
+  ProcessOver.StepPolicy process
+
+namespace CorruptionPolicy
+
+variable {Γ : Interaction.Spec.Node.Context.{w, w}} {process : ProcessOver Γ}
+
+/-- Allow every step transcript: the unconstrained baseline. -/
+abbrev top : CorruptionPolicy process :=
+  ProcessOver.StepPolicy.top
+
+/-- Conjunction of two corruption policies: both must allow. -/
+abbrev inter (left right : CorruptionPolicy process) :
+    CorruptionPolicy process :=
+  ProcessOver.StepPolicy.inter left right
+
+end CorruptionPolicy
+
+end UC
+end Interaction

--- a/VCVio/Interaction/UC/EnvAction.lean
+++ b/VCVio/Interaction/UC/EnvAction.lean
@@ -1,0 +1,168 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.OracleComp.ProbComp
+
+/-!
+# Environment-driven action alphabets
+
+This file introduces `EnvAction Sym X`, a standalone alphabet of
+environment-driven events that may act on a per-step state of type `X`.
+The alphabet `Sym` is the user-supplied symbol set (typically a sum
+type with one constructor per environment event: `compromise`,
+`refresh`, `setEpochParam`, etc.); the `react` function specifies how
+the state evolves on each event.
+
+This vocabulary is the foundation for CJSV22-style adaptive momentary
+corruption (Canetti, Jain, Swanberg, Varia, *Universally Composable
+End-to-End Secure Messaging*, CRYPTO 2022 §3.2). In CJSV22 the
+environment is the privileged source of `Corrupt`-type events, distinct
+from the adversary boundary (which carries port traffic). `EnvAction`
+gives the same separation a typed home in VCVio: corruption events flow
+through `EnvAction`, port traffic flows through `BoundaryAction`, and
+the two channels are kept structurally orthogonal.
+
+The alphabet parameter is named `Sym` rather than the CJSV22-style
+`Σ` because `Σ` is a reserved Lean keyword (sigma types).
+
+## Additive design
+
+`EnvAction` is intentionally **standalone**: it is *not* threaded into
+`OpenNodeSemantics` in this slice. Existing `OpenProcess Party Δ`
+constructions are unaffected, and protocols that do not need
+environment-driven events incur zero cost. A subsequent slice will
+build a corruption-aware wrapper that pairs an `OpenProcess` with a
+state-indexed `EnvAction`; the four `*.corrupt` forwarding lemmas
+(CJSV22 §4.2) live on that wrapper.
+
+## Probabilistic reactions
+
+`react` is `ProbComp`-valued, so corruption-driven state transitions
+can themselves be probabilistic (e.g. simulator-controlled
+randomization on `compromise`). Deterministic events use
+`pure ∘ update` and pay no extra cost.
+-/
+
+/-
+The state type `X` is constrained to `Type 0` because `ProbComp : Type → Type`
+lives in `Type`. This matches the universe convention in
+`VCVio/Interaction/UC/Runtime.lean`, where the runtime layer requires move
+and state types to live in `Type 0` for the same reason.
+-/
+universe u
+
+namespace Interaction
+namespace UC
+
+/--
+`EnvAction Sym X` is the per-event reaction of a per-step state
+`x : X` to environment events drawn from the alphabet `Sym`.
+
+`react : Sym → X → ProbComp X` specifies how each event transforms
+the state. The default `react` is `fun _ x => pure x` (every event is
+a no-op), which keeps the empty alphabet `Sym := Empty` trivially
+satisfiable.
+
+Two concrete instantiations matter here:
+
+* `EnvAction Empty X` — the trivial alphabet, used by every protocol
+  that doesn't participate in environment-driven corruption. Costs
+  nothing; the canonical inhabitant is `EnvAction.empty`.
+* `EnvAction (CorruptionAlphabet Sid Pid) (CorruptionState Sid Pid)` —
+  the canonical CJSV22 instantiation. See
+  `VCVio.Interaction.UC.Corruption` for the alphabet and state
+  definitions.
+
+The structure is independent of the boundary `Δ` so that environment
+events are *not* keyed by port: an environment event acts on whatever
+`X`-typed slice of state the protocol exposes, with no dependence on
+which ports happen to be in scope.
+-/
+@[ext]
+structure EnvAction (Sym : Type u) (X : Type) where
+  /-- The state transition triggered by each event. -/
+  react : Sym → X → ProbComp X := fun _ x => pure x
+
+namespace EnvAction
+
+variable {Sym : Type u} {X : Type}
+
+/--
+The trivial environment-action over the empty alphabet: no events
+ever fire.
+
+Useful as the default for processes that do not care about
+environment-driven dynamics.
+-/
+def empty (X : Type) : EnvAction Empty X where
+  react e _ := e.elim
+
+/--
+The constant environment-action: every event leaves the state
+unchanged.
+
+This is the canonical "passive observer" reaction, useful when a
+process participates in an alphabet (so its `EnvAction` slot is
+non-trivially typed) but its state has no per-event update.
+-/
+def passive (Sym : Type u) (X : Type) : EnvAction Sym X where
+  react _ x := pure x
+
+/--
+Adapt the alphabet of an environment-action along a function
+`g : Sym → Sym'`.
+
+The new alphabet is `Sym`; an event `s : Sym` is reacted to by routing
+it through `g` to obtain `s' : Sym'` and applying the original
+reaction. This is the contravariant action on the alphabet that lets
+coarser alphabets be embedded into finer ones.
+-/
+def comap {Sym Sym' : Type u} {X : Type}
+    (g : Sym → Sym') (e : EnvAction Sym' X) : EnvAction Sym X where
+  react s x := e.react (g s) x
+
+/--
+Adapt the state of an environment-action along a state-projection.
+
+Given `e : EnvAction Sym X` and a projection `π : Y → X` together with
+a re-installation `ι : X → Y → Y` that re-installs the updated `X`
+slice into a larger state `Y`, the lifted action operates on `Y` by
+reacting on the `X`-slice and re-installing the result.
+
+This is the structural lift used when corruption-aware reactions need
+to thread through richer per-step states; the `Corruption` layer uses
+it to lift the canonical `CorruptionState.react` over state-bundled
+`MachineProcess`es.
+-/
+def liftState {Sym : Type u} {X Y : Type}
+    (π : Y → X) (ι : X → Y → Y) (e : EnvAction Sym X) :
+    EnvAction Sym Y where
+  react s y := do
+    let x' ← e.react s (π y)
+    return ι x' y
+
+@[simp]
+theorem comap_id (e : EnvAction Sym X) :
+    comap (id : Sym → Sym) e = e := by
+  ext s x; rfl
+
+@[simp]
+theorem comap_comap {Sym Sym' Sym'' : Type u} {X : Type}
+    (h : Sym → Sym') (g : Sym' → Sym'') (e : EnvAction Sym'' X) :
+    comap h (comap g e) = comap (g ∘ h) e := by
+  ext s x; rfl
+
+@[simp]
+theorem passive_react (Sym : Type u) (X : Type) (s : Sym) (x : X) :
+    (passive Sym X).react s x = pure x := rfl
+
+@[simp]
+theorem empty_react (X : Type) (e : Empty) (x : X) :
+    (empty X).react e x = e.elim := rfl
+
+end EnvAction
+
+end UC
+end Interaction

--- a/VCVio/Interaction/UC/EnvAction.lean
+++ b/VCVio/Interaction/UC/EnvAction.lean
@@ -8,9 +8,9 @@ import VCVio.OracleComp.ProbComp
 /-!
 # Environment-driven action alphabets
 
-This file introduces `EnvAction Sym X`, a standalone alphabet of
+This file introduces `EnvAction Event X`, a standalone alphabet of
 environment-driven events that may act on a per-step state of type `X`.
-The alphabet `Sym` is the user-supplied symbol set (typically a sum
+The alphabet `Event` is the user-supplied event set (typically a sum
 type with one constructor per environment event: `compromise`,
 `refresh`, `setEpochParam`, etc.); the `react` function specifies how
 the state evolves on each event.
@@ -24,8 +24,10 @@ gives the same separation a typed home in VCVio: corruption events flow
 through `EnvAction`, port traffic flows through `BoundaryAction`, and
 the two channels are kept structurally orthogonal.
 
-The alphabet parameter is named `Sym` rather than the CJSV22-style
-`Σ` because `Σ` is a reserved Lean keyword (sigma types).
+The alphabet parameter is named `Event` rather than the CJSV22-style
+`Σ` because `Σ` is a reserved Lean keyword (sigma types). The CSP /
+π-calculus convention "events" is also a more literal description of
+what the alphabet contains than the bare letter `Σ`.
 
 ## Additive design
 
@@ -57,12 +59,12 @@ namespace Interaction
 namespace UC
 
 /--
-`EnvAction Sym X` is the per-event reaction of a per-step state
-`x : X` to environment events drawn from the alphabet `Sym`.
+`EnvAction Event X` is the per-event reaction of a per-step state
+`x : X` to environment events drawn from the alphabet `Event`.
 
-`react : Sym → X → ProbComp X` specifies how each event transforms
+`react : Event → X → ProbComp X` specifies how each event transforms
 the state. The default `react` is `fun _ x => pure x` (every event is
-a no-op), which keeps the empty alphabet `Sym := Empty` trivially
+a no-op), which keeps the empty alphabet `Event := Empty` trivially
 satisfiable.
 
 Two concrete instantiations matter here:
@@ -81,13 +83,13 @@ events are *not* keyed by port: an environment event acts on whatever
 which ports happen to be in scope.
 -/
 @[ext]
-structure EnvAction (Sym : Type u) (X : Type) where
+structure EnvAction (Event : Type u) (X : Type) where
   /-- The state transition triggered by each event. -/
-  react : Sym → X → ProbComp X := fun _ x => pure x
+  react : Event → X → ProbComp X := fun _ x => pure x
 
 namespace EnvAction
 
-variable {Sym : Type u} {X : Type}
+variable {Event : Type u} {X : Type}
 
 /--
 The trivial environment-action over the empty alphabet: no events
@@ -107,56 +109,56 @@ This is the canonical "passive observer" reaction, useful when a
 process participates in an alphabet (so its `EnvAction` slot is
 non-trivially typed) but its state has no per-event update.
 -/
-def passive (Sym : Type u) (X : Type) : EnvAction Sym X where
+def passive (Event : Type u) (X : Type) : EnvAction Event X where
   react _ x := pure x
 
 /--
 Adapt the alphabet of an environment-action along a function
-`g : Sym → Sym'`.
+`g : Event → Event'`.
 
-The new alphabet is `Sym`; an event `s : Sym` is reacted to by routing
-it through `g` to obtain `s' : Sym'` and applying the original
-reaction. This is the contravariant action on the alphabet that lets
-coarser alphabets be embedded into finer ones.
+The new alphabet is `Event`; an event `s : Event` is reacted to by
+routing it through `g` to obtain `s' : Event'` and applying the
+original reaction. This is the contravariant action on the alphabet
+that lets coarser alphabets be embedded into finer ones.
 -/
-def comap {Sym Sym' : Type u} {X : Type}
-    (g : Sym → Sym') (e : EnvAction Sym' X) : EnvAction Sym X where
+def comap {Event Event' : Type u} {X : Type}
+    (g : Event → Event') (e : EnvAction Event' X) : EnvAction Event X where
   react s x := e.react (g s) x
 
 /--
 Adapt the state of an environment-action along a state-projection.
 
-Given `e : EnvAction Sym X` and a projection `π : Y → X` together with
-a re-installation `ι : X → Y → Y` that re-installs the updated `X`
-slice into a larger state `Y`, the lifted action operates on `Y` by
-reacting on the `X`-slice and re-installing the result.
+Given `e : EnvAction Event X` and a projection `π : Y → X` together
+with a re-installation `ι : X → Y → Y` that re-installs the updated
+`X` slice into a larger state `Y`, the lifted action operates on `Y`
+by reacting on the `X`-slice and re-installing the result.
 
 This is the structural lift used when corruption-aware reactions need
 to thread through richer per-step states; the `Corruption` layer uses
 it to lift the canonical `CorruptionState.react` over state-bundled
 `MachineProcess`es.
 -/
-def liftState {Sym : Type u} {X Y : Type}
-    (π : Y → X) (ι : X → Y → Y) (e : EnvAction Sym X) :
-    EnvAction Sym Y where
+def liftState {Event : Type u} {X Y : Type}
+    (π : Y → X) (ι : X → Y → Y) (e : EnvAction Event X) :
+    EnvAction Event Y where
   react s y := do
     let x' ← e.react s (π y)
     return ι x' y
 
 @[simp]
-theorem comap_id (e : EnvAction Sym X) :
-    comap (id : Sym → Sym) e = e := by
+theorem comap_id (e : EnvAction Event X) :
+    comap (id : Event → Event) e = e := by
   ext s x; rfl
 
 @[simp]
-theorem comap_comap {Sym Sym' Sym'' : Type u} {X : Type}
-    (h : Sym → Sym') (g : Sym' → Sym'') (e : EnvAction Sym'' X) :
+theorem comap_comap {Event Event' Event'' : Type u} {X : Type}
+    (h : Event → Event') (g : Event' → Event'') (e : EnvAction Event'' X) :
     comap h (comap g e) = comap (g ∘ h) e := by
   ext s x; rfl
 
 @[simp]
-theorem passive_react (Sym : Type u) (X : Type) (s : Sym) (x : X) :
-    (passive Sym X).react s x = pure x := rfl
+theorem passive_react (Event : Type u) (X : Type) (s : Event) (x : X) :
+    (passive Event X).react s x = pure x := rfl
 
 @[simp]
 theorem empty_react (X : Type) (e : Empty) (x : X) :


### PR DESCRIPTION
## Summary

**Phase F2, Slice 1** of the [Signal-UC roadmap](https://github.com/Verified-zkEVM/VCV-io/blob/main/docs/agents/) (foundation note: `vcvio-signal-uc-foundation-cjsv22.md`; design memo: `vcvio-uc-f2-corruption-design.md`).

Ships the **standalone vocabulary** for CJSV22-style adaptive momentary corruption (Canetti, Jain, Swanberg, Varia, *Universally Composable End-to-End Secure Messaging*, CRYPTO 2022 §3.2). **Touches no existing core file** — every change is additive on top of #297 (F1 Slice 2: `RoutedPacket` / `HasAccessControl` / `subroutineRespecting`).

The two new modules are:

- `VCVio/Interaction/UC/EnvAction.lean` (commit 1, already on the branch)
- `VCVio/Interaction/UC/Corruption.lean` (commit 2, this slice's main payload)

## Stacked-on / dependency

Stacked on top of **#297** (`quang/uc-access-control` → `main`). When that lands, this PR's base will retarget to `main` automatically.

## What lands here

### `EnvAction Sym X` (already on the branch)

The per-event reaction of a per-step state to environment events drawn from an alphabet `Sym`:

```lean
@[ext]
structure EnvAction (Sym : Type u) (X : Type) where
  react : Sym → X → ProbComp X := fun _ x => pure x
```

Companion API: `EnvAction.empty`, `passive`, `comap`, `liftState`, plus `comap_id`, `comap_comap`, `passive_react`, `empty_react` simp lemmas. Alphabet parameter named `Sym` (not CJSV22's `Σ`) because `Σ` is a Lean reserved keyword.

### `Corruption.lean` (this commit)

- **`CorruptionAlphabet Sid Pid`** — inductive `compromise(m)` and `refresh(m)`, indexed by `MachineId`. `deriving DecidableEq`, plus `target` extraction.
- **`Epoch := ℕ`** — per-machine refresh counter.
- **`CorruptionState Sid Pid`** — three-field record:
  - `corrupted : MachineId → Bool` — current snapshot flag
  - `compromised : MachineId → Epoch → Bool` — historical leak flag (monotonically accumulates)
  - `epoch : MachineId → Epoch` — refresh counter
  with `init`, `Inhabited`, `@[ext]`. The two flags are deliberately independent: one tracks the current adversary view, the other the per-epoch leak history.
- **`applyCompromise` / `applyRefresh`** — deterministic state updates. `compromise` snapshots the current epoch as compromised and sets `corrupted m`; `refresh` clears `corrupted m` and increments `epoch m`. Past `compromised` flags are preserved across refreshes (monotonicity, the structural ingredient for PCS).
- **`CorruptionState.reactBase`** — canonical `EnvAction` reaction; **`envActionBase`** packs it as the baseline `EnvAction` every protocol opting in to adaptive momentary corruption inherits.
- 11 simp / theorem lemmas covering per-flag, per-epoch behaviour of `applyCompromise` / `applyRefresh`, including monotonicity (`compromised_applyCompromise_of_compromised`).
- **`LeakableState State Leakage`** typeclass — exposes `leak : State → MachineId → Leakage`. **No default instance**: every protocol must declare what it leaks, surfacing the equivocability obligation (CJSV22 §4.1) as a missing-instance error rather than a meta-theoretic gap. `Leakage` is an `outParam`.
- **`CorruptionPolicy process`** — `StepPolicy` specialization, reusing `top` / `inter` from `Interaction.Concurrent.Policy`.

## Universe constraint

`Sid Pid : Type` (i.e. `Type 0`) because `CorruptionState` participates in `ProbComp`-valued reactions and `ProbComp : Type → Type`. Concrete identity types (`ℕ`, `String`) all satisfy this bound; matches the convention in `Runtime.lean`.

## Additive / non-breaking

- No file outside `VCVio/Interaction/UC/{EnvAction,Corruption}.lean` and the auto-generated `VCVio.lean` import list is touched.
- Nothing here is threaded into `OpenNodeSemantics` in this slice.
- Existing `OpenProcess` / `MachineProcess` constructions are unaffected.
- The corruption-aware composition wrapper (`MachineProcessC`) that pairs `MachineProcess` with a state-indexed `EnvAction` and hosts the four `*.corrupt` forwarding lemmas is **F2 Slice 2**.
- `F_AKE`, `F_E2E`, and the healing theorem are **F2 Slice 3**.

## Axioms

`#print axioms` on every new declaration:

- All `EnvAction` declarations: `Quot.sound` only (from `@[ext]`).
- All `CorruptionAlphabet` / `CorruptionState` core constructors and definitions: zero axioms.
- All `CorruptionState` reaction lemmas: at most `propext` (from `simp` discharging boolean equalities).
- `LeakableState`, `CorruptionPolicy`, `CorruptionPolicy.top`, `CorruptionPolicy.inter`: zero axioms.

No `Classical.choice`, no new axioms anywhere.

## Test plan

- [x] `lake build VCVio.Interaction.UC.Corruption` — green
- [x] `lake build` (full repo) — green; only pre-existing `sorry` warnings in unrelated `FujisakiOkamoto` / `GPVHashAndSign` / `KEMDEM` / `RenyiDivergence` files
- [x] `#print axioms` swept across all new declarations — only `propext` and `Quot.sound` (core Lean axioms)
- [x] `./scripts/update-lib.sh` — `VCVio.lean` regenerated to include both new modules
- [ ] (next slice) corruption-aware composition wrapper `MachineProcessC` + four `*.corrupt` forwarding lemmas

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)