### PR TITLE
feat(relational): invariant-gated simulateQ state-projection lemmas

### DIFF
--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -536,6 +536,76 @@ theorem run'_simulateQ_eq_of_query_map_eq'
   have hmap := congrArg (fun p => Prod.fst <$> p) hrun
   simpa [StateT.run'] using hmap
 
+/-- Invariant-gated state-projection theorem: if `proj` commutes with each oracle
+step *under* a state invariant `inv` that is preserved by every step, then it
+commutes with the full simulation starting from any state satisfying `inv`. This
+is the natural strengthening of `map_run_simulateQ_eq_of_query_map_eq'` for
+projections that only agree on a reachable subset of states. -/
+theorem map_run_simulateQ_eq_of_query_map_eq_inv'
+    {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    {σ₁ σ₂ : Type _}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec')))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec')))
+    (inv : σ₁ → Prop) (proj : σ₁ → σ₂)
+    (hinv : ∀ t s, inv s →
+      ∀ y ∈ support (m := OracleComp spec') ((impl₁ t).run s), inv y.2)
+    (hproj : ∀ t s, inv s →
+      Prod.map id proj <$> (impl₁ t).run s = (impl₂ t).run (proj s))
+    (oa : OracleComp spec α) (s : σ₁) (hs : inv s) :
+    Prod.map id proj <$> (simulateQ impl₁ oa).run s =
+      (simulateQ impl₂ oa).run (proj s) := by
+  induction oa using OracleComp.inductionOn generalizing s with
+  | pure x => simp
+  | query_bind t oa ih =>
+      simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+        OracleQuery.cont_query, id_map, StateT.run_bind, map_bind]
+      have hbind :
+          (do
+              let x ← (impl₁ t).run s
+              Prod.map id proj <$> (simulateQ impl₁ (oa x.1)).run x.2 :
+                OracleComp spec' (α × σ₂)) =
+            (do
+              let x ← (impl₁ t).run s
+              (simulateQ impl₂ (oa x.1)).run (proj x.2)) :=
+        bind_congr_of_forall_mem_support
+          (mx := ((impl₁ t).run s : OracleComp spec' (spec.Range t × σ₁)))
+          (fun x hx => ih x.1 x.2 (hinv t s hs x hx))
+      calc
+        ((impl₁ t).run s >>= fun x =>
+            Prod.map id proj <$> (simulateQ impl₁ (oa x.1)).run x.2)
+            =
+            ((impl₁ t).run s >>= fun x =>
+              (simulateQ impl₂ (oa x.1)).run (proj x.2)) := hbind
+        _ =
+            ((Prod.map id proj <$> (impl₁ t).run s) >>= fun x =>
+              (simulateQ impl₂ (oa x.1)).run x.2) := by
+                  exact
+                    (bind_map_left (m := OracleComp spec') (Prod.map id proj)
+                      ((impl₁ t).run s)
+                      (fun y => (simulateQ impl₂ (oa y.1)).run y.2)).symm
+        _ =
+            ((impl₂ t).run (proj s) >>= fun x =>
+              (simulateQ impl₂ (oa x.1)).run x.2) := by
+                  rw [hproj t s hs]
+
+/-- `run'` projection corollary of `map_run_simulateQ_eq_of_query_map_eq_inv'`. -/
+theorem run'_simulateQ_eq_of_query_map_eq_inv'
+    {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    {σ₁ σ₂ : Type _}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec')))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec')))
+    (inv : σ₁ → Prop) (proj : σ₁ → σ₂)
+    (hinv : ∀ t s, inv s →
+      ∀ y ∈ support (m := OracleComp spec') ((impl₁ t).run s), inv y.2)
+    (hproj : ∀ t s, inv s →
+      Prod.map id proj <$> (impl₁ t).run s = (impl₂ t).run (proj s))
+    (oa : OracleComp spec α) (s : σ₁) (hs : inv s) :
+    (simulateQ impl₁ oa).run' s = (simulateQ impl₂ oa).run' (proj s) := by
+  have hrun :=
+    map_run_simulateQ_eq_of_query_map_eq_inv' impl₁ impl₂ inv proj hinv hproj oa s hs
+  have hmap := congrArg (fun p => Prod.fst <$> p) hrun
+  simpa [StateT.run'] using hmap
+
 /-! ## "Identical until bad" fundamental lemma -/
 
 variable [spec.Fintype] [spec.Inhabited]


### PR DESCRIPTION
## Summary

Add `map_run_simulateQ_eq_of_query_map_eq_inv'` and its `run'` corollary `run'_simulateQ_eq_of_query_map_eq_inv'` to `VCVio.ProgramLogic.Relational.SimulateQ`. They are the natural strengthening of the existing `map_run_simulateQ_eq_of_query_map_eq'` to projections that only agree on a *reachable* subset of states, described by an explicit invariant `inv : σ₁ → Prop`.

```lean
theorem map_run_simulateQ_eq_of_query_map_eq_inv'
    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec')))
    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec')))
    (inv : σ₁ → Prop) (proj : σ₁ → σ₂)
    (hinv  : ∀ t s, inv s → ∀ y ∈ support ((impl₁ t).run s), inv y.2)
    (hproj : ∀ t s, inv s →
      Prod.map id proj <$> (impl₁ t).run s = (impl₂ t).run (proj s))
    (oa : OracleComp spec α) (s : σ₁) (hs : inv s) :
    Prod.map id proj <$> (simulateQ impl₁ oa).run s =
      (simulateQ impl₂ oa).run (proj s)
```

Per-query commutation only needs to hold on states satisfying `inv`, provided every step preserves `inv`. The whole-`simulateQ` projection then follows by a single induction. This pattern arises whenever a small-state simulator is implemented by a larger-state oracle plus an "always-`true`" invariant on the extra fields, e.g. cache overlays for random-oracle programming, dual logs, sign-counter pads, or any state extension by `extendState`.

Both lemmas live next to the unconditional `_eq'` variants and follow the same proof pattern: induction on `oa`, `bind_congr_of_forall_mem_support` to push the invariant through the binder, then `bind_map_left` to swap the projection past the bind.

## Context

Extracted from `quang/fs-cma-to-nma-stage2`'s C7a infrastructure work. Listed as Tier 1 reusable infra in `~/Documents/Notes/vcvio-fs-schnorr-clean-chain.md` (item T1.5). No callers added in this PR; downstream usage will land alongside the forking / Phase-C cleanup.

## Test plan

- [ ] `lake build` (CI)

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)