### PR TITLE
refactor(interaction): redefine `Spec` as polynomial `FreeM` (S1 of poly-substrate campaign)

### DIFF
--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+import ToMathlib.PFunctor.Free
 
 /-!
 # Interaction specifications and transcripts
@@ -29,6 +30,28 @@ the old flat `ProtocolSpec n` model with a dependent-type-native design.
 The key advantage is that later rounds can depend on earlier moves, which
 is mathematically forced in protocols like sumcheck and FRI.
 
+## Polynomial substrate
+
+`Spec` is built directly on top of the polynomial-functor library in
+`ToMathlib/PFunctor`:
+
+```
+Spec := PFunctor.FreeM Spec.basePFunctor PUnit
+```
+
+where `Spec.basePFunctor : PFunctor.{u+1, u}` has positions `Type u`
+(every node carries a move type) and a child family given by the identity
+(continuations are indexed by moves). This is the polynomial that
+generates the *unindexed shape* of an interaction tree; payload-bearing
+shapes are obtained by replacing `PFunctor.FreeM` with the corresponding
+`PFunctor.FreeM ... α` for nontrivial `α` (see `Strategy` / `StepOver`).
+
+The `Spec` notation, `Spec.done`, and `Spec.node` are tagged with
+`@[match_pattern]` so that downstream definitions and proofs continue to
+pattern-match exactly as before, with no rewrite required at call sites.
+The substrate is the truth; the names are an ergonomic re-skin in the
+spirit of `OracleSpec`/`OracleComp`.
+
 ## Module map
 
 - `Basic/` — spec, node contexts, decoration, generic shapes, strategy,
@@ -53,7 +76,12 @@ is mathematically forced in protocols like sumcheck and FRI.
 
 ## References
 
-* Hancock–Setzer (2000), recursion over interaction interfaces
+* Hancock–Setzer (2000), recursion over interaction interfaces; the
+  free interaction structure on a polynomial container
+* Altenkirch–Ghani–Hancock–McBride–Morris (2015), *Indexed Containers*,
+  Journal of Functional Programming 25, e5
+* Spivak–Niu (2024), *Polynomial Functors: A General Theory of
+  Interaction*, MIT Press; the patterns/matter pairing `FreeM ⊣ Cofree`
 * Escardó–Oliva (2023, TCS 974), games as type trees
 * McBride (2010); Dagand–McBride (2014), displayed algebras / ornaments
 -/
@@ -61,6 +89,24 @@ is mathematically forced in protocols like sumcheck and FRI.
 universe u
 
 namespace Interaction
+
+namespace Spec
+
+/-- The polynomial functor that generates the shape of an interaction
+spec: positions are move types `Type u`, and the child family at a
+position `M : Type u` is `M` itself (one continuation per move).
+
+This is the canonical representation of "an interactive node where the
+participant chooses a value of some move type, and the continuation is
+selected by that value". It is independent of payload data, controller
+attribution, and execution semantics; those layers refine the same
+polynomial via `Decoration`, `NodeSemantics`, and `StepOver`. -/
+@[reducible]
+def basePFunctor : PFunctor.{u+1, u} where
+  A := Type u
+  B := id
+
+end Spec
 
 /-- A `Spec` describes the shape of a sequential interaction as a tree.
 Each internal node specifies a move space `Moves`, and the rest of the
@@ -81,15 +127,65 @@ Those additional layers are supplied separately by:
 * `Spec.SyntaxOver`, for the most general local participant syntax over
   realized node contexts;
 * `Spec.ShapeOver`, for the functorial refinement of such syntax;
-* `Spec.InteractionOver`, for local execution laws over such syntax. -/
-inductive Spec : Type (u + 1) where
-  | /-- Terminal node: the interaction is over. -/
-    done : Spec
-  | /-- A round of interaction: a value of type `Moves` is exchanged, then
-    the protocol continues with `rest x` depending on the chosen move `x`. -/
-    node (Moves : Type u) (rest : Moves → Spec) : Spec
+* `Spec.InteractionOver`, for local execution laws over such syntax.
+
+`Spec` is **definitionally** the free monad on `Spec.basePFunctor` at the
+unit payload, exposing the polynomial substrate that the rest of the
+`Interaction` library builds on. The `Spec.done` / `Spec.node` aliases
+are tagged with `@[match_pattern]`, so existing pattern-matching code
+continues to work unchanged. -/
+def Spec : Type (u+1) :=
+  PFunctor.FreeM Spec.basePFunctor.{u} PUnit.{u+1}
 
 namespace Spec
+
+/-- Terminal node: the interaction is over.
+
+This is `PFunctor.FreeM.pure ()` at the polynomial substrate; the
+`@[match_pattern]` attribute makes it usable both as a constructor
+term and as a `match` pattern. -/
+@[match_pattern, reducible]
+def done : Spec := PFunctor.FreeM.pure PUnit.unit
+
+/-- A round of interaction: a value of type `Moves` is exchanged, then
+the protocol continues with `rest x` depending on the chosen move `x`.
+
+This is `PFunctor.FreeM.roll Moves rest` at the polynomial substrate;
+the `@[match_pattern]` attribute makes it usable both as a constructor
+term and as a `match` pattern. -/
+@[match_pattern, reducible]
+def node (Moves : Type u) (rest : Moves → Spec) : Spec :=
+  PFunctor.FreeM.roll Moves rest
+
+/-- Cases eliminator on `Spec` exposing the high-level `done` / `node`
+alternatives. Registered as the default `cases` eliminator so that
+`cases s with | done => ... | node X rest => ...` works transparently
+on top of the polynomial substrate. -/
+@[elab_as_elim, cases_eliminator]
+def casesOn {motive : Spec → Sort*}
+    (s : Spec)
+    (done : motive Spec.done)
+    (node : (X : Type u) → (rest : X → Spec) → motive (Spec.node X rest)) :
+    motive s :=
+  match s with
+  | .done => done
+  | .node X rest => node X rest
+
+/-- Structural recursion eliminator on `Spec` exposing the high-level
+`done` / `node` alternatives, with an induction hypothesis on every
+continuation in the `node` case. Registered as the default `induction`
+eliminator so that `induction s with | done => ... | node X rest ih => ...`
+works transparently on top of the polynomial substrate. -/
+@[elab_as_elim, induction_eliminator]
+def recOn {motive : Spec → Sort*}
+    (s : Spec)
+    (done : motive Spec.done)
+    (node : (X : Type u) → (rest : X → Spec) →
+        ((x : X) → motive (rest x)) → motive (Spec.node X rest)) :
+    motive s :=
+  match s with
+  | .done => done
+  | .node X rest => node X rest (fun x => recOn (rest x) done node)
 
 /-- A complete play through a `Spec`: at each node, a concrete move is
 recorded, producing a root-to-leaf path through the interaction tree.

--- a/VCVio/Interaction/Basic/Strategy.lean
+++ b/VCVio/Interaction/Basic/Strategy.lean
@@ -59,9 +59,9 @@ def Strategy.mapOutput {m : Type u → Type u} [Functor m] :
 theorem Strategy.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor m] {spec : Spec}
     {A : Transcript spec → Type u} (σ : Strategy m spec A) :
     Strategy.mapOutput (fun _ x => x) σ = σ := by
-  cases spec with
+  induction spec with
   | done => rfl
-  | node X rest =>
+  | node X rest ih =>
     rcases σ with ⟨x, cont⟩
     simp only [Strategy.mapOutput]
     congr 1
@@ -70,7 +70,7 @@ theorem Strategy.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor
             Strategy m (rest x) (fun p => A ⟨x, p⟩) → Strategy m (rest x) (fun p => A ⟨x, p⟩)) =
           id := by
       funext s
-      exact @mapOutput_id m _ _ (rest x) (fun p => A ⟨x, p⟩) s
+      exact ih x s
     rw [hid]
     exact LawfulFunctor.id_map cont
 
@@ -80,9 +80,9 @@ theorem Strategy.mapOutput_comp {m : Type u → Type u} [Functor m] [LawfulFunct
     (σ : Strategy m spec A) :
     Strategy.mapOutput (fun tr x => g tr (f tr x)) σ =
       Strategy.mapOutput g (Strategy.mapOutput f σ) := by
-  cases spec with
+  induction spec with
   | done => rfl
-  | node X rest =>
+  | node X rest ih =>
     rcases σ with ⟨x, cont⟩
     simp only [Strategy.mapOutput]
     congr 1
@@ -94,9 +94,7 @@ theorem Strategy.mapOutput_comp {m : Type u → Type u} [Functor m] [LawfulFunct
             @mapOutput m _ (rest x) (fun p => A ⟨x, p⟩) (fun p => B ⟨x, p⟩)
               (fun p y => f ⟨x, p⟩ y)) := by
       funext s
-      exact
-        @mapOutput_comp m _ _ (rest x) (fun p => A ⟨x, p⟩) (fun p => B ⟨x, p⟩) (fun p => C ⟨x, p⟩)
-          (fun p y => g ⟨x, p⟩ y) (fun p y => f ⟨x, p⟩ y) s
+      exact ih x (fun p y => g ⟨x, p⟩ y) (fun p y => f ⟨x, p⟩ y) s
     rw [hcomp, LawfulFunctor.comp_map]
 
 end Spec

--- a/VCVio/Interaction/TwoParty/Refine.lean
+++ b/VCVio/Interaction/TwoParty/Refine.lean
@@ -136,9 +136,9 @@ theorem map_append {S T : Type u → Type v} (f : ∀ X, S X → T X)
     map f (s₁.append s₂) (rd₁.append rd₂) (append sd₁ sd₂) =
       append (map f s₁ rd₁ sd₁)
         (fun tr₁ => map f (s₂ tr₁) (rd₂ tr₁) (sd₂ tr₁)) := by
-  cases s₁ with
+  induction s₁ with
   | done => rfl
-  | node X rest =>
+  | node X rest ih =>
     rcases rd₁ with ⟨role, rRest⟩
     cases role with
     | sender =>
@@ -146,11 +146,11 @@ theorem map_append {S T : Type u → Type v} (f : ∀ X, S X → T X)
       simp only [append, map]
       refine Prod.ext rfl ?_
       funext x
-      exact map_append f (rr x) (fun p => sd₂ ⟨x, p⟩)
+      exact ih x (rr x) (fun p => sd₂ ⟨x, p⟩)
     | receiver =>
       simp only [append, map]
       funext x
-      exact map_append f (sd₁ x) (fun p => sd₂ ⟨x, p⟩)
+      exact ih x (sd₁ x) (fun p => sd₂ ⟨x, p⟩)
 
 theorem map_replicate {S T : Type u → Type v} (f : ∀ X, S X → T X)
     {spec : Spec} {roles : RoleDecoration spec}


### PR DESCRIPTION
## Summary

Slice 1 of the polynomial-substrate campaign for `VCVio/Interaction/`.
Make the polynomial-functor substrate **definitional** rather than a
side isomorphism, mirroring the established `OracleSpec`/`OracleComp`
pattern: the polynomial layer is the truth; `Spec.done`/`Spec.node`
are `@[match_pattern, reducible]` aliases that preserve the high-level
constructor surface for downstream pattern matching.

## What changed

### `VCVio/Interaction/Basic/Spec.lean`

* New `Spec.basePFunctor : PFunctor.{u+1, u}` with positions `Type u`
  and child family `id`. This is the polynomial that generates "an
  interactive node where the participant chooses a value of some move
  type, and the continuation is selected by that value".
* `Spec : Type (u+1) := PFunctor.FreeM Spec.basePFunctor PUnit.{u+1}`
  is now a `def` that unfolds to the free monad on the substrate at
  the unit payload.
* `Spec.done`, `Spec.node` are `@[match_pattern, reducible]` aliases for
  `FreeM.pure ()` and `FreeM.roll`. Existing pattern-matching call
  sites compile unchanged.
* `@[cases_eliminator] Spec.casesOn` and
  `@[induction_eliminator] Spec.recOn` register the high-level
  `done` / `node` named alternatives as the default for the `cases`
  and `induction` tactics. Same pattern as `Mathlib.Order.Interval`'s
  `recBotCoe`.
* Module docstring updated with citations: Hancock-Setzer 2000,
  Altenkirch-Ghani-Hancock-McBride-Morris 2015, Spivak-Niu 2024.

### Downstream changes (3 self-recursive tactic theorems)

`cases spec with` self-recursion is replaced by `induction spec with … ih`
in three theorems where Lean's structural-recursion analyzer would
otherwise need to track decrease through the new `def`-aliased `Spec`.
The conversion is mechanical:

* `Strategy.mapOutput_id`, `Strategy.mapOutput_comp` in
  `VCVio/Interaction/Basic/Strategy.lean` (4 LOC each).
* `Role.Refine.map_append` in `VCVio/Interaction/TwoParty/Refine.lean`
  (4 LOC).

All other call sites compile unchanged via the `@[match_pattern]`
aliases and the registered eliminators. Total downstream blast radius:
**3 theorems**.

## Definitional equalities preserved (verified by `rfl`)

* `Spec.done = FreeM.pure PUnit.unit`
* `Spec.node M rest = FreeM.roll M rest`
* `Spec = FreeM Spec.basePFunctor PUnit`
* `Spec.append .done s₂ = s₂ ()`
* `Spec.append (.node M rest) s₂ = .node M (fun x => …)`
* `Transcript.liftAppend_const` (the load-bearing `rfl` lemma flagged
  in the synthesis memo) survives unchanged.

## Axiom hygiene

* `Spec`, `Spec.basePFunctor`, `Spec.done`, `Spec.node`,
  `Spec.casesOn`, `Spec.recOn`, `Spec.Transcript`, `Spec.ofList`,
  `Spec.append`: **no axioms**.
* `Strategy.mapOutput_id`, `Strategy.mapOutput_comp`,
  `Role.Refine.map_append`: keep their previous `Quot.sound`
  dependency (from `funext`/`congr 1`); no new axioms introduced.

## Test plan

- [x] `lake build` of the full `VCVio` library succeeds (only
  pre-existing `sorry` warnings).
- [x] `lake build Examples LatticeCrypto` succeeds.
- [x] `#print axioms` on every new declaration verified (no new
  axioms).
- [x] `rfl` checks for the load-bearing definitional equalities
  pass (especially `liftAppend_const` and the `Spec.append` reduction
  rules that downstream theorems depend on).

## Campaign context

This is **S1 of 7** in the polynomial-substrate redefinition campaign
(see Notes/vcvio-interaction-redesign-council-synthesis.md §0.2):

| Slice | Branch | Status |
|---|---|---|
| **S1** | `quang/poly-substrate-spec` | **this PR** |
| S2 | `quang/poly-substrate-decoration` | next |
| S3 | `quang/poly-substrate-step` | pending S2 |
| S4 | `quang/poly-substrate-open` | pending S3 |
| S5 | `quang/poly-substrate-behavior` | pending S4 |
| S6 | `quang/poly-substrate-monoidal` | pending S5 |
| S7 | `quang/poly-substrate-typeclass` | pending S6 |

The slices land sequentially against `main`. Each is intended to
be small, well-scoped, and individually reviewable.

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user
(Quang Dao) with approval.

Made with [Cursor](https://cursor.com)