### PR TITLE
feat(sigma): add `SigmaProtocol.simCommitPredictability β`

### DIFF
--- a/VCVio/CryptoFoundations/SigmaProtocol.lean
+++ b/VCVio/CryptoFoundations/SigmaProtocol.lean
@@ -157,6 +157,18 @@ lemma perfectHVZK_iff_hvzk_zero
         simpa using (tvDist_nonneg (σ.realTranscript x w) (simTranscript x)))
     simpa using (tvDist_eq_zero_iff (σ.realTranscript x w) (simTranscript x)).mp hzero
 
+open scoped ENNReal in
+/-- The simulator's commitment marginal has predictability at most `β`: no single
+commitment value is output with probability exceeding `β`. Equivalently, the commitment
+has min-entropy at least `-log₂ β`.
+
+This is a companion assumption to `HVZK` that bounds the collision probability of
+programmed cache entries in the Fiat-Shamir CMA-to-NMA reduction. For Schnorr,
+`β = 1/|G|` because the commitment `g^r` is uniform over the group. -/
+def simCommitPredictability
+    (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) (β : ℝ≥0∞) : Prop :=
+  ∀ x : Stmt, ∀ c₀ : Commit, probOutput (Prod.fst <$> simTranscript x) c₀ ≤ β
+
 end hvzk
 
 section uniqueResponses


### PR DESCRIPTION
## Summary

Define `SigmaProtocol.simCommitPredictability simTranscript β`: the commitment marginal of an HVZK simulator outputs no single commitment with probability exceeding `β`. Equivalently, the commitment has min-entropy at least `-log₂ β`.

```lean
def simCommitPredictability
    (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) (β : ℝ≥0∞) : Prop :=
  ∀ x : Stmt, ∀ c₀ : Commit, probOutput (Prod.fst <$> simTranscript x) c₀ ≤ β
```

This is the companion assumption to `HVZK` that bounds the collision probability of programmed cache entries in the Fiat-Shamir CMA-to-NMA reduction: a programming policy that installs at most `qS` simulated hash points produces at most `qS · (qS + qH) · β` collision mass against `qH` adversary RO queries. For Schnorr `β = 1/|G|` (the commitment `g^r` is uniform); for Okamoto-style schemes `β` is the marginal of `g_1^{r_1} g_2^{r_2}`; for ML-DSA-style schemes `β` is determined by the centred-binomial commitment marginal.

Replaces the previous `1/|Chal|` formulation (`collisionSlack qS qH (1/|Chal|)`) which was correct only for Schnorr where `|Commit| = |Chal|`.

## Context

Pure definition; no existing call site is touched. Downstream consumers (the cleaner Fiat-Shamir CMA→NMA reduction, cf. `~/Documents/Notes/vcvio-fs-schnorr-clean-chain.md`) will take `simCommitPredictability simTranscript β` as a hypothesis and combine it with a per-call programming bound to obtain the canonical collision slack.

## Test plan

- [ ] `lake build` (CI)

---

Posted by Cursor assistant (model: Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)