### PR TITLE
refactor(interaction): polynomial substrate bridges (S3+S4+S5+S6)

### DIFF
--- a/VCVio/Interaction/Basic/Decoration.lean
+++ b/VCVio/Interaction/Basic/Decoration.lean
@@ -58,6 +58,33 @@ schemas: `Spec.Decoration.Schema.View` is the staged telescope view of a
 decoration by `S.toContext`, and `Spec.Decoration.Schema.equivView`
 identifies that staged view with an ordinary decoration of the realized
 context.
+
+## Polynomial substrate (`DecoratedSpec`)
+
+Just as `Spec` is `PFunctor.FreeM Spec.basePFunctor PUnit`, the bundle
+`(spec, Decoration Γ spec)` is `PFunctor.FreeM (Γ.toPFunctor) PUnit`:
+
+```
+DecoratedSpec Γ := PFunctor.FreeM (Γ.toPFunctor) PUnit
+```
+
+`Γ.toPFunctor` is the polynomial whose positions are `Σ X : Type u, Γ X`
+and whose child family is `Sigma.fst`. A free term over this polynomial is
+literally a tree where every internal node carries both a move space `X`
+and a `Γ`-value, with continuations indexed by the move type.
+
+Forgetting the `Γ`-component on positions yields a polynomial lens
+`Γ.toPFunctor → Spec.basePFunctor`, whose lift to free monads is the
+shape-forgetful map `DecoratedSpec.shape : DecoratedSpec Γ → Spec`. The
+fiber of `shape` over a fixed `spec : Spec` is exactly `Decoration Γ spec`,
+formalized as `decoratedSpecEquiv : DecoratedSpec Γ ≃ Σ spec, Decoration Γ spec`.
+
+This makes precise the slogan "a `Γ`-decorated spec is the same data as a
+spec together with a `Γ`-decoration on it". Downstream code can use either
+view: the `Spec`-indexed `Decoration` family is convenient for talking
+about decorations *over a fixed protocol*, while `DecoratedSpec` is the
+right object when shape and metadata vary together (e.g. for the polynomial
+coalgebraic semantics of `ProcessOver`).
 -/
 
 universe u v w w₂
@@ -314,6 +341,99 @@ def Decoration.equivOver {Γ : Node.Context.{u, v}} (A : ∀ X, Γ X → Type w)
   intro x
   cases x with
   | mk d r => exact Decoration.toOver_ofOver A spec d r
+
+/-! ## Polynomial substrate `DecoratedSpec`
+
+A `DecoratedSpec Γ` is the free term of the polynomial `Γ.toPFunctor` at the
+unit payload: a tree where every internal node carries both its move space
+`X` and a `Γ`-value of type `Γ X`, with continuations indexed by `X`.
+
+This is the polynomial substrate that justifies the `Spec`-indexed family
+`Decoration Γ spec`: forgetting the `Γ`-component on positions yields a
+polynomial lens `Γ.toPFunctor → Spec.basePFunctor` whose lift to free
+monads gives `DecoratedSpec.shape`. The fiber of `shape` over a fixed
+`spec` is exactly `Decoration Γ spec`, witnessed by `decoratedSpecEquiv`. -/
+
+/-- A `Γ`-decorated interaction spec, viewed polynomially.
+
+This is the free monad on `Γ.toPFunctor` at the unit payload. Equivalently
+(by `decoratedSpecEquiv`), it bundles a tree shape `spec : Spec` together
+with a `Decoration Γ spec` on it. -/
+def DecoratedSpec (Γ : Node.Context.{u, v}) : Type (max (u+1) v) :=
+  PFunctor.FreeM Γ.toPFunctor PUnit.{u+1}
+
+namespace DecoratedSpec
+
+variable {Γ : Node.Context.{u, v}}
+
+/-- Forget the `Γ`-component on every position, leaving only the underlying
+tree shape. This is the lift to free monads of the polynomial lens
+`Γ.toPFunctor → Spec.basePFunctor` whose position map is `Sigma.fst` and
+whose child map is the identity. -/
+def shape : DecoratedSpec Γ → Spec.{u}
+  | .pure _ => Spec.done
+  | .roll ⟨X, _⟩ rest => Spec.node X (fun x => DecoratedSpec.shape (rest x))
+
+/-- Read off the per-node `Γ`-decoration of a decorated spec, indexed by
+the spec's underlying `shape`. Together with `shape`, this exhibits the
+fiberwise structure of `DecoratedSpec Γ` over `Spec`. -/
+def decoration : (ds : DecoratedSpec Γ) → Decoration Γ (DecoratedSpec.shape ds)
+  | .pure _ => PUnit.unit
+  | .roll ⟨_, γ⟩ rest => ⟨γ, fun x => DecoratedSpec.decoration (rest x)⟩
+
+/-- Pack a tree shape together with a `Γ`-decoration on it into a single
+decorated spec. Inverse to the pair `(shape, decoration)`. -/
+def mk : (spec : Spec.{u}) → Decoration Γ spec → DecoratedSpec Γ
+  | .done, _ => PFunctor.FreeM.pure PUnit.unit
+  | .node X rest, ⟨γ, dRest⟩ =>
+      PFunctor.FreeM.roll ⟨X, γ⟩ (fun x => DecoratedSpec.mk (rest x) (dRest x))
+
+@[simp]
+theorem shape_mk : (spec : Spec.{u}) → (d : Decoration Γ spec) →
+    DecoratedSpec.shape (DecoratedSpec.mk spec d) = spec
+  | .done, _ => rfl
+  | .node X rest, ⟨_, dRest⟩ => by
+    change Spec.node X (fun x => DecoratedSpec.shape (DecoratedSpec.mk (rest x) (dRest x))) =
+      Spec.node X rest
+    exact congr_arg (Spec.node X) (funext fun x => shape_mk (rest x) (dRest x))
+
+theorem decoration_mk : (spec : Spec.{u}) → (d : Decoration Γ spec) →
+    DecoratedSpec.decoration (DecoratedSpec.mk spec d) ≍ d
+  | .done, ⟨⟩ => HEq.rfl
+  | .node X rest, ⟨γ, dRest⟩ => by
+    change ((γ, fun x => DecoratedSpec.decoration (DecoratedSpec.mk (rest x) (dRest x))) :
+        Γ X × (∀ x, Decoration Γ
+          (DecoratedSpec.shape (DecoratedSpec.mk (rest x) (dRest x))))) ≍
+      ((γ, dRest) : Γ X × (∀ x, Decoration Γ (rest x)))
+    refine prod_mk_heq ?_
+    refine Function.hfunext rfl ?_
+    intro x y hxy
+    cases hxy
+    exact decoration_mk (rest x) (dRest x)
+
+@[simp]
+theorem mk_shape_decoration : (ds : DecoratedSpec Γ) →
+    DecoratedSpec.mk (DecoratedSpec.shape ds) (DecoratedSpec.decoration ds) = ds
+  | .pure _ => rfl
+  | .roll ⟨X, γ⟩ rest => by
+    refine congr_arg (PFunctor.FreeM.roll (P := Γ.toPFunctor) ⟨X, γ⟩) ?_
+    funext x
+    exact mk_shape_decoration (rest x)
+
+end DecoratedSpec
+
+/-- The polynomial substrate equivalence: a `Γ`-decorated spec is the same
+data as a tree shape together with a `Γ`-decoration on it.
+
+This is the `Spec`-indexed fiberwise view of `DecoratedSpec Γ`. The forward
+direction takes `(shape, decoration)`; the backward direction is `mk`. -/
+def decoratedSpecEquiv {Γ : Node.Context.{u, v}} :
+    DecoratedSpec Γ ≃ Σ spec : Spec.{u}, Decoration Γ spec where
+  toFun ds := ⟨DecoratedSpec.shape ds, DecoratedSpec.decoration ds⟩
+  invFun p := DecoratedSpec.mk p.1 p.2
+  left_inv ds := DecoratedSpec.mk_shape_decoration ds
+  right_inv p :=
+    Sigma.ext (DecoratedSpec.shape_mk p.1 p.2) (DecoratedSpec.decoration_mk p.1 p.2)
 
 namespace Decoration
 namespace Schema

--- a/VCVio/Interaction/Basic/Node.lean
+++ b/VCVio/Interaction/Basic/Node.lean
@@ -152,6 +152,81 @@ def Context.extendMap
     ContextHom (Context.extend Γ A) (Context.extend Δ B) :=
   fun X ⟨γ, a⟩ => ⟨f X γ, g X γ a⟩
 
+/-! ## Non-dependent context product
+
+`Context.prod Γ Δ` is the non-dependent product of two realized node
+contexts: at each move space `X`, the value type is `Γ X × Δ X`. This is
+the polynomial product of `Γ` and `Δ` viewed as `(Type u → Type _)`-valued
+functors, and is the special case of `Context.extend` whose extension is
+constant in the base value.
+
+Use `Context.prod` when the two contexts carry independent per-node data
+(for example the closed-world `StepContext Party` and a boundary action
+context `BoundaryAction Δ`); use `Context.extend` when the second field
+genuinely depends on the first. -/
+
+/--
+The non-dependent product of two realized node contexts. At each move space
+`X`, the value type is `Γ X × Δ X`. -/
+def Context.prod (Γ : Type u → Type v) (Δ : Type u → Type w) :
+    Type u → Type (max v w) :=
+  fun X => Γ X × Δ X
+
+/-- First projection out of the non-dependent context product. -/
+def Context.prodFst (Γ : Type u → Type v) (Δ : Type u → Type w) :
+    ContextHom (Context.prod Γ Δ) Γ :=
+  fun _ p => p.1
+
+/-- Second projection out of the non-dependent context product. -/
+def Context.prodSnd (Γ : Type u → Type v) (Δ : Type u → Type w) :
+    ContextHom (Context.prod Γ Δ) Δ :=
+  fun _ p => p.2
+
+/--
+Pair two context morphisms into a single morphism into the product context.
+This is the universal property of the non-dependent context product. -/
+def Context.prodPair
+    {Γ : Type u → Type v} {Δ₁ : Type u → Type w} {Δ₂ : Type u → Type w₂}
+    (f : ContextHom Γ Δ₁) (g : ContextHom Γ Δ₂) :
+    ContextHom Γ (Context.prod Δ₁ Δ₂) :=
+  fun X x => (f X x, g X x)
+
+/--
+Map both factors of a non-dependent context product. -/
+def Context.prodMap
+    {Γ₁ : Type u → Type v} {Γ₂ : Type u → Type w}
+    {Δ₁ : Type u → Type w₂} {Δ₂ : Type u → Type w₃}
+    (f : ContextHom Γ₁ Δ₁) (g : ContextHom Γ₂ Δ₂) :
+    ContextHom (Context.prod Γ₁ Γ₂) (Context.prod Δ₁ Δ₂) :=
+  fun X p => (f X p.1, g X p.2)
+
+@[simp]
+theorem Context.prodMap_id {Γ : Context.{u, v}} {Δ : Context.{u, w}} :
+    Context.prodMap (ContextHom.id Γ) (ContextHom.id Δ) =
+      ContextHom.id (Context.prod Γ Δ) := by
+  funext X p
+  cases p
+  rfl
+
+theorem Context.prodMap_comp
+    {Γ₁ : Context.{u, v}} {Γ₂ : Context.{u, w}}
+    {Δ₁ : Context.{u, w₂}} {Δ₂ : Context.{u, w₃}}
+    {Λ₁ : Type u → Type _} {Λ₂ : Type u → Type _}
+    (g₁ : ContextHom Δ₁ Λ₁) (g₂ : ContextHom Δ₂ Λ₂)
+    (f₁ : ContextHom Γ₁ Δ₁) (f₂ : ContextHom Γ₂ Δ₂) :
+    ContextHom.comp (Context.prodMap g₁ g₂) (Context.prodMap f₁ f₂) =
+      Context.prodMap (ContextHom.comp g₁ f₁) (ContextHom.comp g₂ f₂) := by
+  funext X p
+  cases p
+  rfl
+
+/-
+Conceptually `Context.prod Γ Δ` is the constant-family case of
+`Context.extend`. The two are not definitionally equal as types because
+`Prod` and `Sigma` are distinct inductive types in Lean, so we keep
+`Context.prod` as its own primitive with `Prod`-shaped values to support
+the standard `(a, b)` pair syntax at construction sites. -/
+
 /--
 `Schema Γ` is a telescope whose realized node context is `Γ`.
 

--- a/VCVio/Interaction/Basic/Node.lean
+++ b/VCVio/Interaction/Basic/Node.lean
@@ -95,6 +95,27 @@ specializations.
 def Context.empty : Context := fun _ => PUnit
 
 /--
+The polynomial functor whose free monad realizes `Γ`-decorated specs.
+
+Positions are `Σ X : Type u, Γ X`: each node records both its move space
+`X` and a `Γ`-value at that node. The child family is `Sigma.fst`, so a
+continuation at position `⟨X, _⟩` is indexed by `X` itself, exactly as in
+`Spec.basePFunctor`. The forgetful projection `Sigma.fst : Σ X, Γ X → Type u`
+on positions (combined with the identity on children) is a `PFunctor.Lens`
+from `Γ.toPFunctor` to `Spec.basePFunctor`; its lift to free monads is the
+shape-forgetful map `DecoratedSpec.shape` in `Basic/Decoration.lean`.
+
+This is the polynomial substrate that justifies the `Spec`-indexed
+recursion of `Spec.Decoration`: a decorated spec is a free term of this
+polynomial, and the existing `Decoration Γ spec` is exactly its fiber
+over the underlying `spec : Spec`.
+-/
+@[reducible]
+def Context.toPFunctor (Γ : Context.{u, v}) : PFunctor.{max (u+1) v, u} where
+  A := Σ X : Type u, Γ X
+  B := Sigma.fst
+
+/--
 Extend a realized node context by one dependent field.
 
 If `Γ` is the current context and `A X γ` is a new field whose type may depend

--- a/VCVio/Interaction/Concurrent/Process.lean
+++ b/VCVio/Interaction/Concurrent/Process.lean
@@ -7,6 +7,7 @@ import VCVio.Interaction.Basic.Spec
 import VCVio.Interaction.Basic.Decoration
 import VCVio.Interaction.Multiparty.Core
 import ToMathlib.Control.Coalgebra
+import Mathlib.Data.PFunctor.Univariate.M
 
 /-!
 # Dynamic concurrent processes
@@ -480,6 +481,98 @@ structure System (Γ : Interaction.Spec.Node.Context.{w, w₂}) extends toProces
   assumptions : Proc → Prop := fun _ => True
   safe : Proc → Prop := fun _ => True
   inv : Proc → Prop := fun _ => True
+
+/-! ### Polynomial-coalgebra behavior
+
+`StepOver.toPFunctor Γ` (from S3) exhibits one episode of `Γ`-decorated
+interaction as a polynomial functor. Its terminal coalgebra is the M-type
+`PFunctor.M (StepOver.toPFunctor Γ)`: the type of all possibly-infinite
+trees of step protocols.
+
+Every `ProcessOver Γ` is canonically a coalgebra for this polynomial
+functor (`process.step` composed with the polynomial bridge `equivObj`),
+so the universal property of M-types gives a unique coalgebra
+homomorphism `behavior : process.Proc → M (StepOver.toPFunctor Γ)`. This
+function records, at each residual state, the observable infinite tree
+of step protocols obtained by repeatedly running `process.step`.
+
+The universal property is concretely the "bisimulation by uniqueness"
+principle: any candidate behavior function that respects the coalgebra
+structure must equal the canonical one. Equality of behavior trees is
+therefore the canonical observational equivalence on residual states,
+agreeing on the nose with any relational bisimulation witness one might
+construct via `Concurrent.Refinement.Bisimulation`. -/
+
+/-- The terminal coalgebra of `StepOver.toPFunctor Γ`: the type of
+possibly-infinite trees of `Γ`-decorated step protocols. Each such tree
+records one complete observable behavior of a `ProcessOver Γ` from a
+chosen seed state. -/
+abbrev Behavior (Γ : Interaction.Spec.Node.Context.{w, w₂}) :
+    Type (max (w + 1) w₂) :=
+  PFunctor.M (StepOver.toPFunctor Γ)
+
+/-- The unique coalgebra homomorphism from `process` into the terminal
+`StepOver.toPFunctor Γ`-coalgebra. Each residual state is mapped to its
+observable behavior tree. -/
+def behavior {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    (process : ProcessOver.{v, w, w₂} Γ) :
+    process.Proc → Behavior.{w, w₂} Γ :=
+  PFunctor.M.corec (fun p => StepOver.equivObj (process.step p))
+
+/-- The defining equation of `behavior`: destructing the behavior tree at a
+state recovers one step protocol from `process.step`, with each subtree
+obtained by applying `behavior` to the corresponding continuation. -/
+@[simp]
+theorem dest_behavior {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    (process : ProcessOver.{v, w, w₂} Γ) (p : process.Proc) :
+    PFunctor.M.dest (process.behavior p) =
+      (StepOver.toPFunctor Γ).map process.behavior
+        (StepOver.equivObj (process.step p)) :=
+  PFunctor.M.dest_corec _ _
+
+/-- **Bisimulation by uniqueness.** Any function `f : process.Proc → Behavior Γ`
+that commutes with the coalgebra structure (i.e., that satisfies the
+coalgebra-homomorphism diagram for the M-type) agrees with `process.behavior`
+on the nose. This is the universal property of `M (StepOver.toPFunctor Γ)`
+as the terminal `StepOver.toPFunctor Γ`-coalgebra. -/
+theorem behavior_unique {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    (process : ProcessOver.{v, w, w₂} Γ)
+    (f : process.Proc → Behavior.{w, w₂} Γ)
+    (hf : ∀ p, PFunctor.M.dest (f p) =
+      (StepOver.toPFunctor Γ).map f (StepOver.equivObj (process.step p))) :
+    f = process.behavior :=
+  PFunctor.M.corec_unique _ f hf
+
+/-- Two residual states (possibly in different processes over the same
+context) are **observationally equivalent** when their behavior trees are
+equal. By `behavior_unique`, this is the strongest equivalence preserved
+by every `StepOver Γ`-coalgebra homomorphism. -/
+def ObsEq {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    (process₁ process₂ : ProcessOver.{v, w, w₂} Γ)
+    (p₁ : process₁.Proc) (p₂ : process₂.Proc) : Prop :=
+  process₁.behavior p₁ = process₂.behavior p₂
+
+/-- Observational equivalence is reflexive (within a fixed process). -/
+@[refl]
+theorem ObsEq.refl {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    (process : ProcessOver.{v, w, w₂} Γ) (p : process.Proc) :
+    ObsEq process process p p := rfl
+
+/-- Observational equivalence is symmetric. -/
+@[symm]
+theorem ObsEq.symm {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    {process₁ process₂ : ProcessOver.{v, w, w₂} Γ}
+    {p₁ : process₁.Proc} {p₂ : process₂.Proc}
+    (h : ObsEq process₁ process₂ p₁ p₂) :
+    ObsEq process₂ process₁ p₂ p₁ := Eq.symm h
+
+/-- Observational equivalence is transitive. -/
+theorem ObsEq.trans {Γ : Interaction.Spec.Node.Context.{w, w₂}}
+    {process₁ process₂ process₃ : ProcessOver.{v, w, w₂} Γ}
+    {p₁ : process₁.Proc} {p₂ : process₂.Proc} {p₃ : process₃.Proc}
+    (h₁₂ : ObsEq process₁ process₂ p₁ p₂)
+    (h₂₃ : ObsEq process₂ process₃ p₂ p₃) :
+    ObsEq process₁ process₃ p₁ p₃ := Eq.trans h₁₂ h₂₃
 
 end ProcessOver
 

--- a/VCVio/Interaction/Concurrent/Process.lean
+++ b/VCVio/Interaction/Concurrent/Process.lean
@@ -102,6 +102,20 @@ request/response exchange treated as one logical concurrent transition.
 So `StepOver` is the right object when the concurrency layer should expose
 finite sequential structure inside each global step, rather than flattening
 everything into atomic transitions.
+
+## Polynomial reading
+
+`StepOver Γ P` is the application to `P` of the polynomial functor
+`StepOver.toPFunctor Γ` whose positions are `Γ`-decorated specs and whose
+directions over a position are transcripts of its underlying spec. The
+`Equiv` `StepOver.equivObj` exhibits this on the nose by regrouping the
+`(spec, semantics, next)` fields. The position type is itself equivalent to
+`Interaction.Spec.DecoratedSpec Γ` via `Interaction.Spec.decoratedSpecEquiv`,
+identifying `StepOver` as a polynomial substrate built directly on top of
+`Γ.toPFunctor`. The structure form is preserved as the working API because
+its named fields support clean `{ spec := ..., semantics := ..., next := ... }`
+construction at every call site, and projections such as `(mapContext f s).spec`
+are definitionally equal to `s.spec`.
 -/
 structure StepOver (Γ : Interaction.Spec.Node.Context.{w, w₂}) (P : Type v) where
   spec : Interaction.Spec.{w}
@@ -138,6 +152,63 @@ instance {Γ : Interaction.Spec.Node.Context.{w, w₂}} :
   id_map _ := rfl
   comp_map _ _ _ := rfl
   map_const := rfl
+
+namespace StepOver
+
+/-! ### Polynomial bridge
+
+`StepOver Γ P` is the application to `P` of the polynomial functor
+`StepOver.toPFunctor Γ` whose positions are `Γ`-decorated specs and whose
+direction family at each position is the type of complete transcripts of
+the underlying spec. The `Equiv` `StepOver.equivObj` regroups the
+`(spec, semantics, next)` fields into the polynomial form
+`(position, continuation)`; both roundtrips are definitionally `rfl`.
+
+The position type `Σ spec, Decoration Γ spec` is itself equivalent to
+`Interaction.Spec.DecoratedSpec Γ` via `Interaction.Spec.decoratedSpecEquiv`,
+which is the free monad on `Γ.toPFunctor` at the unit payload. This bridge
+identifies `StepOver` as a polynomial substrate sitting directly on top of
+`Γ.toPFunctor` while preserving the structure form's ergonomic call sites
+and definitional projection equalities. -/
+
+/-- The polynomial functor whose application to `P` is `StepOver Γ P`.
+
+A position is a `Γ`-decorated spec — a pair of an interaction shape
+`spec : Spec` and a `Decoration Γ spec` of per-node `Γ`-metadata on it.
+A direction over such a position is a complete transcript of `spec`.
+
+Up to `Interaction.Spec.decoratedSpecEquiv`, positions are exactly
+`Interaction.Spec.DecoratedSpec Γ`, the free term of `Γ.toPFunctor` at the
+unit payload. -/
+@[reducible]
+def toPFunctor (Γ : Interaction.Spec.Node.Context.{w, w₂}) :
+    PFunctor.{max (w+1) w₂, w} where
+  A := Σ spec : Interaction.Spec.{w}, Interaction.Spec.Decoration Γ spec
+  B := fun p => Interaction.Spec.Transcript p.1
+
+/-- `StepOver Γ P` is exactly `(StepOver.toPFunctor Γ).Obj P`, exhibiting
+the step-over structure as a polynomial application.
+
+The forward direction regroups the `(spec, semantics, next)` fields into
+the polynomial form `(position, continuation)`, and the inverse unpacks
+them again. Both roundtrips are definitionally `rfl`. -/
+@[simps]
+def equivObj {Γ : Interaction.Spec.Node.Context.{w, w₂}} {P : Type v} :
+    StepOver.{v, w, w₂} Γ P ≃ (StepOver.toPFunctor Γ).Obj P where
+  toFun s := ⟨⟨s.spec, s.semantics⟩, s.next⟩
+  invFun := fun ⟨⟨spec, semantics⟩, next⟩ => ⟨spec, semantics, next⟩
+  left_inv _ := rfl
+  right_inv := fun ⟨⟨_, _⟩, _⟩ => rfl
+
+/-- The position type of `StepOver.toPFunctor Γ` is the same data as a
+`Γ`-decorated spec, via `Interaction.Spec.decoratedSpecEquiv`. This is the
+bridge that identifies the `StepOver` polynomial as a substrate built on
+top of `Γ.toPFunctor`. -/
+def equivPositions (Γ : Interaction.Spec.Node.Context.{w, w₂}) :
+    (StepOver.toPFunctor Γ).A ≃ Interaction.Spec.DecoratedSpec Γ :=
+  Interaction.Spec.decoratedSpecEquiv.symm
+
+end StepOver
 
 /--
 `ProcessOver Γ` is a continuation-based concurrent process whose current step

--- a/VCVio/Interaction/UC/Computational.lean
+++ b/VCVio/Interaction/UC/Computational.lean
@@ -147,7 +147,7 @@ theorem mono {sem : Semantics T} {ε₁ ε₂ : ℝ} (hε : ε₁ ≤ ε₂)
 
 /-- Replacing the left component of a parallel composition preserves the
 computational emulation bound. -/
-theorem par_left [OpenTheory.CompactClosed T]
+theorem par_left [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε : ℝ}
     {Δ₁ Δ₂ : PortBoundary}
     {real₁ ideal₁ : T.Obj Δ₁}
@@ -160,7 +160,7 @@ theorem par_left [OpenTheory.CompactClosed T]
 
 /-- Replacing the right component of a parallel composition preserves the
 computational emulation bound. -/
-theorem par_right [OpenTheory.CompactClosed T]
+theorem par_right [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε : ℝ}
     {Δ₁ Δ₂ : PortBoundary}
     (W₁ : T.Obj Δ₁)
@@ -172,7 +172,7 @@ theorem par_right [OpenTheory.CompactClosed T]
     exact h₂ _
 
 /-- **Computational UC composition for `par`**: advantages add. -/
-theorem par_compose [OpenTheory.CompactClosed T]
+theorem par_compose [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε₁ ε₂ : ℝ}
     {Δ₁ Δ₂ : PortBoundary}
     {real₁ ideal₁ : T.Obj Δ₁} {real₂ ideal₂ : T.Obj Δ₂}
@@ -183,7 +183,7 @@ theorem par_compose [OpenTheory.CompactClosed T]
 
 /-- Replacing the left factor of a wiring preserves the computational
 emulation bound. -/
-theorem wire_left [OpenTheory.CompactClosed T]
+theorem wire_left [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε : ℝ}
     {Δ₁ Γ Δ₂ : PortBoundary}
     {real₁ ideal₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)}
@@ -196,7 +196,7 @@ theorem wire_left [OpenTheory.CompactClosed T]
 
 /-- Replacing the right factor of a wiring preserves the computational
 emulation bound. -/
-theorem wire_right [OpenTheory.CompactClosed T]
+theorem wire_right [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε : ℝ}
     {Δ₁ Γ Δ₂ : PortBoundary}
     (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ))
@@ -208,7 +208,7 @@ theorem wire_right [OpenTheory.CompactClosed T]
     exact h₂ _
 
 /-- **Computational UC composition for `wire`**: advantages add. -/
-theorem wire_compose [OpenTheory.CompactClosed T]
+theorem wire_compose [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε₁ ε₂ : ℝ}
     {Δ₁ Γ Δ₂ : PortBoundary}
     {real₁ ideal₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)}
@@ -221,7 +221,7 @@ theorem wire_compose [OpenTheory.CompactClosed T]
 /-- **Computational UC composition for `plug`**: when both the protocol
 and the environment emulate their ideals, the advantage of the closed
 real system vs. closed ideal system is bounded by the sum. -/
-theorem plug_compose [OpenTheory.CompactClosed T]
+theorem plug_compose [OpenTheory.HasPlugWireFactor T]
     {sem : Semantics T} {ε₁ ε₂ : ℝ}
     {Δ : PortBoundary}
     {real ideal : T.Obj Δ}
@@ -347,7 +347,7 @@ advantage is negligible, then the parallel composition also has negligible
 advantage. -/
 theorem AsympCompEmulates.par_compose
     {T : ℕ → OpenTheory.{u}} {sem : ∀ n, Semantics (T n)}
-    [∀ n, OpenTheory.CompactClosed (T n)]
+    [∀ n, OpenTheory.HasPlugWireFactor (T n)]
     {Δ₁ Δ₂ : PortBoundary}
     {real₁ ideal₁ : ∀ n, (T n).Obj Δ₁}
     {real₂ ideal₂ : ∀ n, (T n).Obj Δ₂}
@@ -373,7 +373,7 @@ advantage is negligible, then the wired composition also has negligible
 advantage. -/
 theorem AsympCompEmulates.wire_compose
     {T : ℕ → OpenTheory.{u}} {sem : ∀ n, Semantics (T n)}
-    [∀ n, OpenTheory.CompactClosed (T n)]
+    [∀ n, OpenTheory.HasPlugWireFactor (T n)]
     {Δ₁ Γ Δ₂ : PortBoundary}
     {real₁ ideal₁ : ∀ n, (T n).Obj (PortBoundary.tensor Δ₁ Γ)}
     {real₂ ideal₂ :
@@ -401,7 +401,7 @@ distinguishing advantage of the closed real vs. closed ideal system
 is negligible. -/
 theorem AsympCompEmulates.plug_compose
     {T : ℕ → OpenTheory.{u}} {sem : ∀ n, Semantics (T n)}
-    [∀ n, OpenTheory.CompactClosed (T n)]
+    [∀ n, OpenTheory.HasPlugWireFactor (T n)]
     {Δ : PortBoundary}
     {real ideal : ∀ n, (T n).Obj Δ}
     {K_real K_ideal : ∀ n, (T n).Obj (PortBoundary.swap Δ)}

--- a/VCVio/Interaction/UC/Emulates.lean
+++ b/VCVio/Interaction/UC/Emulates.lean
@@ -194,7 +194,7 @@ end Emulates
 
 section Factorization
 
-variable [OpenTheory.CompactClosed T]
+variable [OpenTheory.HasPlugWireFactor T]
 
 /-- The effective plug for the left component of a parallel composition.
 
@@ -366,7 +366,7 @@ end Factorization
 
 namespace Emulates
 
-variable [OpenTheory.CompactClosed T]
+variable [OpenTheory.HasPlugWireFactor T]
 
 /-- Replacing the left component of a parallel composition preserves
 emulation, with the right component and environment held fixed. -/

--- a/VCVio/Interaction/UC/OpenProcess.lean
+++ b/VCVio/Interaction/UC/OpenProcess.lean
@@ -306,11 +306,88 @@ The open-world node context for processes with boundary `Δ`.
 At a node with move space `X`, the context value is
 `OpenNodeSemantics Party Δ X`: the usual controller-path and local-view data,
 plus a `BoundaryAction` describing the node's external traffic.
+
+## Polynomial reading
+
+`OpenNodeContext Party Δ` is, up to the named-field-vs-pair identification
+exhibited by `OpenNodeContext.equivProductView`, the non-dependent context
+product
+
+```
+Spec.Node.Context.prod (StepContext Party) (fun X => BoundaryAction Δ X)
+```
+
+That is, the open node context is the polynomial product of the closed
+`StepContext Party` and the boundary-action context `fun X => BoundaryAction Δ X`,
+with both factors carried independently at each move space `X`. The
+hand-rolled context-homs below (`forget`, `embed`, `map`, `inlTensor`,
+`inrTensor`, `wireLeft`, `wireRight`, `close`) are concrete instances of
+the universal projection / pairing maps for this product, specialized to
+the particular boundary-action transformations they perform. The structure
+form `OpenNodeSemantics extends NodeSemantics` is preserved as the working
+API because it gives clean `{ toNodeSemantics := ..., boundary := ... }`
+construction sites and definitional projections used pervasively below.
 -/
 abbrev OpenNodeContext (Party : Type u) (Δ : PortBoundary) :=
   fun (X : Type w) => OpenNodeSemantics Party Δ X
 
 namespace OpenNodeContext
+
+/-! ### Polynomial-product bridge
+
+Exhibit `OpenNodeContext Party Δ` as the non-dependent polynomial product
+of the closed `StepContext Party` and the boundary-action context, and
+prove that the bridge is a definitional isomorphism (round trips reduce
+to `rfl` by `Prod.mk.eta` and structure eta). The product view lets one
+phrase universal-property arguments without repeatedly pattern-matching
+on `OpenNodeSemantics` literals; the structural API below is the working
+form. -/
+
+/-- The polynomial-product view of `OpenNodeContext`. Lives in the same
+universes as `OpenNodeContext Party Δ` itself: the first universe is the
+move-space universe `w`, and the second is whatever Lean infers for
+`NodeSemantics Party X × BoundaryAction Δ X`. -/
+abbrev productView (Party : Type u) (Δ : PortBoundary) :
+    Spec.Node.Context.{w} :=
+  Spec.Node.Context.prod (StepContext Party)
+    (fun X : Type w => BoundaryAction Δ X)
+
+/--
+Forward direction of the polynomial-product bridge: read off the
+`(NodeSemantics, BoundaryAction)` pair from an `OpenNodeSemantics`. -/
+def toProductView (Party : Type u) (Δ : PortBoundary) :
+    Spec.Node.ContextHom
+      (OpenNodeContext Party Δ : Spec.Node.Context.{w})
+      (productView.{u, w} Party Δ) :=
+  fun _ ons => (ons.toNodeSemantics, ons.boundary)
+
+/--
+Inverse direction of the polynomial-product bridge: reassemble an
+`OpenNodeSemantics` from a `(NodeSemantics, BoundaryAction)` pair. -/
+def ofProductView (Party : Type u) (Δ : PortBoundary) :
+    Spec.Node.ContextHom
+      (productView.{u, w} Party Δ)
+      (OpenNodeContext Party Δ : Spec.Node.Context.{w}) :=
+  fun _ p => { toNodeSemantics := p.1, boundary := p.2 }
+
+@[simp]
+theorem toProductView_ofProductView (Party : Type u) (Δ : PortBoundary) :
+    Spec.Node.ContextHom.comp
+        (toProductView.{u, w} Party Δ) (ofProductView Party Δ) =
+      Spec.Node.ContextHom.id (productView Party Δ) := by
+  funext X p
+  cases p
+  rfl
+
+@[simp]
+theorem ofProductView_toProductView (Party : Type u) (Δ : PortBoundary) :
+    Spec.Node.ContextHom.comp
+        (ofProductView.{u, w} Party Δ) (toProductView Party Δ) =
+      Spec.Node.ContextHom.id (OpenNodeContext Party Δ) := by
+  funext X ons
+  cases ons
+  simp [Spec.Node.ContextHom.comp, Spec.Node.ContextHom.id,
+    toProductView, ofProductView]
 
 /--
 The forgetful map from the open-world context to the closed-world context.
@@ -504,6 +581,50 @@ theorem map_tensor_comp_wireRight (Party : Type u)
   funext X ons
   simp [map, wireRight, Spec.Node.ContextHom.comp,
     OpenNodeSemantics.mapBoundary]
+
+/-! #### Existing context-homs as polynomial-product operations
+
+The following identities exhibit the hand-rolled `OpenNodeContext`
+context-homs above as concrete instances of the universal projections,
+pairing maps, and product maps for the polynomial product `productView`.
+They are documentation rather than a refactor: the named API forms remain
+the working surface, and the equalities below let one switch between the
+two presentations on demand. -/
+
+/-- `forget` is the first projection of the polynomial product, postcomposed
+with the bridge `toProductView`. -/
+theorem forget_eq_prodFst_comp_toProductView
+    (Party : Type u) (Δ : PortBoundary) :
+    forget.{u, w} Party Δ =
+      Spec.Node.ContextHom.comp
+        (Spec.Node.Context.prodFst (StepContext Party)
+          (fun X : Type w => BoundaryAction Δ X))
+        (toProductView Party Δ) := rfl
+
+/-- `embed` is the pairing of the identity on `StepContext` with the
+constant `internal` boundary action, transported back along the bridge. -/
+theorem embed_eq_ofProductView_comp_prodPair
+    (Party : Type u) (Δ : PortBoundary) :
+    embed.{u, w} Party Δ =
+      Spec.Node.ContextHom.comp
+        (ofProductView Party Δ)
+        (Spec.Node.Context.prodPair
+          (Spec.Node.ContextHom.id (StepContext Party))
+          (fun X _ => BoundaryAction.internal Δ X)) := rfl
+
+/-- `map φ` factors as the polynomial-product map of the identity on
+`StepContext` and the boundary-action transport
+`fun X => BoundaryAction.mapBoundary φ`. -/
+theorem map_eq_ofProductView_comp_prodMap_comp_toProductView
+    (Party : Type u) {Δ₁ Δ₂ : PortBoundary} (φ : PortBoundary.Hom Δ₁ Δ₂) :
+    map.{u, w} Party φ =
+      Spec.Node.ContextHom.comp
+        (Spec.Node.ContextHom.comp
+          (ofProductView Party Δ₂)
+          (Spec.Node.Context.prodMap
+            (Spec.Node.ContextHom.id (StepContext Party))
+            (fun X (b : BoundaryAction Δ₁ X) => b.mapBoundary φ)))
+        (toProductView Party Δ₁) := rfl
 
 end OpenNodeContext
 

--- a/VCVio/Interaction/UC/OpenSyntax/Expr.lean
+++ b/VCVio/Interaction/UC/OpenSyntax/Expr.lean
@@ -124,36 +124,37 @@ def unit {Atom : PortBoundary → Type u} : Expr Atom PortBoundary.empty :=
     (Expr.idWire PortBoundary.empty)
 
 /--
-Interpret a quotiented expression in a compact closed target theory.
+Interpret a quotiented expression in a target theory with the full
+plug-wire factorization structure.
 
 Well-defined on the quotient because `Raw.Equiv.interpret_eq` shows that
-equivalent raw expressions interpret the same way in any compact closed theory.
+equivalent raw expressions interpret the same way in any such theory.
 -/
 def interpret {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (e : Expr Atom Δ)
     (T : OpenTheory)
-    [hT : OpenTheory.CompactClosed T]
+    [hT : OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     T.Obj Δ :=
   Quotient.liftOn e
-    (fun r => r.interpret T interp OpenTheory.CompactClosed.idWire)
+    (fun r => r.interpret T interp OpenTheory.HasIdWire.idWire)
     (fun _ _ h => Raw.Equiv.interpret_eq h T interp)
 
 @[simp]
 theorem interpret_mk {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (r : Raw Atom Δ)
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (mk r).interpret T interp =
-      r.interpret T interp OpenTheory.CompactClosed.idWire :=
+      r.interpret T interp OpenTheory.HasIdWire.idWire :=
   rfl
 
 @[simp]
 theorem interpret_atom {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (a : Atom Δ)
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.atom a).interpret T interp = interp a :=
   rfl
@@ -163,7 +164,7 @@ theorem interpret_map {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBounda
     (f : PortBoundary.Hom Δ₁ Δ₂)
     (e : Expr Atom Δ₁)
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.map f e).interpret T interp = T.map f (e.interpret T interp) :=
   Quotient.inductionOn e fun _ => rfl
@@ -173,7 +174,7 @@ theorem interpret_par {Atom : PortBoundary → Type u} {Δ₁ Δ₂ : PortBounda
     (e₁ : Expr Atom Δ₁)
     (e₂ : Expr Atom Δ₂)
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.par e₁ e₂).interpret T interp =
       T.par (e₁.interpret T interp) (e₂.interpret T interp) :=
@@ -185,7 +186,7 @@ theorem interpret_wire {Atom : PortBoundary → Type u}
     (e₁ : Expr Atom (PortBoundary.tensor Δ₁ Γ))
     (e₂ : Expr Atom (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂))
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.wire e₁ e₂).interpret T interp =
       T.wire (e₁.interpret T interp) (e₂.interpret T interp) :=
@@ -195,10 +196,10 @@ theorem interpret_wire {Atom : PortBoundary → Type u}
 theorem interpret_idWire {Atom : PortBoundary → Type u}
     (Γ : PortBoundary)
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.idWire Γ : Expr Atom _).interpret T interp =
-      OpenTheory.CompactClosed.idWire (T := T) Γ :=
+      OpenTheory.HasIdWire.idWire (T := T) Γ :=
   rfl
 
 @[simp]
@@ -206,7 +207,7 @@ theorem interpret_plug {Atom : PortBoundary → Type u} {Δ : PortBoundary}
     (e : Expr Atom Δ)
     (k : Expr Atom (PortBoundary.swap Δ))
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.plug e k).interpret T interp =
       T.plug (e.interpret T interp) (k.interpret T interp) := by
@@ -216,10 +217,10 @@ theorem interpret_plug {Atom : PortBoundary → Type u} {Δ : PortBoundary}
 @[simp]
 theorem interpret_unit {Atom : PortBoundary → Type u}
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (Expr.unit : Expr Atom _).interpret T interp =
-      OpenTheory.Monoidal.unit (T := T) := by
+      OpenTheory.HasUnit.unit (T := T) := by
   simp only [Expr.unit, interpret_map]
   exact OpenTheory.unit_eq.symm
 
@@ -268,9 +269,16 @@ instance lawfulPlug (Atom : PortBoundary → Type u) :
 instance lawful (Atom : PortBoundary → Type u) :
     OpenTheory.IsLawful (Expr.theory Atom) where
 
-instance monoidal (Atom : PortBoundary → Type u) :
-    OpenTheory.Monoidal (Expr.theory Atom) where
+instance hasUnit (Atom : PortBoundary → Type u) :
+    OpenTheory.HasUnit (Expr.theory Atom) where
   unit := Expr.unit
+
+instance hasIdWire (Atom : PortBoundary → Type u) :
+    OpenTheory.HasIdWire (Expr.theory Atom) where
+  idWire := Expr.idWire
+
+instance isMonoidal (Atom : PortBoundary → Type u) :
+    OpenTheory.IsMonoidal (Expr.theory Atom) where
   par_assoc := fun W₁ W₂ W₃ =>
     Quotient.inductionOn₃ W₁ W₂ W₃ fun _ _ _ =>
       Quotient.sound Raw.Equiv.par_assoc
@@ -284,11 +292,20 @@ instance monoidal (Atom : PortBoundary → Type u) :
     Quotient.inductionOn W fun _ =>
       Quotient.sound Raw.Equiv.par_rightUnit
 
-instance compactClosed (Atom : PortBoundary → Type u) :
-    OpenTheory.CompactClosed (Expr.theory Atom) where
-  idWire := Expr.idWire
-  plug_eq_wire := fun W K =>
-    Quotient.inductionOn₂ W K fun _ _ => rfl
+instance isTraced (Atom : PortBoundary → Type u) :
+    OpenTheory.IsTraced (Expr.theory Atom) where
+  wire_assoc := fun W₁ W₂ W₃ =>
+    Quotient.inductionOn₃ W₁ W₂ W₃ fun _ _ _ =>
+      Quotient.sound Raw.Equiv.wire_assoc
+  wire_par_superpose := fun W₁ W₂ W₃ =>
+    Quotient.inductionOn₃ W₁ W₂ W₃ fun _ _ _ =>
+      Quotient.sound Raw.Equiv.wire_par_superpose
+  wire_comm := fun W₁ W₂ =>
+    Quotient.inductionOn₂ W₁ W₂ fun _ _ =>
+      Quotient.sound Raw.Equiv.wire_comm
+
+instance isCompactClosed (Atom : PortBoundary → Type u) :
+    OpenTheory.IsCompactClosed (Expr.theory Atom) where
   wire_idWire := fun _ _ W₂ =>
     Quotient.inductionOn W₂ fun _ =>
       Quotient.sound Raw.Equiv.wire_idWire
@@ -296,15 +313,11 @@ instance compactClosed (Atom : PortBoundary → Type u) :
     Quotient.inductionOn W₁ fun _ =>
       Quotient.sound Raw.Equiv.wire_idWire_right
   unit_eq := rfl
-  wire_par_superpose := fun W₁ W₂ W₃ =>
-    Quotient.inductionOn₃ W₁ W₂ W₃ fun _ _ _ =>
-      Quotient.sound Raw.Equiv.wire_par_superpose
-  wire_assoc := fun W₁ W₂ W₃ =>
-    Quotient.inductionOn₃ W₁ W₂ W₃ fun _ _ _ =>
-      Quotient.sound Raw.Equiv.wire_assoc
-  wire_comm := fun W₁ W₂ =>
-    Quotient.inductionOn₂ W₁ W₂ fun _ _ =>
-      Quotient.sound Raw.Equiv.wire_comm
+
+instance hasPlugWireFactor (Atom : PortBoundary → Type u) :
+    OpenTheory.HasPlugWireFactor (Expr.theory Atom) where
+  plug_eq_wire := fun W K =>
+    Quotient.inductionOn₂ W K fun _ _ => rfl
   plug_par_left := fun W₁ W₂ K =>
     Quotient.inductionOn₃ W₁ W₂ K fun _ _ _ =>
       Quotient.sound Raw.Equiv.plug_par_left

--- a/VCVio/Interaction/UC/OpenSyntax/Interp.lean
+++ b/VCVio/Interaction/UC/OpenSyntax/Interp.lean
@@ -41,18 +41,20 @@ structure Interp
     (Atom : PortBoundary → Type u)
     (Δ : PortBoundary) where
   /--
-  Interpret the free expression in an arbitrary compact closed target theory.
+  Interpret the free expression in an arbitrary target theory with the full
+  plug-wire factorization structure.
   -/
   run :
     (T : OpenTheory.{max (u + 1) 3}) →
-    OpenTheory.CompactClosed T →
+    OpenTheory.HasPlugWireFactor T →
     (∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) →
     T.Obj Δ
 
 namespace Interp
 
 /--
-Interpret a tagless-final expression in a compact closed target theory.
+Interpret a tagless-final expression in a target theory with the full
+plug-wire factorization structure.
 
 This is just the `run` field restated as a named eliminator.
 -/
@@ -61,7 +63,7 @@ abbrev interpret
     {Δ : PortBoundary}
     (W : Interp Atom Δ)
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     T.Obj Δ :=
   W.run T hT interp
@@ -77,7 +79,7 @@ theorem ext
     {W₁ W₂ : Interp Atom Δ}
     (h :
       ∀ (T : OpenTheory.{max (u + 1) 3})
-        (hT : OpenTheory.CompactClosed T)
+        (hT : OpenTheory.HasPlugWireFactor T)
         (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ),
           W₁.run T hT interp = W₂.run T hT interp) :
     W₁ = W₂ := by
@@ -103,7 +105,7 @@ theorem interpret_atom
     {Δ : PortBoundary}
     (a : Atom Δ)
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (atom a).interpret T hT interp = interp a :=
   rfl
@@ -125,7 +127,7 @@ theorem interpret_map
     (f : PortBoundary.Hom Δ₁ Δ₂)
     (W : Interp Atom Δ₁)
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (map f W).interpret T hT interp = T.map f (W.interpret T hT interp) :=
   rfl
@@ -149,7 +151,7 @@ theorem interpret_par
     (W₁ : Interp Atom Δ₁)
     (W₂ : Interp Atom Δ₂)
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (par W₁ W₂).interpret T hT interp =
       T.par (W₁.interpret T hT interp) (W₂.interpret T hT interp) :=
@@ -174,7 +176,7 @@ theorem interpret_wire
     (W₁ : Interp Atom (PortBoundary.tensor Δ₁ Γ))
     (W₂ : Interp Atom (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂))
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (wire W₁ W₂).interpret T hT interp =
       T.wire (W₁.interpret T hT interp) (W₂.interpret T hT interp) :=
@@ -199,7 +201,7 @@ theorem interpret_plug
     (W : Interp Atom Δ)
     (K : Interp Atom (PortBoundary.swap Δ))
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (plug W K).interpret T hT interp =
       T.plug (W.interpret T hT interp) (K.interpret T hT interp) :=
@@ -211,16 +213,17 @@ The monoidal unit (closed system with no boundary).
 def unit
     {Atom : PortBoundary → Type u} :
     Interp Atom PortBoundary.empty :=
-  ⟨fun _ hCC _ => OpenTheory.Monoidal.unit (self := hCC.toMonoidal)⟩
+  ⟨fun _ hCC _ => OpenTheory.HasUnit.unit
+    (self := hCC.toIsCompactClosed.toIsTraced.toIsMonoidal.toHasUnit)⟩
 
 @[simp]
 theorem interpret_unit
     {Atom : PortBoundary → Type u}
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (unit : Interp Atom _).interpret T hT interp =
-      OpenTheory.Monoidal.unit (T := T) :=
+      OpenTheory.HasUnit.unit (T := T) :=
   rfl
 
 /--
@@ -230,17 +233,18 @@ def idWire
     {Atom : PortBoundary → Type u}
     (Γ : PortBoundary) :
     Interp Atom (PortBoundary.tensor (PortBoundary.swap Γ) Γ) :=
-  ⟨fun _ hCC _ => OpenTheory.CompactClosed.idWire (self := hCC) Γ⟩
+  ⟨fun _ hCC _ => OpenTheory.HasIdWire.idWire
+    (self := hCC.toIsCompactClosed.toHasIdWire) Γ⟩
 
 @[simp]
 theorem interpret_idWire
     {Atom : PortBoundary → Type u}
     (Γ : PortBoundary)
     (T : OpenTheory.{max (u + 1) 3})
-    (hT : OpenTheory.CompactClosed T)
+    (hT : OpenTheory.HasPlugWireFactor T)
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
     (idWire Γ : Interp Atom _).interpret T hT interp =
-      OpenTheory.CompactClosed.idWire (T := T) Γ :=
+      OpenTheory.HasIdWire.idWire (T := T) Γ :=
   rfl
 
 /--
@@ -264,7 +268,7 @@ instance lawfulMap
     change Interp.map (PortBoundary.Hom.id Δ) W = W
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.IsLawful T := hT.toMonoidal.toIsLawful
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simp [Interp.map]
   map_comp := by
     intro Δ₁ Δ₂ Δ₃ g f W
@@ -272,7 +276,7 @@ instance lawfulMap
     change Interp.map (PortBoundary.Hom.comp g f) W = Interp.map g (Interp.map f W)
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.IsLawful T := hT.toMonoidal.toIsLawful
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simpa [Interp.map] using
       OpenTheory.map_comp (T := T) g f (W.run T hT interp)
 
@@ -290,7 +294,7 @@ instance lawfulPar
         Interp.par (Interp.map f₁ W₁) (Interp.map f₂ W₂)
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.IsLawful T := hT.toMonoidal.toIsLawful
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simpa [Interp.map, Interp.par] using
       OpenTheory.map_par (T := T) f₁ f₂ (W₁.run T hT interp) (W₂.run T hT interp)
 
@@ -314,7 +318,7 @@ instance lawfulWire
             W₂)
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.IsLawful T := hT.toMonoidal.toIsLawful
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simpa [Interp.map, Interp.wire] using
       OpenTheory.map_wire (T := T) f₁ f₂ (W₁.run T hT interp) (W₂.run T hT interp)
 
@@ -332,7 +336,7 @@ instance lawfulPlug
         Interp.plug W (Interp.map (PortBoundary.Hom.swap f) K)
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.IsLawful T := hT.toMonoidal.toIsLawful
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simpa [Interp.map, Interp.plug] using
       OpenTheory.map_plug (T := T) f (W.run T hT interp) (K.run T hT interp)
 
@@ -340,10 +344,19 @@ instance lawful
     (Atom : PortBoundary → Type u) :
     OpenTheory.IsLawful (Interp.theory Atom) where
 
-instance monoidal
+instance hasUnit
     (Atom : PortBoundary → Type u) :
-    OpenTheory.Monoidal (Interp.theory Atom) where
+    OpenTheory.HasUnit (Interp.theory Atom) where
   unit := Interp.unit
+
+instance hasIdWire
+    (Atom : PortBoundary → Type u) :
+    OpenTheory.HasIdWire (Interp.theory Atom) where
+  idWire := Interp.idWire
+
+instance isMonoidal
+    (Atom : PortBoundary → Type u) :
+    OpenTheory.IsMonoidal (Interp.theory Atom) where
   par_assoc := by
     intro Δ₁ Δ₂ Δ₃ W₁ W₂ W₃
     change Interp Atom Δ₁ at W₁
@@ -355,7 +368,7 @@ instance monoidal
       Interp.par W₁ (Interp.par W₂ W₃)
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.Monoidal T := hT.toMonoidal
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simpa [Interp.map, Interp.par] using
       OpenTheory.par_assoc (T := T) (W₁.run T hT interp)
         (W₂.run T hT interp) (W₃.run T hT interp)
@@ -369,7 +382,7 @@ instance monoidal
       Interp.par W₂ W₁
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.Monoidal T := hT.toMonoidal
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simpa [Interp.map, Interp.par] using
       OpenTheory.par_comm (T := T) (W₁.run T hT interp) (W₂.run T hT interp)
   par_leftUnit := by
@@ -380,7 +393,7 @@ instance monoidal
         (Interp.par Interp.unit W) = W
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.Monoidal T := hT.toMonoidal
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simp [Interp.map, Interp.par, Interp.unit]
   par_rightUnit := by
     intro Δ W
@@ -390,13 +403,72 @@ instance monoidal
         (Interp.par W Interp.unit) = W
     refine Interp.ext ?_
     intro T hT interp
-    let _ : OpenTheory.Monoidal T := hT.toMonoidal
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simp [Interp.map, Interp.par, Interp.unit]
 
-instance compactClosed
+instance isTraced
     (Atom : PortBoundary → Type u) :
-    OpenTheory.CompactClosed (Interp.theory Atom) where
-  idWire := Interp.idWire
+    OpenTheory.IsTraced (Interp.theory Atom) where
+  wire_assoc := by
+    intro Δ₁ Γ₁ Γ₂ Δ₃ W₁ W₂ W₃
+    refine Interp.ext ?_
+    intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
+    simp only [Interp.wire]
+    exact OpenTheory.wire_assoc (T := T)
+      (W₁.run T hT interp) (W₂.run T hT interp) (W₃.run T hT interp)
+  wire_par_superpose := by
+    intro Δ₁ Δ₂ Γ Δ₃ W₁ W₂ W₃
+    refine Interp.ext ?_
+    intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
+    simp only [Interp.wire, Interp.map, Interp.par]
+    exact OpenTheory.wire_par_superpose (T := T)
+      (W₁.run T hT interp) (W₂.run T hT interp) (W₃.run T hT interp)
+  wire_comm := by
+    intro Δ₁ Γ Δ₂ W₁ W₂
+    refine Interp.ext ?_
+    intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
+    simp only [Interp.wire, Interp.map]
+    exact OpenTheory.wire_comm (T := T)
+      (W₁.run T hT interp) (W₂.run T hT interp)
+
+instance isCompactClosed
+    (Atom : PortBoundary → Type u) :
+    OpenTheory.IsCompactClosed (Interp.theory Atom) where
+  wire_idWire := by
+    intro Γ Δ₂ W₂
+    change Interp Atom (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂) at W₂
+    change
+      Interp.wire (Interp.idWire Γ) W₂ = W₂
+    refine Interp.ext ?_
+    intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
+    simp [Interp.wire, Interp.idWire]
+  wire_idWire_right := by
+    intro Γ Δ₁ W₁
+    change Interp Atom (PortBoundary.tensor Δ₁ Γ) at W₁
+    change
+      Interp.wire W₁ (Interp.idWire Γ) = W₁
+    refine Interp.ext ?_
+    intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
+    simp [Interp.wire, Interp.idWire]
+  unit_eq := by
+    change
+      Interp.unit = Interp.map
+        (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
+        (Interp.idWire PortBoundary.empty)
+    refine Interp.ext ?_
+    intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
+    simp only [Interp.unit, Interp.map, Interp.idWire]
+    exact OpenTheory.unit_eq (T := T)
+
+instance hasPlugWireFactor
+    (Atom : PortBoundary → Type u) :
+    OpenTheory.HasPlugWireFactor (Interp.theory Atom) where
   plug_eq_wire := by
     intro Δ W K
     change Interp Atom Δ at W
@@ -410,58 +482,14 @@ instance compactClosed
               (PortBoundary.swap Δ)).symm.toHom K))
     refine Interp.ext ?_
     intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simp [Interp.plug, Interp.map, Interp.wire,
       OpenTheory.plug_eq_wire (T := T) (W.run T hT interp) (K.run T hT interp)]
-  wire_idWire := by
-    intro Γ Δ₂ W₂
-    change Interp Atom (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂) at W₂
-    change
-      Interp.wire (Interp.idWire Γ) W₂ = W₂
-    refine Interp.ext ?_
-    intro T hT interp
-    simp [Interp.wire, Interp.idWire]
-  wire_idWire_right := by
-    intro Γ Δ₁ W₁
-    change Interp Atom (PortBoundary.tensor Δ₁ Γ) at W₁
-    change
-      Interp.wire W₁ (Interp.idWire Γ) = W₁
-    refine Interp.ext ?_
-    intro T hT interp
-    simp [Interp.wire, Interp.idWire]
-  unit_eq := by
-    change
-      Interp.unit = Interp.map
-        (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
-        (Interp.idWire PortBoundary.empty)
-    refine Interp.ext ?_
-    intro T hT interp
-    simp only [Interp.unit, Interp.map, Interp.idWire]
-    exact OpenTheory.unit_eq (T := T)
-  wire_par_superpose := by
-    intro Δ₁ Δ₂ Γ Δ₃ W₁ W₂ W₃
-    refine Interp.ext ?_
-    intro T hT interp
-    simp only [Interp.wire, Interp.map, Interp.par]
-    exact OpenTheory.wire_par_superpose (T := T)
-      (W₁.run T hT interp) (W₂.run T hT interp) (W₃.run T hT interp)
-  wire_assoc := by
-    intro Δ₁ Γ₁ Γ₂ Δ₃ W₁ W₂ W₃
-    refine Interp.ext ?_
-    intro T hT interp
-    simp only [Interp.wire]
-    exact OpenTheory.wire_assoc (T := T)
-      (W₁.run T hT interp) (W₂.run T hT interp) (W₃.run T hT interp)
-  wire_comm := by
-    intro Δ₁ Γ Δ₂ W₁ W₂
-    refine Interp.ext ?_
-    intro T hT interp
-    simp only [Interp.wire, Interp.map]
-    exact OpenTheory.wire_comm (T := T)
-      (W₁.run T hT interp) (W₂.run T hT interp)
   plug_par_left := by
     intro Δ₁ Δ₂ W₁ W₂ K
     refine Interp.ext ?_
     intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simp only [Interp.plug, Interp.par, Interp.map, Interp.wire]
     exact OpenTheory.plug_par_left (T := T)
       (W₁.run T hT interp) (W₂.run T hT interp) (K.run T hT interp)
@@ -469,6 +497,7 @@ instance compactClosed
     intro Δ₁ Γ Δ₂ W₁ W₂ K
     refine Interp.ext ?_
     intro T hT interp
+    letI : OpenTheory.HasPlugWireFactor T := hT
     simp only [Interp.plug, Interp.wire, Interp.map]
     exact OpenTheory.plug_wire_left (T := T)
       (W₁.run T hT interp) (W₂.run T hT interp) (K.run T hT interp)

--- a/VCVio/Interaction/UC/OpenSyntax/Raw.lean
+++ b/VCVio/Interaction/UC/OpenSyntax/Raw.lean
@@ -335,10 +335,10 @@ theorem Equiv.interpret_eq
     {e₁ e₂ : Raw Atom Δ}
     (h : Equiv e₁ e₂)
     (T : OpenTheory)
-    [OpenTheory.CompactClosed T]
+    [OpenTheory.HasPlugWireFactor T]
     (interp : ∀ {Δ : PortBoundary}, Atom Δ → T.Obj Δ) :
-    e₁.interpret T interp OpenTheory.CompactClosed.idWire =
-      e₂.interpret T interp OpenTheory.CompactClosed.idWire := by
+    e₁.interpret T interp OpenTheory.HasIdWire.idWire =
+      e₂.interpret T interp OpenTheory.HasIdWire.idWire := by
   induction h with
   | refl => rfl
   | symm _ ih => exact ih.symm

--- a/VCVio/Interaction/UC/OpenTheory.lean
+++ b/VCVio/Interaction/UC/OpenTheory.lean
@@ -9,8 +9,10 @@ import VCVio.Interaction.UC.Interface
 # Open composition algebra with monoidal coherence
 
 This module defines `OpenTheory`, a boundary-indexed algebra of open systems,
-together with a hierarchy of lawfulness classes capturing increasingly strong
-equational properties.
+together with a granular hierarchy of lawfulness classes capturing
+increasingly strong equational properties. The split mirrors the categorical
+distinction between symmetric monoidal, traced symmetric monoidal
+(Joyal-Street-Verity), and compact closed categories.
 
 ## Operations
 
@@ -22,17 +24,46 @@ equational properties.
 
 ## Class hierarchy
 
+Data classes (operations beyond the four primitives):
+
+* `HasUnit`: a distinguished `unit : Obj empty` (the monoidal unit).
+* `HasIdWire`: a coevaluation `idWire : ∀ Γ, Obj (swap Γ ⊗ Γ)`.
+
+Naturality (Prop classes):
+
 * `IsLawfulMap`: functoriality of `map` (identity and composition).
 * `IsLawfulPar`/`IsLawfulWire`/`IsLawfulPlug`: naturality of each combinator
   with respect to boundary adaptation.
 * `IsLawful`: bundles all naturality laws.
-* `Monoidal`: symmetric monoidal coherence for `par` (associativity,
-  commutativity, left and right unit laws via a distinguished `unit` object).
-* `CompactClosed`: compact closed structure (`idWire` as coevaluation,
-  `plug` derivable from `wire`, zig-zag identity for `wire_idWire`).
 
-Concrete realizations include the free models (`Expr.theory`, `Interp.theory`)
-and the process-backed `openTheory` in `OpenProcessModel.lean`.
+Symmetric monoidal coherence:
+
+* `IsMonoidal` (extends `IsLawful`, `HasUnit`): associativity, commutativity
+  (braiding), and left/right unit laws for `par`.
+
+Trace algebra (JSV traced symmetric monoidal):
+
+* `IsTraced` (extends `IsMonoidal`): wire associativity, par-superposition,
+  and wire commutativity.
+
+Compact closure (snake / zig-zag):
+
+* `IsCompactClosed` (extends `IsTraced`, `HasIdWire`): left and right zig-zag
+  identities `wire_idWire`/`wire_idWire_right` and `unit_eq` identifying the
+  monoidal unit with the trivial coevaluation.
+
+Plug factorization:
+
+* `HasPlugWireFactor` (extends `IsCompactClosed`): `plug` derivable from
+  `wire` via the unit, and the two factorization laws relating closure of
+  parallel and wired composites to closure of one component.
+
+The chain `IsMonoidal → IsTraced → IsCompactClosed → HasPlugWireFactor` lets
+each model declare exactly the strength it can honestly satisfy. The free
+models (`Expr.theory`, `Interp.theory`) instantiate the entire chain. The
+process-backed `openTheory` in `OpenProcessModel.lean` instantiates only
+`IsLawful`; its monoidal coherence and snake equations hold up to
+`OpenProcessIso`, not strict equality.
 -/
 
 universe u
@@ -56,8 +87,9 @@ primitive composition operations:
 * `plug` closes an open system against a matching context on the swapped
   boundary, yielding a closed system.
 
-Lawfulness is stratified into three levels via the class hierarchy
-`IsLawful ≤ Monoidal ≤ CompactClosed` (see the module docstring).
+Lawfulness is stratified into a granular class hierarchy starting at
+`IsLawful` and continuing through `IsMonoidal`, `IsTraced`,
+`IsCompactClosed`, and `HasPlugWireFactor` (see the module docstring).
 
 Universe polymorphism: one ambient pair of universes for ports and
 messages on both sides of every boundary, keeping `PortBoundary.swap` inside
@@ -133,6 +165,35 @@ structure OpenTheory where
     Obj (PortBoundary.empty)
 
 namespace OpenTheory
+
+/-! ### Operation-only data classes -/
+
+/--
+`HasUnit T` distinguishes a closed object `unit : T.Obj empty`, intended to
+play the role of the symmetric monoidal unit.
+
+This is purely a data class. Whether `unit` actually behaves as a left/right
+unit for `par` (up to boundary equivalence) is the content of `IsMonoidal`.
+-/
+class HasUnit (T : _root_.Interaction.UC.OpenTheory.{u}) where
+  /-- The distinguished unit object on the empty boundary. -/
+  unit : T.Obj PortBoundary.empty
+
+/--
+`HasIdWire T` distinguishes a coevaluation morphism on every boundary,
+`idWire Γ : T.Obj (swap Γ ⊗ Γ)`, intended to play the role of the categorical
+unit of duality between `Γ` and `swap Γ`.
+
+This is purely a data class. Whether `idWire` actually satisfies the
+zig-zag (snake) identities is the content of `IsCompactClosed`.
+-/
+class HasIdWire (T : _root_.Interaction.UC.OpenTheory.{u}) where
+  /-- The identity-wire / coevaluation on boundary `Γ`: a process exposing
+  `swap Γ ⊗ Γ` that behaves as a bidirectional relay. -/
+  idWire : ∀ (Γ : PortBoundary),
+    T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Γ)
+
+/-! ### Naturality (functoriality of `map` and naturality of `par`/`wire`/`plug`) -/
 
 /--
 `IsLawfulMap T` states that boundary adaptation in `T` behaves functorially.
@@ -255,17 +316,19 @@ later, once the library settles on the right notion of boundary equivalence.
 class IsLawful (T : _root_.Interaction.UC.OpenTheory.{u}) :
     Prop extends IsLawfulPar T, IsLawfulWire T, IsLawfulPlug T
 
+/-! ### Symmetric monoidal coherence -/
+
 /--
-`Monoidal T` extends `IsLawful T` with the symmetric monoidal coherence
-laws for `par`: a unit object, plus associativity, commutativity (braiding),
+`IsMonoidal T` extends `IsLawful T` and `HasUnit T` with the symmetric
+monoidal coherence laws for `par`: associativity, commutativity (braiding),
 and left/right unit laws up to boundary equivalence.
 
 Pentagon and hexagon coherence conditions are deferred: they are derivable
 in the free models and hold trivially for the concrete model up to process
 isomorphism.
 -/
-class Monoidal (T : _root_.Interaction.UC.OpenTheory.{u}) extends IsLawful T where
-  unit : T.Obj PortBoundary.empty
+class IsMonoidal (T : _root_.Interaction.UC.OpenTheory.{u})
+    extends IsLawful T, HasUnit T where
   par_assoc :
     ∀ {Δ₁ Δ₂ Δ₃ : PortBoundary}
       (W₁ : T.Obj Δ₁) (W₂ : T.Obj Δ₂) (W₃ : T.Obj Δ₃),
@@ -280,51 +343,28 @@ class Monoidal (T : _root_.Interaction.UC.OpenTheory.{u}) extends IsLawful T whe
   par_leftUnit :
     ∀ {Δ : PortBoundary} (W : T.Obj Δ),
       T.map (PortBoundary.Equiv.tensorEmptyLeft Δ).toHom
-        (T.par unit W) = W
+        (T.par (HasUnit.unit (T := T)) W) = W
   par_rightUnit :
     ∀ {Δ : PortBoundary} (W : T.Obj Δ),
       T.map (PortBoundary.Equiv.tensorEmptyRight Δ).toHom
-        (T.par W unit) = W
+        (T.par W (HasUnit.unit (T := T))) = W
+
+/-! ### Trace algebra (Joyal-Street-Verity traced symmetric monoidal) -/
 
 /--
-`CompactClosed T` extends `Monoidal T` with a coevaluation morphism
-(`idWire`) and laws that connect it to `wire` and `plug`.
+`IsTraced T` extends `IsMonoidal T` with the three trace axioms of a
+Joyal-Street-Verity traced symmetric monoidal category, formulated for the
+binary `wire` operator: wire associativity (vanishing II), wire-par
+superposition, and wire commutativity (yanking via the symmetry).
 
-The `idWire Γ` process relays messages on the boundary `swap Γ ⊗ Γ`. The
-key property `wire_idWire` says that wiring any process against the identity
-wire leaves it unchanged (zig-zag identity). Together with `plug_eq_wire`,
-this characterizes the compact closed structure.
+These axioms make sense without `HasIdWire` or any snake equation: they are
+purely about the algebra of `wire` itself and how it interacts with `par`.
+A model satisfies `IsTraced` exactly when its `wire` operation behaves like
+a JSV trace; the existence of duals (i.e., compact closure) is a separate
+class layered on top.
 -/
-class CompactClosed (T : _root_.Interaction.UC.OpenTheory.{u})
-    extends Monoidal T where
-  /-- The identity wire (coevaluation): a process on the boundary `swap Γ ⊗ Γ`
-  that relays messages bidirectionally. -/
-  idWire : ∀ (Γ : PortBoundary),
-    T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Γ)
-  /-- `plug` is derivable from `wire` plus boundary reshaping. -/
-  plug_eq_wire :
-    ∀ {Δ : PortBoundary}
-      (W : T.Obj Δ) (K : T.Obj (PortBoundary.swap Δ)),
-      T.plug W K =
-        T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
-          (T.wire
-            (T.map (PortBoundary.Equiv.tensorEmptyLeft Δ).symm.toHom W)
-            (T.map (PortBoundary.Equiv.tensorEmptyRight
-              (PortBoundary.swap Δ)).symm.toHom K))
-  /-- Left zig-zag: wiring the identity wire on the left is a no-op. -/
-  wire_idWire :
-    ∀ (Γ : PortBoundary) {Δ₂ : PortBoundary}
-      (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)),
-      T.wire (idWire Γ) W₂ = W₂
-  /-- Right zig-zag: wiring the identity wire on the right is a no-op. -/
-  wire_idWire_right :
-    ∀ (Γ : PortBoundary) {Δ₁ : PortBoundary}
-      (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)),
-      T.wire W₁ (idWire Γ) = W₁
-  /-- The monoidal unit is the coevaluation at the trivial boundary. -/
-  unit_eq :
-    unit = T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
-      (idWire PortBoundary.empty)
+class IsTraced (T : _root_.Interaction.UC.OpenTheory.{u})
+    extends IsMonoidal T where
   /-- Wire associativity: sequential wiring can be reassociated.
 
   Wiring `W₁` with `W₂` through `Γ₁` and then with `W₃` through `Γ₂`
@@ -338,8 +378,7 @@ class CompactClosed (T : _root_.Interaction.UC.OpenTheory.{u})
       T.wire (T.wire W₁ W₂) W₃ = T.wire W₁ (T.wire W₂ W₃)
   /-- Wire-par superposition (left): if the left factor of a parallel
   composition does not share a boundary with the second wire argument,
-  it can be factored out of the wire. This is one of the axioms of
-  traced symmetric monoidal categories. -/
+  it can be factored out of the wire. -/
   wire_par_superpose :
     ∀ {Δ₁ Δ₂ Γ Δ₃ : PortBoundary}
       (W₁ : T.Obj Δ₁)
@@ -364,6 +403,64 @@ class CompactClosed (T : _root_.Interaction.UC.OpenTheory.{u})
               (PortBoundary.Equiv.tensorComm (PortBoundary.swap Γ) Δ₂).toHom
               W₂)
             (T.map (PortBoundary.Equiv.tensorComm Δ₁ Γ).toHom W₁))
+
+/-! ### Compact closure (snake / zig-zag identities) -/
+
+/--
+`IsCompactClosed T` extends `IsTraced T` and `HasIdWire T` with the snake
+(zig-zag) identities relating the coevaluation `idWire` to `wire`, plus the
+identification `unit_eq` of the monoidal unit with the trivial coevaluation.
+
+These laws say that `swap Γ` is a categorical dual of `Γ`, witnessed by
+`idWire Γ` as the coevaluation. In our setting the trace algebra and the
+duality structure are independent (since `wire` is a primitive, not derived
+from η/ε), so `IsCompactClosed` extends `IsTraced` rather than living
+side-by-side with it: a model that satisfies `IsCompactClosed` also has a
+JSV trace.
+-/
+class IsCompactClosed (T : _root_.Interaction.UC.OpenTheory.{u})
+    extends IsTraced T, HasIdWire T where
+  /-- Left zig-zag: wiring the identity wire on the left is a no-op. -/
+  wire_idWire :
+    ∀ (Γ : PortBoundary) {Δ₂ : PortBoundary}
+      (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)),
+      T.wire (HasIdWire.idWire (T := T) Γ) W₂ = W₂
+  /-- Right zig-zag: wiring the identity wire on the right is a no-op. -/
+  wire_idWire_right :
+    ∀ (Γ : PortBoundary) {Δ₁ : PortBoundary}
+      (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)),
+      T.wire W₁ (HasIdWire.idWire (T := T) Γ) = W₁
+  /-- The monoidal unit is the coevaluation at the trivial boundary. -/
+  unit_eq :
+    HasUnit.unit (T := T) =
+      T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
+        (HasIdWire.idWire (T := T) PortBoundary.empty)
+
+/-! ### Plug-wire factorization -/
+
+/--
+`HasPlugWireFactor T` extends `IsCompactClosed T` with the three laws
+identifying `plug` as a derived operation: `plug` factors through `wire`
+via the unit (`plug_eq_wire`), and closure of a parallel or wired composite
+factors through closure of one component (`plug_par_left`/`plug_wire_left`).
+
+This is the "everything bundle" used by downstream UC composition theorems:
+`[HasPlugWireFactor T]` automatically supplies all of `IsCompactClosed T`,
+`IsTraced T`, `IsMonoidal T`, `IsLawful T`, `HasUnit T`, and `HasIdWire T`
+through the inheritance chain.
+-/
+class HasPlugWireFactor (T : _root_.Interaction.UC.OpenTheory.{u})
+    extends IsCompactClosed T where
+  /-- `plug` is derivable from `wire` plus boundary reshaping. -/
+  plug_eq_wire :
+    ∀ {Δ : PortBoundary}
+      (W : T.Obj Δ) (K : T.Obj (PortBoundary.swap Δ)),
+      T.plug W K =
+        T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
+          (T.wire
+            (T.map (PortBoundary.Equiv.tensorEmptyLeft Δ).symm.toHom W)
+            (T.map (PortBoundary.Equiv.tensorEmptyRight
+              (PortBoundary.swap Δ)).symm.toHom K))
   /-- Plug-par factorization (left): plugging a parallel composition against
   a context factors into wiring the right component into the context, then
   plugging the left component against the result.
@@ -652,99 +749,60 @@ theorem mapEquiv_plug
   simpa [OpenTheory.mapEquiv] using
     map_plug (T := T) e.toHom W K
 
+/-! ### Symmetric monoidal coherence -/
+
 /--
 Reassociating a nested parallel composition of three open systems.
 -/
 theorem par_assoc
-    [Monoidal T]
+    [IsMonoidal T]
     {Δ₁ Δ₂ Δ₃ : PortBoundary}
     (W₁ : T.Obj Δ₁) (W₂ : T.Obj Δ₂) (W₃ : T.Obj Δ₃) :
     T.mapEquiv (PortBoundary.Equiv.tensorAssoc Δ₁ Δ₂ Δ₃)
       (T.par (T.par W₁ W₂) W₃) =
     T.par W₁ (T.par W₂ W₃) :=
-  Monoidal.par_assoc W₁ W₂ W₃
+  IsMonoidal.par_assoc W₁ W₂ W₃
 
 /--
 Swapping the components of a parallel composition along the tensor
 commutativity equivalence.
 -/
 theorem par_comm
-    [Monoidal T]
+    [IsMonoidal T]
     {Δ₁ Δ₂ : PortBoundary}
     (W₁ : T.Obj Δ₁) (W₂ : T.Obj Δ₂) :
     T.mapEquiv (PortBoundary.Equiv.tensorComm Δ₁ Δ₂)
       (T.par W₁ W₂) =
     T.par W₂ W₁ :=
-  Monoidal.par_comm W₁ W₂
+  IsMonoidal.par_comm W₁ W₂
 
 /-- The monoidal unit is a left identity for parallel composition. -/
 @[simp]
 theorem par_leftUnit
-    [Monoidal T]
+    [IsMonoidal T]
     {Δ : PortBoundary}
     (W : T.Obj Δ) :
     T.mapEquiv (PortBoundary.Equiv.tensorEmptyLeft Δ)
-      (T.par (Monoidal.unit (T := T)) W) = W :=
-  Monoidal.par_leftUnit W
+      (T.par (HasUnit.unit (T := T)) W) = W :=
+  IsMonoidal.par_leftUnit W
 
 /-- The monoidal unit is a right identity for parallel composition. -/
 @[simp]
 theorem par_rightUnit
-    [Monoidal T]
+    [IsMonoidal T]
     {Δ : PortBoundary}
     (W : T.Obj Δ) :
     T.mapEquiv (PortBoundary.Equiv.tensorEmptyRight Δ)
-      (T.par W (Monoidal.unit (T := T))) = W :=
-  Monoidal.par_rightUnit W
+      (T.par W (HasUnit.unit (T := T))) = W :=
+  IsMonoidal.par_rightUnit W
 
-/-- `plug` expressed via `wire` and boundary reshaping. -/
-theorem plug_eq_wire
-    [CompactClosed T]
-    {Δ : PortBoundary}
-    (W : T.Obj Δ) (K : T.Obj (PortBoundary.swap Δ)) :
-    T.plug W K =
-      T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
-        (T.wire
-          (T.map (PortBoundary.Equiv.tensorEmptyLeft Δ).symm.toHom W)
-          (T.map (PortBoundary.Equiv.tensorEmptyRight
-            (PortBoundary.swap Δ)).symm.toHom K)) :=
-  CompactClosed.plug_eq_wire W K
-
-/-- Left zig-zag: wiring the identity wire on the left is a no-op. -/
-@[simp]
-theorem wire_idWire
-    [CompactClosed T]
-    {Γ : PortBoundary}
-    {Δ₂ : PortBoundary}
-    (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)) :
-    T.wire (CompactClosed.idWire (T := T) Γ) W₂ = W₂ :=
-  CompactClosed.wire_idWire Γ W₂
-
-/-- Right zig-zag: wiring the identity wire on the right is a no-op. -/
-@[simp]
-theorem wire_idWire_right
-    [CompactClosed T]
-    {Γ : PortBoundary}
-    {Δ₁ : PortBoundary}
-    (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)) :
-    T.wire W₁ (CompactClosed.idWire (T := T) Γ) = W₁ :=
-  CompactClosed.wire_idWire_right Γ W₁
-
-/-- The monoidal unit is the coevaluation at the trivial boundary. -/
-theorem unit_eq
-    [CompactClosed T] :
-    Monoidal.unit (T := T) =
-      T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
-        (CompactClosed.idWire (T := T) PortBoundary.empty) :=
-  CompactClosed.unit_eq
-
-/-! ### Wire algebra -/
+/-! ### Trace algebra -/
 
 /-- Wire-par superposition: the left factor of a parallel composition
 can be moved outside a wire when it doesn't share the contracted
 boundary. -/
 theorem wire_par_superpose
-    [CompactClosed T]
+    [IsTraced T]
     {Δ₁ Δ₂ Γ Δ₃ : PortBoundary}
     (W₁ : T.Obj Δ₁)
     (W₂ : T.Obj (PortBoundary.tensor Δ₂ Γ))
@@ -755,22 +813,22 @@ theorem wire_par_superpose
       W₃ =
     T.mapEquiv (PortBoundary.Equiv.tensorAssoc Δ₁ Δ₂ Δ₃).symm
       (T.par W₁ (T.wire W₂ W₃)) :=
-  CompactClosed.wire_par_superpose W₁ W₂ W₃
+  IsTraced.wire_par_superpose W₁ W₂ W₃
 
 /-- Wire associativity: sequential wiring can be reassociated. -/
 theorem wire_assoc
-    [CompactClosed T]
+    [IsTraced T]
     {Δ₁ Γ₁ Γ₂ Δ₃ : PortBoundary}
     (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ₁))
     (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ₁) Γ₂))
     (W₃ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ₂) Δ₃)) :
     T.wire (T.wire W₁ W₂) W₃ = T.wire W₁ (T.wire W₂ W₃) :=
-  CompactClosed.wire_assoc W₁ W₂ W₃
+  IsTraced.wire_assoc W₁ W₂ W₃
 
 /-- Wire commutativity: the roles of the two wire factors are
 interchangeable up to boundary reshaping. -/
 theorem wire_comm
-    [CompactClosed T]
+    [IsTraced T]
     {Δ₁ Γ Δ₂ : PortBoundary}
     (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ))
     (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)) :
@@ -780,14 +838,59 @@ theorem wire_comm
           (T.mapEquiv
             (PortBoundary.Equiv.tensorComm (PortBoundary.swap Γ) Δ₂) W₂)
           (T.mapEquiv (PortBoundary.Equiv.tensorComm Δ₁ Γ) W₁)) :=
-  CompactClosed.wire_comm W₁ W₂
+  IsTraced.wire_comm W₁ W₂
+
+/-! ### Compact closure (snake / zig-zag) -/
+
+/-- Left zig-zag: wiring the identity wire on the left is a no-op. -/
+@[simp]
+theorem wire_idWire
+    [IsCompactClosed T]
+    {Γ : PortBoundary}
+    {Δ₂ : PortBoundary}
+    (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂)) :
+    T.wire (HasIdWire.idWire (T := T) Γ) W₂ = W₂ :=
+  IsCompactClosed.wire_idWire Γ W₂
+
+/-- Right zig-zag: wiring the identity wire on the right is a no-op. -/
+@[simp]
+theorem wire_idWire_right
+    [IsCompactClosed T]
+    {Γ : PortBoundary}
+    {Δ₁ : PortBoundary}
+    (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ)) :
+    T.wire W₁ (HasIdWire.idWire (T := T) Γ) = W₁ :=
+  IsCompactClosed.wire_idWire_right Γ W₁
+
+/-- The monoidal unit is the coevaluation at the trivial boundary. -/
+theorem unit_eq
+    [IsCompactClosed T] :
+    HasUnit.unit (T := T) =
+      T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
+        (HasIdWire.idWire (T := T) PortBoundary.empty) :=
+  IsCompactClosed.unit_eq
+
+/-! ### Plug-wire factorization -/
+
+/-- `plug` expressed via `wire` and boundary reshaping. -/
+theorem plug_eq_wire
+    [HasPlugWireFactor T]
+    {Δ : PortBoundary}
+    (W : T.Obj Δ) (K : T.Obj (PortBoundary.swap Δ)) :
+    T.plug W K =
+      T.map (PortBoundary.Equiv.tensorEmptyLeft PortBoundary.empty).toHom
+        (T.wire
+          (T.map (PortBoundary.Equiv.tensorEmptyLeft Δ).symm.toHom W)
+          (T.map (PortBoundary.Equiv.tensorEmptyRight
+            (PortBoundary.swap Δ)).symm.toHom K)) :=
+  HasPlugWireFactor.plug_eq_wire W K
 
 /-- Plug-par factorization (left): plugging a parallel composition against a
 context factors through the left component.
 
-See `CompactClosed.plug_par_left` for the full docstring. -/
+See `HasPlugWireFactor.plug_par_left` for the full docstring. -/
 theorem plug_par_left
-    [CompactClosed T]
+    [HasPlugWireFactor T]
     {Δ₁ Δ₂ : PortBoundary}
     (W₁ : T.Obj Δ₁) (W₂ : T.Obj Δ₂)
     (K : T.Obj (PortBoundary.swap (PortBoundary.tensor Δ₁ Δ₂))) :
@@ -799,14 +902,14 @@ theorem plug_par_left
             (Δ₂ := PortBoundary.empty)
             K
             (T.mapEquiv (PortBoundary.Equiv.tensorEmptyRight Δ₂).symm W₂))) :=
-  CompactClosed.plug_par_left W₁ W₂ K
+  HasPlugWireFactor.plug_par_left W₁ W₂ K
 
 /-- Plug-wire factorization (left): closing a wired composition against a
 context factors through the left wire component.
 
-See `CompactClosed.plug_wire_left` for the full docstring. -/
+See `HasPlugWireFactor.plug_wire_left` for the full docstring. -/
 theorem plug_wire_left
-    [CompactClosed T]
+    [HasPlugWireFactor T]
     {Δ₁ Γ Δ₂ : PortBoundary}
     (W₁ : T.Obj (PortBoundary.tensor Δ₁ Γ))
     (W₂ : T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂))
@@ -820,7 +923,7 @@ theorem plug_wire_left
           K
           (T.mapEquiv (PortBoundary.Equiv.tensorComm
             (PortBoundary.swap Γ) Δ₂) W₂)) :=
-  CompactClosed.plug_wire_left W₁ W₂ K
+  HasPlugWireFactor.plug_wire_left W₁ W₂ K
 
 end Laws
 


### PR DESCRIPTION
## Summary

Stack of four additive slices (**S3, S4, S5, S6**) on the polynomial-substrate redesign for `VCVio/Interaction/`. Each slice follows the §0.6 calibration rule: bridge-first, redefine only when a redefinition has no definitional regression at downstream call sites. **All four slices are additive: zero downstream call-site changes outside the files touched.**

The earlier slices S1 (`Spec` polynomial substrate, [#306](https://github.com/Verified-zkEVM/VCV-io/pull/306)) and S2 (`DecoratedSpec` polynomial substrate, [#307](https://github.com/Verified-zkEVM/VCV-io/pull/307)) are already landed on main. This PR continues the campaign at the `StepOver`/`ProcessOver` and `OpenTheory` layers.

### S3 — `StepOver` polynomial bridge

Adds, inside `namespace Interaction.Concurrent.StepOver` in `VCVio/Interaction/Concurrent/Process.lean`:

- `StepOver.toPFunctor Γ : PFunctor` whose positions are `Σ spec, Decoration Γ spec` and direction family is `Transcript spec`.
- `StepOver.equivObj : StepOver Γ P ≃ (StepOver.toPFunctor Γ).Obj P`, an `rfl`-roundtrip pure regrouping of `(spec, semantics, next)` into the polynomial form `(position, continuation)`.
- `StepOver.equivPositions : (StepOver.toPFunctor Γ).A ≃ DecoratedSpec Γ` exhibiting the `Γ.toPFunctor` substrate at the position layer.

The full polynomial redefinition `def StepOver Γ P := FreeM Γ.toPFunctor P` was attempted but **calibrated down to an additive bridge**: the projection `(mapContext f s).spec = s.spec` is only propositional under the `FreeM` form (it has to recurse through the tree), but it is `rfl` under the structure form. 12+ rewrite call sites in `OpenProcess.lean` and `OpenProcessModel.lean` rely on this being definitional. Bridge-first preserves all those call sites verbatim while still naming the polynomial substrate.

### S4 — `Context.prod` + `OpenNodeContext` polynomial-product bridge

Adds:

- `Spec.Node.Context.{prod, prodFst, prodSnd, prodPair, prodMap}` to `VCVio/Interaction/Basic/Node.lean`: the non-dependent context product, with universal-property projection / pairing / functorial maps.
- `OpenNodeContext.{productView, toProductView, ofProductView}` polynomial-product bridge in `VCVio/Interaction/UC/OpenProcess.lean`: exhibits `OpenNodeContext Party Δ` as the non-dependent product of `StepContext Party` and `BoundaryAction Δ` via mutually-inverse `ContextHom`s.
- Three demonstrative `_eq_` naturality identities (`forget_eq_prodFst_comp_toProductView`, `embed_eq_ofProductView_comp_prodPair`, `map_eq_ofProductView_comp_prodMap_comp_toProductView`) showing the existing 8 hand-rolled `OpenNodeContext` context-homs are concrete instances of the universal projection / pairing / product-map for the polynomial product. All three are `rfl`-clean.

### S5 — `ProcessOver.behavior` + canonical `ObsEq`

Adds, inside `namespace Interaction.Concurrent.ProcessOver`:

- `Behavior Γ : Type _ := PFunctor.M (StepOver.toPFunctor Γ)` — the terminal `StepOver.toPFunctor Γ`-coalgebra.
- `behavior : (process : ProcessOver Γ) → process.Proc → Behavior Γ := M.corec (equivObj ∘ process.step)` — the unique coalgebra homomorphism into the terminal coalgebra.
- `dest_behavior` (`@[simp]`) — the `M.dest`-defining equation.
- `behavior_unique` — the bisim-by-uniqueness universal property (any `f : process.Proc → Behavior Γ` satisfying the coalgebra-homomorphism diagram for `M` agrees with `process.behavior` on the nose).
- `ObsEq process₁ process₂ p₁ p₂ : Prop := process₁.behavior p₁ = process₂.behavior p₂` — canonical observational equivalence on residual states (4-arg form, supports comparing states of different processes over the same context, as needed for UC simulation arguments).
- `ObsEq.{refl, symm, trans}` — equivalence-relation API.

Closes the Niu-Spivak patterns/matter loop: `OracleComp` is `FreeM` (patterns); `StepOver` is `FreeM` for a different polynomial (also patterns); `ProcessOver.behavior` lands in `M` (matter). Existing `Concurrent.Refinement.Bisimulation` is preserved verbatim — `ObsEq` complements it as the *coalgebraic* behavioral equivalence without replacing the operational/relational simulation API.

### S6 — `OpenTheory` granular class hierarchy

Replaces the bundled `OpenTheory.{Monoidal, CompactClosed}` classes with a Mathlib-style granular hierarchy under `namespace OpenTheory`:

- **Data classes** (no laws): `HasUnit T` (just `unit : T.Obj PortBoundary.empty`) and `HasIdWire T` (just `idWire : ∀ Γ, T.Obj (PortBoundary.tensor (PortBoundary.swap Γ) Γ)`).
- **Lawfulness chain**: `IsMonoidal extends IsLawful, HasUnit` (`par_assoc`, `par_comm`, `par_leftUnit`, `par_rightUnit`) → `IsTraced extends IsMonoidal` (Joyal-Street-Verity trace axioms `wire_assoc`, `wire_par_superpose`, `wire_comm`) → `IsCompactClosed extends IsTraced, HasIdWire` (snake/zig-zag identities `wire_idWire`, `wire_idWire_right`, `unit_eq`) → `HasPlugWireFactor extends IsCompactClosed` (closure-factorization identities `plug_eq_wire`, `plug_par_left`, `plug_wire_left`).

**Why granular** (Mathlib precedent: `Monoid → CommMonoid → Group`):

1. `(Poly, ⊗)` is monoidal closed but **not** compact closed in the strict equational sense. The canonical process model in `OpenProcessModel.lean` only satisfies the snake equations *up to bisim* (`OpenProcessIso`), not strict equality, and consequently could not be made an instance of the bundled class at all. The granular split lets future weak-equational models instantiate `IsTraced` and skip `IsCompactClosed`.
2. Many UC-composition theorems in `Computational.lean`/`Emulates.lean` need only `HasPlugWireFactor`, not the full snake equations. The granular split surfaces this dependency cleanly.
3. Each instance in `Expr.theory` / `Interp.theory` is now a focused ~30-line block instead of the previous 200+-line bundled `compactClosed` instance.

Migration recipe at use sites: old `let _ : OpenTheory.IsLawful T := hT.toMonoidal.toIsLawful` becomes `letI : OpenTheory.HasPlugWireFactor T := hT`. `letI` registers the hypothesis with the local instance cache, and TC inference transitively closes through all the `extends` projections.

Free models `Expr.theory Atom` and `Interp.theory Atom` in `OpenSyntax/{Expr, Interp}.lean` each now provide six instances (`hasUnit`, `hasIdWire`, `isMonoidal`, `isTraced`, `isCompactClosed`, `hasPlugWireFactor`) instead of the previous two (`monoidal`, `compactClosed`).

## Axiom hygiene

Verified all of `OpenTheory.{par_assoc, par_comm, par_leftUnit, par_rightUnit, wire_assoc, wire_par_superpose, wire_comm, wire_idWire, wire_idWire_right, unit_eq, plug_eq_wire, plug_par_left, plug_wire_left}`, `Interp.{isMonoidal, isTraced, isCompactClosed, hasPlugWireFactor}`, `Expr.{isMonoidal, isCompactClosed, hasPlugWireFactor}`, and `Emulates.par_left` / `CompEmulates.{par_left, wire_compose, plug_compose}` depend only on `[propext, Classical.choice, Quot.sound]`. Same for the `StepOver.{toPFunctor, equivObj, equivPositions}` bridge, the `Context.prod` infrastructure, the `OpenNodeContext.{productView, toProductView, ofProductView}` round-trip lemmas, and `ProcessOver.{behavior, dest_behavior, behavior_unique, ObsEq.refl, ObsEq.symm, ObsEq.trans}`. **No new project-specific axioms.**

## Diff stat

```
 VCVio/Interaction/Basic/Node.lean           |  75 ++++++
 VCVio/Interaction/Concurrent/Process.lean   | 164 +++++++++++++
 VCVio/Interaction/UC/Computational.lean     |  20 +-
 VCVio/Interaction/UC/Emulates.lean          |   4 +-
 VCVio/Interaction/UC/OpenProcess.lean       | 121 ++++++++++
 VCVio/Interaction/UC/OpenSyntax/Expr.lean   |  75 +++---
 VCVio/Interaction/UC/OpenSyntax/Interp.lean | 153 ++++++++-----
 VCVio/Interaction/UC/OpenSyntax/Raw.lean    |   6 +-
 VCVio/Interaction/UC/OpenTheory.lean        | 341 ++++++++++++++++++----------
 9 files changed, 732 insertions(+), 227 deletions(-)
```

## Test plan

- [x] `lake build` clean (only pre-existing `sorry`s in unrelated CryptoFoundations files).
- [x] Axiom audit on the new declarations in this stack — all depend only on `[propext, Classical.choice, Quot.sound]`.
- [x] All `rfl`-load-bearing definitional equalities preserved at the `StepOver` and `OpenNodeContext` layers (S3, S4 are pure additive bridges).
- [x] Existing `Concurrent.Refinement.Bisimulation` API preserved verbatim (S5 adds `ObsEq` alongside, not in place of).
- [x] Free models `Expr.theory` and `Interp.theory` instantiate the full new class chain, providing all six granular instances (S6).

## Notes

- Stacked on already-merged S1 (#306) and S2 (#307).
- Related design memo lives at `Documents/Notes/vcvio-interaction-redesign-council-synthesis.md` (not in this repo) — see §0.5 for the per-slice status table and §0.6 for the calibration rule that drove the additive-bridge approach.
- S7 (`IsPolynomial Γ` typeclass) was attempted on this branch and dropped after review (see PR comment); the trivial documentation form had no downstream caller and gated no theorem. The right time to add it back is when a concrete caller requires the polynomial property in its original Option A non-trivial form.

---

*Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.*


Made with [Cursor](https://cursor.com)
