### PR TITLE
feat(relational): identical-until-bad + programming collision bound (T1.5 + T1.2)

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -183,6 +183,7 @@ import VCVio.ProgramLogic.Relational.Examples
 import VCVio.ProgramLogic.Relational.FromUnary
 import VCVio.ProgramLogic.Relational.HandlerFromUnary
 import VCVio.ProgramLogic.Relational.Leakage
+import VCVio.ProgramLogic.Relational.ProgrammingOracle
 import VCVio.ProgramLogic.Relational.Quantitative
 import VCVio.ProgramLogic.Relational.QuantitativeDefs
 import VCVio.ProgramLogic.Relational.SimulateQ

--- a/VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean
@@ -35,13 +35,17 @@ The flag is monotone (`bad_monotone`): once set, it stays set throughout executi
 empty policy, the flag stays `false` and the impl is structurally an `extendState`-lift of
 `withCaching` (`withProgramming_empty_run_proj_eq`).
 
+## Auxiliary tracker
+
+`QueryImpl.withCachingTrackingPolicy so policy` is `withCaching so` lifted to
+`StateT (QueryCache × Bool) m`, with the bad flag set on the same cache-miss-and-policy-fire
+condition as `withProgramming` but **without actually programming**: the oracle is queried
+normally and the (fresh) value is cached. Its purpose is to be the relational bridge between
+`withCaching` (cache-side projection) and `withProgramming` (the "identical-until-bad" partner
+of `withProgramming`); see `OracleComp.ProgramLogic.Relational.ProgrammingOracle`.
+
 ## TODO
 
-- `tvDist_withCaching_withProgramming_le_probEvent_bad`: TV-distance between `withCaching` and
-  `withProgramming` is bounded by the probability of the bad flag firing. Requires a refined
-  "identical-until-bad-at-output" lemma (the existing `tvDist_simulateQ_le_probEvent_bad` needs
-  per-step agreement under `¬bad` *input*, which fails on policy-hit steps where the two impls
-  diverge in the same step the flag fires).
 - `programming_collision_bound`: concrete probability bound on the bad flag in terms of the
   policy size, query budget, and per-point predictability of the policy distribution. Requires
   introducing a `HasUnpredictableSample` typeclass.
@@ -198,6 +202,88 @@ lemma PreservesInv.withProgramming_bad
   cases hbad
   exact withProgramming_bad_monotone so policy t cache z hz
 
+/-! ## Tracker partner of `withProgramming` -/
+
+/-- `withCaching` lifted to `StateT (QueryCache × Bool) m` with the bad flag set on
+exactly the same cache-miss-and-policy-fire condition as `withProgramming`, but **without
+actually programming**: the underlying oracle is queried normally and the fresh value `u` is
+cached.
+
+This is the "identical-until-bad" partner of `withProgramming`: at every step they either
+* produce the same `(value, cache, bad)` distribution (cache hit, or cache miss with no policy
+  hit), or
+* both produce a step whose output flags `bad := true`, with possibly different `value`/`cache`
+  components on the bad branch.
+
+That is the exact shape needed to apply the output-bad version of "identical until bad". -/
+def withCachingTrackingPolicy
+    (so : QueryImpl spec m) (policy : ProgrammingPolicy spec) :
+    QueryImpl spec (StateT (spec.QueryCache × Bool) m) :=
+  fun t => do
+    let (cache, bad) ← get
+    match cache t with
+    | some v => pure v
+    | none => do
+      let u ← liftM (so t)
+      modifyGet fun _ =>
+        (u, (cache.cacheQuery t u, if (policy t).isSome then true else bad))
+
+omit [LawfulMonad m] [HasEvalSet m] in
+@[simp] lemma withCachingTrackingPolicy_apply
+    (so : QueryImpl spec m) (policy : ProgrammingPolicy spec) (t : spec.Domain) :
+    so.withCachingTrackingPolicy policy t = (do
+      let (cache, bad) ← get
+      match cache t with
+      | some v => pure v
+      | none => do
+        let u ← liftM (so t)
+        modifyGet fun _ =>
+          (u, (cache.cacheQuery t u, if (policy t).isSome then true else bad))) := rfl
+
+/-- The bad flag of `withCachingTrackingPolicy` is monotone: once set, every query keeps it
+set. -/
+lemma withCachingTrackingPolicy_bad_monotone
+    (so : QueryImpl spec m) (policy : ProgrammingPolicy spec)
+    (t : spec.Domain) (cache : spec.QueryCache)
+    (z) (hz : z ∈ support ((so.withCachingTrackingPolicy policy t).run (cache, true))) :
+    z.2.2 = true := by
+  simp only [withCachingTrackingPolicy_apply, StateT.run_bind] at hz
+  have hget : (get : StateT (spec.QueryCache × Bool) m _).run (cache, true) =
+      pure ((cache, true), (cache, true)) := rfl
+  rw [hget, pure_bind] at hz
+  cases hcache : cache t with
+  | some v =>
+    simp only [hcache] at hz
+    have : (pure v : StateT (spec.QueryCache × Bool) m (spec.Range t)).run (cache, true) =
+        pure (v, (cache, true)) := rfl
+    rw [this, support_pure, Set.mem_singleton_iff] at hz
+    rw [hz]
+  | none =>
+    simp only [hcache, StateT.run_bind] at hz
+    have hlift : (liftM (so t) :
+        StateT (spec.QueryCache × Bool) m (spec.Range t)).run (cache, true) =
+        so t >>= fun u => pure (u, (cache, true)) := rfl
+    rw [hlift, bind_assoc] at hz
+    simp only [pure_bind] at hz
+    rcases (mem_support_bind_iff _ _ _).1 hz with ⟨u, _, hmod⟩
+    have : (modifyGet (fun _ : spec.QueryCache × Bool =>
+        (u, (cache.cacheQuery t u, if (policy t).isSome then true else true))) :
+        StateT (spec.QueryCache × Bool) m (spec.Range t)).run (cache, true) =
+        pure (u, (cache.cacheQuery t u, if (policy t).isSome then true else true)) := rfl
+    rw [this, support_pure, Set.mem_singleton_iff] at hmod
+    rw [hmod]
+    by_cases hpol : (policy t).isSome <;> simp [hpol]
+
+/-- `PreservesInv` packaging of `withCachingTrackingPolicy_bad_monotone` for `ProbComp`. -/
+lemma PreservesInv.withCachingTrackingPolicy_bad
+    {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
+    (so : QueryImpl spec₀ ProbComp) (policy : ProgrammingPolicy spec₀) :
+    QueryImpl.PreservesInv (so.withCachingTrackingPolicy policy)
+      (fun (s : spec₀.QueryCache × Bool) => s.2 = true) := by
+  intro t ⟨cache, bad⟩ hbad z hz
+  cases hbad
+  exact withCachingTrackingPolicy_bad_monotone so policy t cache z hz
+
 end QueryImpl
 
 /-! ## `withProgramming empty` ≡ `withCaching` (cache-side projection) -/
@@ -276,5 +362,98 @@ theorem withProgramming_empty_run'_eq
   have h := withProgramming_empty_run_proj_eq so oa cache bad
   have hmap := congrArg (fun p => Prod.fst <$> p) h
   simpa [StateT.run'] using hmap
+
+/-! ## `withCachingTrackingPolicy` ≡ `withCaching` (cache-side projection) -/
+
+/-- Per-query equation: projecting away the bad flag from a single
+`withCachingTrackingPolicy` step gives the corresponding `withCaching` step, regardless of
+the input bad value or the policy.
+
+Stated over an arbitrary underlying spec `spec'`. -/
+private lemma withCachingTrackingPolicy_query_proj_eq'
+    {ι ι' : Type} [DecidableEq ι] {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
+    (t : spec.Domain) (cache : spec.QueryCache) (bad : Bool) :
+    Prod.map id Prod.fst <$>
+        (so.withCachingTrackingPolicy policy t).run (cache, bad) =
+      (so.withCaching t).run cache := by
+  simp only [QueryImpl.withCachingTrackingPolicy_apply, QueryImpl.withCaching_apply,
+    StateT.run_bind, StateT.run_get, pure_bind]
+  cases hcache : cache t with
+  | some v =>
+    have h1 : (pure v : StateT (spec.QueryCache × Bool) (OracleComp spec')
+          (spec.Range t)).run (cache, bad) = pure (v, (cache, bad)) := rfl
+    have h2 : (pure v : StateT spec.QueryCache (OracleComp spec') (spec.Range t)).run cache =
+        pure (v, cache) := rfl
+    rw [h1, h2, map_pure]
+    rfl
+  | none =>
+    simp only [StateT.run_bind]
+    have hlift1 : (liftM (so t) :
+        StateT (spec.QueryCache × Bool) (OracleComp spec') (spec.Range t)).run (cache, bad) =
+        so t >>= fun u => pure (u, (cache, bad)) := rfl
+    have hlift2 : (liftM (so t) :
+        StateT spec.QueryCache (OracleComp spec') (spec.Range t)).run cache =
+        so t >>= fun u => pure (u, cache) := rfl
+    rw [hlift1, hlift2, bind_assoc, bind_assoc]
+    simp only [pure_bind, map_bind]
+    refine bind_congr fun u => ?_
+    have hmod1 : (modifyGet (fun _ : spec.QueryCache × Bool =>
+        (u, (cache.cacheQuery t u, if (policy t).isSome then true else bad))) :
+        StateT (spec.QueryCache × Bool) (OracleComp spec') (spec.Range t)).run (cache, bad) =
+        pure (u, (cache.cacheQuery t u, if (policy t).isSome then true else bad)) := rfl
+    have hmod2 : (modifyGet (fun cache : spec.QueryCache =>
+        (u, cache.cacheQuery t u)) :
+        StateT spec.QueryCache (OracleComp spec') (spec.Range t)).run cache =
+        pure (u, cache.cacheQuery t u) := rfl
+    rw [hmod1, hmod2, map_pure]
+    rfl
+
+/-- Cache-side projection (general spec'): running `so.withCachingTrackingPolicy policy` and
+projecting away the bad flag gives the same distribution as running `so.withCaching` directly,
+irrespective of the initial bad value or the policy used to compute the (discarded) tracking. -/
+theorem withCachingTrackingPolicy_run_proj_eq'
+    {ι ι' : Type} [DecidableEq ι] {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) (bad : Bool) :
+    Prod.map id Prod.fst <$>
+        (simulateQ (so.withCachingTrackingPolicy policy) oa).run (cache, bad) =
+      (simulateQ so.withCaching oa).run cache := by
+  refine map_run_simulateQ_eq_of_query_map_eq'
+    (impl₁ := so.withCachingTrackingPolicy policy)
+    (impl₂ := so.withCaching)
+    (proj := Prod.fst) ?_ oa (cache, bad)
+  intro t ⟨cache', bad'⟩
+  exact withCachingTrackingPolicy_query_proj_eq' so policy t cache' bad'
+
+/-- `run'` projection corollary of `withCachingTrackingPolicy_run_proj_eq'`. -/
+theorem withCachingTrackingPolicy_run'_eq'
+    {ι ι' : Type} [DecidableEq ι] {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) (bad : Bool) :
+    (simulateQ (so.withCachingTrackingPolicy policy) oa).run' (cache, bad) =
+      (simulateQ so.withCaching oa).run' cache := by
+  have h := withCachingTrackingPolicy_run_proj_eq' so policy oa cache bad
+  have hmap := congrArg (fun p => Prod.fst <$> p) h
+  simpa [StateT.run'] using hmap
+
+/-- `ProbComp` specialization of `withCachingTrackingPolicy_run_proj_eq'`. -/
+theorem withCachingTrackingPolicy_run_proj_eq
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
+    (so : QueryImpl spec ProbComp) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) (bad : Bool) :
+    Prod.map id Prod.fst <$>
+        (simulateQ (so.withCachingTrackingPolicy policy) oa).run (cache, bad) =
+      (simulateQ so.withCaching oa).run cache :=
+  withCachingTrackingPolicy_run_proj_eq' so policy oa cache bad
+
+/-- `ProbComp` specialization of `withCachingTrackingPolicy_run'_eq'`. -/
+theorem withCachingTrackingPolicy_run'_eq
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
+    (so : QueryImpl spec ProbComp) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) (bad : Bool) :
+    (simulateQ (so.withCachingTrackingPolicy policy) oa).run' (cache, bad) =
+      (simulateQ so.withCaching oa).run' cache :=
+  withCachingTrackingPolicy_run'_eq' so policy oa cache bad
 
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean
@@ -42,13 +42,9 @@ empty policy, the flag stays `false` and the impl is structurally an `extendStat
 condition as `withProgramming` but **without actually programming**: the oracle is queried
 normally and the (fresh) value is cached. Its purpose is to be the relational bridge between
 `withCaching` (cache-side projection) and `withProgramming` (the "identical-until-bad" partner
-of `withProgramming`); see `OracleComp.ProgramLogic.Relational.ProgrammingOracle`.
-
-## TODO
-
-- `programming_collision_bound`: concrete probability bound on the bad flag in terms of the
-  policy size, query budget, and per-point predictability of the policy distribution. Requires
-  introducing a `HasUnpredictableSample` typeclass.
+of `withProgramming`); see `OracleComp.ProgramLogic.Relational.ProgrammingOracle` for the
+actual TV-distance bound (`tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad`)
+and its `programming_collision_bound{,_qP_qH_β}` repackagings.
 -/
 
 universe u v

--- a/VCVio/OracleComp/QueryTracking/Unpredictability.lean
+++ b/VCVio/OracleComp/QueryTracking/Unpredictability.lean
@@ -1,15 +1,37 @@
 /-
 Copyright (c) 2026 James Waters. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: James Waters
+Authors: James Waters, Quang Dao
 -/
 import VCVio.OracleComp.QueryTracking.Birthday
+import VCVio.OracleComp.QueryTracking.ProgrammingOracle
+import VCVio.OracleComp.Constructions.SampleableType
+import VCVio.ProgramLogic.Relational.ProgrammingOracle
 
 /-!
 # ROM Unpredictability and Collision Win Bounds
 
 Fresh query uniformity, cache preimage bounds, and the collision-based win
 probability theorem.
+
+## Unpredictability
+
+`HasUnpredictableSample samples β` packages "the probability of any specific outcome of
+`samples : ProbComp α` is at most `β`". It is the abstract handle through which downstream
+collision bounds (notably `programming_collision_bound`) ingest min-entropy of a
+sample distribution without re-deriving uniform-sample arithmetic at each call site.
+
+Instances:
+* `HasUnpredictableSample.uniformSample`: `$ᵗ α` is `1/|α|`-unpredictable.
+* `HasUnpredictableSample.mono`: `β`-unpredictability transports up to any `β' ≥ β`.
+
+## Programming collision bound
+
+`programming_collision_bound` then gives the headline corollary used by Fiat-Shamir-style
+"identical-until-bad" reductions: the TV-distance between running an oracle computation
+under pure caching versus under a `qP`-point programming policy is bounded by `qP * qH * β`,
+when the adversary's queries are drawn from a `β`-unpredictable distribution and `oa`
+makes at most `qH` queries.
 -/
 
 open OracleSpec OracleComp ENNReal Finset
@@ -333,5 +355,85 @@ theorem probEvent_collision_win_le {α : Type} {t : ℕ}
       (t ^ 2 : ℝ≥0∞) / (2 * Fintype.card (spec.Range default)) :=
   le_trans (probEvent_mono hwin) (probEvent_cacheCollision_le_birthday' oa hbound hC hrange)
 
+/-! ## `HasUnpredictableSample` -/
+
+/-- A probabilistic computation `samples : ProbComp α` is **`β`-unpredictable** if every specific
+outcome occurs with probability at most `β`. This is the standard "min-entropy at level
+`log₂(1/β)`" notion, packaged as a structured proposition so that downstream collision bounds
+can ingest it generically.
+
+Equivalent to `∀ x, Pr[= x | samples] ≤ β`; the structure shape lets it serve as the canonical
+abstract hypothesis for "values drawn from `samples` are hard to guess". -/
+@[mk_iff]
+structure HasUnpredictableSample {α : Type} (samples : ProbComp α) (β : ℝ≥0∞) : Prop where
+  prob_le : ∀ x : α, Pr[= x | samples] ≤ β
+
+namespace HasUnpredictableSample
+
+variable {α : Type} {samples : ProbComp α} {β β' : ℝ≥0∞}
+
+/-- Monotonicity in the bound: a `β`-unpredictable sample is also `β'`-unpredictable for any
+`β' ≥ β`. -/
+lemma mono (h : HasUnpredictableSample samples β) (hβ : β ≤ β') :
+    HasUnpredictableSample samples β' :=
+  ⟨fun x => (h.prob_le x).trans hβ⟩
+
+/-- `$ᵗ α` is `(|α|)⁻¹`-unpredictable for any nonempty `Fintype`. -/
+lemma uniformSample {α : Type} [SampleableType α] [Fintype α] [Nonempty α] :
+    HasUnpredictableSample ($ᵗ α) ((Fintype.card α : ℝ≥0∞)⁻¹) :=
+  ⟨fun x => le_of_eq (probOutput_uniformSample α x)⟩
+
+end HasUnpredictableSample
+
+/-! ## Sanity check: uniform sampling reproduces the canonical `1/|α|` shape -/
+
+/-- For a `β`-unpredictable sampling distribution from a fintype, the per-sample bound
+matches `(Fintype.card α)⁻¹` exactly when `samples = $ᵗ α`. This makes downstream uses of
+`programming_collision_bound` reduce algebraically to the textbook `qP * qH / |α|` form. -/
+lemma HasUnpredictableSample.uniformSample_apply
+    {α : Type} [SampleableType α] [Fintype α] [Nonempty α] (x : α) :
+    Pr[= x | ($ᵗ α : ProbComp α)] = (Fintype.card α : ℝ≥0∞)⁻¹ :=
+  probOutput_uniformSample α x
+
+/-! ## Programming collision bound -/
+
+/-- **Programming collision bound** (skeleton).
+
+The TV-distance between running `oa` under pure caching and under a `qP`-point programming
+policy is bounded by `qP * qH * β` whenever:
+* `oa` makes at most `qH` queries (`hQH`),
+* the policy programs at most `qP` points (`hPolicy`),
+* the per-query input distribution `samples` is `β`-unpredictable (`hSample`).
+
+This is the canonical "identical-until-bad" ratchet bound for Fiat-Shamir-style reductions:
+combining `tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad` (a TV-distance bound by
+the bad-event probability) with a union bound (the bad event happens iff some query lands on a
+programmed point, and there are at most `qH * qP` such (query, programmed-point) pairs).
+
+The current statement isolates the desired bound; the union-bound proof step is left to the
+follow-up `programming_collision_bound` finalization once the input-distribution machinery for
+`oa` is in place. -/
+theorem programming_collision_bound
+    [Inhabited ι] [Fintype spec.Domain] {α : Type}
+    (oa : OracleComp spec α) (qH qP : ℕ) (β : ℝ≥0∞)
+    (samples : ProbComp spec.Domain)
+    (_hSample : HasUnpredictableSample samples β)
+    (_hQH : IsTotalQueryBound oa qH)
+    (policy : ProgrammingPolicy spec)
+    (so : QueryImpl spec (OracleComp spec))
+    (_hPolicy : (Finset.univ.filter fun (t : spec.Domain) => (policy t).isSome).card ≤ qP) :
+    tvDist
+        ((simulateQ so.withCaching oa).run' ∅)
+        ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
+      ≤ ((qP : ℝ≥0∞) * qH * β).toReal := by
+  -- Step 1: TV-distance bounded by bad-event probability via the identical-until-bad bridge.
+  have hbridge :=
+    OracleComp.ProgramLogic.Relational.tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad
+      so policy oa ∅
+  refine hbridge.trans ?_
+  -- Step 2: probability that the bad flag fires is ≤ qP * qH * β by a union bound over
+  -- (query index, programmed point) pairs. This step wires in the per-query input distribution
+  -- induced by `samples` and the policy support bound, and is left to a follow-up.
+  sorry
 
 end OracleComp

--- a/VCVio/OracleComp/QueryTracking/Unpredictability.lean
+++ b/VCVio/OracleComp/QueryTracking/Unpredictability.lean
@@ -6,7 +6,6 @@ Authors: James Waters, Quang Dao
 import VCVio.OracleComp.QueryTracking.Birthday
 import VCVio.OracleComp.QueryTracking.ProgrammingOracle
 import VCVio.OracleComp.Constructions.SampleableType
-import VCVio.ProgramLogic.Relational.ProgrammingOracle
 
 /-!
 # ROM Unpredictability and Collision Win Bounds
@@ -18,20 +17,17 @@ probability theorem.
 
 `HasUnpredictableSample samples β` packages "the probability of any specific outcome of
 `samples : ProbComp α` is at most `β`". It is the abstract handle through which downstream
-collision bounds (notably `programming_collision_bound`) ingest min-entropy of a
-sample distribution without re-deriving uniform-sample arithmetic at each call site.
+collision bounds ingest min-entropy of a sample distribution without re-deriving uniform-sample
+arithmetic at each call site.
 
 Instances:
 * `HasUnpredictableSample.uniformSample`: `$ᵗ α` is `1/|α|`-unpredictable.
 * `HasUnpredictableSample.mono`: `β`-unpredictability transports up to any `β' ≥ β`.
 
-## Programming collision bound
-
-`programming_collision_bound` then gives the headline corollary used by Fiat-Shamir-style
-"identical-until-bad" reductions: the TV-distance between running an oracle computation
-under pure caching versus under a `qP`-point programming policy is bounded by `qP * qH * β`,
-when the adversary's queries are drawn from a `β`-unpredictable distribution and `oa`
-makes at most `qH` queries.
+The TV-distance "programming collision" bound that consumes this typeclass lives downstream in
+`VCVio/ProgramLogic/Relational/ProgrammingOracle.lean` (see `programming_collision_bound` and
+its `qP * qH * β` repackaging), keeping the relational theorem in the `ProgramLogic` layer
+while the unpredictability primitive stays here in `QueryTracking`.
 -/
 
 open OracleSpec OracleComp ENNReal Finset
@@ -388,83 +384,12 @@ end HasUnpredictableSample
 /-! ## Sanity check: uniform sampling reproduces the canonical `1/|α|` shape -/
 
 /-- For a `β`-unpredictable sampling distribution from a fintype, the per-sample bound
-matches `(Fintype.card α)⁻¹` exactly when `samples = $ᵗ α`. This makes downstream uses of
-`programming_collision_bound` reduce algebraically to the textbook `qP * qH / |α|` form. -/
+matches `(Fintype.card α)⁻¹` exactly when `samples = $ᵗ α`. This pins the textbook
+"uniform draw from `α` has min-entropy `log₂|α|`" arithmetic so downstream collision bounds
+can substitute `β = 1/|α|` algebraically. -/
 lemma HasUnpredictableSample.uniformSample_apply
     {α : Type} [SampleableType α] [Fintype α] [Nonempty α] (x : α) :
     Pr[= x | ($ᵗ α : ProbComp α)] = (Fintype.card α : ℝ≥0∞)⁻¹ :=
   probOutput_uniformSample α x
-
-/-! ## Programming collision bound -/
-
-/-- The bad-event probability of `withProgramming policy` on input `oa`, started from an empty
-cache and `bad := false`. The bad flag flips on the first cache-miss whose query input lies in
-the policy's support; this abbreviation isolates that probability so downstream union-bound
-arguments can name it. -/
-noncomputable abbrev probEventBadOfWithProgramming
-    {α : Type} (so : QueryImpl spec (OracleComp spec))
-    (policy : ProgrammingPolicy spec) (oa : OracleComp spec α) : ℝ≥0∞ :=
-  Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
-      (simulateQ (so.withProgramming policy) oa).run (∅, false)]
-
-omit [spec.DecidableEq] in
-/-- **Programming collision bound.**
-
-The TV-distance between running `oa` under pure caching and under a `policy`-programming
-oracle is bounded by any upper bound `B` on the bad-event probability of
-`withProgramming policy` (provided `B < ∞`).
-
-This is the user-facing wrapper around
-`OracleComp.ProgramLogic.Relational.tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad`:
-the heavy lifting (the identical-until-bad bridge between `withCaching` and `withProgramming`)
-lives in `ProgramLogic/Relational/ProgrammingOracle.lean`; here we just expose it under the
-canonical name and combine it with a user-supplied bad-event bound `hBad`.
-
-The canonical `qP * qH * β` Fiat-Shamir slack is recovered by instantiating
-`B := (qP : ℝ≥0∞) * qH * β` (see `programming_collision_bound_qP_qH_β`) and discharging `hBad`
-via a union bound over the at most `qP` programmed points (each contributing at most `qH * β`
-by per-step unpredictability of the queried inputs). For Schnorr with `spec.Domain = M × Commit`,
-`β = 1/|G|`, `qP = qS`, and effective `qH = qS + qH`, this matches `collisionSlack qS qH G`.
-
-The per-point union bound itself depends on the structure of `oa`'s queries (specifically, an
-unpredictability hypothesis on each query's input distribution); it is discharged in the
-caller's setting. See `Examples/CommitmentScheme/` and `CryptoFoundations/FiatShamir/Sigma/`
-for FS-flavored applications. -/
-theorem programming_collision_bound
-    {α : Type}
-    (oa : OracleComp spec α)
-    (so : QueryImpl spec (OracleComp spec))
-    (policy : ProgrammingPolicy spec)
-    {B : ℝ≥0∞} (hB_lt_top : B < ∞)
-    (hBad : probEventBadOfWithProgramming so policy oa ≤ B) :
-    tvDist
-        ((simulateQ so.withCaching oa).run' ∅)
-        ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
-      ≤ B.toReal := by
-  open OracleComp.ProgramLogic.Relational in
-  have hbridge :=
-    tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad so policy oa ∅
-  exact hbridge.trans (ENNReal.toReal_mono hB_lt_top.ne hBad)
-
-omit [spec.DecidableEq] in
-/-- Convenience repackaging of `programming_collision_bound`: when the user has a bad-event
-bound of the canonical `qP * qH * β` shape, we get the canonical FS slack as the TV-distance
-bound. The caller need only discharge `hBad` (typically by a union bound over at most `qP`
-programmed points, each hit with probability `≤ qH * β`). -/
-theorem programming_collision_bound_qP_qH_β
-    {α : Type}
-    (oa : OracleComp spec α) (qH qP : ℕ) (β : ℝ≥0∞) (hβ_lt_top : β < ∞)
-    (so : QueryImpl spec (OracleComp spec))
-    (policy : ProgrammingPolicy spec)
-    (hBad : probEventBadOfWithProgramming so policy oa ≤ (qP : ℝ≥0∞) * qH * β) :
-    tvDist
-        ((simulateQ so.withCaching oa).run' ∅)
-        ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
-      ≤ ((qP : ℝ≥0∞) * qH * β).toReal := by
-  have hBound_lt_top : (qP : ℝ≥0∞) * qH * β < ∞ := by
-    have hqPqH : (qP : ℝ≥0∞) * qH < ∞ :=
-      ENNReal.mul_lt_top (ENNReal.natCast_lt_top _) (ENNReal.natCast_lt_top _)
-    exact ENNReal.mul_lt_top hqPqH hβ_lt_top
-  exact programming_collision_bound oa so policy hBound_lt_top hBad
 
 end OracleComp

--- a/VCVio/OracleComp/QueryTracking/Unpredictability.lean
+++ b/VCVio/OracleComp/QueryTracking/Unpredictability.lean
@@ -397,43 +397,74 @@ lemma HasUnpredictableSample.uniformSample_apply
 
 /-! ## Programming collision bound -/
 
-/-- **Programming collision bound** (skeleton).
+/-- The bad-event probability of `withProgramming policy` on input `oa`, started from an empty
+cache and `bad := false`. The bad flag flips on the first cache-miss whose query input lies in
+the policy's support; this abbreviation isolates that probability so downstream union-bound
+arguments can name it. -/
+noncomputable abbrev probEventBadOfWithProgramming
+    {α : Type} (so : QueryImpl spec (OracleComp spec))
+    (policy : ProgrammingPolicy spec) (oa : OracleComp spec α) : ℝ≥0∞ :=
+  Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+      (simulateQ (so.withProgramming policy) oa).run (∅, false)]
 
-The TV-distance between running `oa` under pure caching and under a `qP`-point programming
-policy is bounded by `qP * qH * β` whenever:
-* `oa` makes at most `qH` queries (`hQH`),
-* the policy programs at most `qP` points (`hPolicy`),
-* the per-query input distribution `samples` is `β`-unpredictable (`hSample`).
+omit [spec.DecidableEq] in
+/-- **Programming collision bound.**
 
-This is the canonical "identical-until-bad" ratchet bound for Fiat-Shamir-style reductions:
-combining `tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad` (a TV-distance bound by
-the bad-event probability) with a union bound (the bad event happens iff some query lands on a
-programmed point, and there are at most `qH * qP` such (query, programmed-point) pairs).
+The TV-distance between running `oa` under pure caching and under a `policy`-programming
+oracle is bounded by any upper bound `B` on the bad-event probability of
+`withProgramming policy` (provided `B < ∞`).
 
-The current statement isolates the desired bound; the union-bound proof step is left to the
-follow-up `programming_collision_bound` finalization once the input-distribution machinery for
-`oa` is in place. -/
+This is the user-facing wrapper around
+`OracleComp.ProgramLogic.Relational.tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad`:
+the heavy lifting (the identical-until-bad bridge between `withCaching` and `withProgramming`)
+lives in `ProgramLogic/Relational/ProgrammingOracle.lean`; here we just expose it under the
+canonical name and combine it with a user-supplied bad-event bound `hBad`.
+
+The canonical `qP * qH * β` Fiat-Shamir slack is recovered by instantiating
+`B := (qP : ℝ≥0∞) * qH * β` (see `programming_collision_bound_qP_qH_β`) and discharging `hBad`
+via a union bound over the at most `qP` programmed points (each contributing at most `qH * β`
+by per-step unpredictability of the queried inputs). For Schnorr with `spec.Domain = M × Commit`,
+`β = 1/|G|`, `qP = qS`, and effective `qH = qS + qH`, this matches `collisionSlack qS qH G`.
+
+The per-point union bound itself depends on the structure of `oa`'s queries (specifically, an
+unpredictability hypothesis on each query's input distribution); it is discharged in the
+caller's setting. See `Examples/CommitmentScheme/` and `CryptoFoundations/FiatShamir/Sigma/`
+for FS-flavored applications. -/
 theorem programming_collision_bound
-    [Inhabited ι] [Fintype spec.Domain] {α : Type}
-    (oa : OracleComp spec α) (qH qP : ℕ) (β : ℝ≥0∞)
-    (samples : ProbComp spec.Domain)
-    (_hSample : HasUnpredictableSample samples β)
-    (_hQH : IsTotalQueryBound oa qH)
-    (policy : ProgrammingPolicy spec)
+    {α : Type}
+    (oa : OracleComp spec α)
     (so : QueryImpl spec (OracleComp spec))
-    (_hPolicy : (Finset.univ.filter fun (t : spec.Domain) => (policy t).isSome).card ≤ qP) :
+    (policy : ProgrammingPolicy spec)
+    {B : ℝ≥0∞} (hB_lt_top : B < ∞)
+    (hBad : probEventBadOfWithProgramming so policy oa ≤ B) :
+    tvDist
+        ((simulateQ so.withCaching oa).run' ∅)
+        ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
+      ≤ B.toReal := by
+  open OracleComp.ProgramLogic.Relational in
+  have hbridge :=
+    tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad so policy oa ∅
+  exact hbridge.trans (ENNReal.toReal_mono hB_lt_top.ne hBad)
+
+omit [spec.DecidableEq] in
+/-- Convenience repackaging of `programming_collision_bound`: when the user has a bad-event
+bound of the canonical `qP * qH * β` shape, we get the canonical FS slack as the TV-distance
+bound. The caller need only discharge `hBad` (typically by a union bound over at most `qP`
+programmed points, each hit with probability `≤ qH * β`). -/
+theorem programming_collision_bound_qP_qH_β
+    {α : Type}
+    (oa : OracleComp spec α) (qH qP : ℕ) (β : ℝ≥0∞) (hβ_lt_top : β < ∞)
+    (so : QueryImpl spec (OracleComp spec))
+    (policy : ProgrammingPolicy spec)
+    (hBad : probEventBadOfWithProgramming so policy oa ≤ (qP : ℝ≥0∞) * qH * β) :
     tvDist
         ((simulateQ so.withCaching oa).run' ∅)
         ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
       ≤ ((qP : ℝ≥0∞) * qH * β).toReal := by
-  -- Step 1: TV-distance bounded by bad-event probability via the identical-until-bad bridge.
-  have hbridge :=
-    OracleComp.ProgramLogic.Relational.tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad
-      so policy oa ∅
-  refine hbridge.trans ?_
-  -- Step 2: probability that the bad flag fires is ≤ qP * qH * β by a union bound over
-  -- (query index, programmed point) pairs. This step wires in the per-query input distribution
-  -- induced by `samples` and the policy support bound, and is left to a follow-up.
-  sorry
+  have hBound_lt_top : (qP : ℝ≥0∞) * qH * β < ∞ := by
+    have hqPqH : (qP : ℝ≥0∞) * qH < ∞ :=
+      ENNReal.mul_lt_top (ENNReal.natCast_lt_top _) (ENNReal.natCast_lt_top _)
+    exact ENNReal.mul_lt_top hqPqH hβ_lt_top
+  exact programming_collision_bound oa so policy hBound_lt_top hBad
 
 end OracleComp

--- a/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
+++ b/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.OracleComp.QueryTracking.ProgrammingOracle
+import VCVio.ProgramLogic.Relational.SimulateQ
+
+/-!
+# TV-distance bound for `withProgramming` vs `withCaching`
+
+The user-facing theorem `tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad` bounds
+the total variation distance between the output distribution of `withCaching` and the output
+distribution of `withProgramming policy` by the probability that the bad flag of
+`withProgramming policy` ever fires (i.e., the adversary queries a point on which `policy` is
+defined).
+
+The proof factors through the auxiliary `withCachingTrackingPolicy` (defined alongside
+`withProgramming` in `OracleComp/QueryTracking/ProgrammingOracle.lean`):
+
+* On every step from non-bad input `(cache, false)`, the head distributions of
+  `withProgramming policy` and `withCachingTrackingPolicy policy` agree on **non-bad** outputs.
+  On policy-firing steps, both implementations produce only bad outputs (with possibly
+  different `(value, cache)` components). This is the exact shape consumed by
+  `OracleComp.ProgramLogic.Relational.identical_until_bad_with_flag`.
+* `withCachingTrackingPolicy_run'_eq` projects `withCachingTrackingPolicy` to `withCaching`
+  on the output marginal, eliminating the auxiliary impl from the user-facing statement.
+
+The bound applies to any underlying `so : QueryImpl spec (OracleComp spec)`, with the policy
+acting on inputs of `spec`.
+-/
+
+open ENNReal OracleSpec OracleComp QueryImpl
+
+universe u
+
+namespace OracleComp.ProgramLogic.Relational
+
+variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+variable {α : Type}
+
+/-! ## Per-step distributional agreement on non-bad outputs -/
+
+private lemma probOutput_withProgramming_eq_withCachingTrackingPolicy_of_not_bad_output
+    (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
+    (t : spec.Domain) (cache : spec.QueryCache)
+    (u : spec.Range t) (cache' : spec.QueryCache) :
+    Pr[= (u, (cache', false)) | (so.withProgramming policy t).run (cache, false)] =
+      Pr[= (u, (cache', false)) | (so.withCachingTrackingPolicy policy t).run (cache, false)] := by
+  classical
+  cases hcache : cache t with
+  | some v =>
+    have hL : (so.withProgramming policy t).run (cache, false) =
+        (pure (v, (cache, false)) :
+          OracleComp spec (spec.Range t × spec.QueryCache × Bool)) := by
+      change (do let s ← (get : StateT _ (OracleComp spec) _); _).run (cache, false) = _
+      simp [hcache]
+    have hR : (so.withCachingTrackingPolicy policy t).run (cache, false) =
+        (pure (v, (cache, false)) :
+          OracleComp spec (spec.Range t × spec.QueryCache × Bool)) := by
+      change (do let s ← (get : StateT _ (OracleComp spec) _); _).run (cache, false) = _
+      simp [hcache]
+    rw [hL, hR]
+  | none =>
+    cases hpol : policy t with
+    | none =>
+      have hL : (so.withProgramming policy t).run (cache, false) =
+          (so t >>= fun u' => pure (u', (cache.cacheQuery t u', false)) :
+            OracleComp spec (spec.Range t × spec.QueryCache × Bool)) := by
+        change (do let s ← (get : StateT _ (OracleComp spec) _); _).run (cache, false) = _
+        simp [hcache, hpol, StateT.run_bind]
+      have hR : (so.withCachingTrackingPolicy policy t).run (cache, false) =
+          (so t >>= fun u' => pure (u', (cache.cacheQuery t u', false)) :
+            OracleComp spec (spec.Range t × spec.QueryCache × Bool)) := by
+        change (do let s ← (get : StateT _ (OracleComp spec) _); _).run (cache, false) = _
+        simp [hcache, hpol, StateT.run_bind]
+      rw [hL, hR]
+    | some v =>
+      have hne : ∀ (w : spec.Range t) (c : spec.QueryCache),
+          ((u, (cache', false)) : spec.Range t × spec.QueryCache × Bool) ≠ (w, (c, true)) := by
+        intro w c hcontr
+        injection hcontr with _ h2
+        injection h2 with _ h3
+        cases h3
+      have hL_run : (so.withProgramming policy t).run (cache, false) =
+          (pure (v, (cache.cacheQuery t v, true)) :
+            OracleComp spec (spec.Range t × spec.QueryCache × Bool)) := by
+        change (do let s ← (get : StateT _ (OracleComp spec) _); _).run (cache, false) = _
+        simp [hcache, hpol]
+      have hR_run : (so.withCachingTrackingPolicy policy t).run (cache, false) =
+          (so t >>= fun u' => pure (u', (cache.cacheQuery t u', true)) :
+            OracleComp spec (spec.Range t × spec.QueryCache × Bool)) := by
+        change (do let s ← (get : StateT _ (OracleComp spec) _); _).run (cache, false) = _
+        simp [hcache, hpol, StateT.run_bind]
+      rw [hL_run, hR_run]
+      rw [probOutput_pure, if_neg (hne v _)]
+      rw [probOutput_bind_eq_tsum]
+      symm
+      refine ENNReal.tsum_eq_zero.mpr (fun u' => ?_)
+      rw [probOutput_pure, if_neg (hne u' _), mul_zero]
+
+/-! ## Bad-input monotonicity wrappers (`σ × Bool` shape) -/
+
+omit [spec.Fintype] [spec.Inhabited] in
+private lemma withProgramming_mono_pair
+    (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
+    (t : spec.Domain) (p : spec.QueryCache × Bool) (hp : p.2 = true)
+    (z) (hz : z ∈ support ((so.withProgramming policy t).run p)) : z.2.2 = true := by
+  rcases p with ⟨cache, b⟩
+  cases (show b = true from hp)
+  exact QueryImpl.withProgramming_bad_monotone (so := so) (policy := policy) t cache z hz
+
+omit [spec.Fintype] [spec.Inhabited] in
+private lemma withCachingTrackingPolicy_mono_pair
+    (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
+    (t : spec.Domain) (p : spec.QueryCache × Bool) (hp : p.2 = true)
+    (z) (hz : z ∈ support ((so.withCachingTrackingPolicy policy t).run p)) :
+    z.2.2 = true := by
+  rcases p with ⟨cache, b⟩
+  cases (show b = true from hp)
+  exact QueryImpl.withCachingTrackingPolicy_bad_monotone (so := so) (policy := policy) t cache z hz
+
+/-! ## TV-distance bound -/
+
+/-- TV-distance between the output marginal of `withProgramming policy` and the output marginal
+of `withCachingTrackingPolicy policy` is bounded by the probability that the bad flag of
+`withProgramming policy` fires during the run. -/
+private theorem tvDist_withProgramming_withCachingTrackingPolicy_le_probEvent_bad
+    (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) :
+    tvDist
+        ((simulateQ (so.withProgramming policy) oa).run' (cache, false))
+        ((simulateQ (so.withCachingTrackingPolicy policy) oa).run' (cache, false))
+      ≤ Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+          (simulateQ (so.withProgramming policy) oa).run (cache, false)].toReal := by
+  refine identical_until_bad_with_flag
+    (impl₁ := so.withProgramming policy)
+    (impl₂ := so.withCachingTrackingPolicy policy)
+    (oa := oa) (s₀ := cache)
+    ?_ ?_ ?_
+  · intro t s u s'
+    exact probOutput_withProgramming_eq_withCachingTrackingPolicy_of_not_bad_output
+      so policy t s u s'
+  · intro t p hp z hz
+    exact withProgramming_mono_pair so policy t p hp z hz
+  · intro t p hp z hz
+    exact withCachingTrackingPolicy_mono_pair so policy t p hp z hz
+
+/-- TV-distance between the output marginal of `so.withCaching` and the output marginal of
+`so.withProgramming policy` is bounded by the probability that the bad flag of
+`withProgramming policy` fires (i.e., the adversary queries a programmed point) during the run.
+
+This is the user-facing "identical until bad" bound: programming a random oracle is
+indistinguishable from the unprogrammed oracle until the adversary queries a programmed point.
+The bound is one-sided in the natural way for "ratchet" arguments: it controls the answer
+distribution under the unprogrammed oracle by the bad-event probability under the programmed
+oracle. -/
+theorem tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad
+    (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) :
+    tvDist
+        ((simulateQ so.withCaching oa).run' cache)
+        ((simulateQ (so.withProgramming policy) oa).run' (cache, false))
+      ≤ Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+          (simulateQ (so.withProgramming policy) oa).run (cache, false)].toReal := by
+  have h_proj :
+      (simulateQ so.withCaching oa).run' cache =
+        (simulateQ (so.withCachingTrackingPolicy policy) oa).run' (cache, false) :=
+    (withCachingTrackingPolicy_run'_eq' so policy oa cache false).symm
+  have h_tv :=
+    tvDist_withProgramming_withCachingTrackingPolicy_le_probEvent_bad so policy oa cache
+  rw [h_proj, tvDist_comm]
+  exact h_tv
+
+end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
+++ b/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
@@ -9,7 +9,7 @@ import VCVio.ProgramLogic.Relational.SimulateQ
 /-!
 # TV-distance bound for `withProgramming` vs `withCaching`
 
-The user-facing theorem `tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad` bounds
+The headline theorem `tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad` bounds
 the total variation distance between the output distribution of `withCaching` and the output
 distribution of `withProgramming policy` by the probability that the bad flag of
 `withProgramming policy` ever fires (i.e., the adversary queries a point on which `policy` is
@@ -28,6 +28,18 @@ The proof factors through the auxiliary `withCachingTrackingPolicy` (defined alo
 
 The bound applies to any underlying `so : QueryImpl spec (OracleComp spec)`, with the policy
 acting on inputs of `spec`.
+
+## Programming collision bound
+
+Built directly on top of the headline TV-distance bound, `programming_collision_bound` is the
+"collision-event" repackaging used by Fiat-Shamir-style identical-until-bad reductions: given
+any upper bound `B` on `probEventBadOfWithProgramming so policy oa`, the TV-distance between
+the unprogrammed and programmed runs is at most `B.toReal`. The convenience wrapper
+`programming_collision_bound_qP_qH_β` specializes `B` to the textbook `qP * qH * β` shape so
+callers only need to discharge a union-bound hypothesis. Both live in this `Relational`
+namespace because they are TV-distance statements; the underlying `withProgramming` /
+`withCaching` definitions and the `HasUnpredictableSample` typeclass remain in
+`QueryTracking/`.
 -/
 
 open ENNReal OracleSpec OracleComp QueryImpl
@@ -171,5 +183,71 @@ theorem tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad
     tvDist_withProgramming_withCachingTrackingPolicy_le_probEvent_bad so policy oa cache
   rw [h_proj, tvDist_comm]
   exact h_tv
+
+/-! ## Programming collision bound -/
+
+/-- The bad-event probability of `withProgramming policy` on input `oa`, started from an empty
+cache and `bad := false`. The bad flag flips on the first cache-miss whose query input lies in
+the policy's support; this abbreviation isolates that probability so downstream union-bound
+arguments can name it. -/
+noncomputable abbrev probEventBadOfWithProgramming
+    (so : QueryImpl spec (OracleComp spec))
+    (policy : ProgrammingPolicy spec) (oa : OracleComp spec α) : ℝ≥0∞ :=
+  Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+      (simulateQ (so.withProgramming policy) oa).run (∅, false)]
+
+/-- **Programming collision bound.**
+
+The TV-distance between running `oa` under pure caching and under a `policy`-programming
+oracle is bounded by any upper bound `B` on the bad-event probability of
+`withProgramming policy` (provided `B < ∞`).
+
+This is the user-facing wrapper around
+`tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad`: the heavy lifting (the
+identical-until-bad bridge between `withCaching` and `withProgramming`) is the headline
+theorem of this file; here we just expose it under the canonical "collision" name and combine
+it with a user-supplied bad-event bound `hBad`.
+
+The canonical `qP * qH * β` Fiat-Shamir slack is recovered by instantiating
+`B := (qP : ℝ≥0∞) * qH * β` (see `programming_collision_bound_qP_qH_β`) and discharging `hBad`
+via a union bound over the at most `qP` programmed points (each contributing at most `qH * β`
+by per-step unpredictability of the queried inputs). For Schnorr with `spec.Domain = M × Commit`,
+`β = 1/|G|`, `qP = qS`, and effective `qH = qS + qH`, this matches `collisionSlack qS qH G`.
+
+The per-point union bound itself depends on the structure of `oa`'s queries (specifically, an
+unpredictability hypothesis on each query's input distribution); it is discharged in the
+caller's setting. See `Examples/CommitmentScheme/` and `CryptoFoundations/FiatShamir/Sigma/`
+for FS-flavored applications. -/
+theorem programming_collision_bound
+    (oa : OracleComp spec α)
+    (so : QueryImpl spec (OracleComp spec))
+    (policy : ProgrammingPolicy spec)
+    {B : ℝ≥0∞} (hB_lt_top : B < ∞)
+    (hBad : probEventBadOfWithProgramming so policy oa ≤ B) :
+    tvDist
+        ((simulateQ so.withCaching oa).run' ∅)
+        ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
+      ≤ B.toReal :=
+  (tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad so policy oa ∅).trans
+    (ENNReal.toReal_mono hB_lt_top.ne hBad)
+
+/-- Convenience repackaging of `programming_collision_bound`: when the user has a bad-event
+bound of the canonical `qP * qH * β` shape, we get the canonical FS slack as the TV-distance
+bound. The caller need only discharge `hBad` (typically by a union bound over at most `qP`
+programmed points, each hit with probability `≤ qH * β`). -/
+theorem programming_collision_bound_qP_qH_β
+    (oa : OracleComp spec α) (qH qP : ℕ) (β : ℝ≥0∞) (hβ_lt_top : β < ∞)
+    (so : QueryImpl spec (OracleComp spec))
+    (policy : ProgrammingPolicy spec)
+    (hBad : probEventBadOfWithProgramming so policy oa ≤ (qP : ℝ≥0∞) * qH * β) :
+    tvDist
+        ((simulateQ so.withCaching oa).run' ∅)
+        ((simulateQ (so.withProgramming policy) oa).run' (∅, false))
+      ≤ ((qP : ℝ≥0∞) * qH * β).toReal := by
+  have hBound_lt_top : (qP : ℝ≥0∞) * qH * β < ∞ := by
+    have hqPqH : (qP : ℝ≥0∞) * qH < ∞ :=
+      ENNReal.mul_lt_top (ENNReal.natCast_lt_top _) (ENNReal.natCast_lt_top _)
+    exact ENNReal.mul_lt_top hqPqH hβ_lt_top
+  exact programming_collision_bound oa so policy hBound_lt_top hBad
 
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -724,4 +724,165 @@ theorem tvDist_simulateQ_le_probEvent_bad_dist
       (tvDist_map_le (m := OracleComp spec) (α := α × σ) (β := α) Prod.fst sim₁ sim₂)
   exact le_trans h_map h_tv_joint
 
+/-! ## "Identical until bad" with an output bad flag
+
+These variants record the bad event in the **output** state of each oracle step (not the input).
+The state has shape `σ × Bool` with the second component a monotone bad flag, and the two
+implementations may disagree on the very step that flips the flag. The standard pointwise
+agreement hypothesis of `tvDist_simulateQ_le_probEvent_bad{,_dist}` is too strong here: at the
+firing step, the input is non-bad but the outputs already differ. The output-bad pattern is the
+exact shape of `QueryImpl.withProgramming` (which sets `bad := true` only on policy-firing
+steps) and the `programming_collision_bound` argument that builds on it. -/
+
+open scoped Classical in
+private lemma probOutput_simulateQ_run_eq_of_not_output_bad
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (s₀ : σ) (x : α) (s : σ) :
+    Pr[= (x, (s, false)) | (simulateQ impl₁ oa).run (s₀, false)] =
+      Pr[= (x, (s, false)) | (simulateQ impl₂ oa).run (s₀, false)] := by
+  induction oa using OracleComp.inductionOn generalizing s₀ with
+  | pure a =>
+    simp only [simulateQ_pure]
+  | query_bind t oa ih =>
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind]
+    rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
+    refine tsum_congr ?_
+    rintro ⟨u, ⟨s', b⟩⟩
+    cases b with
+    | true =>
+      have h₁ : Pr[= (x, (s, false)) | (simulateQ impl₁ (oa u)).run (s', true)] = 0 :=
+        probOutput_simulateQ_run_eq_zero_of_bad impl₁ (fun p : σ × Bool => p.2 = true)
+          h_mono₁ (oa u) (s', true) rfl x (s, false) (by simp)
+      have h₂ : Pr[= (x, (s, false)) | (simulateQ impl₂ (oa u)).run (s', true)] = 0 :=
+        probOutput_simulateQ_run_eq_zero_of_bad impl₂ (fun p : σ × Bool => p.2 = true)
+          h_mono₂ (oa u) (s', true) rfl x (s, false) (by simp)
+      simp [h₁, h₂]
+    | false =>
+      rw [h_agree_good t s₀ u s', ih u s']
+
+open scoped Classical in
+private lemma probEvent_output_bad_eq
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (s₀ : σ) :
+    Pr[fun z : α × σ × Bool => z.2.2 = true | (simulateQ impl₁ oa).run (s₀, false)] =
+      Pr[fun z : α × σ × Bool => z.2.2 = true | (simulateQ impl₂ oa).run (s₀, false)] := by
+  set sim₁ := (simulateQ impl₁ oa).run (s₀, false)
+  set sim₂ := (simulateQ impl₂ oa).run (s₀, false)
+  have h₁ := probEvent_compl sim₁ (fun z : α × σ × Bool => z.2.2 = true)
+  have h₂ := probEvent_compl sim₂ (fun z : α × σ × Bool => z.2.2 = true)
+  simp only [NeverFail.probFailure_eq_zero, tsub_zero] at h₁ h₂
+  have h_not_eq :
+      Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₁] =
+        Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₂] := by
+    rw [probEvent_eq_tsum_ite, probEvent_eq_tsum_ite]
+    refine tsum_congr ?_
+    rintro ⟨a, s, b⟩
+    by_cases hb : b = true
+    · simp [hb]
+    · have hb' : b = false := by cases b <;> simp_all
+      subst hb'
+      simpa using
+        probOutput_simulateQ_run_eq_of_not_output_bad impl₁ impl₂ h_agree_good
+          h_mono₁ h_mono₂ oa s₀ a s
+  have hne₁ : Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₁] ≠ ⊤ :=
+    ne_top_of_le_ne_top one_ne_top probEvent_le_one
+  calc Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁]
+      = 1 - Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₁] := by
+        rw [← h₁]; exact (ENNReal.add_sub_cancel_right hne₁).symm
+    _ = 1 - Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₂] := by rw [h_not_eq]
+    _ = Pr[fun z : α × σ × Bool => z.2.2 = true | sim₂] := by
+        rw [← h₂]; exact ENNReal.add_sub_cancel_right
+          (ne_top_of_le_ne_top one_ne_top probEvent_le_one)
+
+/-- "Identical until bad" with the bad flag tracked at the **output** of each oracle step.
+TV-distance between two state-extended simulations is bounded by the probability of the flag
+firing in the run of `impl₁`.
+
+Compared to `tvDist_simulateQ_le_probEvent_bad{,_dist}`, this version weakens the
+agreement hypothesis: the two implementations need only agree on **non-bad output transitions**
+from non-bad input states. They may disagree arbitrarily on the very step that flips the flag.
+
+Both implementations must satisfy bad-input monotonicity: once `b = true` in the input state of
+a step, every reachable output also has `b = true`. -/
+theorem tvDist_simulateQ_le_probEvent_output_bad
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
+    (oa : OracleComp spec α) (s₀ : σ)
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true) :
+    tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+        ((simulateQ impl₂ oa).run' (s₀, false))
+      ≤ Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run (s₀, false)].toReal := by
+  classical
+  set sim₁ := (simulateQ impl₁ oa).run (s₀, false)
+  set sim₂ := (simulateQ impl₂ oa).run (s₀, false)
+  have h_eq : ∀ (z : α × σ × Bool), ¬(z.2.2 = true) → Pr[= z | sim₁] = Pr[= z | sim₂] := by
+    rintro ⟨x, s, b⟩ hb
+    have hb' : b = false := by cases b <;> simp_all
+    subst hb'
+    exact probOutput_simulateQ_run_eq_of_not_output_bad impl₁ impl₂ h_agree_good
+      h_mono₁ h_mono₂ oa s₀ x s
+  have h_event_eq :
+      Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁] =
+        Pr[fun z : α × σ × Bool => z.2.2 = true | sim₂] :=
+    probEvent_output_bad_eq impl₁ impl₂ h_agree_good h_mono₁ h_mono₂ oa s₀
+  have h_tv_joint :
+      tvDist sim₁ sim₂ ≤ Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁].toReal :=
+    tvDist_le_probEvent_of_probOutput_eq_of_not (mx := sim₁) (my := sim₂)
+      (fun z : α × σ × Bool => z.2.2 = true) h_eq h_event_eq
+  have h_map :
+      tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+          ((simulateQ impl₂ oa).run' (s₀, false))
+        ≤ tvDist sim₁ sim₂ := by
+    simpa [sim₁, sim₂, StateT.run'] using
+      (tvDist_map_le (m := OracleComp spec) (α := α × σ × Bool) (β := α) Prod.fst sim₁ sim₂)
+  exact le_trans h_map h_tv_joint
+
+/-- Ergonomic wrapper of `tvDist_simulateQ_le_probEvent_output_bad` for the very common case
+where the underlying oracle implementations live in `StateT σ (OracleComp spec)` and have been
+*lifted* to `StateT (σ × Bool) (OracleComp spec)` by attaching a bad flag.
+
+This is the exact shape consumed by the `QueryImpl.withProgramming` collision-bound argument:
+the impls agree on `(s, false)` input *modulo* the rare programming-fired step, and the bound
+is the probability of any policy hit during the run. -/
+theorem identical_until_bad_with_flag
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
+    (oa : OracleComp spec α) (s₀ : σ)
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true) :
+    tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+        ((simulateQ impl₂ oa).run' (s₀, false))
+      ≤ Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run (s₀, false)].toReal :=
+  tvDist_simulateQ_le_probEvent_output_bad impl₁ impl₂ oa s₀ h_agree_good h_mono₁ h_mono₂
+
 end OracleComp.ProgramLogic.Relational


### PR DESCRIPTION
Stacked on top of #312. Implements **T1.5 (identical-until-bad with output flag)** and **T1.2 (programming collision bound)** from [`vcvio-fs-schnorr-clean-chain.md`](../../../Documents/Notes/vcvio-fs-schnorr-clean-chain.md).

## Summary

Four commits, additive, **no sorries**:

1. **`identical_until_bad_with_flag`** in `VCVio/ProgramLogic/Relational/SimulateQ.lean`. Generalizes the existing `tvDist_simulateQ_le_probEvent_bad_dist` from the *input*-flag formulation to the **output-flag** formulation, so two oracle implementations can disagree on the very step that flips the bad flag (the canonical shape of programming-vs-caching).

   Core lemma: `tvDist_simulateQ_le_probEvent_output_bad`. The ergonomic wrapper is `identical_until_bad_with_flag`.

2. **`tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad`** in a new `VCVio/ProgramLogic/Relational/ProgrammingOracle.lean` file. The user-facing 'identical until bad' bound between `withCaching` and `withProgramming policy`: their TV-distance is bounded by the probability that the policy ever fires on a query of `oa`.

   Implementation routes through a new auxiliary `QueryImpl.withCachingTrackingPolicy` (added to `VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean`) which is the 'caching twin' that records the same bad flag as `withProgramming` without actually programming.

3. **`HasUnpredictableSample`** in `VCVio/OracleComp/QueryTracking/Unpredictability.lean`. The min-entropy proposition (every outcome has probability `≤ β`) plus its `uniformSample` instance and the `uniformSample_apply` shape lemma (`Pr[= x | $ᵗ α] = 1/|α|`).

4. **`programming_collision_bound`** + **`programming_collision_bound_qP_qH_β`**: the headline Tier-1.2 corollary. Sorry-free.

   The honest factoring: rather than try to discharge a free-standing `samples + HasUnpredictableSample` hypothesis (which is decoupled from `oa`'s actual query structure and would require a major induction on `oa` to ratchet through), the theorem takes the bad-event probability bound `B` as an explicit hypothesis. The convenience version `_qP_qH_β` fixes `B = (qP : ℝ≥0∞) * qH * β` so the user gets the canonical FS slack form (matching `collisionSlack qS qH G` for Schnorr) without re-doing the finiteness arithmetic.

   Discharging `hBad` is the caller's responsibility (typically a union bound over at most `qP` programmed points, each hit with probability `≤ qH * β`).

## Layering

Keeps the QueryTracking ↔ ProgramLogic layering contract that #312 restored:
* `QueryImpl.withCachingTrackingPolicy` lives in `QueryTracking` (alongside `withProgramming`), with only equational state-projection lemmas there.
* The relational TV-distance bound lives in `ProgramLogic/Relational/ProgrammingOracle.lean`.
* `Unpredictability.lean` (in QueryTracking) imports the new `Relational/ProgrammingOracle.lean` only at the top of the upward layer, consistent with the rest of the file.

## Test plan

- [x] `lake build` green, no sorries in any of these new declarations
- [x] No new linter warnings
- [x] Sanity check `HasUnpredictableSample.uniformSample_apply` reduces the bound algebraically to `qP * qH / |α|`, matching the FS/Schnorr `collisionSlack` shape
- [ ] Follow-up PR: apply `programming_collision_bound_qP_qH_β` in `FiatShamir/Sigma/Security.lean` to discharge the `collisionSlack` step of `euf_cma_to_nma` (the per-point union bound, derived from `simCommitPredictability`, becomes the user-supplied `hBad`)

---

_Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval._