### PR TITLE
feat(VCVio): update constructions in `QueryTracking` to use `OracleSpec` namespace

### DIFF
--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -120,7 +120,7 @@ private def loggingROQueryImpl :
 
 /-- Lift a `ProbComp` computation into the BR93 random-oracle world. -/
 private def liftProbComp {α : Type} (px : ProbComp α) : OracleComp (RO_Spec Rand M) α :=
-  OracleComp.liftComp (spec := unifSpec) (superSpec := RO_Spec Rand M) px
+  px
 
 /-- Real one-time CPA game in the random-oracle model. -/
 def cpaGame (tdp : TrapdoorPermutation PK SK Rand)

--- a/Examples/CommitmentScheme/Binding.lean
+++ b/Examples/CommitmentScheme/Binding.lean
@@ -118,10 +118,10 @@ private lemma binding_rest_noCollision_le_inv
     (cache₁ : QueryCache (CMOracle M S C))
     (hno : ¬ CacheHasCollision cache₁) :
     Pr[fun z => z.1 = true |
-      (simulateQ cachingOracle
-        (((CMOracle M S C).query (m₀, s₀) : OracleComp (CMOracle M S C) _) >>= fun c₀ =>
-          ((CMOracle M S C).query (m₁, s₁) : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
-          pure (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c)))).run cache₁] ≤
+      (simulateQ (CMOracle M S C).cachingOracle do
+        let c₀ ← (CMOracle M S C).query (m₀, s₀)
+        let c₁ ← (CMOracle M S C).query (m₁, s₁)
+        return (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))).run cache₁] ≤
       (Fintype.card C : ℝ≥0∞)⁻¹ := by
   by_cases hneq : m₀ ≠ m₁
   · let q₀ : (CMOracle M S C).Domain := (m₀, s₀)
@@ -132,9 +132,9 @@ private lemma binding_rest_noCollision_le_inv
     by_cases hq₀_none : cache₁ q₀ = none
     · simpa [q₀, q₁] using probEvent_from_fresh_query_le_inv
         (t := q₀) (target := c) (cache₀ := cache₁) hq₀_none
-        (cont := fun u =>
-          ((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
-            pure (decide (m₀ ≠ m₁) && (u == c) && (c₁ == c))) (by
+        (cont := fun u => do
+          let c₁ ← (CMOracle M S C).query q₁
+          return (decide (m₀ ≠ m₁) && (u == c) && (c₁ == c))) (by
           intro u hu
           apply probEvent_eq_zero
           intro z hz hwin
@@ -148,13 +148,13 @@ private lemma binding_rest_noCollision_le_inv
           simp [hneq, hu] at hwin)
     · rcases Option.ne_none_iff_exists'.mp hq₀_none with ⟨v₀, hq₀⟩
       have hrun₀ :
-          (simulateQ cachingOracle
-            (((CMOracle M S C).query q₀ : OracleComp (CMOracle M S C) _) >>= fun c₀ =>
-              ((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
-              pure (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c)))).run cache₁ =
-          (simulateQ cachingOracle
-            (((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
-              pure (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c)))).run cache₁ := by
+          (simulateQ (CMOracle M S C).cachingOracle do
+            let c₀ ← (CMOracle M S C).query q₀
+            let c₁ ← (CMOracle M S C).query q₁
+            return (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))).run cache₁ =
+          (simulateQ (CMOracle M S C).cachingOracle do
+            let c₁ ← (CMOracle M S C).query q₁
+            return (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c))).run cache₁ := by
         simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
         have hcache :
             (liftM ((CMOracle M S C).cachingOracle q₀) :
@@ -181,9 +181,9 @@ private lemma binding_rest_noCollision_le_inv
             exact cache_lookup_eq_of_noCollision hno (hv₀ ▸ hq₀)
               ⟨v₁, hq₁, heq_of_eq hv₁⟩
           have hrun₁ :
-              (simulateQ cachingOracle
-                (((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
-                  pure (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c)))).run cache₁ =
+              (simulateQ (CMOracle M S C).cachingOracle do
+                let c₁ ← (CMOracle M S C).query q₁
+                return (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c))).run cache₁ =
               pure (decide (m₀ ≠ m₁) && (v₀ == c) && (v₁ == c), cache₁) := by
             simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
             have hcache :
@@ -238,10 +238,10 @@ private lemma binding_win_le_advCollision_add_fresh {t : ℕ}
     Pr[fun z => CacheHasCollision z.2 | (simulateQ cachingOracle A.run).run ∅] +
     (Fintype.card C : ℝ≥0∞)⁻¹ := by
   let restPart : (C × M × S × M × S) → OracleComp (CMOracle M S C) Bool
-    | (c, m₀, s₀, m₁, s₁) =>
-        ((CMOracle M S C).query (m₀, s₀) : OracleComp (CMOracle M S C) _) >>= fun c₀ =>
-          ((CMOracle M S C).query (m₁, s₁) : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
-          pure (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))
+    | (c, m₀, s₀, m₁, s₁) => do
+        let c₀ ← (CMOracle M S C).query (m₀, s₀)
+        let c₁ ← (CMOracle M S C).query (m₁, s₁)
+        return (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))
   have hdecomp : bindingInner A = A.run >>= restPart := by
     simp [bindingInner, restPart]
   rw [bindingGame_eq, hdecomp, simulateQ_bind, StateT.run_bind]

--- a/Examples/CommitmentScheme/Binding.lean
+++ b/Examples/CommitmentScheme/Binding.lean
@@ -119,8 +119,8 @@ private lemma binding_rest_noCollision_le_inv
     (hno : ¬ CacheHasCollision cache₁) :
     Pr[fun z => z.1 = true |
       (simulateQ cachingOracle
-        ((liftM ((CMOracle M S C).query (m₀, s₀))) >>= fun c₀ =>
-          (liftM ((CMOracle M S C).query (m₁, s₁))) >>= fun c₁ =>
+        (((CMOracle M S C).query (m₀, s₀) : OracleComp (CMOracle M S C) _) >>= fun c₀ =>
+          ((CMOracle M S C).query (m₁, s₁) : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
           pure (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c)))).run cache₁] ≤
       (Fintype.card C : ℝ≥0∞)⁻¹ := by
   by_cases hneq : m₀ ≠ m₁
@@ -133,7 +133,7 @@ private lemma binding_rest_noCollision_le_inv
     · simpa [q₀, q₁] using probEvent_from_fresh_query_le_inv
         (t := q₀) (target := c) (cache₀ := cache₁) hq₀_none
         (cont := fun u =>
-          (liftM ((CMOracle M S C).query q₁)) >>= fun c₁ =>
+          ((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
             pure (decide (m₀ ≠ m₁) && (u == c) && (c₁ == c))) (by
           intro u hu
           apply probEvent_eq_zero
@@ -149,11 +149,11 @@ private lemma binding_rest_noCollision_le_inv
     · rcases Option.ne_none_iff_exists'.mp hq₀_none with ⟨v₀, hq₀⟩
       have hrun₀ :
           (simulateQ cachingOracle
-            ((liftM ((CMOracle M S C).query q₀)) >>= fun c₀ =>
-              (liftM ((CMOracle M S C).query q₁)) >>= fun c₁ =>
+            (((CMOracle M S C).query q₀ : OracleComp (CMOracle M S C) _) >>= fun c₀ =>
+              ((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
               pure (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c)))).run cache₁ =
           (simulateQ cachingOracle
-            ((liftM ((CMOracle M S C).query q₁)) >>= fun c₁ =>
+            (((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
               pure (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c)))).run cache₁ := by
         simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
         have hcache :
@@ -182,7 +182,7 @@ private lemma binding_rest_noCollision_le_inv
               ⟨v₁, hq₁, heq_of_eq hv₁⟩
           have hrun₁ :
               (simulateQ cachingOracle
-                ((liftM ((CMOracle M S C).query q₁)) >>= fun c₁ =>
+                (((CMOracle M S C).query q₁ : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
                   pure (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c)))).run cache₁ =
               pure (decide (m₀ ≠ m₁) && (v₀ == c) && (v₁ == c), cache₁) := by
             simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
@@ -239,8 +239,8 @@ private lemma binding_win_le_advCollision_add_fresh {t : ℕ}
     (Fintype.card C : ℝ≥0∞)⁻¹ := by
   let restPart : (C × M × S × M × S) → OracleComp (CMOracle M S C) Bool
     | (c, m₀, s₀, m₁, s₁) =>
-        (liftM ((CMOracle M S C).query (m₀, s₀))) >>= fun c₀ =>
-          (liftM ((CMOracle M S C).query (m₁, s₁))) >>= fun c₁ =>
+        ((CMOracle M S C).query (m₀, s₀) : OracleComp (CMOracle M S C) _) >>= fun c₀ =>
+          ((CMOracle M S C).query (m₁, s₁) : OracleComp (CMOracle M S C) _) >>= fun c₁ =>
           pure (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))
   have hdecomp : bindingInner A = A.run >>= restPart := by
     simp [bindingInner, restPart]

--- a/Examples/CommitmentScheme/Binding.lean
+++ b/Examples/CommitmentScheme/Binding.lean
@@ -84,7 +84,7 @@ private lemma binding_win_implies_collision {t : ℕ} (A : BindingAdversary M S 
   -- Cache monotonicity: cache₂ ≤ cache₃, so cache₃ also has (m₀, s₀) ↦ c₀
   have hcache_mono : cache₂ ≤ cache₃ := by
     have hmem₃_co : (c₁, cache₃) ∈ support
-        ((cachingOracle (spec := CMOracle M S C) (m₁, s₁)).run cache₂) := by
+        (((CMOracle M S C).cachingOracle (m₁, s₁)).run cache₂) := by
       simp only [cachingOracle.simulateQ_query] at hmem₃; exact hmem₃
     unfold cachingOracle at hmem₃_co
     exact QueryImpl.withCaching_cache_le
@@ -157,7 +157,7 @@ private lemma binding_rest_noCollision_le_inv
               pure (decide (m₀ ≠ m₁) && (v₀ == c) && (c₁ == c)))).run cache₁ := by
         simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
         have hcache :
-            (liftM (cachingOracle (spec := CMOracle M S C) q₀) :
+            (liftM ((CMOracle M S C).cachingOracle q₀) :
               StateT (QueryCache (CMOracle M S C))
                 (OracleComp (CMOracle M S C)) _).run cache₁ =
             pure (v₀, cache₁) := by
@@ -187,7 +187,7 @@ private lemma binding_rest_noCollision_le_inv
               pure (decide (m₀ ≠ m₁) && (v₀ == c) && (v₁ == c), cache₁) := by
             simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
             have hcache :
-                (liftM (cachingOracle (spec := CMOracle M S C) q₁) :
+                (liftM ((CMOracle M S C).cachingOracle q₁) :
                   StateT (QueryCache (CMOracle M S C))
                     (OracleComp (CMOracle M S C)) _).run cache₁ =
                 pure (v₁, cache₁) := by

--- a/Examples/CommitmentScheme/Common.lean
+++ b/Examples/CommitmentScheme/Common.lean
@@ -59,21 +59,25 @@ lemma probEvent_from_fresh_query_le_inv
       Pr[ fun z => z.1 = true |
         (simulateQ cachingOracle (cont u)).run (cache₀.cacheQuery t u)] = 0) :
     Pr[fun z => z.1 = true |
-      (simulateQ cachingOracle
-        (((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= cont)).run cache₀] ≤
+      (simulateQ (CMOracle M S C).cachingOracle do
+        let u ← (CMOracle M S C).query t
+        cont u).run cache₀] ≤
       (Fintype.card C : ℝ≥0∞)⁻¹ := by
   have hrun :
-      (simulateQ cachingOracle
-        (((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= cont)).run cache₀ =
-      (((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= fun u =>
+      (simulateQ (CMOracle M S C).cachingOracle do
+        let u ← (CMOracle M S C).query t
+        cont u).run cache₀ =
+      (do
+        let u ← (CMOracle M S C).query t
         (simulateQ cachingOracle (cont u)).run (cache₀.cacheQuery t u)) := by
     simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
     have hstep :
         (liftM ((CMOracle M S C).cachingOracle t) :
           StateT (QueryCache (CMOracle M S C))
             (OracleComp (CMOracle M S C)) _).run cache₀ =
-        ((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= fun u =>
-          pure (u, cache₀.cacheQuery t u) := by
+        (do
+          let u ← (CMOracle M S C).query t
+          pure (u, cache₀.cacheQuery t u)) := by
       simp only [cachingOracle.apply_eq, liftM, MonadLiftT.monadLift, MonadLift.monadLift,
         StateT.run_bind, StateT.run_get, pure_bind, hfresh]
       change (StateT.lift (PFunctor.FreeM.lift ((CMOracle M S C).query t)) cache₀ >>= _) = _

--- a/Examples/CommitmentScheme/Common.lean
+++ b/Examples/CommitmentScheme/Common.lean
@@ -60,19 +60,19 @@ lemma probEvent_from_fresh_query_le_inv
         (simulateQ cachingOracle (cont u)).run (cache₀.cacheQuery t u)] = 0) :
     Pr[fun z => z.1 = true |
       (simulateQ cachingOracle
-        ((liftM ((CMOracle M S C).query t)) >>= cont)).run cache₀] ≤
+        (((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= cont)).run cache₀] ≤
       (Fintype.card C : ℝ≥0∞)⁻¹ := by
   have hrun :
       (simulateQ cachingOracle
-        ((liftM ((CMOracle M S C).query t)) >>= cont)).run cache₀ =
-      (liftM ((CMOracle M S C).query t) >>= fun u =>
+        (((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= cont)).run cache₀ =
+      (((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= fun u =>
         (simulateQ cachingOracle (cont u)).run (cache₀.cacheQuery t u)) := by
     simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
     have hstep :
         (liftM ((CMOracle M S C).cachingOracle t) :
           StateT (QueryCache (CMOracle M S C))
             (OracleComp (CMOracle M S C)) _).run cache₀ =
-        liftM ((CMOracle M S C).query t) >>= fun u =>
+        ((CMOracle M S C).query t : OracleComp (CMOracle M S C) _) >>= fun u =>
           pure (u, cache₀.cacheQuery t u) := by
       simp only [cachingOracle.apply_eq, liftM, MonadLiftT.monadLift, MonadLift.monadLift,
         StateT.run_bind, StateT.run_get, pure_bind, hfresh]
@@ -85,18 +85,18 @@ lemma probEvent_from_fresh_query_le_inv
     simp [OracleQuery.cont_query]
   rw [hrun, probEvent_bind_eq_tsum]
   calc
-    ∑' u, Pr[= u | liftM ((CMOracle M S C).query t)] *
+    ∑' u, Pr[= u | ((CMOracle M S C).query t : OracleComp (CMOracle M S C) _)] *
         Pr[fun z => z.1 = true |
           (simulateQ cachingOracle (cont u)).run (cache₀.cacheQuery t u)]
       ≤ ∑' u, if u = target then (Fintype.card C : ℝ≥0∞)⁻¹ else 0 := by
         refine ENNReal.tsum_le_tsum fun u => ?_
         by_cases hu : u = target
         · calc
-            Pr[= u | liftM ((CMOracle M S C).query t)] *
+            Pr[= u | ((CMOracle M S C).query t : OracleComp (CMOracle M S C) _)] *
                 Pr[fun z => z.1 = true |
                   (simulateQ cachingOracle (cont u)).run
                     (cache₀.cacheQuery t u)]
-              ≤ Pr[= u | liftM ((CMOracle M S C).query t)] * 1 :=
+              ≤ Pr[= u | ((CMOracle M S C).query t : OracleComp (CMOracle M S C) _)] * 1 :=
                   mul_le_mul' le_rfl probEvent_le_one
             _ = (Fintype.card C : ℝ≥0∞)⁻¹ := by
                 rw [mul_one]

--- a/Examples/CommitmentScheme/Common.lean
+++ b/Examples/CommitmentScheme/Common.lean
@@ -69,7 +69,7 @@ lemma probEvent_from_fresh_query_le_inv
         (simulateQ cachingOracle (cont u)).run (cache₀.cacheQuery t u)) := by
     simp only [simulateQ_query_bind, OracleQuery.input_query, StateT.run_bind]
     have hstep :
-        (liftM (cachingOracle (spec := CMOracle M S C) t) :
+        (liftM ((CMOracle M S C).cachingOracle t) :
           StateT (QueryCache (CMOracle M S C))
             (OracleComp (CMOracle M S C)) _).run cache₀ =
         liftM ((CMOracle M S C).query t) >>= fun u =>

--- a/Examples/CommitmentScheme/Extractability.lean
+++ b/Examples/CommitmentScheme/Extractability.lean
@@ -152,7 +152,7 @@ private lemma extractability_someWin_implies_collision {t : ℕ}
   -- Cache monotonicity: cache₂ ≤ cache₃
   have hcache_mono₂₃ : cache₂ ≤ cache₃ := by
     have hmem₃_co : (c, cache₃) ∈ support
-        ((cachingOracle (spec := CMOracle M S C) (m, s)).run cache₂) := hmem₃
+        (((CMOracle M S C).cachingOracle (m, s)).run cache₂) := hmem₃
     unfold cachingOracle at hmem₃_co
     exact QueryImpl.withCaching_cache_le
       (QueryImpl.ofLift (CMOracle M S C) (OracleComp (CMOracle M S C)))

--- a/Examples/CommitmentScheme/Extractability.lean
+++ b/Examples/CommitmentScheme/Extractability.lean
@@ -284,12 +284,12 @@ private def extractabilityRestOa {t : ℕ}
     (A : ExtractAdversary M S C AUX t)
     (cm : C) (aux : AUX) (tr : QueryLog (CMOracle M S C)) :
     OracleComp (CMOracle M S C) Bool :=
-  A.open_ aux >>= fun (m, s) =>
-    ((CMOracle M S C).query (m, s) : OracleComp (CMOracle M S C) _) >>= fun c =>
+  A.open_ aux >>= fun (m, s) => do
+    let c ← (CMOracle M S C).query (m, s)
     let extracted := CMExtract cm tr
-    pure (match extracted with
+    return match extracted with
       | some (m', s') => (c == cm) && decide ((m', s') ≠ (m, s))
-      | none => (c == cm))
+      | none => (c == cm)
 
 set_option maxHeartbeats 400000 in
 /- Under a collision-free commit cache, any extractability win must create a fresh

--- a/Examples/CommitmentScheme/Extractability.lean
+++ b/Examples/CommitmentScheme/Extractability.lean
@@ -285,7 +285,7 @@ private def extractabilityRestOa {t : ℕ}
     (cm : C) (aux : AUX) (tr : QueryLog (CMOracle M S C)) :
     OracleComp (CMOracle M S C) Bool :=
   A.open_ aux >>= fun (m, s) =>
-    (liftM ((CMOracle M S C).query (m, s))) >>= fun c =>
+    ((CMOracle M S C).query (m, s) : OracleComp (CMOracle M S C) _) >>= fun c =>
     let extracted := CMExtract cm tr
     pure (match extracted with
       | some (m', s') => (c == cm) && decide ((m', s') ≠ (m, s))

--- a/Examples/CommitmentScheme/Hiding/CountBounds.lean
+++ b/Examples/CommitmentScheme/Hiding/CountBounds.lean
@@ -98,7 +98,7 @@ lemma hiding_distinguish_totalBound_of_choose_count_support
   haveI : Fintype C := Fintype.ofFinite C
   have hres :
       IsTotalQueryBound
-        ((liftM ((CMOracle M S C).query (x.1.1, default))) >>= fun cm =>
+        (((CMOracle M S C).query (x.1.1, default) : OracleComp (CMOracle M S C) _) >>= fun cm =>
           A.distinguish x.1.2 cm)
         ((t + 1) - (∑ s : S, x.2.2 s)) := by
     simpa [hidingOa] using
@@ -106,7 +106,7 @@ lemma hiding_distinguish_totalBound_of_choose_count_support
         (spec := CMOracle M S C)
         (oa := A.choose)
         (ob := fun a =>
-          (liftM ((CMOracle M S C).query (a.1, default))) >>= fun cm =>
+          ((CMOracle M S C).query (a.1, default) : OracleComp (CMOracle M S C) _) >>= fun cm =>
             A.distinguish a.2 cm)
         (n := t + 1)
         (impl := hidingImplCountAll)

--- a/Examples/CommitmentScheme/Hiding/Defs.lean
+++ b/Examples/CommitmentScheme/Hiding/Defs.lean
@@ -211,7 +211,7 @@ theorem hidingImplCountAll_proj_eq_cachingOracle
     (st : QueryCache (CMOracle M S C) × (S → ℕ)) :
     Prod.map id Prod.fst <$>
         (hidingImplCountAll (M := M) (S := S) (C := C) ms).run st =
-      (cachingOracle (spec := CMOracle M S C) ms).run st.1 := by
+      ((CMOracle M S C).cachingOracle ms).run st.1 := by
   rcases st with ⟨cache, counts⟩
   cases hcache : cache ms with
   | some u =>

--- a/Examples/CommitmentScheme/Hiding/Defs.lean
+++ b/Examples/CommitmentScheme/Hiding/Defs.lean
@@ -324,7 +324,7 @@ lemma hiding_distinguish_totalBound_of_choose_support
     ∀ cm : C, IsTotalQueryBound (A.distinguish x.1.2 cm) (t - ∑ ms, x.2 ms) := by
   have hres :
       IsTotalQueryBound
-        ((liftM ((CMOracle M S C).query (x.1.1, s))) >>= fun cm =>
+        (((CMOracle M S C).query (x.1.1, s) : OracleComp (CMOracle M S C) _) >>= fun cm =>
           A.distinguish x.1.2 cm)
         ((t + 1) - ∑ ms, x.2 ms) := by
     simpa [hidingOa] using
@@ -332,7 +332,7 @@ lemma hiding_distinguish_totalBound_of_choose_support
         (spec := CMOracle M S C)
         (oa := A.choose)
         (ob := fun a =>
-          (liftM ((CMOracle M S C).query (a.1, s))) >>= fun cm =>
+          ((CMOracle M S C).query (a.1, s) : OracleComp (CMOracle M S C) _) >>= fun cm =>
             A.distinguish a.2 cm)
         (n := t + 1)
         (h := A.totalBound s)

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
@@ -197,7 +197,7 @@ lemma log_length_le_of_mem_support_run_cached_logging
   have hstep :
       ∀ t : (CMOracle M S C).Domain, ∀ st : QueryCache (CMOracle M S C),
         ∀ x : (CMOracle M S C).Range t × QueryCache (CMOracle M S C),
-          x ∈ support ((cachingOracle (spec := CMOracle M S C) t).run st) →
+          x ∈ support (((CMOracle M S C).cachingOracle t).run st) →
             cost x.2 ≤ cost st + 1 := by
     intro t st x hx
     simp [cost]
@@ -753,7 +753,7 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
             have hcache_hit : (cache₀.cacheQuery (m, s) cm) t = some u := by
               rw [hcache_eq, ht]
             have hcache_fresh_run :
-                (liftM (cachingOracle (spec := CMOracle M S C) t) :
+                (liftM ((CMOracle M S C).cachingOracle t) :
                   StateT (QueryCache (CMOracle M S C))
                     (OracleComp (CMOracle M S C)) _).run
                     (cache₀.cacheQuery (m, s) cm) =
@@ -761,7 +761,7 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
               simp [liftM, MonadLiftT.monadLift, MonadLift.monadLift,
                 StateT.run_bind, StateT.run_get, hcache_hit, pure_bind, StateT.run_pure]
             have hcache_common_run :
-                (liftM (cachingOracle (spec := CMOracle M S C) t) :
+                (liftM ((CMOracle M S C).cachingOracle t) :
                   StateT (QueryCache (CMOracle M S C))
                     (OracleComp (CMOracle M S C)) _).run cache₀ =
                   pure (u, cache₀) := by
@@ -774,7 +774,7 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
             have hcache_none : (cache₀.cacheQuery (m, s) cm) t = none := by
               rw [hcache_eq, ht]
             have hmiss_fresh :
-                (liftM (cachingOracle (spec := CMOracle M S C) t) :
+                (liftM ((CMOracle M S C).cachingOracle t) :
                   StateT (QueryCache (CMOracle M S C))
                     (OracleComp (CMOracle M S C)) _).run
                     (cache₀.cacheQuery (m, s) cm) =
@@ -791,7 +791,7 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
                 StateT.modifyGet, StateT.run]
               rfl
             have hmiss_common :
-                (liftM (cachingOracle (spec := CMOracle M S C) t) :
+                (liftM ((CMOracle M S C).cachingOracle t) :
                   StateT (QueryCache (CMOracle M S C))
                     (OracleComp (CMOracle M S C)) _).run cache₀ =
                   ((CMOracle M S C).query t >>= fun u =>

--- a/Examples/ElGamal/ReductionCost.lean
+++ b/Examples/ElGamal/ReductionCost.lean
@@ -259,13 +259,13 @@ noncomputable def IND_CPA_OneTime_DDHReduction_openProfiled
     AddWriterT (ResourceProfile ω κ) ProbComp Bool := do
   AddWriterT.addTell (ResourceProfile.ofIntrinsic (κ := κ) intrinsic)
   AddWriterT.addTell (profile OneTimeINDCPACapability.chooseMessages)
-  let (m₁, m₂, st) ← monadLift <|
+  let (m₁, m₂, st) ←
     HasQuery.query (spec := oneTimeINDCPASpec G G State (G × G)) (m := ProbComp)
       (.chooseMessages A)
-  let bit ← monadLift ($ᵗ Bool : ProbComp Bool)
+  let bit ← ($ᵗ Bool : ProbComp Bool)
   let c : G × G := (B, T + if bit then m₁ else m₂)
   AddWriterT.addTell (profile OneTimeINDCPACapability.distinguish)
-  let bit' ← monadLift <|
+  let bit' ←
     HasQuery.query (spec := oneTimeINDCPASpec G G State (G × G)) (m := ProbComp)
       (.distinguish st c)
   pure (bit == bit')
@@ -324,13 +324,13 @@ lemma IND_CPA_OneTime_DDHReduction_openProfiled_pathwiseCostEqOnSupport
         ((do
           AddWriterT.addTell (ResourceProfile.ofIntrinsic (κ := κ) intrinsic)
           AddWriterT.addTell (profile OneTimeINDCPACapability.chooseMessages)
-          let (m₁, m₂, st) ← monadLift <|
+          let (m₁, m₂, st) ←
             HasQuery.query (spec := oneTimeINDCPASpec G G State (G × G)) (m := ProbComp)
               (.chooseMessages A)
-          let bit ← monadLift ($ᵗ Bool : ProbComp Bool)
+          let bit ← ($ᵗ Bool : ProbComp Bool)
           let c : G × G := (B, T + if bit then m₁ else m₂)
           AddWriterT.addTell (profile OneTimeINDCPACapability.distinguish)
-          let bit' ← monadLift <|
+          let bit' ←
             HasQuery.query (spec := oneTimeINDCPASpec G G State (G × G)) (m := ProbComp)
               (.distinguish st c)
           pure (bit == bit')) :

--- a/Examples/ProgramLogic/RelationalStep.lean
+++ b/Examples/ProgramLogic/RelationalStep.lean
@@ -53,8 +53,8 @@ example (f : α → OracleComp spec β) :
   rvcstep
 
 example (t : spec.Domain) :
-    ⟪(liftM (query t) : OracleComp spec (spec.Range t))
-     ~ (liftM (query t) : OracleComp spec (spec.Range t))
+    ⟪(query t : OracleComp spec (spec.Range t))
+     ~ (query t : OracleComp spec (spec.Range t))
      | EqRel (spec.Range t)⟫ := by
   rvcstep
 

--- a/Examples/ProgramLogic/UnaryStep.lean
+++ b/Examples/ProgramLogic/UnaryStep.lean
@@ -59,7 +59,7 @@ example (x : α) (xs : List α) (f : β → α → OracleComp spec β)
   vcstep
 
 example (t : spec.Domain) (post : spec.Range t → ℝ≥0∞) :
-    wp⟦(liftM (query t) : OracleComp spec (spec.Range t))⟧ post =
+    wp⟦(query t : OracleComp spec (spec.Range t))⟧ post =
       ∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ℝ≥0∞) * post u := by
   vcstep
 
@@ -79,7 +79,7 @@ example (f : α → β) (oa : OracleComp spec α) (post : β → ℝ≥0∞) :
 
 example (impl : QueryImpl spec (OracleComp spec))
     (hImpl : ∀ (t : spec.Domain),
-      evalDist (impl t) = evalDist (liftM (query t) : OracleComp spec (spec.Range t)))
+      evalDist (impl t) = evalDist (query t : OracleComp spec (spec.Range t)))
     (oa : OracleComp spec α) (post : α → ℝ≥0∞) :
     wp⟦simulateQ impl oa⟧ post = wp⟦oa⟧ post := by
   simpa using OracleComp.ProgramLogic.wp_simulateQ_eq impl hImpl oa post

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -268,7 +268,7 @@ private lemma support_step_inl
     (n : ℕ) (s : simSt M Commit Chal)
     (z : ((unifSpec + (M × Commit →ₒ Chal)).Range (Sum.inl n) × simSt M Commit Chal) ×
       QueryLog (wrappedSpec Chal)) :
-    z ∈ support ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+    z ∈ support ((simulateQ (wrappedSpec Chal).loggingOracle
       (((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inl n)).run s)).run) ↔
     ∃ u : (unifSpec + (M × Commit →ₒ Chal)).Range (Sum.inl n),
       z = ((u, s), [⟨Sum.inl n, u⟩]) := by
@@ -298,7 +298,7 @@ private lemma support_step_inr
     (mc : M × Commit) (s : simSt M Commit Chal)
     (z : ((unifSpec + (M × Commit →ₒ Chal)).Range (Sum.inr mc) × simSt M Commit Chal) ×
       QueryLog (wrappedSpec Chal)) :
-    z ∈ support ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+    z ∈ support ((simulateQ (wrappedSpec Chal).loggingOracle
       (((unifFwd M Commit Chal + roImpl M Commit Chal) (Sum.inr mc)).run s)).run) ↔
     (∃ v, s.1 mc = some v ∧ z = ((v, s), [])) ∨
     (s.1 mc = none ∧ ∃ v,
@@ -358,7 +358,7 @@ private theorem preservesInv_layered
     (Inv : simSt M Commit Chal → QueryLog (wrappedSpec Chal) → Prop)
     (hstep : ∀ t (s : simSt M Commit Chal) (w : QueryLog (wrappedSpec Chal)),
       Inv s w →
-      ∀ z ∈ support ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ∀ z ∈ support ((simulateQ (wrappedSpec Chal).loggingOracle
         (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run s)).run),
       Inv z.1.2 (w ++ z.2))
     (Y : OracleComp (unifSpec + (M × Commit →ₒ Chal)) γ)
@@ -366,7 +366,7 @@ private theorem preservesInv_layered
     (hinit : Inv s₀ w₀)
     {z : (γ × simSt M Commit Chal) × QueryLog (wrappedSpec Chal)}
     (hz : z ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run s₀)).run)) :
     Inv z.1.2 (w₀ ++ z.2) := by
   classical
@@ -388,7 +388,7 @@ private theorem preservesInv_layered
       obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := hz
       have hpres : Inv us_w.1.2 (w₀ ++ us_w.2) := hstep t s₀ w₀ hinit us_w hus_w
       have hpw_split : (pw.1, pw.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w.1.1)).run us_w.1.2)).run) := hpw
       have hih := ih (us_w.1.1) (s₀ := us_w.1.2) (w₀ := w₀ ++ us_w.2)
@@ -414,7 +414,7 @@ private theorem queryLog_length_eq_outer_inr_count
     {z : γ × simSt M Commit Chal}
     {outerLog : QueryLog (wrappedSpec Chal)}
     (hz : (z, outerLog) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run)) :
     z.2.2.length = l₀.length + outerLog.countQ (· = Sum.inr ()) := by
@@ -465,7 +465,7 @@ private theorem queryLog_cache_outer_lockstep
     {z : γ × simSt M Commit Chal}
     {outerLog : QueryLog (wrappedSpec Chal)}
     (hz : (z, outerLog) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run)) :
     (∃ l_new, z.2.2 = l₀ ++ l_new) ∧
@@ -498,7 +498,7 @@ private theorem queryLog_cache_outer_lockstep
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at hz
       obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := hz
       have hpw_split : (pw.1, pw.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w.1.1)).run us_w.1.2)).run) := by
         change pw ∈ support _
@@ -515,7 +515,7 @@ private theorem queryLog_cache_outer_lockstep
       subst hzeq
       subst houter_eq
       have houter : us_w ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w
       cases t with
       | inl n =>
@@ -648,7 +648,7 @@ private theorem queryLog_extends_l₀
     {z : γ × simSt M Commit Chal}
     {outerLog : QueryLog (wrappedSpec Chal)}
     (h : (z, outerLog) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run)) :
     z.2.2.take l₀.length = l₀ := by
@@ -672,7 +672,7 @@ private theorem queryLog_extends_l₀
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at h
       obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := h
       have hpw_split : (pw.1, pw.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w.1.1)).run us_w.1.2)).run) := by
         change pw ∈ support _
@@ -685,7 +685,7 @@ private theorem queryLog_extends_l₀
       have hzeq : z = pw.1 := hz_eq1.symm
       subst hzeq
       have houter : us_w ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w
       cases t with
       | inl n =>
@@ -765,11 +765,11 @@ private theorem inner_prefix_det
     {z₁ z₂ : γ × simSt M Commit Chal}
     {outerLog₁ outerLog₂ : QueryLog (wrappedSpec Chal)}
     (h₁ : (z₁, outerLog₁) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run))
     (h₂ : (z₂, outerLog₂) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run))
     (p suffix₁ suffix₂ : QueryLog (wrappedSpec Chal))
@@ -806,13 +806,13 @@ private theorem inner_prefix_det
       obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
       obtain ⟨us_w₂, hus_w₂, pw₂, hpw₂, hz_eq₂⟩ := h₂
       have hpw₁_split : (pw₁.1, pw₁.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w₁.1.1)).run us_w₁.1.2)).run) := by
         change pw₁ ∈ support _
         exact hpw₁
       have hpw₂_split : (pw₂.1, pw₂.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w₂.1.1)).run us_w₂.1.2)).run) := by
         change pw₂ ∈ support _
@@ -834,10 +834,10 @@ private theorem inner_prefix_det
       have houter₁_eq : us_w₁.2 ++ pw₁.2 = p ++ suffix₁ := hz_eq2₁.trans hlog₁
       have houter₂_eq : us_w₂.2 ++ pw₂.2 = p ++ suffix₂ := hz_eq2₂.trans hlog₂
       have houter₁ : us_w₁ ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₁
       have houter₂ : us_w₂ ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₂
       cases t with
       | inl n =>
@@ -1004,11 +1004,11 @@ private theorem inner_prefix_det_one_more_inr
     {z₁ z₂ : γ × simSt M Commit Chal}
     {outerLog₁ outerLog₂ : QueryLog (wrappedSpec Chal)}
     (h₁ : (z₁, outerLog₁) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run))
     (h₂ : (z₂, outerLog₂) ∈ support
-      ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+      ((simulateQ (wrappedSpec Chal).loggingOracle
         ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) Y).run
           (c₀, l₀))).run))
     (p : QueryLog (wrappedSpec Chal))
@@ -1039,13 +1039,13 @@ private theorem inner_prefix_det_one_more_inr
       obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
       obtain ⟨us_w₂, hus_w₂, pw₂, hpw₂, hz_eq₂⟩ := h₂
       have hpw₁_split : (pw₁.1, pw₁.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w₁.1.1)).run us_w₁.1.2)).run) := by
         change pw₁ ∈ support _
         exact hpw₁
       have hpw₂_split : (pw₂.1, pw₂.2) ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             ((simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal)
               (oa us_w₂.1.1)).run us_w₂.1.2)).run) := by
         change pw₂ ∈ support _
@@ -1069,10 +1069,10 @@ private theorem inner_prefix_det_one_more_inr
       have houter₂_eq : us_w₂.2 ++ pw₂.2 = p ++ (⟨Sum.inr (), v₂⟩ :: rest₂) :=
         hz_eq2₂.trans hlog₂
       have houter₁ : us_w₁ ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₁
       have houter₂ : us_w₂ ∈ support
-          ((simulateQ (loggingOracle (spec := wrappedSpec Chal))
+          ((simulateQ (wrappedSpec Chal).loggingOracle
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀))).run) := hus_w₂
       cases t with
       | inl n =>

--- a/VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean
@@ -211,7 +211,7 @@ private lemma romCRWin_implies_collision [DecidableEq X] [DecidableEq Y]
     cachingOracle_query_caches x cache₁ y cache₂ hmem₂
   have hcache_mono : cache₂ ≤ cache₃ := by
     have hmem₃_co : (y', cache₃) ∈ support
-        ((cachingOracle (spec := ROMHashSpec X Y) x').run cache₂) := by
+        (((ROMHashSpec X Y).cachingOracle x').run cache₂) := by
       simp only [cachingOracle.simulateQ_query] at hmem₃; exact hmem₃
     unfold cachingOracle at hmem₃_co
     exact QueryImpl.withCaching_cache_le

--- a/VCVio/CryptoFoundations/MerkleTree.lean
+++ b/VCVio/CryptoFoundations/MerkleTree.lean
@@ -219,7 +219,7 @@ theorem buildLayer_neverFails (α : Type _) [DecidableEq α]
     [SampleableType α] [(spec α).DecidableEq]
     (preexisting_cache : (spec α).QueryCache) (n : ℕ)
     (leaves : List.Vector α (2 ^ (n + 1))) : NeverFail
-      ((simulateQ (randomOracle (spec := spec α))
+      ((simulateQ (spec α).randomOracle
         (buildLayer α n leaves)).run preexisting_cache) := by
   grind only [buildLayer, = HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
 
@@ -232,7 +232,7 @@ theorem buildMerkleTree_neverFails (α : Type _) [DecidableEq α]
     [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
     (leaves : List.Vector α (2 ^ n)) (preexisting_cache : (spec α).QueryCache) :
     NeverFail
-      ((simulateQ (randomOracle (spec := spec α))
+      ((simulateQ (spec α).randomOracle
         (buildMerkleTree α n leaves)).run preexisting_cache) := by
   grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
 
@@ -425,7 +425,7 @@ theorem completeness [SampleableType α] {n : ℕ} [(spec α).DecidableEq]
     (leaves : List.Vector α (2 ^ n)) (i : Fin (2 ^ n))
     (preexisting_cache : (spec α).QueryCache) :
     NeverFail ((
-      simulateQ (randomOracle (spec := spec α)) (do
+      simulateQ (spec α).randomOracle (do
         let cache ← buildMerkleTree α n leaves
         let proof := generateProof α i cache
         let _ ← (verifyProof (m := OracleComp (spec α)) α i leaves[i]

--- a/VCVio/CryptoFoundations/PRF.lean
+++ b/VCVio/CryptoFoundations/PRF.lean
@@ -66,7 +66,7 @@ def prfIdealQueryImpl [DecidableEq D] [SampleableType R] :
     QueryImpl (PRFOracleSpec D R) (StateT ((D →ₒ R).QueryCache) ProbComp) :=
   (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (StateT ((D →ₒ R).QueryCache) ProbComp) +
-    randomOracle (spec := (D →ₒ R))
+    (D →ₒ R).randomOracle
 
 /-- Real PRF experiment: sample a key, let the adversary query `prf.eval k`. -/
 def prfRealExp (prf : PRFScheme K D R) (adversary : PRFAdversary D R) :

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -411,7 +411,7 @@ def replayOracle [spec.DecidableEq] (i : ι) :
 /-- Run `main` with query logging. This is the first-run object for replay forks. -/
 @[reducible]
 def replayFirstRun (main : OracleComp spec α) : OracleComp spec (α × QueryLog spec) :=
-  (simulateQ (loggingOracle (spec := spec)) main).run
+  (simulateQ spec.loggingOracle main).run
 
 @[simp]
 lemma fst_map_replayFirstRun (main : OracleComp spec α) :

--- a/VCVio/OracleComp/QueryTracking/CachingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingOracle.lean
@@ -91,7 +91,7 @@ end CacheMonotonicity
 end QueryImpl
 
 /-- Oracle for caching queries to the oracles in `spec`, querying fresh values if needed. -/
-@[inline, reducible] def cachingOracle :
+@[inline, reducible] def OracleSpec.cachingOracle :
     QueryImpl spec (StateT spec.QueryCache (OracleComp spec)) :=
   (QueryImpl.ofLift spec (OracleComp spec)).withCaching
 
@@ -111,7 +111,7 @@ because caching changes the oracle semantics (cache hits skip the underlying ora
 lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (cache : QueryCache spec₀) :
-    Pr[⊥ | (simulateQ (cachingOracle (spec := spec₀)) oa).run cache] = Pr[⊥ | oa] := by
+    Pr[⊥ | (simulateQ spec₀.cachingOracle oa).run cache] = Pr[⊥ | oa] := by
   simp only [HasEvalPMF.probFailure_eq_zero]
 
 /-- Trivially true via `probFailure_eq_zero`; see `probFailure_run_simulateQ`. -/
@@ -119,7 +119,7 @@ lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι�
 lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (cache : QueryCache spec₀) :
-    NeverFail ((simulateQ (cachingOracle (spec := spec₀)) oa).run cache) ↔ NeverFail oa := by
+    NeverFail ((simulateQ spec₀.cachingOracle oa).run cache) ↔ NeverFail oa := by
   rw [← probFailure_eq_zero_iff, ← probFailure_eq_zero_iff,
     HasEvalPMF.probFailure_eq_zero, HasEvalPMF.probFailure_eq_zero]
 
@@ -149,9 +149,9 @@ Key properties:
 TODO: generalize `FiatShamir.runtime` to `runtimeWithCache cache` with
 `runtime = runtimeWithCache ∅`, deriving `randomOracle` evaluation from
 `withCacheOverlay` + `evalDist`. -/
-def withCacheOverlay {α : Type u} (cache : spec.QueryCache) (oa : OracleComp spec α) :
+def OracleSpec.withCacheOverlay {α : Type u} (cache : spec.QueryCache) (oa : OracleComp spec α) :
     OracleComp spec α :=
-  StateT.run' (simulateQ cachingOracle oa) cache
+  StateT.run' (simulateQ spec.cachingOracle oa) cache
 
 @[simp]
 lemma withCacheOverlay_pure {α : Type u} (cache : spec.QueryCache) (a : α) :
@@ -160,8 +160,7 @@ lemma withCacheOverlay_pure {α : Type u} (cache : spec.QueryCache) (a : α) :
 
 private lemma fst_map_cachingOracle_run_some (cache : spec.QueryCache) (t : spec.Domain)
     (v : spec.Range t) (hv : cache t = some v) :
-    Prod.fst <$> (cachingOracle (spec := spec) t).run cache =
-      (pure v : OracleComp spec (spec.Range t)) := by
+    Prod.fst <$> (cachingOracle t).run cache = pure v := by
   unfold cachingOracle QueryImpl.withCaching QueryImpl.ofLift
   simp only [StateT.run_bind,
     show (get : StateT spec.QueryCache (OracleComp spec) _).run cache =
@@ -171,7 +170,7 @@ private lemma fst_map_cachingOracle_run_some (cache : spec.QueryCache) (t : spec
 
 private lemma fst_map_cachingOracle_run_none (cache : spec.QueryCache) (t : spec.Domain)
     (hv : cache t = none) :
-    Prod.fst <$> (cachingOracle (spec := spec) t).run cache =
+    Prod.fst <$> (cachingOracle t).run cache =
       (query t : OracleComp spec (spec.Range t)) := by
   unfold cachingOracle QueryImpl.withCaching QueryImpl.ofLift
   simp only [StateT.run_bind,

--- a/VCVio/OracleComp/QueryTracking/Collision.lean
+++ b/VCVio/OracleComp/QueryTracking/Collision.lean
@@ -127,7 +127,7 @@ theorem log_entry_in_cache_and_mono {α : Type}
     rw [StateT.run_bind] at hmem
     rw [support_bind] at hmem; simp only [Set.mem_iUnion] at hmem
     obtain ⟨⟨u, cache_mid⟩, hu_mem, hmem⟩ := hmem
-    have hu_mem' : (u, cache_mid) ∈ support ((cachingOracle (spec := spec) t).run cache₀) := by
+    have hu_mem' : (u, cache_mid) ∈ support ((spec.cachingOracle t).run cache₀) := by
       simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind] at hu_mem ⊢
       exact hu_mem
     have hcache_mid_entry : cache_mid t = some u := by
@@ -249,7 +249,7 @@ theorem cache_entry_in_log_or_initial {α : Type}
         subst h1; rw [h2]
         exact QueryCache.cacheQuery_self w.2 t w.1
     have hcache₀_le_mid : cache₀ ≤ cache_mid := by
-      have hu_mem' : (u, cache_mid) ∈ support ((cachingOracle (spec := spec) t).run cache₀) := by
+      have hu_mem' : (u, cache_mid) ∈ support ((spec.cachingOracle t).run cache₀) := by
         simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind] at hu_mem ⊢
         exact hu_mem
       unfold cachingOracle at hu_mem'
@@ -274,7 +274,7 @@ theorem cache_entry_in_log_or_initial {α : Type}
     rw [hz]
     have hcache_mid_eq : ∀ t₀ : spec.Domain, t₀ ≠ t → cache_mid t₀ = cache₀ t₀ := by
       intro t₀ hne
-      have hu_mem' : (u, cache_mid) ∈ support ((cachingOracle (spec := spec) t).run cache₀) := by
+      have hu_mem' : (u, cache_mid) ∈ support ((spec.cachingOracle t).run cache₀) := by
         simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind] at hu_mem ⊢
         exact hu_mem
       simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind] at hu_mem'

--- a/VCVio/OracleComp/QueryTracking/CountingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CountingOracle.lean
@@ -146,12 +146,12 @@ def costOracle {ω : Type u} [Monoid ω] (costFn : spec.Domain → ω) :
 
 /-- Oracle for counting the number of queries made by a computation. The count is stored as a
 function from oracle indices to counts, to give finer grained information about the count. -/
-def countingOracle [DecidableEq ι] :
+def OracleSpec.countingOracle [DecidableEq ι] :
     QueryImpl spec (WriterT (QueryCount ι) (OracleComp spec)) :=
   (QueryImpl.ofLift spec (OracleComp spec)).withCounting
 
 lemma countingOracle_eq_costOracle [DecidableEq ι] :
-    countingOracle (spec := spec) = costOracle (QueryCount.single ·) := rfl
+    spec.countingOracle = costOracle (QueryCount.single ·) := rfl
 
 namespace costOracle
 
@@ -200,7 +200,7 @@ lemma run_simulateQ_bind_fst (oa : OracleComp spec α) (ob : α → OracleComp s
 @[simp]
 lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type} (oa : OracleComp spec₀ α) :
-    Pr[⊥ | (simulateQ (countingOracle (spec := spec₀)) oa).run] = Pr[⊥ | oa] := by
+    Pr[⊥ | (simulateQ (spec₀.countingOracle) oa).run] = Pr[⊥ | oa] := by
   simp only [countingOracle, QueryImpl.withCounting_eq_withCost,
     QueryImpl.probFailure_run_simulateQ_withCost, simulateQ_ofLift_eq_self]
 
@@ -209,7 +209,7 @@ lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι�
 lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) :
-    NeverFail (simulateQ (countingOracle (spec := spec₀)) oa).run ↔ NeverFail oa := by
+    NeverFail (simulateQ (spec₀.countingOracle) oa).run ↔ NeverFail oa := by
   simp only [countingOracle, QueryImpl.withCounting_eq_withCost,
     QueryImpl.NeverFail_run_simulateQ_withCost_iff, simulateQ_ofLift_eq_self]
 
@@ -217,7 +217,7 @@ lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι
 lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (p : α → Prop) :
-    Pr[ fun z => p z.1 | (simulateQ (countingOracle (spec := spec₀)) oa).run] = Pr[ p | oa] := by
+    Pr[ fun z => p z.1 | (simulateQ (spec₀.countingOracle) oa).run] = Pr[ p | oa] := by
   rw [show (fun z : α × QueryCount ι₀ => p z.1) = p ∘ Prod.fst from rfl,
     ← probEvent_map, fst_map_run_simulateQ]
 
@@ -225,7 +225,7 @@ lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι
 lemma probOutput_fst_map_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
     [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
     (oa : OracleComp spec₀ α) (x : α) :
-    Pr[= x | Prod.fst <$> (simulateQ (countingOracle (spec := spec₀)) oa).run] =
+    Pr[= x | Prod.fst <$> (simulateQ (spec₀.countingOracle) oa).run] =
       Pr[= x | oa] := by
   rw [fst_map_run_simulateQ]
 

--- a/VCVio/OracleComp/QueryTracking/Enforcement.lean
+++ b/VCVio/OracleComp/QueryTracking/Enforcement.lean
@@ -32,7 +32,7 @@ variable {ι : Type u} {spec : OracleSpec ι} {α : Type u}
 /-- Enforcement oracle: wraps the original oracle with a per-index budget tracked via `StateT`.
 When the remaining budget for the queried oracle is positive, the query is forwarded and
 the budget decremented. When the budget is exhausted, `default` is returned silently. -/
-def enforceOracle [DecidableEq ι] [spec.Inhabited] :
+def OracleSpec.enforceOracle [DecidableEq ι] [spec.Inhabited] :
     QueryImpl spec (StateT (ι → ℕ) (OracleComp spec)) :=
   fun t => StateT.mk fun budget =>
     if 0 < budget t then
@@ -46,7 +46,7 @@ variable [DecidableEq ι] [spec.Inhabited]
 
 @[simp]
 lemma run_apply (t : ι) (budget : ι → ℕ) :
-    (enforceOracle (spec := spec) t).run budget =
+    (spec.enforceOracle t).run budget =
       if 0 < budget t then
         (·, Function.update budget t (budget t - 1)) <$> liftM (query t)
       else
@@ -64,7 +64,7 @@ theorem fst_map_run_simulateQ
     rw [isPerIndexQueryBound_query_bind_iff] at h
     obtain ⟨hpos, hcont⟩ := h
     simp only [simulateQ_query_bind]
-    change Prod.fst <$> ((enforceOracle (spec := spec) t).run qb >>=
+    change Prod.fst <$> ((spec.enforceOracle t).run qb >>=
       fun p => (simulateQ enforceOracle (mx p.1)).run p.2) = liftM (query t) >>= mx
     rw [run_apply, if_pos hpos]
     simp only [map_eq_bind_pure_comp, Function.comp, bind_assoc, pure_bind]

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -61,7 +61,7 @@ end QueryImpl
 /-- Simulation oracle for tracking the quries in a `QueryLog`, without modifying the actual
 behavior of the oracle. Requires decidable equality of the indexing set to determine
 which list to update when queries come in. -/
-def loggingOracle {spec : OracleSpec ι} :
+def OracleSpec.loggingOracle {spec : OracleSpec ι} :
     QueryImpl spec (WriterT (QueryLog spec) (OracleComp spec)) :=
   (QueryImpl.ofLift spec (OracleComp spec)).withLogging
 
@@ -74,20 +74,20 @@ lemma probFailure_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) :
     Pr[⊥ | (WriterT.run
-        (simulateQ (loggingOracle (spec := spec)) oa) :
+        (simulateQ spec.loggingOracle oa) :
           OracleComp spec (α × spec.QueryLog))] = Pr[⊥ | oa] := by
   rw [loggingOracle, QueryImpl.probFailure_run_simulateQ_withLogging, simulateQ_ofLift_eq_self]
 
 @[simp]
 lemma fst_map_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     (oa : OracleComp spec α) :
-    Prod.fst <$> (simulateQ (loggingOracle (spec := spec)) oa).run = oa := by
+    Prod.fst <$> (simulateQ spec.loggingOracle oa).run = oa := by
   rw [loggingOracle, QueryImpl.fst_map_run_withLogging, simulateQ_ofLift_eq_self]
 
 @[simp]
 lemma run_simulateQ_bind_fst {spec : OracleSpec.{0, 0} ι} {α β : Type}
     (oa : OracleComp spec α) (ob : α → OracleComp spec β) :
-    ((simulateQ (loggingOracle (spec := spec)) oa).run >>= fun x => ob x.1) = oa >>= ob := by
+    ((simulateQ spec.loggingOracle oa).run >>= fun x => ob x.1) = oa >>= ob := by
   rw [← bind_map_left Prod.fst, fst_map_run_simulateQ]
 
 /-- Specialization of `QueryImpl.NeverFail_run_simulateQ_withLogging_iff` to `loggingOracle`. -/
@@ -95,14 +95,14 @@ lemma run_simulateQ_bind_fst {spec : OracleSpec.{0, 0} ι} {α β : Type}
 lemma NeverFail_run_simulateQ_iff {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) :
-    NeverFail (simulateQ (loggingOracle (spec := spec)) oa).run ↔ NeverFail oa := by
+    NeverFail (simulateQ spec.loggingOracle oa).run ↔ NeverFail oa := by
   rw [loggingOracle, QueryImpl.NeverFail_run_simulateQ_withLogging_iff, simulateQ_ofLift_eq_self]
 
 @[simp]
 lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) (p : α → Prop) :
-    Pr[ fun z => p z.1 | (simulateQ (loggingOracle (spec := spec)) oa).run] = Pr[ p | oa] := by
+    Pr[ fun z => p z.1 | (simulateQ spec.loggingOracle oa).run] = Pr[ p | oa] := by
   rw [show (fun z : α × spec.QueryLog => p z.1) = p ∘ Prod.fst from rfl,
     ← probEvent_map, fst_map_run_simulateQ]
 
@@ -110,7 +110,7 @@ lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
 lemma probOutput_fst_map_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
     [spec.Fintype] [spec.Inhabited]
     (oa : OracleComp spec α) (x : α) :
-    Pr[= x | Prod.fst <$> (simulateQ (loggingOracle (spec := spec)) oa).run] =
+    Pr[= x | Prod.fst <$> (simulateQ spec.loggingOracle oa).run] =
       Pr[= x | oa] := by
   rw [fst_map_run_simulateQ]
 
@@ -187,7 +187,7 @@ theorem log_length_le_of_mem_support_run_simulateQ
       obtain ⟨z', hz', rfl⟩ := hz
       have hqu_log : qu.2.length = 1 := by
         simp only [OracleQuery.cont_query, id_map, OracleQuery.input_query] at hqu
-        have hrun : (loggingOracle (spec := spec) t).run =
+        have hrun : (spec.loggingOracle t).run =
             (query t : OracleComp spec _) >>= fun u =>
               pure (u, [⟨t, u⟩]) := by
           simp [loggingOracle, QueryImpl.withLogging_apply,

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/Basic.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/Basic.lean
@@ -18,7 +18,7 @@ open OracleComp OracleSpec
 /-- The (lazy) random oracle: uniform sampling with caching.
 On query `t`, returns the cached value if present, otherwise samples `$ᵗ spec.Range t`
 uniformly and caches the result. This ensures consistency: same input → same output. -/
-@[inline, reducible] def randomOracle {ι} [DecidableEq ι] {spec : OracleSpec ι}
+@[inline, reducible] def OracleSpec.randomOracle {ι} [DecidableEq ι] {spec : OracleSpec ι}
     [∀ t : spec.Domain, SampleableType (spec.Range t)] :
     QueryImpl spec (StateT spec.QueryCache ProbComp) :=
   uniformSampleImpl.withCaching
@@ -29,7 +29,7 @@ variable {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec.{0, 0} ι₀}
   [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
 
 lemma apply_eq (t : spec₀.Domain) :
-    (randomOracle (spec := spec₀)) t = (do match (← get) t with
+    spec₀.randomOracle t = (do match (← get) t with
     | Option.some u => return u
     | Option.none =>
         let u ← $ᵗ spec₀.Range t

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/Simulation.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/Simulation.lean
@@ -49,16 +49,7 @@ lemma simulateQ_run {α : Type} (oa : ProbComp α) (s : hashSpec.QueryCache) :
     (simulateQ (unifFwdImpl hashSpec) oa).run s = (fun x => (x, s)) <$> oa := by
   induction oa using OracleComp.inductionOn with
   | pure x => simp
-  | query_bind t oa ih =>
-    change
-      (do
-        let a ← (liftM (query t) : ProbComp (unifSpec.Range t))
-        (simulateQ (unifFwdImpl hashSpec) (oa a)).run s) =
-        (do
-          let a ← liftM (query t)
-          (fun x => (x, s)) <$> oa a)
-    simp [show (fun a => (simulateQ (unifFwdImpl hashSpec) (oa a)).run s) =
-            (fun a => (fun x => (x, s)) <$> oa a) from funext fun a => ih a]
+  | query_bind t oa ih => simp [unifFwdImpl, ← ih]
 
 end unifFwdImpl
 
@@ -99,9 +90,7 @@ lemma run'_liftM_bind {α β : Type} (oa : ProbComp α)
 
 @[simp]
 lemma simulateQ_liftM_spec_query (q : hashSpec.Domain) :
-    simulateQ (unifFwdImpl hashSpec + ro)
-      (liftM (hashSpec.query q) : OracleComp (unifSpec + hashSpec) _) =
-      ro q := by
+    simulateQ (unifFwdImpl hashSpec + ro) (hashSpec.query q) = ro q := by
   change simulateQ (unifFwdImpl hashSpec + ro)
     (liftM (liftM (hashSpec.query q) :
       OracleQuery (unifSpec + hashSpec) _)) = _

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -53,7 +53,7 @@ end QueryImpl
 
 /-- Use pregenerated oracle responses for queries, falling back to the real oracle
 when the seed is exhausted. Seed consumption is tracked via `StateT`. -/
-def seededOracle :
+def OracleSpec.seededOracle :
     QueryImpl spec (StateT (QuerySeed spec) (OracleComp spec)) :=
   (QueryImpl.ofLift spec (OracleComp spec)).withPregen
 


### PR DESCRIPTION
This PR moves definitions like `loggingOracle` into the `OracleSpec` namespace, since they already depend on them implicitly and they are defined at root level. This allows for simpler dot notation in many cases where the specification needs to be made explicit for type checking reasons.