### PR TITLE
refactor(interaction): split node metadata into `NodeAuthority` + `NodeObservation`, rename bundle to `NodeProfile` + agent-guide orientation

### DIFF
--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -100,7 +100,7 @@ This is the canonical representation of "an interactive node where the
 participant chooses a value of some move type, and the continuation is
 selected by that value". It is independent of payload data, controller
 attribution, and execution semantics; those layers refine the same
-polynomial via `Decoration`, `NodeSemantics`, and `StepOver`. -/
+polynomial via `Decoration`, `NodeProfile`, and `StepOver`. -/
 @[reducible]
 def basePFunctor : PFunctor.{u+1, u} where
   A := Type u

--- a/VCVio/Interaction/Concurrent/Examples.lean
+++ b/VCVio/Interaction/Concurrent/Examples.lean
@@ -381,7 +381,7 @@ section PhaseOneExamples
 /-- Node semantics for a tiny looping process:
 the adversary actively chooses the boolean step, Bob observes it, and Alice is
 hidden from it. -/
-def loopNode : NodeSemantics Party Bool where
+def loopNode : NodeProfile Party Bool where
   controllers := fun _ => [.adv]
   views
     | .adv => .active

--- a/VCVio/Interaction/Concurrent/Execution.lean
+++ b/VCVio/Interaction/Concurrent/Execution.lean
@@ -62,7 +62,7 @@ inductive Observed {Party : Type u} [DecidableEq Party] (me : Party) :
     step
       {Moves : Type w}
       {rest : Moves → Interaction.Spec.{w}}
-      {node : NodeSemantics Party Moves}
+      {node : NodeProfile Party Moves}
       {semantics : (x : Moves) →
         Interaction.Spec.Decoration (StepContext Party) (rest x)}
       {x : Moves}

--- a/VCVio/Interaction/Concurrent/Machine.lean
+++ b/VCVio/Interaction/Concurrent/Machine.lean
@@ -145,7 +145,7 @@ step inside the richer interaction semantics.
 models to the more general process-centered concurrent layer.
 -/
 def toProcess {Party : Type u} (machine : Machine)
-    (semantics : (σ : machine.State) → NodeSemantics Party (machine.Enabled σ)) :
+    (semantics : (σ : machine.State) → NodeProfile Party (machine.Enabled σ)) :
     Process Party where
   Proc := machine.State
   step σ :=
@@ -160,7 +160,7 @@ Lift `Machine.toProcess` from bare dynamics to the verification-oriented
 invariant predicates.
 -/
 def System.toProcess {Party : Type u} (system : Machine.System)
-    (semantics : (σ : system.State) → NodeSemantics Party (system.Enabled σ)) :
+    (semantics : (σ : system.State) → NodeProfile Party (system.Enabled σ)) :
     Process.System Party where
   toProcess := system.toMachine.toProcess semantics
   init := system.init

--- a/VCVio/Interaction/Concurrent/Process.lean
+++ b/VCVio/Interaction/Concurrent/Process.lean
@@ -28,7 +28,8 @@ The file is organized in two levels:
 * `StepOver Γ P` and `ProcessOver Γ` are the generic forms, parameterized by a
   realized node context `Γ`;
 * `Step Party P` and `Process Party` are the closed-world specializations whose
-  node metadata is exactly `NodeSemantics Party`.
+  node metadata is exactly `NodeProfile Party`, the bundled
+  `NodeAuthority + NodeObservation` view of node-local semantic data.
 
 So the intended reading is:
 
@@ -49,31 +50,65 @@ namespace Interaction
 namespace Concurrent
 
 /--
-`NodeSemantics Party X` records the local semantic data attached to one
+`NodeAuthority Party X` records the controller-attribution part of node-local
+semantic data: which parties are credited as controllers of each move
+`x : X`.
+
+This is one of the two orthogonal layers of `NodeProfile`. It is stored
+separately so that downstream reasoning that depends only on
+controller attribution (corruption policies, scheduler accountability,
+party-side responsibility arguments) can take a `NodeAuthority` parameter
+without committing to any particular observation structure.
+-/
+structure NodeAuthority (Party : Type u) (X : Type w) where
+  controllers : X → List Party := fun _ => []
+
+/--
+`NodeObservation Party X` records the view-attribution part of node-local
+semantic data: what each party `me : Party` locally observes of the
+chosen move `x : X`, expressed as a `Multiparty.LocalView X`.
+
+This is the second of the two orthogonal layers of `NodeProfile`. It
+is stored separately so that downstream reasoning that depends only on
+local views (information-flow arguments, projection / trace semantics,
+view-equivalence proofs) can take a `NodeObservation` parameter without
+committing to any particular controller attribution.
+-/
+structure NodeObservation (Party : Type u) (X : Type w) where
+  views : Party → Multiparty.LocalView X
+
+/--
+`NodeProfile Party X` records the local semantic data attached to one
 sequential interaction node whose move space is `X`.
 
-It packages two orthogonal pieces of information:
+It bundles two orthogonal layers:
 
-* `controllers x` is the controller-path contribution associated to choosing
-  the move `x : X`;
-* `views` assigns to each party its local view of the chosen move `x : X`.
+* `NodeAuthority Party X` — `controllers x` is the controller-path contribution
+  associated to choosing the move `x : X`;
+* `NodeObservation Party X` — `views me` assigns to party `me` its local view
+  of the chosen move.
 
-The controller-path contribution and the local views are intentionally stored
-separately. Many natural systems align them so that the first controller in
-`controllers x` has local view `active`, but this file does not force that
-relationship definitionally.
-Any desired coherence law can be imposed later as a separate well-formedness
-predicate.
+The two layers are intentionally stored as separate factor structures.
+Many natural systems align them so that the first controller in
+`controllers x` has local view `.active`, but this file does not force that
+relationship definitionally; any desired coherence law can be imposed later
+as a separate well-formedness predicate.
+
+Because `NodeProfile` `extends` both factors, the dot-notation accessors
+`node.controllers`, `node.views` and the structure-literal constructor
+`{ controllers := ..., views := ... }` work exactly as if the fields were
+declared inline. The factor projections `node.toNodeAuthority`,
+`node.toNodeObservation` are auto-generated and let downstream code restrict
+attention to a single layer.
 -/
-structure NodeSemantics (Party : Type u) (X : Type w) where
-  controllers : X → List Party := fun _ => []
-  views : Party → Multiparty.LocalView X
+structure NodeProfile (Party : Type u) (X : Type w)
+    extends NodeAuthority Party X, NodeObservation Party X
 
 /--
 The closed-world node context used by the current concurrent semantics.
 
 At a node with move space `X`, the context value is exactly the
-`NodeSemantics Party X` describing:
+`NodeProfile Party X` describing:
 
 * which parties are recorded as controllers of the chosen move, and
 * what each party locally observes of that move.
@@ -81,7 +116,7 @@ At a node with move space `X`, the context value is exactly the
 This is the context whose specialization recovers the existing closed-world
 `Step` / `Process` APIs.
 -/
-abbrev StepContext (Party : Type u) := fun X => NodeSemantics Party X
+abbrev StepContext (Party : Type u) := fun X => NodeProfile Party X
 
 /--
 `StepOver Γ P` is one finite sequential interaction episode whose nodes are

--- a/VCVio/Interaction/UC/EnvAction.lean
+++ b/VCVio/Interaction/UC/EnvAction.lean
@@ -72,7 +72,7 @@ events use `pure ∘ update` and pay no extra cost.
 ## Additive design
 
 `EnvAction` is intentionally **standalone**: it is *not* threaded
-into `OpenNodeSemantics`. Existing `OpenProcess Party Δ`
+into `OpenNodeProfile`. Existing `OpenProcess Party Δ`
 constructions are unaffected, and protocols that do not need
 environment-driven events incur zero cost. The corruption-aware
 wrapper that pairs an `OpenProcess` with a state-indexed

--- a/VCVio/Interaction/UC/EnvOpenProcess.lean
+++ b/VCVio/Interaction/UC/EnvOpenProcess.lean
@@ -32,11 +32,11 @@ The wrapper does two concrete jobs that an ad-hoc tuple does not:
    actions never imports this file. A consumer that does, gets the
    pair as a structure with a typed `react` projection. The env
    channel is **additive** above `OpenProcess` and never threaded
-   into `OpenNodeSemantics`, so adding it costs zero in the rest of
+   into `OpenNodeProfile`, so adding it costs zero in the rest of
    the framework.
 
 The alternative, threading the env-event alphabet `Σ` (with
-`Σ := Empty` default) directly through `OpenNodeSemantics`, would
+`Σ := Empty` default) directly through `OpenNodeProfile`, would
 touch every existing constructor and every `_iso` lemma in
 `OpenProcessModel.lean`. The wrapper achieves the same expressive
 power additively, with zero invasion.
@@ -102,7 +102,7 @@ The state type `State` is constrained to `Type` (universe 0) because
 `EnvAction.react` returns a `ProbComp State` and `ProbComp : Type → Type`.
 
 Existing `OpenProcess` consumers are unaffected: nothing here is
-threaded into `OpenNodeSemantics`. The wrapper is the structural
+threaded into `OpenNodeProfile`. The wrapper is the structural
 foundation for corruption-aware composition and for the canonical
 CJSV22 instantiation `MomentaryCorruption.Process` in
 `MomentaryCorruption.lean`.

--- a/VCVio/Interaction/UC/MachineId.lean
+++ b/VCVio/Interaction/UC/MachineId.lean
@@ -43,7 +43,7 @@ CJSV22 *subroutine respecting* condition:
 * **`MachineProcess.SubroutineRespectingAt sid P`.** A `Prop`-valued
   property saying every reachable step's decoration only attributes
   controllers in session `sid`. Built recursively over `Spec.Decoration`
-  via `OpenNodeSemantics.SessionCoherentAtMove` and
+  via `OpenNodeProfile.SessionCoherentAtMove` and
   `DecorationSessionCoherentAt`.
 
 These three pieces are *additive* on top of the existing `OpenProcess`
@@ -239,9 +239,9 @@ This is the per-move check used by `DecorationSessionCoherentAt`: at the
 node where `x` is chosen, every machine credited as a controller of `x`
 must share the protocol's session identifier.
 -/
-def OpenNodeSemantics.SessionCoherentAtMove
+def OpenNodeProfile.SessionCoherentAtMove
     {Sid Pid : Type u} {Δ : PortBoundary} {X : Type w}
-    (sid : Sid) (ons : OpenNodeSemantics (MachineId Sid Pid) Δ X)
+    (sid : Sid) (ons : OpenNodeProfile (MachineId Sid Pid) Δ X)
     (x : X) : Prop :=
   ∀ m ∈ ons.controllers x, m.sid = sid
 
@@ -251,7 +251,7 @@ transcript iff every visited node attributes only controllers in
 session `sid`.
 
 This is the recursive companion to
-`OpenNodeSemantics.SessionCoherentAtMove`, modeled directly on
+`OpenNodeProfile.SessionCoherentAtMove`, modeled directly on
 `IsSilentDecoration`: the predicate walks the same transcript path
 through the decoration tree and accumulates the per-node coherence
 checks.

--- a/VCVio/Interaction/UC/MomentaryCorruption.lean
+++ b/VCVio/Interaction/UC/MomentaryCorruption.lean
@@ -66,7 +66,7 @@ universes `(v, w)` are exposed.
 ## Additive design
 
 The model is **standalone**: nothing here is threaded into
-`OpenNodeSemantics`. Existing `OpenProcess` constructions are
+`OpenNodeProfile`. Existing `OpenProcess` constructions are
 untouched. The corruption-aware composition operators (par / wire /
 plug lifted from `OpenTheory`) and the four `*.corrupt` forwarding
 lemmas (CJSV22 §4.2) live in a downstream layer that consumes

--- a/VCVio/Interaction/UC/OpenProcess.lean
+++ b/VCVio/Interaction/UC/OpenProcess.lean
@@ -23,14 +23,14 @@ The design follows the layered approach from the UC design notes:
 * `BoundaryAction Δ X` records, at one protocol node with move space `X`,
   whether the node is externally activated and what outbound packets the
   chosen move contributes.
-* `OpenNodeSemantics Party Δ X` extends the existing `NodeSemantics Party X`
+* `OpenNodeProfile Party Δ X` extends the existing `NodeProfile Party X`
   by one `BoundaryAction` field.
 * `OpenNodeContext Party Δ` is the resulting realized node context.
 * `OpenProcess Party Δ` specializes `ProcessOver` to that open context.
 
 The closed-world layer is recovered by the canonical forgetful projection
 `OpenNodeContext.forget`, which drops the boundary action and retains only
-the `NodeSemantics`. This means every `OpenProcess` can be viewed as a plain
+the `NodeProfile`. This means every `OpenProcess` can be viewed as a plain
 closed `Process` by `ProcessOver.mapContext`.
 
 Boundary actions are structurally mappable along `PortBoundary.Hom` via
@@ -250,7 +250,7 @@ theorem mapBoundary_wireRight
 end BoundaryAction
 
 /--
-`OpenNodeSemantics Party Δ X` extends `NodeSemantics Party X` with one
+`OpenNodeProfile Party Δ X` extends `NodeProfile Party X` with one
 `BoundaryAction Δ X` recording the node's interaction with an external
 boundary.
 
@@ -259,33 +259,33 @@ one: the closed part (`controllers`, `views`) describes internal control and
 observation, while `boundary` describes the node's interface with the outside
 world.
 -/
-structure OpenNodeSemantics (Party : Type u) (Δ : PortBoundary) (X : Type w)
-    extends NodeSemantics Party X where
+structure OpenNodeProfile (Party : Type u) (Δ : PortBoundary) (X : Type w)
+    extends NodeProfile Party X where
   boundary : BoundaryAction Δ X := .internal Δ X
 
-namespace OpenNodeSemantics
+namespace OpenNodeProfile
 
 /--
-Build an `OpenNodeSemantics` from a closed `NodeSemantics` by marking the node
+Build an `OpenNodeProfile` from a closed `NodeProfile` by marking the node
 as purely internal (no boundary traffic).
 -/
 def ofClosed {Party : Type u} {Δ : PortBoundary} {X : Type w}
-    (ns : NodeSemantics Party X) : OpenNodeSemantics Party Δ X where
-  toNodeSemantics := ns
+    (ns : NodeProfile Party X) : OpenNodeProfile Party Δ X where
+  toNodeProfile := ns
 
 /--
-Transform the boundary action of an open node semantics along a boundary
-adaptation, preserving the closed-world node semantics.
+Transform the boundary action of an open node profile along a boundary
+adaptation, preserving the closed-world node profile.
 -/
 def mapBoundary {Party : Type u} {Δ₁ Δ₂ : PortBoundary} {X : Type w}
-    (φ : PortBoundary.Hom Δ₁ Δ₂) (ons : OpenNodeSemantics Party Δ₁ X) :
-    OpenNodeSemantics Party Δ₂ X where
-  toNodeSemantics := ons.toNodeSemantics
+    (φ : PortBoundary.Hom Δ₁ Δ₂) (ons : OpenNodeProfile Party Δ₁ X) :
+    OpenNodeProfile Party Δ₂ X where
+  toNodeProfile := ons.toNodeProfile
   boundary := ons.boundary.mapBoundary φ
 
 @[simp]
 theorem mapBoundary_id {Party : Type u} {Δ : PortBoundary} {X : Type w}
-    (ons : OpenNodeSemantics Party Δ X) :
+    (ons : OpenNodeProfile Party Δ X) :
     mapBoundary (PortBoundary.Hom.id Δ) ons = ons := by
   cases ons; simp [mapBoundary, BoundaryAction.mapBoundary_id]
 
@@ -293,18 +293,18 @@ theorem mapBoundary_id {Party : Type u} {Δ : PortBoundary} {X : Type w}
 theorem mapBoundary_comp {Party : Type u}
     {Δ₁ Δ₂ Δ₃ : PortBoundary} {X : Type w}
     (g : PortBoundary.Hom Δ₂ Δ₃) (f : PortBoundary.Hom Δ₁ Δ₂)
-    (ons : OpenNodeSemantics Party Δ₁ X) :
+    (ons : OpenNodeProfile Party Δ₁ X) :
     mapBoundary g (mapBoundary f ons) =
       mapBoundary (PortBoundary.Hom.comp g f) ons := by
   cases ons; simp [mapBoundary, BoundaryAction.mapBoundary_comp]
 
-end OpenNodeSemantics
+end OpenNodeProfile
 
 /--
 The open-world node context for processes with boundary `Δ`.
 
 At a node with move space `X`, the context value is
-`OpenNodeSemantics Party Δ X`: the usual controller-path and local-view data,
+`OpenNodeProfile Party Δ X`: the usual controller-path and local-view data,
 plus a `BoundaryAction` describing the node's external traffic.
 
 ## Polynomial reading
@@ -324,12 +324,12 @@ hand-rolled context-homs below (`forget`, `embed`, `map`, `inlTensor`,
 `inrTensor`, `wireLeft`, `wireRight`, `close`) are concrete instances of
 the universal projection / pairing maps for this product, specialized to
 the particular boundary-action transformations they perform. The structure
-form `OpenNodeSemantics extends NodeSemantics` is preserved as the working
-API because it gives clean `{ toNodeSemantics := ..., boundary := ... }`
+form `OpenNodeProfile extends NodeProfile` is preserved as the working
+API because it gives clean `{ toNodeProfile := ..., boundary := ... }`
 construction sites and definitional projections used pervasively below.
 -/
 abbrev OpenNodeContext (Party : Type u) (Δ : PortBoundary) :=
-  fun (X : Type w) => OpenNodeSemantics Party Δ X
+  fun (X : Type w) => OpenNodeProfile Party Δ X
 
 namespace OpenNodeContext
 
@@ -340,13 +340,13 @@ of the closed `StepContext Party` and the boundary-action context, and
 prove that the bridge is a definitional isomorphism (round trips reduce
 to `rfl` by `Prod.mk.eta` and structure eta). The product view lets one
 phrase universal-property arguments without repeatedly pattern-matching
-on `OpenNodeSemantics` literals; the structural API below is the working
+on `OpenNodeProfile` literals; the structural API below is the working
 form. -/
 
 /-- The polynomial-product view of `OpenNodeContext`. Lives in the same
 universes as `OpenNodeContext Party Δ` itself: the first universe is the
 move-space universe `w`, and the second is whatever Lean infers for
-`NodeSemantics Party X × BoundaryAction Δ X`. -/
+`NodeProfile Party X × BoundaryAction Δ X`. -/
 abbrev productView (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.Context.{w} :=
   Spec.Node.Context.prod (StepContext Party)
@@ -354,21 +354,21 @@ abbrev productView (Party : Type u) (Δ : PortBoundary) :
 
 /--
 Forward direction of the polynomial-product bridge: read off the
-`(NodeSemantics, BoundaryAction)` pair from an `OpenNodeSemantics`. -/
+`(NodeProfile, BoundaryAction)` pair from an `OpenNodeProfile`. -/
 def toProductView (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.ContextHom
       (OpenNodeContext Party Δ : Spec.Node.Context.{w})
       (productView.{u, w} Party Δ) :=
-  fun _ ons => (ons.toNodeSemantics, ons.boundary)
+  fun _ ons => (ons.toNodeProfile, ons.boundary)
 
 /--
 Inverse direction of the polynomial-product bridge: reassemble an
-`OpenNodeSemantics` from a `(NodeSemantics, BoundaryAction)` pair. -/
+`OpenNodeProfile` from a `(NodeProfile, BoundaryAction)` pair. -/
 def ofProductView (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.ContextHom
       (productView.{u, w} Party Δ)
       (OpenNodeContext Party Δ : Spec.Node.Context.{w}) :=
-  fun _ p => { toNodeSemantics := p.1, boundary := p.2 }
+  fun _ p => { toNodeProfile := p.1, boundary := p.2 }
 
 @[simp]
 theorem toProductView_ofProductView (Party : Type u) (Δ : PortBoundary) :
@@ -392,14 +392,14 @@ theorem ofProductView_toProductView (Party : Type u) (Δ : PortBoundary) :
 /--
 The forgetful map from the open-world context to the closed-world context.
 
-This drops the `BoundaryAction` and retains only the `NodeSemantics`
+This drops the `BoundaryAction` and retains only the `NodeProfile`
 (controllers and local views).
 -/
 def forget (Party : Type u) (Δ : PortBoundary) :
     Spec.Node.ContextHom
       (OpenNodeContext Party Δ : Spec.Node.Context.{w})
       (StepContext Party) :=
-  fun _ ons => ons.toNodeSemantics
+  fun _ ons => ons.toNodeProfile
 
 /--
 The embedding from the closed-world context into the open-world context.
@@ -438,7 +438,7 @@ theorem map_comp (Party : Type u)
       (OpenNodeContext.map.{u, w} Party g) (OpenNodeContext.map Party f) =
       OpenNodeContext.map Party (PortBoundary.Hom.comp g f) := by
   funext X ons; simp [map, Spec.Node.ContextHom.comp,
-    OpenNodeSemantics.mapBoundary_comp]
+    OpenNodeProfile.mapBoundary_comp]
 
 /--
 Embed the left factor's open-world context into the tensor boundary context.
@@ -452,7 +452,7 @@ def inlTensor (Party : Type u)
       (OpenNodeContext Party Δ₁ : Spec.Node.Context.{w})
       (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
-    toNodeSemantics := ons.toNodeSemantics
+    toNodeProfile := ons.toNodeProfile
     boundary := ons.boundary.embedInlTensor Δ₂
   }
 
@@ -468,7 +468,7 @@ def inrTensor (Party : Type u)
       (OpenNodeContext Party Δ₂ : Spec.Node.Context.{w})
       (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
-    toNodeSemantics := ons.toNodeSemantics
+    toNodeProfile := ons.toNodeProfile
     boundary := ons.boundary.embedInrTensor Δ₁
   }
 
@@ -483,7 +483,7 @@ def wireLeft (Party : Type u)
       (OpenNodeContext Party (PortBoundary.tensor Δ₁ Γ) : Spec.Node.Context.{w})
       (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
-    toNodeSemantics := ons.toNodeSemantics
+    toNodeProfile := ons.toNodeProfile
     boundary := ons.boundary.wireLeft Δ₂
   }
 
@@ -500,7 +500,7 @@ def wireRight (Party : Type u)
         Spec.Node.Context.{w})
       (OpenNodeContext Party (PortBoundary.tensor Δ₁ Δ₂) : Spec.Node.Context.{w}) :=
   fun _ ons => {
-    toNodeSemantics := ons.toNodeSemantics
+    toNodeProfile := ons.toNodeProfile
     boundary := ons.boundary.wireRight Δ₁
   }
 
@@ -514,7 +514,7 @@ def close (Party : Type u) (Δ : PortBoundary) :
       (OpenNodeContext Party Δ : Spec.Node.Context.{w})
       (OpenNodeContext Party PortBoundary.empty : Spec.Node.Context.{w}) :=
   fun _ ons => {
-    toNodeSemantics := ons.toNodeSemantics
+    toNodeProfile := ons.toNodeProfile
     boundary := ons.boundary.closed
   }
 
@@ -529,7 +529,7 @@ theorem map_tensor_comp_inlTensor (Party : Type u)
       (map Party f₁) := by
   funext X ons
   simp [map, inlTensor, Spec.Node.ContextHom.comp,
-    OpenNodeSemantics.mapBoundary]
+    OpenNodeProfile.mapBoundary]
 
 theorem map_tensor_comp_inrTensor (Party : Type u)
     {Δ₁ Δ₁' Δ₂ Δ₂' : PortBoundary}
@@ -542,7 +542,7 @@ theorem map_tensor_comp_inrTensor (Party : Type u)
       (map Party f₂) := by
   funext X ons
   simp [map, inrTensor, Spec.Node.ContextHom.comp,
-    OpenNodeSemantics.mapBoundary]
+    OpenNodeProfile.mapBoundary]
 
 theorem close_comp_map (Party : Type u)
     {Δ₁ Δ₂ : PortBoundary}
@@ -553,7 +553,7 @@ theorem close_comp_map (Party : Type u)
     close Party Δ₁ := by
   funext X ons
   simp [close, map, Spec.Node.ContextHom.comp,
-    OpenNodeSemantics.mapBoundary, BoundaryAction.closed, BoundaryAction.mapBoundary]
+    OpenNodeProfile.mapBoundary, BoundaryAction.closed, BoundaryAction.mapBoundary]
 
 theorem map_tensor_comp_wireLeft (Party : Type u)
     {Δ₁ Δ₁' Γ Δ₂ Δ₂' : PortBoundary}
@@ -566,7 +566,7 @@ theorem map_tensor_comp_wireLeft (Party : Type u)
       (map Party (PortBoundary.Hom.tensor f₁ (PortBoundary.Hom.id Γ))) := by
   funext X ons
   simp [map, wireLeft, Spec.Node.ContextHom.comp,
-    OpenNodeSemantics.mapBoundary]
+    OpenNodeProfile.mapBoundary]
 
 theorem map_tensor_comp_wireRight (Party : Type u)
     {Δ₁ Δ₁' Γ Δ₂ Δ₂' : PortBoundary}
@@ -580,7 +580,7 @@ theorem map_tensor_comp_wireRight (Party : Type u)
         (PortBoundary.Hom.id (PortBoundary.swap Γ)) f₂)) := by
   funext X ons
   simp [map, wireRight, Spec.Node.ContextHom.comp,
-    OpenNodeSemantics.mapBoundary]
+    OpenNodeProfile.mapBoundary]
 
 /-! #### Existing context-homs as polynomial-product operations
 
@@ -631,7 +631,7 @@ end OpenNodeContext
 /--
 The open-world specialization of `StepOver`.
 
-Here the node context carries `OpenNodeSemantics Party Δ`, so every node
+Here the node context carries `OpenNodeProfile Party Δ`, so every node
 records both the usual controller/view data and its boundary traffic against
 `Δ`.
 -/
@@ -642,7 +642,7 @@ abbrev OpenStep (Party : Type u) (Δ : PortBoundary) (P : Type v) :=
 The open-world specialization of `ProcessOver`.
 
 An `OpenProcess Party Δ` is a continuation-based process whose steps are
-decorated by `OpenNodeSemantics Party Δ`. It exposes the directed boundary
+decorated by `OpenNodeProfile Party Δ`. It exposes the directed boundary
 `Δ` to an external context.
 
 The closed-world `Process Party` is recovered by
@@ -753,7 +753,7 @@ theorem isSilentStep_mapBoundary_iff {Party : Type u} {Δ₁ Δ₂ : PortBoundar
     IsSilentStep (p.mapBoundary φ) s tr ↔ IsSilentStep p s tr := by
   apply isSilentDecoration_iff_map
   intro X ons
-  simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+  simp [OpenNodeContext.map, OpenNodeProfile.mapBoundary, BoundaryAction.mapBoundary]
 
 /-! ## OpenProcessIso: weak bisimulation equivalence for open processes -/
 

--- a/VCVio/Interaction/UC/OpenProcessModel.lean
+++ b/VCVio/Interaction/UC/OpenProcessModel.lean
@@ -44,7 +44,7 @@ variable (Party : Type u)
 
 /-- The hidden scheduler node shared by `par`, `wire`, and `plug`. -/
 private def schedulerNode (Δ : PortBoundary) :
-    OpenNodeSemantics Party Δ (ULift.{w} Bool) where
+    OpenNodeProfile Party Δ (ULift.{w} Bool) where
   controllers := fun _ => []
   views := fun _ => .hidden
   boundary := .internal Δ _
@@ -103,7 +103,7 @@ private theorem schedulerNode_mapBoundary
     (φ : PortBoundary.Hom Δ₁ Δ₂) :
     (schedulerNode.{u, w} Party Δ₁).mapBoundary φ =
       schedulerNode Party Δ₂ := by
-  simp [schedulerNode, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary,
+  simp [schedulerNode, OpenNodeProfile.mapBoundary, BoundaryAction.mapBoundary,
     BoundaryAction.internal]
 
 instance : OpenTheory.IsLawfulPar (openTheory.{u, v, w} Party) where
@@ -549,7 +549,7 @@ theorem openTheory_plug_eq_wire_iso
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
       · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
       · intro X ons
-        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+        simp [OpenNodeContext.map, OpenNodeProfile.mapBoundary, BoundaryAction.mapBoundary]
       · intro X ons; simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
     | false =>
       refine ⟨⟨⟨false⟩, rest⟩, fun h => hvisible ?_, rfl⟩
@@ -559,7 +559,7 @@ theorem openTheory_plug_eq_wire_iso
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
       · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
       · intro X ons
-        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+        simp [OpenNodeContext.map, OpenNodeProfile.mapBoundary, BoundaryAction.mapBoundary]
       · intro X ons; simp [OpenNodeContext.wireRight, BoundaryAction.wireRight]
   · intro ⟨⟨b⟩, rest⟩ _
     match b with
@@ -575,7 +575,7 @@ theorem openTheory_plug_eq_wire_iso
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
       · intro X ons; simp [OpenNodeContext.wireLeft, BoundaryAction.wireLeft]
       · intro X ons
-        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+        simp [OpenNodeContext.map, OpenNodeProfile.mapBoundary, BoundaryAction.mapBoundary]
       · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
     | false =>
       refine ⟨⟨⟨false⟩, rest⟩, fun h => hvisible ?_, rfl⟩
@@ -584,7 +584,7 @@ theorem openTheory_plug_eq_wire_iso
           ((isSilentDecoration_iff_map _ ?_ _ _).mp h.2))⟩
       · intro X ons; simp [OpenNodeContext.wireRight, BoundaryAction.wireRight]
       · intro X ons
-        simp [OpenNodeContext.map, OpenNodeSemantics.mapBoundary, BoundaryAction.mapBoundary]
+        simp [OpenNodeContext.map, OpenNodeProfile.mapBoundary, BoundaryAction.mapBoundary]
       · intro X ons; simp [OpenNodeContext.close, BoundaryAction.closed]
 
 /-- The monoidal unit equals the coevaluation at the trivial boundary,

--- a/docs/agents/interaction.md
+++ b/docs/agents/interaction.md
@@ -12,8 +12,9 @@ The framework is organized around a few stable principles:
   on the move chosen.
   All composition, decoration, and strategy types respect this structure.
 - **Control vs observation are orthogonal.**
-  Who *chooses* a move (`Control`) and who *sees* a move (`Profile`, `LocalView`)
-  are independent axes.
+  Who *chooses* a move (per-node: `NodeAuthority`; per-spec-tree: `Concurrent.Control`)
+  and who *sees* a move (per-node: `NodeObservation`; per-party-per-node:
+  `Multiparty.LocalView`; per-spec-tree: `Concurrent.Profile`) are independent axes.
   A party can control a node but see only a quotient of its own move, or observe
   a node fully without controlling it.
 - **Boundary vs composition.**
@@ -44,6 +45,77 @@ The framework is organized around a few stable principles:
 
 Dependencies flow downward: `Concurrent/` may import `Multiparty/` and `Basic/`;
 `TwoParty/` and `Multiparty/` import only `Basic/`.
+
+## Core concepts: Spec, Node, Party, Profile
+
+Before reading any one file, it helps to fix four words. They are the load-bearing
+vocabulary of the entire `Interaction/` layer.
+
+### Node — a structural location in the protocol tree
+
+A `Spec` is an interaction tree (`VCVio/Interaction/Basic/Spec.lean`). A **node** is one
+branching point of that tree: a pair `(Moves : Type, rest : Moves → Spec)`. It is *not*
+an actor; it is a location where some next move gets chosen. At the level of `Spec`
+alone, a node knows its move space and its continuation family, and nothing else: not
+who chooses, not who watches, not what monad runs, not what data is attached. Those
+concerns are deferred to companion layers (`Decoration`, `NodeProfile`, `StepOver`,
+`SyntaxOver`, `InteractionOver`).
+
+The namespace `Spec.Node.*` (`Context`, `Schema`, `ContextHom` in
+`VCVio/Interaction/Basic/Node.lean`) is *generic node-context infrastructure*: for any
+type family `Γ : Type → Type`, a `Γ`-decoration attaches one `Γ X` value at every node
+with move space `X`.
+
+### Party — an actor that plays across many nodes
+
+A `Party` is a free type parameter introduced by the *content* layers (`Multiparty/`,
+`Concurrent/`, `UC/`). A party is an actor that may control or observe moves at
+*various* nodes throughout the same protocol tree. A party is whole-tree (it has a
+strategy across the entire `Spec`); a node is local (it lives at one location in the
+tree). Typically there are *many more* nodes than parties: a long protocol may have
+unboundedly many nodes (or a continuation-based infinite stream of them via
+`ProcessOver`), but always the same finite party set.
+
+### LocalView — what a single party sees at a single node
+
+`Multiparty.LocalView X` (`Multiparty/Core.lean`) records how *one* party locally
+experiences a node whose move space is `X`. The four constructors
+`active` / `observe` / `hidden` / `quotient Obs toObs` are the canonical observation
+modes. A `LocalView` is the smallest atomic node × party × observation triple in the
+framework.
+
+### NodeProfile — per-node attribution of who-authors-what and who-sees-what
+
+`NodeProfile Party X` (`Concurrent/Process.lean`) is the bridge between a single node
+and the whole party set. It bundles two orthogonal factor structures:
+
+- `NodeAuthority Party X`: `controllers : X → List Party` — for each possible move,
+  which parties are credited as having authored it.
+- `NodeObservation Party X`: `views : Party → Multiparty.LocalView X` — for each
+  party, what local view they have at this node.
+
+The structure `extends` both factors, so dot-notation field access
+(`node.controllers x`, `node.views me`) and the structure-literal constructor
+`{ controllers := ..., views := ... }` work transparently. Code that depends only on
+authorship can take a `NodeAuthority Party X` parameter; code that depends only on
+observation can take a `NodeObservation Party X` parameter.
+
+`OpenNodeProfile Party Δ X` (`UC/OpenProcess.lean`) is the open-system extension that
+adds one `BoundaryAction Δ X` field for external traffic.
+
+### Mental picture
+
+The protocol tree is the stage; **nodes** are scenes on the stage; **parties** are
+actors who appear in many scenes; a **`NodeProfile`** is one scene's cast list and
+sightlines. `LocalView` is a single actor's vantage on a single scene.
+
+| Concept | Scope | Role |
+|---|---|---|
+| `Spec` | whole protocol tree | branching shape of all possible plays |
+| Node | one location in the tree | one scene: move space + continuation |
+| Party | spans the whole tree | actor; may control or observe at various nodes |
+| `Multiparty.LocalView X` | one node × one party | that party's vantage on that one scene |
+| `NodeProfile Party X` | one node × all parties | full cast list + sightlines for that scene |
 
 ## Core types
 
@@ -191,15 +263,29 @@ supporting `Packet`, `Query`, `Hom`, `comp` (Poly's composition product),
 `compUnit` (composition unit), and boundary equivalences.
 
 `OpenTheory` provides the compositional algebra: `map`, `par`, `wire`, `plug`.
-Lawfulness is stratified into a class hierarchy:
+Lawfulness is stratified into a granular Mathlib-style class hierarchy. Carriers:
+
+- `HasUnit` — distinguished monoidal unit object for `par`.
+- `HasIdWire` — distinguished identity-wire builder for `wire`.
+
+Naturality:
 
 - `IsLawfulMap` / `IsLawfulPar` / `IsLawfulWire` / `IsLawfulPlug`:
-  functoriality of `map` and naturality of combinators.
+  functoriality of `map` and naturality of each combinator.
 - `IsLawful`: bundles all naturality laws.
-- `Monoidal`: symmetric monoidal coherence for `par` (associativity,
-  commutativity, left/right unit laws via a distinguished `unit` object).
-- `CompactClosed`: compact closed structure with `idWire` as coevaluation,
-  derivation of `plug` from `wire`, and a zig-zag identity (`wire_idWire`).
+
+Coherence (each subsequent class adds laws on top of the previous):
+
+- `IsMonoidal`: symmetric monoidal coherence for `par` (associativity,
+  commutativity, left/right unit laws via the `HasUnit` object).
+- `IsTraced`: Joyal-Street-Verity traced symmetric monoidal structure
+  (`wire`-trace yanking, sliding, vanishing).
+- `IsCompactClosed`: compact closed structure (a `(Poly, ⊗)`-friendly
+  weakening; the strict snake equations are *not* asserted, since
+  `(Poly, ⊗)` is monoidal closed but not strictly compact closed; see
+  Spivak arXiv:2202.00534 §4.3).
+- `HasPlugWireFactor`: closure-factorization identities relating
+  `plug` to `wire` (`plug_eq_wire`, `plug_par_left`, `plug_wire_left`).
 
 `OpenProcessIso` (in `OpenProcess.lean`) provides a bisimulation-based
 equivalence for `OpenProcess`, used to state monoidal and compact closed laws
@@ -296,7 +382,7 @@ import VCVio.Interaction.Concurrent.Process
 | `Control.lean` | `Control`, `scheduler?`, `current?`, `controllers` |
 | `Profile.lean` | `Profile`, `observe`, `residual`, `frontierView` |
 | `Current.lean` | `view`, `observe`, `residualView` |
-| `Process.lean` | `StepOver`, `ProcessOver`, `Process`, systems, `Functor (StepOver Γ)`, `Coalg` instance, `interleave` |
+| `Process.lean` | `NodeAuthority`, `NodeObservation`, `NodeProfile`, `StepOver`, `ProcessOver`, `Process`, systems, `Functor (StepOver Γ)`, `Coalg` instance, `interleave`, `ProcessOver.{Behavior, behavior, ObsEq}` |
 | `Tree.lean` | Structural concurrent syntax → `Process` |
 | `Machine.lean` | `Machine`, `Machine.toProcess`, `Machine.StepFun`, `Coalg` instance |
 | `Execution.lean` | `Trace`, `ObservedTrace` for processes |
@@ -315,11 +401,11 @@ import VCVio.Interaction.Concurrent.Process
 | File | Purpose |
 |------|---------|
 | `Interface.lean` | `Interface`, `PortBoundary`, `Hom`, `Equiv`, `comp`/`compUnit`, tensor/swap |
-| `OpenTheory.lean` | `OpenTheory` algebra, `IsLawful`, `Monoidal`, `CompactClosed` |
-| `OpenSyntax/Raw.lean` | `Raw` syntax tree, `Raw.interpret`, `Raw.Equiv` (incl. monoidal/CC equations) |
-| `OpenSyntax/Interp.lean` | `Interp` (tagless-final), `Monoidal`/`CompactClosed` instances |
-| `OpenSyntax/Expr.lean` | `Expr` (quotient of `Raw`), `Monoidal`/`CompactClosed` instances, `Expr.toInterp` |
-| `OpenProcess.lean` | `BoundaryAction`, `OpenProcess`, `OpenProcessIso` (bisimulation equivalence) |
+| `OpenTheory.lean` | `OpenTheory` algebra, `IsLawful`, `HasUnit`, `HasIdWire`, `IsMonoidal`, `IsTraced`, `IsCompactClosed`, `HasPlugWireFactor` |
+| `OpenSyntax/Raw.lean` | `Raw` syntax tree, `Raw.interpret`, `Raw.Equiv` (incl. monoidal/traced/CC equations) |
+| `OpenSyntax/Interp.lean` | `Interp` (tagless-final), granular `HasUnit` / `HasIdWire` / `IsMonoidal` / `IsTraced` / `IsCompactClosed` / `HasPlugWireFactor` instances |
+| `OpenSyntax/Expr.lean` | `Expr` (quotient of `Raw`), granular `OpenTheory` lawfulness instances, `Expr.toInterp` |
+| `OpenProcess.lean` | `BoundaryAction`, `OpenNodeProfile`, `OpenNodeContext` (with polynomial-product bridge `productView`), `OpenProcess`, `OpenProcessIso` (bisimulation equivalence) |
 | `OpenProcessModel.lean` | `openTheory` (concrete model), `IsLawful`, monoidal/CC laws up to `OpenProcessIso` |
 | `Emulates.lean` | `Emulates`, `UCSecure` (contextual emulation and UC security) |
 | `Computational.lean` | `Semantics`, `CompEmulates`, `AsympCompEmulates` (computational observation layer) |


### PR DESCRIPTION
## Summary

Lands the S8 work (node-metadata split + rename) **on `main`**, where it was always meant to land. The original PR [#318](https://github.com/Verified-zkEVM/VCV-io/pull/318) was accidentally merged into the parent stack branch `quang/poly-substrate-bridges` instead of `main`. Since `main` already contains S2-S6 (via [#317](https://github.com/Verified-zkEVM/VCV-io/pull/317)), the substantive file diff between `main` and `quang/poly-substrate-bridges` is exactly the 11 S8 files (+116/-81). This PR cherry-picks the squash-merged commit `e2d15b4` byte-identically onto a fresh branch off `main`, then adds an agent-guide orientation enhancement on top.

After this lands, both `quang/poly-substrate-bridges` and `quang/node-semantics-split` can be deleted (the merged-into-`bridges` work is fully captured here).

## Commits

1. `refactor(interaction/concurrent): split node metadata into NodeAuthority + NodeObservation, rename bundle to NodeProfile (#318)` — byte-identical cherry-pick of the squash-merged S8 commit.
2. `docs(interaction): add core-concepts orientation, refresh post-S6/S8 references` — new commit on top.

## (1) Node-metadata split + rename

### Factor structures (new)

```lean
structure NodeAuthority (Party : Type u) (X : Type w) where
  controllers : X → List Party := fun _ => []

structure NodeObservation (Party : Type u) (X : Type w) where
  views : Party → Multiparty.LocalView X
```

### Bundle (renamed `NodeSemantics → NodeProfile`)

```lean
structure NodeProfile (Party : Type u) (X : Type w)
    extends NodeAuthority Party X, NodeObservation Party X
```

### Open variant (renamed `OpenNodeSemantics → OpenNodeProfile`, projection renamed `toNodeSemantics → toNodeProfile`)

```lean
structure OpenNodeProfile (Party : Type u) (Δ : PortBoundary) (X : Type w)
    extends NodeProfile Party X where
  boundary : BoundaryAction Δ X := .internal Δ X
```

### Why split

The two layers are conceptually orthogonal. Downstream reasoning that depends only on controller attribution (corruption policies, scheduler accountability, party-side responsibility arguments) can now take a `NodeAuthority Party X` parameter without committing to any particular observation structure; symmetrically for view-only reasoning (information-flow arguments, projection / trace semantics) and `NodeObservation Party X`.

### Why these names

- `Observation` clashed with the existing `Concurrent.Observation` namespace in `VCVio/Interaction/Concurrent/Observation.lean` (the trace-equivalence layer). The `NodeObservation` prefix removes that ambiguity at the type-name level.
- The codebase already uses a `Node*` prefix for content-layer node metadata (e.g. `OpenNodeProfile`); aligning the factors and the bundle on that convention keeps the family coherent.
- `NodeProfile` is consistent with the existing `Profile` family (`Multiparty.Profile.ViewProfile`, `Concurrent.Profile`) and reads more directly than `NodeSemantics` for a structure that bundles per-node attribution data.

### Compatibility through `extends`

- Dot-notation field access (`node.controllers x`, `node.views me`) resolves through the parent chain, so call sites that only touch fields are unchanged.
- The structure-literal constructor `{ controllers := ..., views := ... }` flattens parents, so `Tree.lean`, `Examples.lean`, and `OpenProcessModel.lean`'s scheduler-node literal are unchanged.
- `OpenNodeProfile extends NodeProfile` and the `{ toNodeProfile := ..., boundary := ... }` literal pattern is preserved verbatim across all 7 context-hom definitions in `OpenProcess.lean`.

Type / projection identifiers are renamed across `Process.lean`, `OpenProcess.lean`, `OpenProcessModel.lean`, `Machine.lean`, `Examples.lean`, `Execution.lean`, `MachineId.lean`, `EnvOpenProcess.lean`, `EnvAction.lean`, `MomentaryCorruption.lean`, plus the `Spec.lean` docstring cross-reference.

## (2) Agent-guide orientation

Adds a new "Core concepts: Spec, Node, Party, Profile" subsection to `docs/agents/interaction.md` that fixes the four load-bearing words of the `Interaction/` layer: a `Spec` is the protocol tree, a *node* is one branching location in that tree, a *party* is an actor that plays across many nodes, and `NodeProfile Party X` is the per-node attribution bundle that bridges the two scopes. Includes the stage / scenes / actors mental picture, a comparison table, and a cross-reference to `OpenNodeProfile`.

Also refreshes the now-stale references that S6 + S8 made inaccurate:

- `OpenTheory.lean` description and the "Open systems" section now list the granular S6 class hierarchy: `HasUnit`, `HasIdWire`, `IsLawfulMap` / `IsLawfulPar` / `IsLawfulWire` / `IsLawfulPlug`, `IsLawful`, `IsMonoidal`, `IsTraced`, `IsCompactClosed`, `HasPlugWireFactor`, with a one-line note on the Spivak arXiv:2202.00534 §4.3 caveat about why `IsCompactClosed` is the weakened (no-strict-snake) form.
- `OpenSyntax/{Interp, Expr}.lean` index entries reflect the granular instance set.
- `Process.lean` index entry now lists `NodeAuthority`, `NodeObservation`, `NodeProfile`, and the S5 additions `ProcessOver.{Behavior, behavior, ObsEq}`.
- `OpenProcess.lean` index entry now lists `OpenNodeProfile`, `OpenNodeContext` (with the S4 polynomial-product bridge `productView`), the existing `BoundaryAction` and `OpenProcessIso`.
- The "Control vs observation are orthogonal" design-philosophy bullet is tightened to disambiguate the per-node, per-party-per-node, and per-spec-tree views.

No Lean source changes in commit (2). The Lean docstrings already carry the type-level documentation; conceptual orientation lives in the agent guide where it is discoverable and avoids cluttering the source.

## Test plan

- [x] Full build clean (3578 jobs).
- [x] Axiom check on every renamed declaration: `NodeAuthority`, `NodeObservation`, `NodeProfile`, `NodeProfile.{toNodeAuthority, toNodeObservation}`, `OpenNodeProfile`, `OpenNodeProfile.{toNodeProfile, ofClosed, mapBoundary, SessionCoherentAtMove}` depend on no axioms; `OpenNodeProfile.{mapBoundary_id, mapBoundary_comp}` depend only on the Mathlib-foundational `propext` / `Quot.sound` (already present transitively via `funext`). No project-specific axioms introduced.
- [x] Cherry-picked commit (1) is byte-identical to the squash-merged `e2d15b4` already on `quang/poly-substrate-bridges`.

---

> Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)