### PR TITLE
feat(VCVio): add naming accessors for Interface and OracleComp

### DIFF
--- a/VCVio/Interaction/UC/Interface.lean
+++ b/VCVio/Interaction/UC/Interface.lean
@@ -26,7 +26,8 @@ Every definition is an `abbrev` over existing `PFunctor` / chart / lens
 machinery, so the established theory is reused definitionally while
 presenting names that read naturally in the interaction setting.
 
-* `Interface` is `PFunctor`: ports `A` and per-port messages `B a`.
+* `Interface` is `PFunctor`, with interaction-facing accessors `I.port` and
+  `I.message a` for the raw polynomial fields `A` and `B a`.
 * `Interface.Packet I` is one concrete boundary message on interface `I`.
 * `Interface.Hom I J` is `PFunctor.Chart I J` (forward packet transport,
   covariant on both components).
@@ -84,8 +85,8 @@ namespace UC
 
 An interface packages:
 
-* a type of ports `A`, and
-* for each port `a : A`, a type of messages `B a`.
+* a type of ports, written `I.port`, and
+* for each port `a : I.port`, a type of messages `I.message a`.
 
 This is the same dependent-container structure already used throughout the
 existing `PFunctor` world. The point of the new name is only to reflect the
@@ -96,12 +97,28 @@ abbrev Interface := PFunctor
 namespace Interface
 
 /--
+The type of ports exposed by an interface.
+
+This is the interaction-facing name for `PFunctor.A`.
+-/
+abbrev port (I : Interface.{uA, uB}) : Type uA :=
+  I.A
+
+/--
+The type of messages carried on port `a` of an interface.
+
+This is the interaction-facing name for `PFunctor.B`.
+-/
+abbrev message (I : Interface.{uA, uB}) (a : I.port) : Type uB :=
+  I.B a
+
+/--
 `Packet I` is one concrete message on interface `I`.
 
 It consists of:
 
-* a chosen port `a : I.A`, and
-* a message `m : I.B a` carried on that port.
+* a chosen port `a : I.port`, and
+* a message `m : I.message a` carried on that port.
 
 This is exactly `PFunctor.Idx I`, reused under a boundary-oriented name.
 -/
@@ -204,7 +221,7 @@ This is the interaction-facing name for `PFunctor.Chart.toFunA`.
 abbrev onPort
     {I : Interface.{uA, uB}}
     {J : Interface.{vA, vB}}
-    (f : Hom I J) : I.A → J.A :=
+    (f : Hom I J) : I.port → J.port :=
   f.toFunA
 
 /--
@@ -219,7 +236,7 @@ interaction-facing name for `PFunctor.Chart.toFunB`.
 abbrev onMsg
     {I : Interface.{uA, uB}}
     {J : Interface.{vA, vB}}
-    (f : Hom I J) : {a : I.A} → I.B a → J.B (f.onPort a) :=
+    (f : Hom I J) : {a : I.port} → I.message a → J.message (f.onPort a) :=
   fun {a} => f.toFunB a
 
 /-- The identity interface translation. -/
@@ -415,7 +432,7 @@ This is the interaction-facing name for `PFunctor.Lens.toFunA`.
 abbrev onPort
     {I : Interface.{uA, uB}}
     {J : Interface.{vA, vB}}
-    (f : QueryHom I J) : I.A → J.A :=
+    (f : QueryHom I J) : I.port → J.port :=
   f.toFunA
 
 /--
@@ -432,7 +449,7 @@ interaction-facing name for `PFunctor.Lens.toFunB`.
 abbrev onMsg
     {I : Interface.{uA, uB}}
     {J : Interface.{vA, vB}}
-    (f : QueryHom I J) : ∀ a : I.A, J.B (f.onPort a) → I.B a :=
+    (f : QueryHom I J) : ∀ a : I.port, J.message (f.onPort a) → I.message a :=
   f.toFunB
 
 /-- The identity interface query hom. -/
@@ -765,13 +782,13 @@ polynomial functors; see Niu–Spivak 2024).
 
 A position of `comp I J` is a pair of:
 
-* a port `a : I.A` on the outer interface, and
-* for each response `m : I.B a` on that port, a port of the inner interface:
-  a function `I.B a → J.A`.
+* a port `a : I.port` on the outer interface, and
+* for each response `m : I.message a` on that port, a port of the inner
+  interface: a function `I.message a → J.port`.
 
 A direction at a composed position `⟨a, f⟩` is a dependent pair `⟨u, v⟩`
-where `u : I.B a` is a response on port `a` and `v : J.B (f u)` is a
-response on the resulting inner port.
+where `u : I.message a` is a response on port `a` and
+`v : J.message (f u)` is a response on the resulting inner port.
 
 This models sequential dependence: one interface's response determines which
 port of the next interface is activated.

--- a/VCVio/OracleComp/OracleComp.lean
+++ b/VCVio/OracleComp/OracleComp.lean
@@ -29,6 +29,16 @@ namespace OracleComp
 -- We want these to show up regardless of specifically opening `OracleSpec`
 export OracleSpec (query query_def)
 
+/-- Make one oracle query at input `t`, then continue with `k` on the response.
+
+This is the `PFunctor.FreeM.roll` constructor specialized to `OracleComp`;
+the `@[match_pattern]` attribute makes it usable both as a term and as a
+`match` pattern. -/
+@[match_pattern, reducible]
+def queryBind {α} (t : spec.Domain) (k : spec.Range t → OracleComp spec α) :
+    OracleComp spec α :=
+  PFunctor.FreeM.roll t k
+
 instance (spec : OracleSpec ι) : Monad (OracleComp spec) :=
   inferInstanceAs (Monad (PFunctor.FreeM spec.toPFunctor))
 
@@ -70,6 +80,41 @@ protected lemma pure_def (x : α) :
 
 protected lemma bind_def (oa : OracleComp spec α) (ob : α → OracleComp spec β) :
     oa >>= ob = PFunctor.FreeM.bind oa ob := rfl
+
+/-- Cases eliminator on `OracleComp` exposing the high-level `pure` /
+`queryBind` alternatives. Registered as the default `cases` eliminator so that
+`cases oa with | pure x => ... | queryBind t k => ...` works transparently on
+top of the free-monad substrate. -/
+@[elab_as_elim, cases_eliminator]
+def casesOn {α} {motive : OracleComp spec α → Sort*}
+    (oa : OracleComp spec α)
+    (pure : (x : α) → motive (PFunctor.FreeM.pure x : OracleComp spec α))
+    (queryBind : (t : spec.Domain) →
+      (k : spec.Range t → OracleComp spec α) →
+      motive (OracleComp.queryBind (spec := spec) t k)) :
+    motive oa :=
+  match oa with
+  | .pure x => pure x
+  | .queryBind t k => queryBind t k
+
+/-- Structural recursion eliminator on `OracleComp` exposing the high-level
+`pure` / `queryBind` alternatives, with an induction hypothesis on every
+continuation in the `queryBind` case. Registered as the default `induction`
+eliminator so that
+`induction oa with | pure x => ... | queryBind t k ih => ...`
+works transparently on top of the free-monad substrate. -/
+@[elab_as_elim, induction_eliminator]
+def recOn {α} {motive : OracleComp spec α → Sort*}
+    (oa : OracleComp spec α)
+    (pure : (x : α) → motive (PFunctor.FreeM.pure x : OracleComp spec α))
+    (queryBind : (t : spec.Domain) →
+      (k : spec.Range t → OracleComp spec α) →
+      ((u : spec.Range t) → motive (k u)) →
+      motive (OracleComp.queryBind (spec := spec) t k)) :
+    motive oa :=
+  match oa with
+  | .pure x => pure x
+  | .queryBind t k => queryBind t k (fun u => recOn (k u) pure queryBind)
 
 protected lemma failure_def : (failure : OptionT (OracleComp spec) α) = OptionT.fail := rfl
 
@@ -188,8 +233,8 @@ variable (x : α) (y : β) (t : spec.Domain) (u : spec.Range t)
 
 /-- Returns `true` for computations that don't query any oracles or fail, else `false`. -/
 def isPure {α : Type _} : OracleComp spec α → Bool
-  | PFunctor.FreeM.pure _ => true
-  | PFunctor.FreeM.roll _ _ => false
+  | .pure _ => true
+  | .queryBind _ _ => false
 
 @[simp] lemma isPure_pure : isPure (pure x : OracleComp spec α) = true := rfl
 @[simp] lemma isPure_query : isPure (query t : OracleComp spec _) = false := rfl


### PR DESCRIPTION
## Summary
- add `Interface.port` / `Interface.message` accessors and switch `Interface.lean` signatures and docs to the interaction-facing names
- add `OracleComp.queryBind` as a `@[match_pattern]` alias and register `casesOn` / `recOn` so `pure` / `queryBind` work directly in matches and induction

## Test plan
- [x] `lake update`
- [x] `lake exe cache get`
- [x] `lake build` (succeeds; existing unrelated `sorry` warnings remain)

Posted by Cursor assistant (model: GPT-5.4) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)