### PR TITLE
style: forbid ASCII section banners; use /-! ## -/ headers

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -21,6 +21,7 @@ Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for the repo's explicit attribution 
 - Preserve existing headers on routine edits.
 - Only rewrite attribution when a file is genuinely new or materially replaced.
 - Do not add a separate AI-attribution line.
+- For inline section breaks within a Lean file, use Mathlib-style doc-comment headers `/-! ## Title -/` (or the multi-line `/-! ## Title \n\n explanation -/` form). **Do not use ASCII banners** such as `-- ====...===` flanking a `-- § Title` line. The `/-!` form is rendered by `doc-gen4`; ASCII banners are not, and they make the file feel artificially partitioned. If a section is large enough to want a loud header, it is usually large enough to want its own `namespace` or its own file. See *Section Headers Within A File* in [`CONTRIBUTING.md`](CONTRIBUTING.md).
 
 ## What This Project Is
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,11 +60,42 @@ When in doubt, prefer:
   5. module docstring
   Keep exactly one blank line between these blocks.
 
+### Section Headers Within A File
+
+Use Mathlib-style doc-comment section headers, **not** ASCII banners.
+
+For an inline section break inside a Lean file, use a one-line docstring header that doc-gen will render in the generated documentation:
+
+```lean
+/-! ## Section title -/
+```
+
+Or, for a section with its own paragraph of explanation:
+
+```lean
+/-!
+## Section title
+
+Optional paragraph describing what the section contains.
+-/
+```
+
+Do **not** use ASCII banners such as:
+
+```lean
+-- ============================================================================
+-- § Section title
+-- ============================================================================
+```
+
+ASCII banners are visually loud, do not appear in the generated documentation, and make the file feel partitioned in a way that the type system does not enforce. Prefer the `/-!` form, which both reads as natural prose and surfaces in `doc-gen4` output. If a section is large enough to warrant its own banner, it is usually large enough to warrant its own `namespace` or its own file.
+
 ## Style Notes
 
 - Keep imports at the top of the file.
 - Follow Mathlib naming conventions where possible.
 - Respect the module layering documented in [`AGENTS.md`](AGENTS.md).
+- Use `/-! ## Title -/` doc-headers, not ASCII banners, for inline section breaks (see *Documentation Expectations* above).
 
 ## Licensing
 

--- a/Examples/CompositionDiagram.lean
+++ b/Examples/CompositionDiagram.lean
@@ -78,9 +78,7 @@ private def renderDHAtom : ∀ {Δ : PortBoundary}, DHAtom Δ → String
   | _, .simulator => "Simulator"
   | _, .dummyChannel => "Dummy Channel"
 
--- ============================================================================
--- § Communication infrastructure
--- ============================================================================
+/-! ## Communication infrastructure -/
 
 /-- Two directional channels running in parallel: Alice→Bob ∥ Bob→Alice. -/
 @[show_composition]
@@ -99,9 +97,7 @@ wire(par(Channel A→B, Channel B→A), Adversary)
 def insecureNetwork : Raw DHAtom bd2 :=
   channels ⊞ .atom .adversary
 
--- ============================================================================
--- § Real world
--- ============================================================================
+/-! ## Real world -/
 
 /-- Protocol parties: Alice ∥ Bob. -/
 @[show_composition]
@@ -133,9 +129,7 @@ plug(wire(par(Alice, Bob), insecureNetwork), Environment)
 def realWorld : Raw DHAtom PortBoundary.empty :=
   protocolExecution ⊠ .atom .environment
 
--- ============================================================================
--- § Ideal world
--- ============================================================================
+/-! ## Ideal world -/
 
 /-- Ideal parties: the ideal key-exchange functionality ∥ the UC simulator. -/
 @[show_composition]
@@ -157,9 +151,7 @@ plug(wire(par(Ideal KE, Simulator), Dummy Channel), Environment)
 def idealWorld : Raw DHAtom PortBoundary.empty :=
   idealParties ⊞ .atom .dummyChannel ⊠ .atom .environment
 
--- ============================================================================
--- § DOT output
--- ============================================================================
+/-! ## DOT output -/
 
 #eval IO.println "=== Real World ==="
 #eval IO.println (Raw.toDot renderDHAtom realWorld)

--- a/VCVio/Interaction/UC/Corruption.lean
+++ b/VCVio/Interaction/UC/Corruption.lean
@@ -74,9 +74,7 @@ universe w w₂
 namespace Interaction
 namespace UC
 
--- ============================================================================
--- § Corruption alphabet and epoch
--- ============================================================================
+/-! ## Corruption alphabet and epoch -/
 
 /--
 The standard CJSV22 corruption alphabet for a fixed `(Sid, Pid)`
@@ -134,9 +132,7 @@ own `Epoch`-isomorphic type; the framework only requires
 -/
 abbrev Epoch : Type := ℕ
 
--- ============================================================================
--- § Corruption state
--- ============================================================================
+/-! ## Corruption state -/
 
 /--
 `CorruptionState Sid Pid` packages the two-flag corruption tracking
@@ -321,9 +317,7 @@ theorem compromised_applyCompromise_of_compromised
 
 end CorruptionState
 
--- ============================================================================
--- § Leakable state (equivocability obligation)
--- ============================================================================
+/-! ## Leakable state (equivocability obligation) -/
 
 /--
 `LeakableState State Leakage` exposes an extraction function that
@@ -356,9 +350,7 @@ class LeakableState
     (Leakage : outParam Type) where
   leak : State → MachineId Sid Pid → Leakage
 
--- ============================================================================
--- § Corruption policy
--- ============================================================================
+/-! ## Corruption policy -/
 
 open Interaction.Concurrent
 

--- a/VCVio/Interaction/UC/Emulates.lean
+++ b/VCVio/Interaction/UC/Emulates.lean
@@ -190,9 +190,7 @@ theorem plug_invariance
 
 end Emulates
 
--- ============================================================================
--- § Structural factorization of `close` under composition
--- ============================================================================
+/-! ## Structural factorization of `close` under composition -/
 
 section Factorization
 
@@ -364,9 +362,7 @@ theorem OpenTheory.plug_comm
 
 end Factorization
 
--- ============================================================================
--- § UC composition theorems
--- ============================================================================
+/-! ## UC composition theorems -/
 
 namespace Emulates
 

--- a/VCVio/Interaction/UC/MachineId.lean
+++ b/VCVio/Interaction/UC/MachineId.lean
@@ -145,9 +145,7 @@ need session-aware identity instantiate this abbreviation.
 abbrev MachineProcess (Sid Pid : Type u) (Δ : PortBoundary) :=
   OpenProcess.{u, v, w} (MachineId Sid Pid) Δ
 
--- ============================================================================
--- § Per-process access control
--- ============================================================================
+/-! ## Per-process access control -/
 
 /--
 `HasAccessControl P` is the per-process predicate deciding which routed
@@ -227,9 +225,7 @@ theorem MachineProcess.allowed_allowSameSession
     (MachineProcess.allowSameSession owner P).allowed rp =
       rp.sender.sameSession owner := rfl
 
--- ============================================================================
--- § Subroutine respecting predicate
--- ============================================================================
+/-! ## Subroutine respecting predicate -/
 
 /--
 A node semantics is **session-coherent at** `sid` for a chosen move `x`

--- a/VCVio/Interaction/UC/OpenProcess.lean
+++ b/VCVio/Interaction/UC/OpenProcess.lean
@@ -576,9 +576,7 @@ predicates used throughout VCVio.
 abbrev OpenProcess.System (Party : Type u) (Δ : PortBoundary) :=
   ProcessOver.System (OpenNodeContext Party Δ : Spec.Node.Context.{w})
 
--- ============================================================================
--- § Silent steps and weak bisimulation
--- ============================================================================
+/-! ## Silent steps and weak bisimulation -/
 
 /-- A transcript path through a decorated open-process spec is **silent** when
 every visited node is not externally activated (`isActivated = false`).
@@ -636,9 +634,7 @@ theorem isSilentStep_mapBoundary_iff {Party : Type u} {Δ₁ Δ₂ : PortBoundar
   intro X ons
   simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
 
--- ============================================================================
--- § OpenProcessIso: weak bisimulation equivalence for open processes
--- ============================================================================
+/-! ## OpenProcessIso: weak bisimulation equivalence for open processes -/
 
 /--
 Two open processes with the same boundary are **weakly bisimilar** when there

--- a/VCVio/Interaction/UC/OpenProcessModel.lean
+++ b/VCVio/Interaction/UC/OpenProcessModel.lean
@@ -142,9 +142,7 @@ instance : OpenTheory.IsLawfulPlug (openTheory.{u, v, w} Party) where
 
 instance : OpenTheory.IsLawful (openTheory.{u, v, w} Party) where
 
--- ============================================================================
--- § Monoidal and compact closed laws up to bisimilarity
--- ============================================================================
+/-! ## Monoidal and compact closed laws up to bisimilarity -/
 
 /-- Parallel composition of open processes is associative up to bisimilarity:
 reassociating the internal scheduler nesting does not change the observable

--- a/VCVio/Interaction/UC/OpenSyntax/Expr.lean
+++ b/VCVio/Interaction/UC/OpenSyntax/Expr.lean
@@ -223,9 +223,7 @@ theorem interpret_unit {Atom : PortBoundary → Type u}
   simp only [Expr.unit, interpret_map]
   exact OpenTheory.unit_eq.symm
 
--- ============================================================================
--- § Lawful OpenTheory instance
--- ============================================================================
+/-! ## Lawful OpenTheory instance -/
 
 /--
 The free lawful `OpenTheory` whose objects are quotiented expressions over
@@ -314,9 +312,7 @@ instance compactClosed (Atom : PortBoundary → Type u) :
     Quotient.inductionOn₃ W₁ W₂ K fun _ _ _ =>
       Quotient.sound Raw.Equiv.plug_wire_left
 
--- ============================================================================
--- § Bridge: Expr → Interp
--- ============================================================================
+/-! ## Bridge: Expr → Interp -/
 
 /--
 Embed a quotiented expression into the tagless-final representation.

--- a/VCVioWidgets/OpenSyntax/Panel.lean
+++ b/VCVioWidgets/OpenSyntax/Panel.lean
@@ -34,9 +34,7 @@ the panel with
 to see the composition diagram.
 -/
 
--- ============================================================================
--- § Intermediate tree representation
--- ============================================================================
+/-! ## Intermediate tree representation -/
 
 inductive CompTree where
   | atom (label : String)
@@ -47,9 +45,7 @@ inductive CompTree where
   | opaque (label : String)
   deriving Inhabited
 
--- ============================================================================
--- § Meta-level expression extraction
--- ============================================================================
+/-! ## Meta-level expression extraction -/
 
 private def rawPrefix : Name := `Interaction.UC.OpenSyntax.Raw
 
@@ -112,9 +108,7 @@ where
         let fmt ← ppExpr e
         return .opaque fmt.pretty
 
--- ============================================================================
--- § Graph rendering (D3 force-directed via GraphDisplay)
--- ============================================================================
+/-! ## Graph rendering (D3 force-directed via GraphDisplay) -/
 
 private structure GraphState where
   vertices : Array GraphDisplay.Vertex
@@ -285,9 +279,7 @@ private def compTreeToGraph (tree : CompTree) : GraphDisplay.Props :=
     showDetails := true
   }
 
--- ============================================================================
--- § Attribute registry
--- ============================================================================
+/-! ## Attribute registry -/
 
 structure RegisteredComp where
   modName : Name
@@ -323,9 +315,7 @@ def getRegisteredCompositions (modName : Name) : CoreM (Array Name) := do
     | some names => names
     | none => #[]
 
--- ============================================================================
--- § Panel widget
--- ============================================================================
+/-! ## Panel widget -/
 
 private def css (entries : List (String × String)) : Json :=
   Json.mkObj <| entries.map fun (k, v) => (k, Json.str v)

--- a/VCVioWidgets/OpenSyntax/TreePanel.lean
+++ b/VCVioWidgets/OpenSyntax/TreePanel.lean
@@ -29,9 +29,7 @@ top-down tree layout algorithm. No physics simulation; the diagram is
 stable and hierarchical.
 -/
 
--- ============================================================================
--- § Tree layout computation
--- ============================================================================
+/-! ## Tree layout computation -/
 
 private structure LayoutNode where
   id : Nat
@@ -129,9 +127,7 @@ private partial def layoutTree (tree : CompTree) (depth : Float) (st : LayoutSta
         nodes := st.nodes.push node
         edges := st.edges.push edge })
 
--- ============================================================================
--- § SVG rendering via Html.element
--- ============================================================================
+/-! ## SVG rendering via Html.element -/
 
 private def findNode (nodes : Array LayoutNode) (id : Nat) : Option LayoutNode :=
   nodes.find? (·.id == id)
@@ -242,9 +238,7 @@ private def renderTreeSvg (tree : CompTree) : Html :=
     ("height", Json.str svgH)]
     (#[defs] ++ edgeElems ++ nodeElems)
 
--- ============================================================================
--- § Panel widget
--- ============================================================================
+/-! ## Panel widget -/
 
 private def css (entries : List (String × String)) : Json :=
   Json.mkObj <| entries.map fun (k, v) => (k, Json.str v)


### PR DESCRIPTION
## Summary

- **Mechanical scrub**: replace the 25 ASCII section banners across 9 files with one-line Mathlib-style doc-headers `/-! ## Title -/`. All titles preserved verbatim. No semantics change.
- **New rule** in `CONTRIBUTING.md` (Documentation Expectations → *Section Headers Within A File*) and a one-line pointer in `AGENTS.md` (the canonical agent guide).

## Stacked-on / dependency

Stacked on top of **#297** (F1 Slice 2 + F2 Slice 1 combined). When that lands, this PR's base will retarget to `main` automatically.

The scrub touches `Corruption.lean` (which is added by #297), so this PR has to live downstream of #297. Everything else it touches is on `main` already.

(Note: originally stacked on #300, which has since been folded into #297. This PR's base was retargeted from `quang/uc-corruption` → `quang/uc-access-control` to reflect the consolidation; the diff is unchanged.)

## Why

ASCII banners like:

```lean
-- ============================================================================
-- § Section title
-- ============================================================================
```

- are visually loud and dominate the diff,
- do **not** appear in the generated documentation (`doc-gen4` ignores them),
- create a sense of structural partitioning that the type system does not enforce, and
- duplicate what a `namespace` or a separate file already gives you, semantically.

The Mathlib-standard alternative `/-! ## Title -/` reads as natural prose, surfaces in `doc-gen4`, and matches what the rest of `VCVio/SSP/`, `VCVio/ProgramLogic/`, `VCVio/Interaction/UC/Computational.lean` etc. already use.

## Files touched

Source scrub (commit `3c9d63f`):

| File                                          | Banners removed |
| --------------------------------------------- | --------------- |
| `Examples/CompositionDiagram.lean`            | 4               |
| `VCVio/Interaction/UC/Corruption.lean`        | 4               |
| `VCVio/Interaction/UC/Emulates.lean`          | 2               |
| `VCVio/Interaction/UC/MachineId.lean`         | 2               |
| `VCVio/Interaction/UC/OpenProcess.lean`       | 2               |
| `VCVio/Interaction/UC/OpenProcessModel.lean`  | 1               |
| `VCVio/Interaction/UC/OpenSyntax/Expr.lean`   | 2               |
| `VCVioWidgets/OpenSyntax/Panel.lean`          | 5               |
| `VCVioWidgets/OpenSyntax/TreePanel.lean`      | 3               |
| **Total**                                     | **25**          |

Each three-line banner becomes one line `/-! ## Title -/`, titles preserved verbatim.

Doc rule (commit `cdb05bd`):

- `CONTRIBUTING.md` — new *Section Headers Within A File* subsection under *Documentation Expectations*, plus a one-line entry in *Style Notes*.
- `AGENTS.md` — one-line entry in *Attribution, Headers, And Docstrings* pointing at the CONTRIBUTING.md section.
- `CLAUDE.md` is a symlink to `AGENTS.md`, so it picks up the change automatically.

## Test plan

- [x] `lake build` (full repo) — green; only pre-existing `sorry` warnings in unrelated files
- [x] `rg '^-- =' VCVio/ Examples/ VCVioWidgets/` — empty (no banners remain)
- [x] `./scripts/lint-style.sh` on touched files — clean (the lint errors that report are all pre-existing and in untouched files)

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user (Quang Dao) with approval.