### PR TITLE
refactor(interaction): cut over LocalView to ViewMode + Multiparty.Observation kernel + NodeView

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -35,5 +35,6 @@ import Examples.RF_RP_Switching_alt
 import Examples.Regev
 import Examples.Schnorr
 import Examples.SchnorrExtractorRuntime
+import Examples.SealedSender.AspectObservation
 import Examples.Signature
 import Examples.SimpleTwoServerPIR

--- a/Examples/SealedSender/AspectObservation.lean
+++ b/Examples/SealedSender/AspectObservation.lean
@@ -1,0 +1,266 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.Multiparty.ObservationProfile
+
+/-!
+# Sketch: aspect-indexed observation kernels for sealed-sender messaging
+
+A Signal-flavored single-step protocol used to exercise
+`Multiparty.Observation` and the `ObservationProfile` algebra.
+
+Three real parties (Sender, Server, Recipient) plus a passive Network observer
+exchange one structured packet. Different parties — and different
+**corruptions** of those parties — observe **different projections** of the
+same underlying packet. The honest Server is "honest-but-curious" and sees
+routing + ciphertext but not the MAC tag; the passive Network observer sees
+only the envelope, the ciphertext length, and the timestamp; corruption
+modes upgrade or downgrade specific parties' observation kernels.
+
+The point of this sketch is not to model a complete protocol. It is to
+demonstrate that:
+
+* per-party observation kernels are naturally **`Observation`-valued** functions
+  of a corruption mode, not `ViewMode`-valued ones;
+* refinement (`≤` on `Observation` via the `Preorder` instance) is the natural
+  "this corruption reveals no more than that one" relation;
+* coalition observations (`⊔` on `Observation` via the `Max` instance) are the
+  natural Σ-product join in the information lattice;
+* the lifting back into the `ViewProfile` / `Profile.Strategy` pipeline goes
+  through `ObservationProfile.toViewProfile`, with one bridge step per node.
+
+Sealed-sender (the Server's view of `envFrom` is *removed*) and a MAC-aware
+network adversary (the Network's view of `macTag` and `tagLen` is *added*)
+are concrete corruption directions in this sketch.
+
+Throughout, we use Mathlib's order notation (`⊤`, `⊥`, `≤`, `⊔`) rather than
+the named `Observation.top` / `Observation.bot` / `Observation.Refines` /
+`Observation.combine` operations. Both APIs are equivalent definitionally;
+the notation buys readability and lets profile-level facts come through
+`Pi`-instance lifting.
+-/
+
+universe u
+
+namespace Examples
+namespace SealedSender
+
+open Interaction Multiparty
+
+/-! ## Packet, parties, and modes -/
+
+/-- An idealized end-to-end packet for one send. -/
+structure Packet where
+  /-- Sender id (numeric placeholder). -/
+  envFrom : Nat
+  /-- Recipient id. -/
+  envTo : Nat
+  /-- Payload (numeric placeholder). -/
+  ciphertext : Nat
+  /-- Length of the ciphertext. -/
+  ctLen : Nat
+  timestamp : Nat
+  macTag : Nat
+  tagLen : Nat
+
+/-- The four parties in the sketch: real Sender / Server / Recipient and a
+passive Network observer. -/
+inductive Party
+  | Sender
+  | Server
+  | Recipient
+  | Net
+  deriving DecidableEq
+
+/-- A small space of corruption modes. -/
+inductive Mode
+  | clean
+  | serverFull         -- Server fully corrupted: sees the entire packet
+  | serverSealed       -- Sealed-sender: Server's `envFrom` is hidden
+  | netMacAware        -- Network adversary additionally sees the MAC tag
+  deriving DecidableEq
+
+/-! ## Honest per-party observation views -/
+
+/-- The honest Server's observation: routing + ciphertext + timestamp, no MAC. -/
+structure ServerView where
+  envFrom : Nat
+  envTo : Nat
+  ciphertext : Nat
+  timestamp : Nat
+
+/-- The honest passive Network observer: envelope + ciphertext length + timestamp. -/
+structure NetView where
+  envFrom : Nat
+  envTo : Nat
+  ctLen : Nat
+  timestamp : Nat
+
+/-- Sealed-sender's view of the Server: as `ServerView` but with `envFrom`
+stripped. -/
+structure ServerSealedView where
+  envTo : Nat
+  ciphertext : Nat
+  timestamp : Nat
+
+/-- The MAC-aware passive network observer: like `NetView` but also sees the
+MAC tag and its length. -/
+structure NetMacAwareView where
+  envFrom : Nat
+  envTo : Nat
+  ctLen : Nat
+  timestamp : Nat
+  macTag : Nat
+  tagLen : Nat
+
+/-! ## Honest and corrupted observations -/
+
+namespace Observations
+
+/-- Honest Server projection. -/
+def serverHonest : Observation Packet :=
+  ⟨ServerView, fun p => ⟨p.envFrom, p.envTo, p.ciphertext, p.timestamp⟩⟩
+
+/-- Sealed-sender Server projection: drops `envFrom`. -/
+def serverSealed : Observation Packet :=
+  ⟨ServerSealedView, fun p => ⟨p.envTo, p.ciphertext, p.timestamp⟩⟩
+
+/-- Server fully corrupted: identity projection (top of the information
+lattice). -/
+def serverFull : Observation Packet := ⊤
+
+/-- Honest passive Network observer: envelope + length + time. -/
+def netHonest : Observation Packet :=
+  ⟨NetView, fun p => ⟨p.envFrom, p.envTo, p.ctLen, p.timestamp⟩⟩
+
+/-- MAC-aware network observer: adds `macTag` and `tagLen` to `netHonest`. -/
+def netMacAware : Observation Packet :=
+  ⟨NetMacAwareView,
+    fun p => ⟨p.envFrom, p.envTo, p.ctLen, p.timestamp, p.macTag, p.tagLen⟩⟩
+
+/-! ### Refinement facts on individual observations
+
+Each fact is a single-line `⟨factor_map, fun _ => rfl⟩` proof, illustrating
+how refinement reduces to giving a Σ-factorization between observation
+types. -/
+
+/-- Sealed-sender Server is no more revealing than honest Server: drop `envFrom`. -/
+theorem serverSealed_le_serverHonest : serverSealed ≤ serverHonest :=
+  ⟨fun v => ⟨v.envTo, v.ciphertext, v.timestamp⟩, fun _ => rfl⟩
+
+/-- Honest Server is no more revealing than fully-corrupted Server: project
+out the four observed fields. -/
+theorem serverHonest_le_serverFull : serverHonest ≤ serverFull :=
+  ⟨fun p => ⟨p.envFrom, p.envTo, p.ciphertext, p.timestamp⟩, fun _ => rfl⟩
+
+/-- By transitivity, sealed-sender Server is no more revealing than the fully
+corrupted Server. -/
+theorem serverSealed_le_serverFull : serverSealed ≤ serverFull :=
+  le_trans serverSealed_le_serverHonest serverHonest_le_serverFull
+
+/-- Honest Network observer is no more revealing than the MAC-aware variant. -/
+theorem netHonest_le_netMacAware : netHonest ≤ netMacAware :=
+  ⟨fun v => ⟨v.envFrom, v.envTo, v.ctLen, v.timestamp⟩, fun _ => rfl⟩
+
+end Observations
+
+/-! ## Per-mode observation profiles -/
+
+open Profile
+
+/-- The corruption-mode-indexed observation: for each mode and party, the
+observation kernel of that party in that mode.
+
+* In every mode, `Sender` and `Recipient` see the full packet (their
+  operational shapes — `.pick` and `.observe` respectively — would be
+  recovered from a separate operational decoration; here we only record their
+  *observation kernel*, which is the top of the information lattice `⊤`).
+* `Server`'s kernel varies with the mode: honest, sealed, or fully corrupted.
+* `Net`'s kernel varies between honest and MAC-aware. -/
+def observationOf : Mode → Party → Observation Packet
+  | _,                .Sender    => ⊤
+  | _,                .Recipient => ⊤
+  | .clean,           .Server    => Observations.serverHonest
+  | .serverSealed,    .Server    => Observations.serverSealed
+  | .serverFull,      .Server    => Observations.serverFull
+  | .netMacAware,     .Server    => Observations.serverHonest
+  | .clean,           .Net       => Observations.netHonest
+  | .serverSealed,    .Net       => Observations.netHonest
+  | .serverFull,      .Net       => Observations.netHonest
+  | .netMacAware,     .Net       => Observations.netMacAware
+
+/-- The observation profile attached to one node in a given corruption mode.
+
+This is the *kernel-form* analogue of a `ViewProfile` per node. Plugging it
+into `Profile.Strategy` requires `ObservationProfile.toViewProfile` to bridge
+to the existing endpoint pipeline. -/
+def observationProfile (m : Mode) : ObservationProfile Party Packet :=
+  fun p => observationOf m p
+
+/-- The induced view profile (each party's observation kernel becomes the
+universal `.react` `ViewMode`). -/
+def viewProfile (m : Mode) : ViewProfile Party Packet :=
+  ObservationProfile.toViewProfile (observationProfile m)
+
+/-! ## Refinement facts on profiles
+
+These illustrate the payoff of working at the kernel level: monotonicity in
+the corruption order is proved pointwise by the per-observation refinement
+facts above, with no four-case `ViewMode` matching. The pointwise `≤` on
+profiles comes from `Pi.preorder` and the per-party `Preorder (Observation
+Packet)` instance — no manual `Refines` definition is needed. -/
+
+/-- Sealed-sender mode is no more revealing than the clean mode (only `Server`
+differs, and the sealed-sender Server kernel refines the honest Server
+kernel). -/
+theorem observationProfile_serverSealed_le_clean :
+    observationProfile .serverSealed ≤ observationProfile .clean := by
+  intro p
+  cases p
+  · exact le_refl _
+  · exact Observations.serverSealed_le_serverHonest
+  · exact le_refl _
+  · exact le_refl _
+
+/-- Clean mode is no more revealing than fully-corrupted-Server mode (only
+`Server` differs, and the honest Server kernel refines the fully-corrupted
+Server kernel). -/
+theorem observationProfile_clean_le_serverFull :
+    observationProfile .clean ≤ observationProfile .serverFull := by
+  intro p
+  cases p
+  · exact le_refl _
+  · exact Observations.serverHonest_le_serverFull
+  · exact le_refl _
+  · exact le_refl _
+
+/-- Clean mode is no more revealing than the MAC-aware-network mode. -/
+theorem observationProfile_clean_le_netMacAware :
+    observationProfile .clean ≤ observationProfile .netMacAware := by
+  intro p
+  cases p
+  · exact le_refl _
+  · exact le_refl _
+  · exact le_refl _
+  · exact Observations.netHonest_le_netMacAware
+
+/-! ## Coalition example
+
+The `Server`-`Net` coalition's observation in the clean mode is the Σ-product
+of `serverHonest` and `netHonest`. Both factors refine into it, automatically. -/
+
+/-- The Server-plus-Net coalition kernel in the clean mode: a Σ-product of
+the two honest kernels (the **join** in the information lattice). -/
+def serverNetCoalitionClean : Observation Packet :=
+  Observations.serverHonest ⊔ Observations.netHonest
+
+example : Observations.serverHonest ≤ serverNetCoalitionClean :=
+  Observation.refines_combine_left _ _
+
+example : Observations.netHonest ≤ serverNetCoalitionClean :=
+  Observation.refines_combine_right _ _
+
+end SealedSender
+end Examples

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -104,6 +104,8 @@ import VCVio.Interaction.Multiparty.Broadcast
 import VCVio.Interaction.Multiparty.Core
 import VCVio.Interaction.Multiparty.Directed
 import VCVio.Interaction.Multiparty.Examples
+import VCVio.Interaction.Multiparty.Observation
+import VCVio.Interaction.Multiparty.ObservationProfile
 import VCVio.Interaction.Multiparty.Profile
 import VCVio.Interaction.TwoParty.Compose
 import VCVio.Interaction.TwoParty.Decoration

--- a/VCVio/Interaction/Concurrent/Current.lean
+++ b/VCVio/Interaction/Concurrent/Current.lean
@@ -22,12 +22,12 @@ frontier event for a fixed party.
 This is the key conceptual bridge:
 
 * if the fixed party currently controls the next decision, its current local
-  view is `active`;
+  view is `pick`;
 * otherwise, its current local view is the observation view induced by the
   current frontier profile.
 
 At a `par` node, this means:
-* when both sides are live, the scheduler's local view is `active` on the full
+* when both sides are live, the scheduler's local view is `pick` on the full
   frontier event type `Front S`;
 * when only one side remains live, control collapses to that side's own current
   controller and local view.
@@ -89,14 +89,14 @@ This preserves the meaning of the local view while avoiding a spurious right
 branch tag in the observation when the right side is dead.
 -/
 private def liftLeftView {left right : Spec} (rightEmpty : IsEmpty (Front right)) :
-    Multiparty.LocalView (Front left) → Multiparty.LocalView (Front (.par left right))
-  | .active => .active
+    Multiparty.ViewMode (Front left) → Multiparty.ViewMode (Front (.par left right))
+  | .pick => .pick
   | .observe => .observe
   | .hidden => .hidden
-  | .quotient Obs toObs =>
-      .quotient Obs (fun
+  | .react ⟨Obs, toObs⟩ =>
+      .react ⟨Obs, fun
         | .left event => toObs event
-        | .right event => False.elim (rightEmpty.false event))
+        | .right event => False.elim (rightEmpty.false event)⟩
 
 /--
 Lift a local view on the right frontier into the full frontier of a parallel
@@ -106,14 +106,14 @@ This preserves the meaning of the local view while avoiding a spurious left
 branch tag in the observation when the left side is dead.
 -/
 private def liftRightView {left right : Spec} (leftEmpty : IsEmpty (Front left)) :
-    Multiparty.LocalView (Front right) → Multiparty.LocalView (Front (.par left right))
-  | .active => .active
+    Multiparty.ViewMode (Front right) → Multiparty.ViewMode (Front (.par left right))
+  | .pick => .pick
   | .observe => .observe
   | .hidden => .hidden
-  | .quotient Obs toObs =>
-      .quotient Obs (fun
+  | .react ⟨Obs, toObs⟩ =>
+      .react ⟨Obs, fun
         | .left event => False.elim (leftEmpty.false event)
-        | .right event => toObs event)
+        | .right event => toObs event⟩
 
 /--
 `view me control profile` is the current local view of the next frontier event
@@ -121,10 +121,10 @@ for the fixed party `me`.
 
 It is computed from both control and observation structure:
 
-* at an atomic node, the owner recorded by `control` gets `active`, while every
+* at an atomic node, the owner recorded by `control` gets `pick`, while every
   other party gets the frontier observation induced by `profile`;
 * at a parallel node with two live sides, the scheduler recorded by `control`
-  gets `active` on the full frontier event type, while every other party gets
+  gets `pick` on the full frontier event type, while every other party gets
   the profile-induced frontier observation;
 * at a parallel node with exactly one live side, control collapses to that
   side's current local view and is then lifted back to the full frontier type
@@ -134,17 +134,17 @@ It is computed from both control and observation structure:
 This is the fundamental current-step local interface for the concurrent layer.
 -/
 def view {Party : Type u} [DecidableEq Party] (me : Party) :
-    {S : Spec} → Control Party S → Profile Party S → Multiparty.LocalView (Front S)
+    {S : Spec} → Control Party S → Profile Party S → Multiparty.ViewMode (Front S)
   | .done, .done, .done => .hidden
   | .node _ _, .node owner _, profile =>
-      if me = owner then .active else Profile.frontierView me profile
+      if me = owner then .pick else Profile.frontierView me profile
   | .par left right, .par scheduler leftControl rightControl,
       profile@(.par leftProfile rightProfile) =>
       match hLeft : leftControl.isLive with
       | true =>
           match hRight : rightControl.isLive with
           | true =>
-              if me = scheduler then .active else Profile.frontierView me profile
+              if me = scheduler then .pick else Profile.frontierView me profile
           | false =>
               let rightEmpty : IsEmpty (Front right) := frontIsEmptyOfNotLive rightControl hRight
               liftLeftView rightEmpty (view me leftControl leftProfile)
@@ -188,7 +188,7 @@ interaction.
 -/
 def residualView {Party : Type u} [DecidableEq Party] (me : Party) :
     {S : Spec} → (control : Control Party S) → (profile : Profile Party S) →
-      (event : Front S) → Multiparty.LocalView (Front (Concurrent.residual event))
+      (event : Front S) → Multiparty.ViewMode (Front (Concurrent.residual event))
   | _, control, profile, event =>
       view me (Control.residual control event) (Profile.residual profile event)
 

--- a/VCVio/Interaction/Concurrent/Examples.lean
+++ b/VCVio/Interaction/Concurrent/Examples.lean
@@ -59,9 +59,9 @@ def delivery : Spec :=
 and the adversary sees only the public header. -/
 def deliveryProfile : Profile Party delivery :=
   .node (fun
-      | .alice => .active
+      | .alice => .pick
       | .bob => .observe
-      | .adv => .quotient Nat Prod.fst)
+      | .adv => .react ⟨Nat, Prod.fst⟩)
     (fun _ => .done)
 
 example : Profile.ObsType Party.alice deliveryProfile = (Nat × Bool) := rfl
@@ -150,7 +150,7 @@ example : Current.controller? inFlightControl = some .adv := rfl
 example : Current.scheduler? inFlightControl = some .adv := rfl
 
 example :
-    Current.view Party.adv inFlightControl inFlightProfile = Multiparty.LocalView.active := by
+    Current.view Party.adv inFlightControl inFlightProfile = Multiparty.ViewMode.pick := by
   rfl
 
 example :
@@ -174,11 +174,11 @@ example : Current.controller? afterDelivery = some .bob := rfl
 example : Current.scheduler? afterDelivery = none := rfl
 
 example :
-    Current.view Party.bob afterDelivery afterDeliveryProfile = Multiparty.LocalView.active := by
+    Current.view Party.bob afterDelivery afterDeliveryProfile = Multiparty.ViewMode.pick := by
   rfl
 
 example :
-    Current.view Party.adv afterDelivery afterDeliveryProfile = Multiparty.LocalView.hidden := by
+    Current.view Party.adv afterDelivery afterDeliveryProfile = Multiparty.ViewMode.hidden := by
   rfl
 
 example :
@@ -384,7 +384,7 @@ hidden from it. -/
 def loopNode : NodeProfile Party Bool where
   controllers := fun _ => [.adv]
   views
-    | .adv => .active
+    | .adv => .pick
     | .bob => .observe
     | .alice => .hidden
 

--- a/VCVio/Interaction/Concurrent/Process.lean
+++ b/VCVio/Interaction/Concurrent/Process.lean
@@ -29,7 +29,7 @@ The file is organized in two levels:
   realized node context `Γ`;
 * `Step Party P` and `Process Party` are the closed-world specializations whose
   node metadata is exactly `NodeProfile Party`, the bundled
-  `NodeAuthority + NodeObservation` view of node-local semantic data.
+  `NodeAuthority + NodeView` view of node-local semantic data.
 
 So the intended reading is:
 
@@ -64,18 +64,24 @@ structure NodeAuthority (Party : Type u) (X : Type w) where
   controllers : X → List Party := fun _ => []
 
 /--
-`NodeObservation Party X` records the view-attribution part of node-local
+`NodeView Party X` records the view-attribution part of node-local
 semantic data: what each party `me : Party` locally observes of the
-chosen move `x : X`, expressed as a `Multiparty.LocalView X`.
+chosen move `x : X`, expressed as a `Multiparty.ViewMode X`.
 
 This is the second of the two orthogonal layers of `NodeProfile`. It
 is stored separately so that downstream reasoning that depends only on
 local views (information-flow arguments, projection / trace semantics,
-view-equivalence proofs) can take a `NodeObservation` parameter without
+view-equivalence proofs) can take a `NodeView` parameter without
 committing to any particular controller attribution.
+
+The name avoids confusion with `Multiparty.Observation X`, which is the
+unrelated **per-move information-lattice kernel** living in
+`Multiparty/Observation.lean`. `NodeView` is the per-party operational
+view assignment at one node; `Observation` is one quotient morphism
+`X → Obs` packaged with its codomain.
 -/
-structure NodeObservation (Party : Type u) (X : Type w) where
-  views : Party → Multiparty.LocalView X
+structure NodeView (Party : Type u) (X : Type w) where
+  views : Party → Multiparty.ViewMode X
 
 /--
 `NodeProfile Party X` records the local semantic data attached to one
@@ -85,7 +91,7 @@ It bundles two orthogonal layers:
 
 * `NodeAuthority Party X` — `controllers x` is the controller-path contribution
   associated to choosing the move `x : X`;
-* `NodeObservation Party X` — `views me` assigns to party `me` its local view
+* `NodeView Party X` — `views me` assigns to party `me` its local view
   of the chosen move.
 
 The two layers are intentionally stored as separate factor structures.
@@ -98,11 +104,11 @@ Because `NodeProfile` `extends` both factors, the dot-notation accessors
 `node.controllers`, `node.views` and the structure-literal constructor
 `{ controllers := ..., views := ... }` work exactly as if the fields were
 declared inline. The factor projections `node.toNodeAuthority`,
-`node.toNodeObservation` are auto-generated and let downstream code restrict
+`node.toNodeView` are auto-generated and let downstream code restrict
 attention to a single layer.
 -/
 structure NodeProfile (Party : Type u) (X : Type w)
-    extends NodeAuthority Party X, NodeObservation Party X
+    extends NodeAuthority Party X, NodeView Party X
 
 /--
 The closed-world node context used by the current concurrent semantics.

--- a/VCVio/Interaction/Concurrent/Profile.lean
+++ b/VCVio/Interaction/Concurrent/Profile.lean
@@ -18,7 +18,7 @@ what each party can observe when a frontier event is scheduled.
 
 The design here stays structural and continuation-based:
 
-* `Profile Party S` recursively attaches a `Multiparty.LocalView` to every
+* `Profile Party S` recursively attaches a `Multiparty.ViewMode` to every
   atomic node of the concurrent spec `S`;
 * `Profile.residual` transports such a profile across one scheduled frontier
   event;
@@ -27,7 +27,7 @@ The design here stays structural and continuation-based:
 * `Profile.observe me profile event` computes the actual observation exposed by
   a concrete frontier event `event`;
 * `Profile.frontierView me profile` packages the whole current frontier as a
-  single `Multiparty.LocalView`.
+  single `Multiparty.ViewMode`.
 
 This is intentionally only an observation/profile layer.
 It does **not** yet introduce:
@@ -67,7 +67,7 @@ inductive Profile (Party : Type u) : Spec → Type (u + 1) where
   | /-- Profile of an atomic node: each party gets a local view of the move
     type, and the continuation records residual profiles for each chosen move. -/
     node {Moves : Type u} {rest : Moves → Spec}
-      (views : Party → Multiparty.LocalView Moves)
+      (views : Party → Multiparty.ViewMode Moves)
       (cont : (x : Moves) → Profile Party (rest x)) :
       Profile Party (.node Moves rest)
   | /-- Profile of a parallel concurrent spec. -/
@@ -117,7 +117,7 @@ def ObsType {Party : Type u} (me : Party) :
 party `me` by the scheduled frontier event `event`.
 
 This is computed structurally:
-* at an atomic node, use the underlying `Multiparty.LocalView.obsOf`;
+* at an atomic node, use the underlying `Multiparty.ViewMode.obsOf`;
 * at a parallel node, tag observations by whether the event came from the left
   or right concurrent component.
 -/
@@ -130,31 +130,32 @@ def observe {Party : Type u} (me : Party) :
 
 /--
 `frontierView me profile` packages the entire current frontier of `profile`
-into a single `Multiparty.LocalView`.
+into a single `Multiparty.ViewMode`.
 
 This is useful when one wants to treat the current scheduled frontier event as a
 single global move:
-* atomic nodes reuse the party's underlying atomic local view, with `active`
+* atomic nodes reuse the party's underlying atomic local view, with `pick`
   collapsing to `observe` because the scheduled frontier event itself is already
   fixed;
-* parallel nodes expose a quotient view whose observations are exactly
+* parallel nodes expose a `react`-form view whose observations are exactly
   `ObsType me profile`.
 
 So `frontierView` is an observation-level concurrent local view, not yet a full
 local process semantics for the participant.
 -/
 def frontierView {Party : Type u} (me : Party) :
-    {S : Spec} → (profile : Profile Party S) → Multiparty.LocalView (Front S)
+    {S : Spec} → (profile : Profile Party S) → Multiparty.ViewMode (Front S)
   | .done, .done => .hidden
   | .node _ _, .node views _ =>
       match views me with
-      | .active => .observe
+      | .pick => .observe
       | .observe => .observe
       | .hidden => .hidden
-      | .quotient Obs toObs =>
-          .quotient (PLift Obs) (fun
-            | .move x => ⟨toObs x⟩)
-  | .par _ _, profile => .quotient (PLift (ObsType me profile)) (fun e => ⟨observe me profile e⟩)
+      | .react ⟨Obs, toObs⟩ =>
+          .react ⟨PLift Obs, fun
+            | .move x => ⟨toObs x⟩⟩
+  | .par _ _, profile =>
+      .react ⟨PLift (ObsType me profile), fun e => ⟨observe me profile e⟩⟩
 
 end Profile
 end Concurrent

--- a/VCVio/Interaction/Multiparty/Broadcast.lean
+++ b/VCVio/Interaction/Multiparty/Broadcast.lean
@@ -18,7 +18,7 @@ observed branch.
 
 The node metadata for this model is simply the acting party itself.
 A fixed participant's endpoint is then obtained by supplying a resolver from
-acting parties to `LocalView`.
+acting parties to `ViewMode`.
 
 For concrete finite party types, resolvers are intended to be written by
 pattern matching. This preserves the strongest definitional behavior of the
@@ -50,17 +50,17 @@ At each node, the acting party recorded by `parties` is passed to `resolve`,
 which determines how the fixed participant locally sees that node.
 
 Typical broadcast resolvers use only:
-* `LocalView.active` at the participant's own nodes, and
-* `LocalView.observe` at all other nodes.
+* `ViewMode.pick` at the participant's own nodes, and
+* `ViewMode.observe` at all other nodes.
 
 But the definition itself is intentionally more general: it exposes the full
-`LocalView` interface rather than hard-coding one particular resolver.
+`ViewMode` interface rather than hard-coding one particular resolver.
 -/
 abbrev Strategy
     (m : Type u → Type u)
     {Party : Type u}
     (spec : Spec) (parties : PartyDecoration Party spec)
-    (resolve : ∀ {X : Type u}, Party → LocalView X)
+    (resolve : ∀ {X : Type u}, Party → ViewMode X)
     (Output : Spec.Transcript spec → Type u) :=
   Multiparty.Strategy m (resolve := fun X owner => resolve (X := X) owner) spec parties Output
 

--- a/VCVio/Interaction/Multiparty/Core.lean
+++ b/VCVio/Interaction/Multiparty/Core.lean
@@ -6,12 +6,14 @@ Authors: Quang Dao
 import VCVio.Interaction.Basic.Spec
 import VCVio.Interaction.Basic.Decoration
 import VCVio.Interaction.Basic.Syntax
+import VCVio.Interaction.Multiparty.Observation
 
 /-!
-# Native local views for multiparty interactions
+# View modes: per-participant local-view shapes for multiparty interactions
 
 This file introduces the smallest common local layer for multiparty
-interaction in the `Interaction` framework.
+interaction in the `Interaction` framework, on top of the kernel-form
+`Multiparty.Observation` algebra (`Multiparty/Observation.lean`).
 
 The current two-party layer distinguishes between:
 * the side that chooses the next move, and
@@ -29,12 +31,13 @@ channel without learning the payload itself.
 
 The definitions in this file are intentionally local and minimal.
 
-* `LocalView X` records how one fixed participant locally sees a chosen move
+* `ViewMode X` records how one fixed participant locally sees a chosen move
   `x : X` at one node.
-* `LocalView.Action` is the canonical local node shape associated to that view.
-* `LocalView.Kernel` is the **maximally general single-projection form** of a
-  local view, packaging just the observation type and projection function.
-  Every `LocalView` collapses to a `Kernel` via `LocalView.toKernel`.
+* `ViewMode.Action` is the canonical local node shape associated to that view.
+* `ViewMode.toObservation` collapses a `ViewMode` into the maximally general
+  single-projection form `Multiparty.Observation`.
+* `Observation.toViewMode` lifts an arbitrary observation back into `ViewMode`
+  via the universal `.react` constructor.
 * `localSyntax` packages the four-mode `Action` shape as a `Spec.SyntaxOver`.
 * `Strategy` is the induced whole-tree local endpoint type, obtained from
   arbitrary node-local metadata through `SyntaxOver.comap`.
@@ -49,59 +52,80 @@ model. In particular, it does not choose between:
 Those models are recovered later by choosing different node decorations and
 different resolvers.
 
-## Two layers of observation: kernel vs operational shape
+## Two layers of observation: information lattice vs operational shape
 
-`LocalView` carries information along **two orthogonal axes**:
+`ViewMode` carries information along **two orthogonal axes**:
 
 * an **information axis**: what observation does the participant make? This is
   fully captured by a single projection `toObs : X → Obs` packaged with its
-  codomain `Obs`. We call this the *kernel* of the local view; see
-  `LocalView.Kernel`.
+  codomain `Obs`, i.e. by an `Observation X`. The induced ordering by
+  informativeness gives a lattice with bottom `Observation.bot X` (no
+  information) and top `Observation.top X = ⟨X, id⟩` (full information); see
+  `Multiparty/Observation.lean`.
 * an **operational axis**: how does the participant interact with that
   observation in continuation passing? Does it choose the move (effectful
   selection), wait for it (function-from-X), or commit to a uniform
   continuation family in advance (function-into-Cont)? This is encoded in the
-  four constructors `active`, `observe`, `hidden`, `quotient`, each of which
+  four constructors `pick`, `observe`, `hidden`, `react`, each of which
   specializes `Action` to a definitionally simpler shape.
 
-The four-constructor enumeration is the *ergonomically convenient* form for
-common patterns: it lets `LocalView.Action` reduce by `rfl` for each pattern,
-which keeps protocol examples short. `LocalView.Kernel` is the *semantically
-universal* form: any `LocalView` collapses to a kernel, and protocols that
-need only the observation can build kernels directly.
+### Why four constructors instead of two
+
+A more parsimonious presentation would split the two axes completely: a
+two-mode `pick | react Observation` `ViewMode`, with `observe` and `hidden`
+recovered as `react (Observation.top X)` and `react (Observation.bot X)`
+respectively. That presentation is informationally equivalent: `observe`
+*morally is* `react Observation.top` and `hidden` *morally is*
+`react Observation.bot`. They are precisely the two extremes of the
+information lattice on `X`.
+
+We deliberately keep all four constructors because the operational
+specializations are **not definitionally equal** to their universal
+react-form encodings. Compare:
+
+```text
+ViewMode.Action .observe m Cont   = (x : X) → m (Cont x)
+Observation.Action ⟨X, id⟩ m Cont = (o : X) → m ((x : X) → x = o → Cont x)
+
+ViewMode.Action .hidden m Cont                    = m ((x : X) → Cont x)
+Observation.Action ⟨PUnit, fun _ => unit⟩ m Cont
+                = (_ : PUnit) → m ((x : X) → unit = unit → Cont x)
+```
+
+The specialized forms are the ones that example endpoint computations want
+to land on by `rfl`. Keeping `observe` and `hidden` as separate constructors
+preserves those `rfl` reductions while still exposing the universal
+`react`-form for genuinely arbitrary observations.
+
+So the four constructors should be read as the two operational extremes of
+the information lattice (`observe = top`, `hidden = bot`) plus one orthogonal
+authorship-of-shape mode (`pick`, the `Σ-of-X` shape) and one universal
+catch-all (`react`, the `Observation`-parameterized shape).
 
 This file does **not** carry authorship-of-move information; that lives in
 `Concurrent.NodeAuthority.controllers : X → List Party`, which credits each
 possible move `x : X` with the (possibly multiple) parties responsible for
-choosing it. In particular, the choice between `LocalView.active` and
-`LocalView.observe` is a *node shape* decision (effectful Σ-of-X vs
+choosing it. In particular, the choice between `ViewMode.pick` and
+`ViewMode.observe` is a *node shape* decision (effectful Σ-of-X vs
 function-from-X), not the canonical authorship attribution.
 
 ## Literature
 
-Three independent literature traditions converge on the kernel form
-`Σ Obs : Type, X → Obs`:
+The kernel form `Σ Obs : Type, X → Obs` (here `Multiparty.Observation`)
+arises in three independent traditions; see the docstring of
+`Multiparty/Observation.lean` for citations. The closest type-theoretic
+ancestor of the four-constructor operational shape is Hancock-Setzer
+"Interactive Programs in Dependent Type Theory", whose Command/Response
+interfaces with embedded observation modes mirror the
+`pick` / `observe` / `hidden` / `react` taxonomy.
 
-* Halpern-Vardi epistemic logic ("Reasoning About Knowledge"): agent
-  observation as a projection from global state to local indistinguishability
-  classes;
-* Goguen-Meseguer noninterference / Sabelfeld-Myers info-flow: per-level
-  projection of observable outputs;
-* Honda-Yoshida-Carbone multiparty session types and Cruz-Filipe-Montesi
-  endpoint projection: projection of a global type / global play to a single
-  role's local view;
-* Hancock-Setzer interactive interfaces: the type-theoretic ancestor of the
-  four-constructor operational shape (Command/Response with embedded
-  observation modes).
+See `docs/agents/interaction.md` for the design rationale of the
+information-vs-operational split.
 
-See `docs/agents/interaction.md` for a brief literature map and the design
-rationale for the kernel-vs-operational split.
-
-Naming note:
-this file does not introduce a new global multiparty protocol syntax. The
-existing `Interaction.Spec` already captures the global branching structure.
-The multiparty layer only describes how one fixed participant locally sees each
-node of such a spec.
+Naming note: this file does not introduce a new global multiparty protocol
+syntax. The existing `Interaction.Spec` already captures the global branching
+structure. The multiparty layer only describes how one fixed participant
+locally sees each node of such a spec.
 -/
 
 universe u v
@@ -110,7 +134,7 @@ namespace Interaction
 namespace Multiparty
 
 /--
-`LocalView X` is the local observation mode of one fixed participant at one
+`ViewMode X` is the local observation mode of one fixed participant at one
 protocol node whose move space is `X`.
 
 It answers the following question:
@@ -119,62 +143,75 @@ It answers the following question:
 > locally experience the actual chosen move `x : X` of that node?
 
 The possibilities are:
-* `active` — this participant locally selects the next move (effectful
+* `pick` — this participant locally selects the next move (effectful
   Σ-of-X shape for `Action`);
 * `observe` — this participant is told the full chosen move and continues
-  after seeing it (function-from-X shape for `Action`);
+  after seeing it (function-from-X shape for `Action`); informationally, this
+  is the top of the observation lattice on `X`;
 * `hidden` — this participant is not told the chosen move at the node itself,
   so any future behavior depending on that move must already be prepared
-  uniformly over all possible moves;
-* `quotient Obs toObs` — this participant is told only the observation
-  `toObs x : Obs`, not the full move `x`.
+  uniformly over all possible moves; informationally, this is the bottom of
+  the observation lattice;
+* `react k` — the participant is told only the observation `k.2 x : k.1`
+  exposed by the universal kernel `k : Observation X`. This is the universal
+  `Action`-shape and subsumes all observation patterns not captured by
+  `observe`/`hidden`.
 
 These four constructors carry information along **two separate axes**:
-* **operational** — they pick out four definitionally distinct `Action` shapes
-  (see `LocalView.Action`), enabling `rfl` reductions for common patterns;
-* **observational** — they all collapse to a single quotient morphism
-  `X → Obs` packaged with its codomain (see `LocalView.Kernel`).
+* **operational** — they pick out four definitionally distinct `Action`
+  shapes (see `ViewMode.Action`), enabling `rfl` reductions for common
+  patterns;
+* **observational** — they all collapse to a single observation kernel
+  `X → Obs` packaged with its codomain (see `ViewMode.toObservation`).
 
-The operational distinction between `active` and `observe` is **not** a
+Note that `observe` and `hidden` are operationally specialized cases of
+`react`: morally `observe = react (Observation.top X)` and `hidden =
+react (Observation.bot X)`. They are kept as separate constructors because
+their specialized `Action` shapes are *not* definitionally equal to the
+universal `react` form (see the file docstring), and protocol examples want
+to land on the specialized shapes by `rfl`.
+
+The operational distinction between `pick` and `observe` is **not** a
 canonical authorship attribution. Authorship-of-move is recorded by
 `Concurrent.NodeAuthority.controllers : X → List Party`, a *per-move* and
-possibly *multi-controller* assignment. `LocalView.active` indicates only
-that a participant chooses *locally* in its endpoint type; whether it is the
+possibly *multi-controller* assignment. `ViewMode.pick` indicates only that a
+participant chooses *locally* in its endpoint type; whether it is the
 protocol-level controller of a particular move is recorded separately.
 
-`LocalView` is intentionally local. It does not describe the global
+`ViewMode` is intentionally local. It does not describe the global
 communication discipline that produced it, nor who else sees the move.
 
 For protocols whose participants make arbitrary observations not captured by
-the `active`/`observe`/`hidden` patterns, prefer `LocalView.Kernel` directly:
-it is the maximally general observation primitive.
+the `pick` / `observe` / `hidden` patterns, prefer `react` (or build an
+`Observation` directly and lift via `Observation.toViewMode`).
 -/
-inductive LocalView (X : Type u) : Type (u + 1) where
-  | active
+inductive ViewMode (X : Type u) : Type (u + 1) where
+  | pick
   | observe
   | hidden
-  | quotient (Obs : Type u) (toObs : X → Obs)
+  | react (k : Observation X)
 
-namespace LocalView
+namespace ViewMode
 
 /--
 `ObsType view` is the type of concrete observations made by a participant with
 local view `view` when some actual move `x` occurs.
 
 Reading by cases:
-* for `active` and `observe`, the participant learns the full move;
-* for `hidden`, the participant learns nothing (`PUnit`);
-* for `quotient Obs toObs`, the participant learns only the quotient
-  observation `toObs x : Obs`.
+* for `pick` and `observe`, the participant learns the full move (the
+  observation type is `X` itself, the top of the information lattice);
+* for `hidden`, the participant learns nothing (`PUnit`, the bottom);
+* for `react ⟨Obs, toObs⟩`, the participant learns the kernel observation
+  `Obs`.
 
-This packages the information content of a `LocalView` independently from the
-more structured endpoint semantics of `LocalView.Action`.
+This packages the information content of a `ViewMode` independently from the
+more structured endpoint semantics of `ViewMode.Action`.
 -/
-def ObsType {X : Type u} : LocalView X → Type u
-  | .active => X
+def ObsType {X : Type u} : ViewMode X → Type u
+  | .pick => X
   | .observe => X
   | .hidden => PUnit
-  | .quotient Obs _ => Obs
+  | .react ⟨Obs, _⟩ => Obs
 
 /--
 `obsOf view x` is the concrete observation exposed by local view `view` when
@@ -182,182 +219,159 @@ the actual move was `x`.
 
 This forgets any control or continuation structure and keeps only the
 information that is revealed:
-* `active` and `observe` reveal the full move;
+* `pick` and `observe` reveal the full move;
 * `hidden` reveals nothing;
-* `quotient Obs toObs` reveals `toObs x`.
+* `react ⟨_, toObs⟩` reveals `toObs x`.
 -/
-def obsOf {X : Type u} : (view : LocalView X) → X → view.ObsType
-  | .active, x => x
+def obsOf {X : Type u} : (view : ViewMode X) → X → view.ObsType
+  | .pick, x => x
   | .observe, x => x
   | .hidden, _ => PUnit.unit
-  | .quotient _ toObs, x => toObs x
+  | .react ⟨_, toObs⟩, x => toObs x
 
 /--
-`LocalView.Action view m Cont` is the canonical local node type for a fixed
+`ViewMode.Action view m Cont` is the canonical local node type for a fixed
 participant with local view `view` at a node whose move space is `X`.
 
 Interpretation by cases:
-* if `view = active`, the participant effectfully selects a move `x : X` and
+* if `view = pick`, the participant effectfully selects a move `x : X` and
   produces the matching continuation;
 * if `view = observe`, the participant waits for the externally chosen move
   and then produces the continuation for that move;
 * if `view = hidden`, the participant does not observe the chosen move at this
   node, so it must effectfully prepare an entire family of continuations, one
   for each possible move;
-* if `view = quotient Obs toObs`, the participant is told only an observation
+* if `view = react ⟨Obs, toObs⟩`, the participant is told only an observation
   `o : Obs`; it must then effectfully provide continuations for every move
-  whose observation agrees with `o`.
+  whose observation agrees with `o`. This is the universal shape.
 
 This is the native multiparty analogue of `Interaction.Role.Action` from the
 two-party layer, extended by hidden and partial-observation cases.
 -/
-def Action {X : Type u} (view : LocalView X) (m : Type u → Type u)
+def Action {X : Type u} (view : ViewMode X) (m : Type u → Type u)
     (Cont : X → Type u) : Type u :=
   match view with
-  | .active => m ((x : X) × Cont x)
+  | .pick => m ((x : X) × Cont x)
   | .observe => (x : X) → m (Cont x)
   | .hidden => m ((x : X) → Cont x)
-  | .quotient Obs toObs => (o : Obs) → m ((x : X) → toObs x = o → Cont x)
+  | .react ⟨Obs, toObs⟩ => (o : Obs) → m ((x : X) → toObs x = o → Cont x)
 
 /--
-`LocalView.Kernel X` is the **polynomial-element** form of a local view: a
-single quotient morphism `toObs : X → Obs` packaged with its codomain `Obs`.
-
-This is the maximally general "what does a participant see" primitive. Three
-independent literature traditions converge on this exact object: epistemic
-logic (Halpern-Vardi), noninterference / info-flow (Goguen-Meseguer,
-Sabelfeld-Myers), and session-type / endpoint-projection frameworks
-(Honda-Yoshida-Carbone, Cruz-Filipe-Montesi).
-
-Every `LocalView X` collapses to a `Kernel X` via `LocalView.toKernel`,
-forgetting only the operational `Action` shape (the four-constructor
-enumeration is more ergonomic for `Action`-shape `rfl` reductions, but carries
-the same observational content as the corresponding kernel).
-
-Use `Kernel` directly when the protocol carries arbitrary observation types
-not captured by `active` / `observe` / `hidden`. Use `LocalView` when those
-specialized operational shapes are wanted.
--/
-abbrev Kernel (X : Type u) : Type (u + 1) := Σ Obs : Type u, X → Obs
-
-namespace Kernel
-
-variable {X : Type u}
-
-/--
-`Kernel.Action k m Cont` is the maximally general local node shape associated
-to a kernel `k = ⟨Obs, toObs⟩`.
-
-It coincides definitionally with `LocalView.Action (.quotient Obs toObs) m Cont`
-(see `LocalView.Action_quotient_eq_kernel_Action`).
--/
-def Action (k : Kernel X) (m : Type u → Type u) (Cont : X → Type u) : Type u :=
-  (o : k.1) → m ((x : X) → k.2 x = o → Cont x)
-
-end Kernel
-
-/--
-`toKernel v` is the canonical kernel form of a `LocalView v`: it forgets the
+`toObservation v` is the canonical kernel form of `v`: it forgets the
 operational `Action` shape and keeps only the observation type `Obs` and
 projection `toObs : X → Obs`.
 
 By construction:
-* `.active` and `.observe` both map to `⟨X, id⟩` (full information);
-* `.hidden` maps to `⟨PUnit, fun _ => PUnit.unit⟩` (zero information);
-* `.quotient Obs toObs` maps to `⟨Obs, toObs⟩`.
+* `.pick` and `.observe` both map to `Observation.top X = ⟨X, id⟩` (full
+  information, top of the observation lattice);
+* `.hidden` maps to `Observation.bot X = ⟨PUnit, fun _ => PUnit.unit⟩` (zero
+  information, bottom of the lattice);
+* `.react k` maps to `k`.
 
-`.active` and `.observe` collapse to the same kernel because they differ only
-in operational `Action` shape (effectful Σ-of-X vs function-from-X), not in
-observation content. The "this party authors the move" semantics that one
-might expect from `.active` lives instead in
+`.pick` and `.observe` collapse to the same observation because they differ
+only in operational `Action` shape (effectful Σ-of-X vs function-from-X), not
+in observation content. The "this party authors the move" semantics that one
+might expect from `.pick` lives instead in
 `Concurrent.NodeAuthority.controllers`.
 -/
-def toKernel {X : Type u} : LocalView X → Kernel X
-  | .active => ⟨X, id⟩
-  | .observe => ⟨X, id⟩
-  | .hidden => ⟨PUnit, fun _ => PUnit.unit⟩
-  | .quotient Obs toObs => ⟨Obs, toObs⟩
+def toObservation {X : Type u} : ViewMode X → Observation X
+  | .pick => Observation.top X
+  | .observe => Observation.top X
+  | .hidden => Observation.bot X
+  | .react k => k
 
-@[simp] theorem toKernel_active {X : Type u} :
-    toKernel (X := X) .active = ⟨X, id⟩ := rfl
+@[simp] theorem toObservation_pick {X : Type u} :
+    toObservation (X := X) .pick = Observation.top X := rfl
 
-@[simp] theorem toKernel_observe {X : Type u} :
-    toKernel (X := X) .observe = ⟨X, id⟩ := rfl
+@[simp] theorem toObservation_observe {X : Type u} :
+    toObservation (X := X) .observe = Observation.top X := rfl
 
-@[simp] theorem toKernel_hidden {X : Type u} :
-    toKernel (X := X) .hidden = ⟨PUnit, fun _ => PUnit.unit⟩ := rfl
+@[simp] theorem toObservation_hidden {X : Type u} :
+    toObservation (X := X) .hidden = Observation.bot X := rfl
 
-@[simp] theorem toKernel_quotient {X : Type u} (Obs : Type u) (toObs : X → Obs) :
-    toKernel (.quotient Obs toObs) = ⟨Obs, toObs⟩ := rfl
-
-/--
-The `ObsType` of a `LocalView` agrees definitionally with the first projection
-of its kernel form, by case analysis.
--/
-@[simp] theorem ObsType_eq_toKernel_fst {X : Type u} (v : LocalView X) :
-    v.ObsType = (toKernel v).1 := by
-  cases v <;> rfl
+@[simp] theorem toObservation_react {X : Type u} (k : Observation X) :
+    toObservation (.react k) = k := rfl
 
 /--
-The observation `obsOf v x` agrees with the kernel-form projection
-`(toKernel v).snd x` (modulo the type identification of
-`ObsType_eq_toKernel_fst`, hence stated as `HEq`).
+The `ObsType` of a `ViewMode` agrees definitionally with the first projection
+of its observation form, by case analysis.
 -/
-theorem obsOf_eq_toKernel_snd {X : Type u} (v : LocalView X) (x : X) :
-    HEq (obsOf v x) ((toKernel v).2 x) := by
-  cases v <;> rfl
+@[simp] theorem ObsType_eq_toObservation_fst {X : Type u} (v : ViewMode X) :
+    v.ObsType = (toObservation v).1 := by
+  cases v with
+  | react k => rcases k with ⟨_, _⟩; rfl
+  | _ => rfl
 
 /--
-The `Action` shape of `.quotient Obs toObs` coincides definitionally with the
-maximally general `Kernel.Action` of the corresponding kernel.
-
-This makes `.quotient` the universal `Action` shape: any protocol that builds
-its endpoint with `Kernel.Action` can equivalently work with
-`LocalView.Action (.quotient ..)`.
+The observation `obsOf v x` agrees with the kernel projection
+`(toObservation v).snd x` (modulo the type identification of
+`ObsType_eq_toObservation_fst`, hence stated as `HEq`).
 -/
-@[simp] theorem Action_quotient_eq_kernel_Action {X : Type u}
-    (Obs : Type u) (toObs : X → Obs)
+theorem obsOf_eq_toObservation_snd {X : Type u} (v : ViewMode X) (x : X) :
+    HEq (obsOf v x) ((toObservation v).2 x) := by
+  cases v with
+  | react k => rcases k with ⟨_, _⟩; rfl
+  | _ => rfl
+
+/--
+The `Action` shape of `.react ⟨Obs, toObs⟩` coincides definitionally with
+the universal `Observation.Action` of the corresponding kernel.
+
+This makes `.react` the universal `Action` shape: any protocol that builds
+its endpoint with `Observation.Action` can equivalently work with
+`ViewMode.Action (.react ⟨..⟩)`.
+-/
+@[simp] theorem Action_react_eq_Observation_Action {X : Type u}
+    (k : Observation X)
     (m : Type u → Type u) (Cont : X → Type u) :
-    LocalView.Action (.quotient Obs toObs) m Cont
-      = Kernel.Action ⟨Obs, toObs⟩ m Cont := rfl
-
-/--
-`fromKernel k` canonically embeds a kernel `k = ⟨Obs, toObs⟩` into `LocalView`
-via the universal `.quotient` constructor.
-
-`fromKernel` is a one-sided inverse of `toKernel`:
-`toKernel (fromKernel k) = k`. The reverse round-trip
-`fromKernel (toKernel v)` only equals `v` when `v` is itself a `.quotient`;
-for `.active` / `.observe` / `.hidden`, the round-trip lands on the
-corresponding `.quotient`, which is intended (those constructors carry
-operational shape information that the kernel form deliberately discards).
--/
-def fromKernel {X : Type u} : Kernel X → LocalView X
-  | ⟨Obs, toObs⟩ => .quotient Obs toObs
-
-@[simp] theorem toKernel_fromKernel {X : Type u} (k : Kernel X) :
-    toKernel (fromKernel k) = k := by
-  rcases k with ⟨Obs, toObs⟩
+    ViewMode.Action (.react k) m Cont
+      = Observation.Action k m Cont := by
+  rcases k with ⟨_, _⟩
   rfl
 
-end LocalView
+end ViewMode
+
+namespace Observation
 
 /--
-`LocalViewContext` is the plain node context whose metadata at each node is
-just one `LocalView` of that node's move space.
+`k.toViewMode` canonically embeds an observation kernel `k = ⟨Obs, toObs⟩`
+into `ViewMode` via the universal `.react` constructor.
+
+`toViewMode` is a one-sided inverse of `ViewMode.toObservation`:
+`(k.toViewMode).toObservation = k`. The reverse round-trip
+`(v.toObservation).toViewMode` only equals `v` when `v` is itself a `.react`;
+for `.pick` / `.observe` / `.hidden`, the round-trip lands on the
+corresponding `.react` (those constructors carry operational shape
+information that the kernel form deliberately discards, but their
+information content is preserved as `Observation.top` / `Observation.bot`).
+-/
+def toViewMode {X : Type u} (k : Observation X) : ViewMode X :=
+  .react k
+
+@[simp] theorem toViewMode_eq_react {X : Type u} (k : Observation X) :
+    toViewMode k = .react k := rfl
+
+@[simp] theorem toObservation_toViewMode {X : Type u} (k : Observation X) :
+    (toViewMode k).toObservation = k := rfl
+
+end Observation
+
+/--
+`ViewModeContext` is the plain node context whose metadata at each node is
+just one `ViewMode` of that node's move space.
 
 This is the direct multiparty local-view analogue of the two-party
 `RoleContext`.
-More structured multiparty models usually decorate nodes by richer metadata and
-then project that metadata to `LocalView` via `SyntaxOver.comap`.
+More structured multiparty models usually decorate nodes by richer metadata
+and then project that metadata to `ViewMode` via `SyntaxOver.comap`.
 -/
-abbrev LocalViewContext : Spec.Node.Context.{u, u + 1} := fun X : Type u => LocalView X
+abbrev ViewModeContext : Spec.Node.Context.{u, u + 1} := fun X : Type u => ViewMode X
 
 /--
 `localSyntax m` is the fundamental local syntax for one fixed participant when
-the node metadata already is that participant's `LocalView`.
+the node metadata already is that participant's `ViewMode`.
 
-At a node with move space `X`, view `v : LocalView X`, and continuation family
+At a node with move space `X`, view `v : ViewMode X`, and continuation family
 `Cont : X → Type`, the local node object is exactly `v.Action m Cont`.
 
 This syntax uses the singleton agent type `PUnit`, because it describes the
@@ -365,7 +379,7 @@ endpoint of one fixed participant viewpoint rather than a whole participant
 profile.
 -/
 def localSyntax (m : Type u → Type u) :
-    Spec.SyntaxOver (PUnit : Type) (fun X : Type u => LocalView X) where
+    Spec.SyntaxOver (PUnit : Type) (fun X : Type u => ViewMode X) where
   Node _ _ view Cont := view.Action m Cont
 
 /--
@@ -374,7 +388,7 @@ one fixed participant in a multiparty interaction.
 
 Inputs:
 * `Γ` is any chosen node-local metadata context;
-* `resolve : Γ → LocalView` explains how the fixed participant locally sees a
+* `resolve : Γ → ViewMode` explains how the fixed participant locally sees a
   node carrying metadata `γ : Γ X`;
 * `ctxs : Spec.Decoration Γ spec` supplies that metadata across the protocol
   tree.
@@ -390,7 +404,7 @@ metadata contexts `Γ`, decorations `ctxs`, and resolvers `resolve`.
 abbrev Strategy
     (m : Type u → Type u)
     {Γ : Spec.Node.Context.{u, v}}
-    (resolve : Spec.Node.ContextHom Γ (fun X : Type u => LocalView X))
+    (resolve : Spec.Node.ContextHom Γ (fun X : Type u => ViewMode X))
     (spec : Spec) (ctxs : Spec.Decoration Γ spec)
     (Output : Spec.Transcript spec → Type u) :=
   Spec.SyntaxOver.Family ((localSyntax m).comap resolve) PUnit.unit spec ctxs Output

--- a/VCVio/Interaction/Multiparty/Core.lean
+++ b/VCVio/Interaction/Multiparty/Core.lean
@@ -71,10 +71,11 @@ universal* form: any `LocalView` collapses to a kernel, and protocols that
 need only the observation can build kernels directly.
 
 This file does **not** carry authorship-of-move information; that lives in
-`Concurrent.NodeAuthority.controllers : Party → Bool`. In particular, the
-choice between `LocalView.active` and `LocalView.observe` is a *node shape*
-decision (effectful Σ-of-X vs function-from-X), not the canonical predicate
-for "this party authors the move".
+`Concurrent.NodeAuthority.controllers : X → List Party`, which credits each
+possible move `x : X` with the (possibly multiple) parties responsible for
+choosing it. In particular, the choice between `LocalView.active` and
+`LocalView.observe` is a *node shape* decision (effectful Σ-of-X vs
+function-from-X), not the canonical authorship attribution.
 
 ## Literature
 
@@ -135,10 +136,11 @@ These four constructors carry information along **two separate axes**:
   `X → Obs` packaged with its codomain (see `LocalView.Kernel`).
 
 The operational distinction between `active` and `observe` is **not** a
-canonical authorship predicate. Authorship-of-move is recorded by
-`Concurrent.NodeAuthority.controllers : Party → Bool`. `LocalView.active`
-indicates that a participant chooses *locally* in its endpoint type; whether
-it is the protocol-level controller is recorded separately.
+canonical authorship attribution. Authorship-of-move is recorded by
+`Concurrent.NodeAuthority.controllers : X → List Party`, a *per-move* and
+possibly *multi-controller* assignment. `LocalView.active` indicates only
+that a participant chooses *locally* in its endpoint type; whether it is the
+protocol-level controller of a particular move is recorded separately.
 
 `LocalView` is intentionally local. It does not describe the global
 communication discipline that produced it, nor who else sees the move.

--- a/VCVio/Interaction/Multiparty/Core.lean
+++ b/VCVio/Interaction/Multiparty/Core.lean
@@ -32,7 +32,10 @@ The definitions in this file are intentionally local and minimal.
 * `LocalView X` records how one fixed participant locally sees a chosen move
   `x : X` at one node.
 * `LocalView.Action` is the canonical local node shape associated to that view.
-* `localSyntax` packages that local node shape as a `Spec.SyntaxOver`.
+* `LocalView.Kernel` is the **maximally general single-projection form** of a
+  local view, packaging just the observation type and projection function.
+  Every `LocalView` collapses to a `Kernel` via `LocalView.toKernel`.
+* `localSyntax` packages the four-mode `Action` shape as a `Spec.SyntaxOver`.
 * `Strategy` is the induced whole-tree local endpoint type, obtained from
   arbitrary node-local metadata through `SyntaxOver.comap`.
 
@@ -45,6 +48,53 @@ model. In particular, it does not choose between:
 
 Those models are recovered later by choosing different node decorations and
 different resolvers.
+
+## Two layers of observation: kernel vs operational shape
+
+`LocalView` carries information along **two orthogonal axes**:
+
+* an **information axis**: what observation does the participant make? This is
+  fully captured by a single projection `toObs : X → Obs` packaged with its
+  codomain `Obs`. We call this the *kernel* of the local view; see
+  `LocalView.Kernel`.
+* an **operational axis**: how does the participant interact with that
+  observation in continuation passing? Does it choose the move (effectful
+  selection), wait for it (function-from-X), or commit to a uniform
+  continuation family in advance (function-into-Cont)? This is encoded in the
+  four constructors `active`, `observe`, `hidden`, `quotient`, each of which
+  specializes `Action` to a definitionally simpler shape.
+
+The four-constructor enumeration is the *ergonomically convenient* form for
+common patterns: it lets `LocalView.Action` reduce by `rfl` for each pattern,
+which keeps protocol examples short. `LocalView.Kernel` is the *semantically
+universal* form: any `LocalView` collapses to a kernel, and protocols that
+need only the observation can build kernels directly.
+
+This file does **not** carry authorship-of-move information; that lives in
+`Concurrent.NodeAuthority.controllers : Party → Bool`. In particular, the
+choice between `LocalView.active` and `LocalView.observe` is a *node shape*
+decision (effectful Σ-of-X vs function-from-X), not the canonical predicate
+for "this party authors the move".
+
+## Literature
+
+Three independent literature traditions converge on the kernel form
+`Σ Obs : Type, X → Obs`:
+
+* Halpern-Vardi epistemic logic ("Reasoning About Knowledge"): agent
+  observation as a projection from global state to local indistinguishability
+  classes;
+* Goguen-Meseguer noninterference / Sabelfeld-Myers info-flow: per-level
+  projection of observable outputs;
+* Honda-Yoshida-Carbone multiparty session types and Cruz-Filipe-Montesi
+  endpoint projection: projection of a global type / global play to a single
+  role's local view;
+* Hancock-Setzer interactive interfaces: the type-theoretic ancestor of the
+  four-constructor operational shape (Command/Response with embedded
+  observation modes).
+
+See `docs/agents/interaction.md` for a brief literature map and the design
+rationale for the kernel-vs-operational split.
 
 Naming note:
 this file does not introduce a new global multiparty protocol syntax. The
@@ -68,17 +118,34 @@ It answers the following question:
 > locally experience the actual chosen move `x : X` of that node?
 
 The possibilities are:
-* `active` — this participant chooses the next move;
-* `observe` — this participant is told the full chosen move and continues after
-  seeing it;
+* `active` — this participant locally selects the next move (effectful
+  Σ-of-X shape for `Action`);
+* `observe` — this participant is told the full chosen move and continues
+  after seeing it (function-from-X shape for `Action`);
 * `hidden` — this participant is not told the chosen move at the node itself,
   so any future behavior depending on that move must already be prepared
   uniformly over all possible moves;
 * `quotient Obs toObs` — this participant is told only the observation
   `toObs x : Obs`, not the full move `x`.
 
+These four constructors carry information along **two separate axes**:
+* **operational** — they pick out four definitionally distinct `Action` shapes
+  (see `LocalView.Action`), enabling `rfl` reductions for common patterns;
+* **observational** — they all collapse to a single quotient morphism
+  `X → Obs` packaged with its codomain (see `LocalView.Kernel`).
+
+The operational distinction between `active` and `observe` is **not** a
+canonical authorship predicate. Authorship-of-move is recorded by
+`Concurrent.NodeAuthority.controllers : Party → Bool`. `LocalView.active`
+indicates that a participant chooses *locally* in its endpoint type; whether
+it is the protocol-level controller is recorded separately.
+
 `LocalView` is intentionally local. It does not describe the global
 communication discipline that produced it, nor who else sees the move.
+
+For protocols whose participants make arbitrary observations not captured by
+the `active`/`observe`/`hidden` patterns, prefer `LocalView.Kernel` directly:
+it is the maximally general observation primitive.
 -/
 inductive LocalView (X : Type u) : Type (u + 1) where
   | active
@@ -149,6 +216,127 @@ def Action {X : Type u} (view : LocalView X) (m : Type u → Type u)
   | .observe => (x : X) → m (Cont x)
   | .hidden => m ((x : X) → Cont x)
   | .quotient Obs toObs => (o : Obs) → m ((x : X) → toObs x = o → Cont x)
+
+/--
+`LocalView.Kernel X` is the **polynomial-element** form of a local view: a
+single quotient morphism `toObs : X → Obs` packaged with its codomain `Obs`.
+
+This is the maximally general "what does a participant see" primitive. Three
+independent literature traditions converge on this exact object: epistemic
+logic (Halpern-Vardi), noninterference / info-flow (Goguen-Meseguer,
+Sabelfeld-Myers), and session-type / endpoint-projection frameworks
+(Honda-Yoshida-Carbone, Cruz-Filipe-Montesi).
+
+Every `LocalView X` collapses to a `Kernel X` via `LocalView.toKernel`,
+forgetting only the operational `Action` shape (the four-constructor
+enumeration is more ergonomic for `Action`-shape `rfl` reductions, but carries
+the same observational content as the corresponding kernel).
+
+Use `Kernel` directly when the protocol carries arbitrary observation types
+not captured by `active` / `observe` / `hidden`. Use `LocalView` when those
+specialized operational shapes are wanted.
+-/
+abbrev Kernel (X : Type u) : Type (u + 1) := Σ Obs : Type u, X → Obs
+
+namespace Kernel
+
+variable {X : Type u}
+
+/--
+`Kernel.Action k m Cont` is the maximally general local node shape associated
+to a kernel `k = ⟨Obs, toObs⟩`.
+
+It coincides definitionally with `LocalView.Action (.quotient Obs toObs) m Cont`
+(see `LocalView.Action_quotient_eq_kernel_Action`).
+-/
+def Action (k : Kernel X) (m : Type u → Type u) (Cont : X → Type u) : Type u :=
+  (o : k.1) → m ((x : X) → k.2 x = o → Cont x)
+
+end Kernel
+
+/--
+`toKernel v` is the canonical kernel form of a `LocalView v`: it forgets the
+operational `Action` shape and keeps only the observation type `Obs` and
+projection `toObs : X → Obs`.
+
+By construction:
+* `.active` and `.observe` both map to `⟨X, id⟩` (full information);
+* `.hidden` maps to `⟨PUnit, fun _ => PUnit.unit⟩` (zero information);
+* `.quotient Obs toObs` maps to `⟨Obs, toObs⟩`.
+
+`.active` and `.observe` collapse to the same kernel because they differ only
+in operational `Action` shape (effectful Σ-of-X vs function-from-X), not in
+observation content. The "this party authors the move" semantics that one
+might expect from `.active` lives instead in
+`Concurrent.NodeAuthority.controllers`.
+-/
+def toKernel {X : Type u} : LocalView X → Kernel X
+  | .active => ⟨X, id⟩
+  | .observe => ⟨X, id⟩
+  | .hidden => ⟨PUnit, fun _ => PUnit.unit⟩
+  | .quotient Obs toObs => ⟨Obs, toObs⟩
+
+@[simp] theorem toKernel_active {X : Type u} :
+    toKernel (X := X) .active = ⟨X, id⟩ := rfl
+
+@[simp] theorem toKernel_observe {X : Type u} :
+    toKernel (X := X) .observe = ⟨X, id⟩ := rfl
+
+@[simp] theorem toKernel_hidden {X : Type u} :
+    toKernel (X := X) .hidden = ⟨PUnit, fun _ => PUnit.unit⟩ := rfl
+
+@[simp] theorem toKernel_quotient {X : Type u} (Obs : Type u) (toObs : X → Obs) :
+    toKernel (.quotient Obs toObs) = ⟨Obs, toObs⟩ := rfl
+
+/--
+The `ObsType` of a `LocalView` agrees definitionally with the first projection
+of its kernel form, by case analysis.
+-/
+@[simp] theorem ObsType_eq_toKernel_fst {X : Type u} (v : LocalView X) :
+    v.ObsType = (toKernel v).1 := by
+  cases v <;> rfl
+
+/--
+The observation `obsOf v x` agrees with the kernel-form projection
+`(toKernel v).snd x` (modulo the type identification of
+`ObsType_eq_toKernel_fst`, hence stated as `HEq`).
+-/
+theorem obsOf_eq_toKernel_snd {X : Type u} (v : LocalView X) (x : X) :
+    HEq (obsOf v x) ((toKernel v).2 x) := by
+  cases v <;> rfl
+
+/--
+The `Action` shape of `.quotient Obs toObs` coincides definitionally with the
+maximally general `Kernel.Action` of the corresponding kernel.
+
+This makes `.quotient` the universal `Action` shape: any protocol that builds
+its endpoint with `Kernel.Action` can equivalently work with
+`LocalView.Action (.quotient ..)`.
+-/
+@[simp] theorem Action_quotient_eq_kernel_Action {X : Type u}
+    (Obs : Type u) (toObs : X → Obs)
+    (m : Type u → Type u) (Cont : X → Type u) :
+    LocalView.Action (.quotient Obs toObs) m Cont
+      = Kernel.Action ⟨Obs, toObs⟩ m Cont := rfl
+
+/--
+`fromKernel k` canonically embeds a kernel `k = ⟨Obs, toObs⟩` into `LocalView`
+via the universal `.quotient` constructor.
+
+`fromKernel` is a one-sided inverse of `toKernel`:
+`toKernel (fromKernel k) = k`. The reverse round-trip
+`fromKernel (toKernel v)` only equals `v` when `v` is itself a `.quotient`;
+for `.active` / `.observe` / `.hidden`, the round-trip lands on the
+corresponding `.quotient`, which is intended (those constructors carry
+operational shape information that the kernel form deliberately discards).
+-/
+def fromKernel {X : Type u} : Kernel X → LocalView X
+  | ⟨Obs, toObs⟩ => .quotient Obs toObs
+
+@[simp] theorem toKernel_fromKernel {X : Type u} (k : Kernel X) :
+    toKernel (fromKernel k) = k := by
+  rcases k with ⟨Obs, toObs⟩
+  rfl
 
 end LocalView
 

--- a/VCVio/Interaction/Multiparty/Directed.lean
+++ b/VCVio/Interaction/Multiparty/Directed.lean
@@ -36,8 +36,8 @@ ordered pair `(src, dst)` of parties.
 
 The intended semantics are directed point-to-point communication:
 `src` chooses the next move, `dst` receives that move, and all other parties
-are locally hidden at that node unless a richer resolver specifies a quotient
-observation.
+are locally hidden at that node unless a richer resolver specifies a partial
+observation kernel via `ViewMode.react`.
 -/
 abbrev EdgeDecoration (Party : Type u) :=
   Spec.Decoration (fun _ => Party × Party)
@@ -60,7 +60,7 @@ abbrev Strategy
     (m : Type u → Type u)
     {Party : Type u}
     (spec : Spec) (edges : EdgeDecoration Party spec)
-    (resolve : ∀ {X : Type u}, Party → Party → LocalView X)
+    (resolve : ∀ {X : Type u}, Party → Party → ViewMode X)
     (Output : Spec.Transcript spec → Type u) :=
   Multiparty.Strategy m
     (resolve := fun X edge => resolve (X := X) edge.1 edge.2) spec edges Output

--- a/VCVio/Interaction/Multiparty/Examples.lean
+++ b/VCVio/Interaction/Multiparty/Examples.lean
@@ -47,45 +47,45 @@ namespace ThreeParty
 `resolveBroadcastFor me owner` is the local-view projection of the broadcast
 model to the fixed participant `me`.
 
-At nodes owned by `me`, the result is `LocalView.active`.
-At all other nodes, the result is `LocalView.observe`.
+At nodes owned by `me`, the result is `ViewMode.pick`.
+At all other nodes, the result is `ViewMode.observe`.
 
 This definition is written by pattern matching, rather than by equality tests,
 so that endpoint types reduce definitionally in examples.
 -/
-def resolveBroadcastFor (me owner : ThreeParty) {X : Type u} : LocalView X :=
+def resolveBroadcastFor (me owner : ThreeParty) {X : Type u} : ViewMode X :=
       match me, owner with
-      | .prover, .prover => .active
+      | .prover, .prover => .pick
       | .prover, .verifier => .observe
       | .prover, .extractor => .observe
       | .verifier, .prover => .observe
-      | .verifier, .verifier => .active
+      | .verifier, .verifier => .pick
       | .verifier, .extractor => .observe
       | .extractor, .prover => .observe
       | .extractor, .verifier => .observe
-      | .extractor, .extractor => .active
+      | .extractor, .extractor => .pick
 
 /--
 `resolveDirectedFor me src dst` is the local-view projection of the directed
 model to the fixed participant `me`.
 
 It returns:
-* `active` when `me` is the node's source party;
+* `pick` when `me` is the node's source party;
 * `observe` when `me` is the node's designated destination party;
 * `hidden` otherwise.
 
 As in the broadcast model, this resolver is defined by pattern matching, so
 that local endpoint types unfold definitionally.
 -/
-def resolveDirectedFor (me src dst : ThreeParty) {X : Type u} : LocalView X :=
+def resolveDirectedFor (me src dst : ThreeParty) {X : Type u} : ViewMode X :=
       match me, src, dst with
-      | .prover, .prover, _ => .active
+      | .prover, .prover, _ => .pick
       | .prover, _, .prover => .observe
       | .prover, _, _ => .hidden
-      | .verifier, .verifier, _ => .active
+      | .verifier, .verifier, _ => .pick
       | .verifier, _, .verifier => .observe
       | .verifier, _, _ => .hidden
-      | .extractor, .extractor, _ => .active
+      | .extractor, .extractor, _ => .pick
       | .extractor, _, .extractor => .observe
       | .extractor, _, _ => .hidden
 
@@ -211,9 +211,9 @@ learns only the public tag, and the outsider learns nothing. -/
 private def scheduledViews :
     Profile.Decoration ScheduleParty (scheduledSpec Msg Flag) :=
   ⟨(fun
-      | .adversary => .active
+      | .adversary => .pick
       | .recipient => .observe
-      | .auditor => .quotient Flag Prod.fst
+      | .auditor => .react ⟨Flag, Prod.fst⟩
       | .outsider => .hidden), fun _ => ⟨⟩⟩
 
 /-- The adversary chooses the full scheduled event. -/
@@ -342,10 +342,10 @@ This single node already captures several adversarial powers:
 private def networkViews :
     Profile.Decoration DeliveryParty (networkSpec Msg) :=
   ⟨(fun
-      | .adversary => .active
-      | .bob => .quotient (Option Msg) (bobObservation (Msg := Msg))
-      | .carol => .quotient (Option Msg) (carolObservation (Msg := Msg))
-      | .auditor => .quotient DeliverySummary (deliverySummary (Msg := Msg))
+      | .adversary => .pick
+      | .bob => .react ⟨Option Msg, bobObservation (Msg := Msg)⟩
+      | .carol => .react ⟨Option Msg, carolObservation (Msg := Msg)⟩
+      | .auditor => .react ⟨DeliverySummary, deliverySummary (Msg := Msg)⟩
       | .outsider => .hidden), fun _ => ⟨⟩⟩
 
 /-- The adversary chooses the exact network action. -/
@@ -438,19 +438,19 @@ adversarially chosen moves.
 private def corruptionViews :
     Profile.Decoration CorruptionParty (corruptionSpec Secret) :=
   ⟨(fun
-      | .adversary => .active
+      | .adversary => .pick
       | .alice => .observe
       | .bob => .observe
       | .monitor => .observe), fun
       | .alice =>
           ⟨(fun
-              | .adversary => .active
+              | .adversary => .pick
               | .alice => .observe
               | .bob => .hidden
               | .monitor => .hidden), fun _ => ⟨⟩⟩
       | .bob =>
           ⟨(fun
-              | .adversary => .active
+              | .adversary => .pick
               | .alice => .hidden
               | .bob => .observe
               | .monitor => .hidden), fun _ => ⟨⟩⟩⟩
@@ -463,8 +463,8 @@ It is written explicitly so that the resulting endpoint computation reduces by
 `rfl`.
 -/
 private def corruptionAdversaryViews :
-    Spec.Decoration (fun X : Type u => LocalView X) (corruptionSpec Secret) :=
-  ⟨.active, fun _ => ⟨.active, fun _ => ⟨⟩⟩⟩
+    Spec.Decoration (fun X : Type u => ViewMode X) (corruptionSpec Secret) :=
+  ⟨.pick, fun _ => ⟨.pick, fun _ => ⟨⟩⟩⟩
 
 /--
 `corruptionMonitorViews` is the local-view projection of `corruptionViews`
@@ -474,7 +474,7 @@ The monitor learns the public corruption decision but is hidden from the later
 secret-bearing move in every branch.
 -/
 private def corruptionMonitorViews :
-    Spec.Decoration (fun X : Type u => LocalView X) (corruptionSpec Secret) :=
+    Spec.Decoration (fun X : Type u => ViewMode X) (corruptionSpec Secret) :=
   ⟨.observe, fun _ => ⟨.hidden, fun _ => ⟨⟩⟩⟩
 
 /--
@@ -482,7 +482,7 @@ The post-corruption secret-bearing node viewed from the branch where Alice is
 the corrupted party.
 -/
 private def aliceAfterSelfCorruptionViews :
-    Spec.Decoration (fun X : Type u => LocalView X) (Spec.node Secret fun _ => .done) :=
+    Spec.Decoration (fun X : Type u => ViewMode X) (Spec.node Secret fun _ => .done) :=
   ⟨.observe, fun _ => ⟨⟩⟩
 
 /--
@@ -490,7 +490,7 @@ The same post-corruption secret-bearing node viewed from the branch where Bob
 is corrupted instead, so Alice is hidden from the move.
 -/
 private def aliceAfterBobCorruptionViews :
-    Spec.Decoration (fun X : Type u => LocalView X) (Spec.node Secret fun _ => .done) :=
+    Spec.Decoration (fun X : Type u => ViewMode X) (Spec.node Secret fun _ => .done) :=
   ⟨.hidden, fun _ => ⟨⟩⟩
 
 /--
@@ -511,7 +511,7 @@ adversary's first move can induce for Alice.
 -/
 example :
     Multiparty.Strategy m
-      (resolve := Spec.Node.ContextHom.id (fun X : Type u => LocalView X))
+      (resolve := Spec.Node.ContextHom.id (fun X : Type u => ViewMode X))
       (Spec.node Secret fun _ => .done) (aliceAfterSelfCorruptionViews Secret)
       (fun _ => α)
     = ((_ : Secret) → m α) := by
@@ -524,7 +524,7 @@ If Bob is corrupted instead, Alice is hidden from the same second-step node.
 -/
 example :
     Multiparty.Strategy m
-      (resolve := Spec.Node.ContextHom.id (fun X : Type u => LocalView X))
+      (resolve := Spec.Node.ContextHom.id (fun X : Type u => ViewMode X))
       (Spec.node Secret fun _ => .done) (aliceAfterBobCorruptionViews Secret)
       (fun _ => α)
     = m ((_ : Secret) → α) := by

--- a/VCVio/Interaction/Multiparty/Observation.lean
+++ b/VCVio/Interaction/Multiparty/Observation.lean
@@ -1,0 +1,304 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.Basic.Spec
+import Mathlib.Order.Lattice
+import Mathlib.Order.BoundedOrder.Basic
+
+/-!
+# Observations: the information lattice of a single move
+
+This file defines `Multiparty.Observation X`, the **maximally general
+single-projection form** of a local view at a node whose move space is `X`,
+together with its information-lattice algebra.
+
+`Observation X = Σ Obs : Type u, X → Obs` is one quotient morphism `X → Obs`
+packaged with its codomain. Three independent literature traditions converge
+on this exact object:
+
+* Halpern-Vardi epistemic logic ("Reasoning About Knowledge"): an agent's
+  observation is a projection from global state to local indistinguishability
+  classes;
+* Goguen-Meseguer noninterference / Sabelfeld-Myers info-flow: per-level
+  projection of observable outputs;
+* Honda-Yoshida-Carbone multiparty session types and Cruz-Filipe-Montesi
+  endpoint projection: projection of a global type / global play to one
+  role's local view.
+
+## Polynomial substrate
+
+`Observation` is built directly on top of the polynomial-functor library
+in `ToMathlib/PFunctor`, mirroring the pattern by which
+`Interaction.Spec` is built from `Spec.basePFunctor`:
+
+```
+Observation X := PFunctor.Idx (Observation.basePFunctor X)
+```
+
+where `Observation.basePFunctor X : PFunctor.{u+1, u}` has positions
+`Type u` (one position per observation codomain) and a child family
+`Obs ↦ X → Obs` (the projections from `X` into that codomain). Thus an
+observation of `X` is precisely an *element* (in `PFunctor.Idx` terms) of
+this polynomial: a chosen codomain `Obs` together with a projection
+`X → Obs`. The `Σ`-form `Σ Obs : Type u, X → Obs` is recovered
+definitionally because `PFunctor.Idx P` unfolds to `Σ a, P.B a`. The
+polynomial substrate is the truth; the `Observation` name is an
+ergonomic re-skin in the spirit of `OracleSpec` / `OracleComp` and
+`Spec.done` / `Spec.node`.
+
+## Information lattice
+
+The intended order on `Observation X` is *informativeness*, ordered low ≤ high:
+
+* `Observation.bot X = ⟨PUnit, fun _ => PUnit.unit⟩` is the **bottom** of the
+  lattice: zero information, the coarsest (one-class) partition.
+* `Observation.top X = ⟨X, id⟩` is the **top**: full information, the finest
+  (all-singleton) partition.
+* `Observation.Refines k₁ k₂` (`k₁ ⊑ k₂`) means "`k₁` reveals no more than
+  `k₂`": the projection of `k₁` factors through that of `k₂`.
+* `Observation.combine k₁ k₂` is the **join** in the information lattice: the
+  Σ-product of both kernels, i.e. the universal kernel that records what is
+  learned by jointly observing through `k₁` and `k₂`.
+* `Observation.postcomp k f` post-composes the projection of `k` with `f`,
+  yielding a kernel that is automatically refined by `k` (a downgrade).
+
+The dual meet (greatest common reduction, the coarsest kernel that both
+refine) requires quotienting `X` by the joint indistinguishability relation
+and is deferred until a use case requires it.
+
+## Mathlib lattice notation
+
+The named operations above are also exposed via Mathlib's order typeclasses
+so that standard notation works on `Observation X`:
+
+* `(⊤ : Observation X) = Observation.top X` via `Top`;
+* `(⊥ : Observation X) = Observation.bot X` via `Bot`;
+* `k₁ ≤ k₂` denotes `k₁.Refines k₂` via `LE` and `Preorder`;
+* `bot_le` and `le_top` come from the `OrderBot` and `OrderTop` instances;
+* `k₁ ⊔ k₂ = Observation.combine k₁ k₂` via `Max`.
+
+Note that `Refines` is only a *preorder*, not a partial order: two
+observations may mutually refine each other through different bijections of
+their codomains (e.g. `⟨X × Y, _⟩` and `⟨Y × X, _⟩`). For that reason we do
+not declare `SemilatticeSup` (which would require antisymmetry); the
+join-style theorems for `combine` are stated as named lemmas instead.
+
+A practical payoff is that `Pi`-instance lifting in Mathlib then transfers
+all of this notation pointwise to per-party observation profiles
+`Party → Observation X` (see `Multiparty/ObservationProfile.lean`) for free.
+
+## Action shape
+
+`Observation.Action k m Cont` is the maximally general local node type
+associated to a kernel: it asks the participant to commit to a uniform
+continuation family conditioned on the observation `o : k.1`. The four-mode
+operational refinement and its `rfl`-friendly action shapes live in
+`Multiparty/Core.lean` (`ViewMode`); this file only knows the universal form.
+-/
+
+universe u v
+
+namespace Interaction
+namespace Multiparty
+
+namespace Observation
+
+/-- The polynomial functor whose index type is `Multiparty.Observation X`:
+positions are observation codomains `Type u`, and the child family at a
+position `Obs : Type u` is the type of projections `X → Obs`.
+
+Following the convention established by `Interaction.Spec.basePFunctor`,
+this exposes `Observation X` as the index type
+`PFunctor.Idx (basePFunctor X) = Σ Obs : Type u, X → Obs` of a specific
+polynomial functor: the universal "observations of `X`" container. An
+element of the polynomial is precisely a chosen codomain together with a
+projection from `X` into it. -/
+@[reducible]
+def basePFunctor (X : Type u) : PFunctor.{u + 1, u} where
+  A := Type u
+  B := (X → ·)
+
+end Observation
+
+/--
+`Observation X` is the polynomial-element form of a local view at a node
+whose move space is `X`: a single quotient morphism `toObs : X → Obs`
+packaged with its codomain `Obs`.
+
+It is **definitionally** the index type of `Observation.basePFunctor X`:
+`Observation X = PFunctor.Idx (basePFunctor X) = Σ Obs : Type u, X → Obs`,
+mirroring the pattern by which `Interaction.Spec` is defined as
+`PFunctor.FreeM Spec.basePFunctor PUnit`. The `Σ`-pair literal
+`⟨Obs, π⟩` works directly as a constructor, and the projections `k.1` /
+`k.2` recover the codomain and projection.
+
+This is the maximally general "what does a participant see" primitive. It
+is the carrier of the information lattice (see `Observation.top`,
+`Observation.bot`, `Observation.Refines`, `Observation.combine`).
+
+Operationally specialized observations with simpler `Action` shapes live in
+`Multiparty/Core.lean` as the four-constructor `ViewMode` type; every
+`ViewMode` collapses to an `Observation` via `ViewMode.toObservation`, and
+every `Observation` lifts back into `ViewMode` via `Observation.toViewMode`
+(equivalently, the universal `ViewMode.react` constructor).
+-/
+abbrev Observation (X : Type u) : Type (u + 1) :=
+  PFunctor.Idx (Observation.basePFunctor X)
+
+namespace Observation
+
+variable {X : Type u}
+
+/--
+`Observation.top X = ⟨X, id⟩` is the **top** of the information lattice on
+`X`: the identity projection, recording the entire move.
+
+Every `Observation X` refines `Observation.top X`.
+-/
+protected def top (X : Type u) : Observation X := ⟨X, id⟩
+
+/--
+`Observation.bot X = ⟨PUnit, fun _ => PUnit.unit⟩` is the **bottom** of the
+information lattice on `X`: the constant projection to a singleton, recording
+nothing about the move.
+
+`Observation.bot X` refines every `Observation X`.
+-/
+protected def bot (X : Type u) : Observation X := ⟨PUnit, fun _ => PUnit.unit⟩
+
+/--
+`Observation.Refines k₁ k₂` (read "`k₁` refines `k₂`") holds when `k₁` is no
+more revealing than `k₂`: the projection of `k₁` factors through that of
+`k₂`.
+
+Equivalently, every `k₂`-indistinguishability class is a union of
+`k₁`-indistinguishability classes, so observers using `k₁` learn at most what
+observers using `k₂` learn. This is the natural ordering in which
+`Observation.bot` is least and `Observation.top` is greatest.
+-/
+def Refines (k₁ k₂ : Observation X) : Prop :=
+  ∃ f : k₂.1 → k₁.1, ∀ x, k₁.2 x = f (k₂.2 x)
+
+@[refl] theorem Refines.refl (k : Observation X) : k.Refines k :=
+  ⟨id, fun _ => rfl⟩
+
+theorem Refines.trans {k₁ k₂ k₃ : Observation X}
+    (h₁₂ : k₁.Refines k₂) (h₂₃ : k₂.Refines k₃) : k₁.Refines k₃ := by
+  obtain ⟨f, hf⟩ := h₁₂
+  obtain ⟨g, hg⟩ := h₂₃
+  exact ⟨f ∘ g, fun x => (hf x).trans (congrArg f (hg x))⟩
+
+/-- The bottom kernel refines every kernel: zero information is no more
+revealing than any kernel. -/
+theorem bot_refines (k : Observation X) : (Observation.bot X).Refines k :=
+  ⟨fun _ => PUnit.unit, fun _ => rfl⟩
+
+/-- Every kernel refines the top kernel: any kernel is no more revealing
+than the identity projection. -/
+theorem refines_top (k : Observation X) : k.Refines (Observation.top X) :=
+  ⟨k.2, fun _ => rfl⟩
+
+/--
+`Observation.combine k₁ k₂` is the **join** in the information lattice: the
+Σ-product of both kernels' observations.
+
+It is the canonical way to combine two parties' views into a coalition view,
+and the universal kernel that records what is learned by jointly observing
+through `k₁` and `k₂`. Since `Refines` orders by informativeness,
+`combine k₁ k₂` carries strictly more information than either factor.
+-/
+def combine (k₁ k₂ : Observation X) : Observation X :=
+  ⟨k₁.1 × k₂.1, fun x => (k₁.2 x, k₂.2 x)⟩
+
+theorem refines_combine_left (k₁ k₂ : Observation X) : k₁.Refines (combine k₁ k₂) :=
+  ⟨Prod.fst, fun _ => rfl⟩
+
+theorem refines_combine_right (k₁ k₂ : Observation X) : k₂.Refines (combine k₁ k₂) :=
+  ⟨Prod.snd, fun _ => rfl⟩
+
+/-- `combine` is the least upper bound for `Refines`: any kernel `k` that is
+refined by both `k₁` and `k₂` is refined by `combine k₁ k₂`. -/
+theorem combine_refines_of {k k₁ k₂ : Observation X}
+    (h₁ : k₁.Refines k) (h₂ : k₂.Refines k) : (combine k₁ k₂).Refines k := by
+  obtain ⟨f₁, hf₁⟩ := h₁
+  obtain ⟨f₂, hf₂⟩ := h₂
+  refine ⟨fun y => (f₁ y, f₂ y), fun x => ?_⟩
+  change (k₁.2 x, k₂.2 x) = (f₁ (k.2 x), f₂ (k.2 x))
+  rw [hf₁, hf₂]
+
+/--
+`k.postcomp f` post-composes the projection of `k` with `f : k.1 → Y`,
+yielding a kernel that is automatically refined by `k`.
+
+This is the workhorse for "downgrading" an observation: if a corruption mode
+strips a field from the observation type, the new kernel is `postcomp` of the
+old one with the field-removal map.
+-/
+def postcomp (k : Observation X) {Y : Type u} (f : k.1 → Y) : Observation X :=
+  ⟨Y, fun x => f (k.2 x)⟩
+
+theorem postcomp_refines (k : Observation X) {Y : Type u} (f : k.1 → Y) :
+    (k.postcomp f).Refines k :=
+  ⟨f, fun _ => rfl⟩
+
+/--
+`Observation.Action k m Cont` is the maximally general local node shape
+associated to a kernel `k = ⟨Obs, toObs⟩`.
+
+It asks the participant to commit to an entire family of continuations
+indexed by the observation `o : Obs`: for each observed value `o`, an
+effectful map sending each move `x : X` whose observation is `o` to its
+continuation `Cont x`.
+
+Operationally specialized shapes (the simpler `Σ-of-X`, `function-from-X`,
+and `function-into-Cont` patterns) live in `Multiparty/Core.lean` as
+`ViewMode.Action`; this is the universal shape that they all collapse to.
+-/
+def Action (k : Observation X) (m : Type u → Type u) (Cont : X → Type u) : Type u :=
+  (o : k.1) → m ((x : X) → k.2 x = o → Cont x)
+
+/-! ### Mathlib lattice typeclass instances
+
+The instances below expose the information-lattice algebra of `Observation X`
+through Mathlib's standard order classes. They are non-defining: each one is
+a thin wrapper over the named operations above (`Observation.top`,
+`Observation.bot`, `Refines`, `combine`).
+
+A `SemilatticeSup` instance would require antisymmetry of `Refines`, which
+fails in general (mutually refining kernels related by codomain bijections),
+so we expose only `Max` for the `⊔` notation; the join-style lemmas live as
+named theorems above.
+-/
+
+instance : Top (Observation X) := ⟨Observation.top X⟩
+
+instance : Bot (Observation X) := ⟨Observation.bot X⟩
+
+instance : LE (Observation X) := ⟨Refines⟩
+
+instance : Preorder (Observation X) where
+  le_refl := Refines.refl
+  le_trans _ _ _ := Refines.trans
+
+instance : OrderTop (Observation X) where
+  le_top := refines_top
+
+instance : OrderBot (Observation X) where
+  bot_le := bot_refines
+
+instance : Max (Observation X) := ⟨combine⟩
+
+@[simp] theorem top_def : (⊤ : Observation X) = Observation.top X := rfl
+
+@[simp] theorem bot_def : (⊥ : Observation X) = Observation.bot X := rfl
+
+@[simp] theorem le_def {k₁ k₂ : Observation X} : k₁ ≤ k₂ ↔ k₁.Refines k₂ := Iff.rfl
+
+@[simp] theorem sup_def (k₁ k₂ : Observation X) : k₁ ⊔ k₂ = combine k₁ k₂ := rfl
+
+end Observation
+
+end Multiparty
+end Interaction

--- a/VCVio/Interaction/Multiparty/ObservationProfile.lean
+++ b/VCVio/Interaction/Multiparty/ObservationProfile.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.Multiparty.Profile
+
+/-!
+# Observation-form profiles for compositional reasoning about disclosure
+
+This file is the kernel-form analogue of `Multiparty/Profile.lean`. It
+packages the **maximally general single-projection** form of a per-party
+local-view decoration as a node context, and exposes the pointwise lift of
+`Multiparty.Observation`'s information-lattice algebra to per-party profiles.
+
+The motivation is **compositional reasoning about observation**:
+
+* `ViewMode X` (the four-mode enumeration) is the operationally convenient
+  form, with `rfl`-reducing `Action` shapes per pattern; it is the right
+  input to `Profile.Strategy`.
+* `Observation X = Σ Obs : Type u, X → Obs` is the semantically universal
+  form, and the natural carrier for an algebra of observations: refinement
+  is a Σ-factorization, coalition combination is a Σ-product, and
+  corruption-indexed observation policies naturally produce
+  `Observation`-valued maps `mode → party → Observation`.
+
+`ObservationProfile.toViewProfile` lifts an observation profile back into a
+`ViewProfile` via the universal `.react` constructor (`Observation.toViewMode`)
+so that the existing `Profile.Strategy` pipeline can consume observation
+profiles unchanged at the cost of dropping the operational `.pick` /
+`.observe` / `.hidden` shapes. For mixed protocols where some parties want
+those operational shapes, prefer building `ViewProfile`s directly and using
+`ObservationProfile` only where the kernel algebra is needed.
+
+## Pointwise information lattice
+
+Because `Observation X` carries Mathlib's `Top`, `Bot`, `LE`, `Preorder`,
+`OrderTop`, `OrderBot`, and `Max` instances (see `Multiparty/Observation.lean`),
+the per-party profile type `Party → Observation X` automatically inherits
+them pointwise via `Pi.preorder`, `Pi.instOrderTop`, `Pi.instOrderBot`, and
+`Pi.instMax`. Concretely:
+
+* `(⊤ : ObservationProfile Party X)` is the all-`Observation.top` profile
+  (every party sees the entire move; top of the pointwise lattice);
+* `(⊥ : ObservationProfile Party X)` is the all-`Observation.bot` profile
+  (every party sees nothing; bottom);
+* `k₁ ≤ k₂` means "`k₁` is no more revealing than `k₂` at every party"
+  (`∀ p, (k₁ p).Refines (k₂ p)` by `Pi.le_def`);
+* `k₁ ⊔ k₂` is the pointwise Σ-product, the **join**: each party gets the
+  joint observation of `k₁ p` and `k₂ p`;
+* `bot_le` and `le_top` come for free from the lifted `OrderBot` / `OrderTop`.
+
+Per-party `Refines` is also still available as `(k₁ p).Refines (k₂ p)` for
+explicit reasoning.
+
+The dual meet (greatest common reduction) is not provided here for the same
+reason as in `Multiparty/Observation.lean`: it requires quotienting `X` by
+the joint indistinguishability relation, and the underlying `Refines` is
+only a preorder (not antisymmetric).
+-/
+
+universe u v
+
+namespace Interaction
+namespace Multiparty
+namespace Profile
+
+/--
+`ObservationProfile Party X` assigns to each party its observation kernel of
+a node whose move space is `X`.
+
+This is the kernel-form analogue of `ViewProfile`. The two are related by
+`ObservationProfile.toViewProfile`, which lifts each per-party observation
+into a `ViewMode` via the universal `.react` constructor
+(`Observation.toViewMode`).
+
+For most strategy-side use, work with `ViewProfile`. For compositional
+reasoning about observation algebra (refinement, coalition combination,
+corruption-indexed observation policies), build `ObservationProfile`s and
+convert at the boundary.
+
+The pointwise information-lattice algebra (`⊤`, `⊥`, `≤`, `⊔`, plus the
+standard `bot_le` and `le_top` lemmas) is inherited from the per-party
+`Observation X` instances via `Pi.preorder`, `Pi.instOrderTop`,
+`Pi.instOrderBot`, and `Pi.instMax`.
+-/
+abbrev ObservationProfile (Party : Type u) : Spec.Node.Context.{u, u + 1} :=
+  fun X => Party → Observation X
+
+namespace ObservationProfile
+
+variable {Party : Type u} {X : Type u}
+
+/--
+`ObservationProfile.toViewProfile k` lifts a per-party observation profile to
+a per-party view profile via `Observation.toViewMode`.
+
+Concretely each party's view becomes the universal `.react` form of its
+observation. This is the bridge between the kernel-form algebra of
+`ObservationProfile` and the endpoint-shape API of `ViewProfile` /
+`Profile.Strategy`.
+
+Caveat: this lifting forgets the operational `.pick` / `.observe` /
+`.hidden` shapes. For protocols where a participant's endpoint should
+genuinely have the `Σ-of-X` (pick) or function-from-X (observe) shape,
+either build a mixed profile that uses `ViewMode` directly for those
+parties, or compose the observation profile with a separate operational
+decoration downstream.
+-/
+def toViewProfile (k : ObservationProfile Party X) : ViewProfile Party X :=
+  fun p => Observation.toViewMode (k p)
+
+@[simp] theorem toViewProfile_apply (k : ObservationProfile Party X) (p : Party) :
+    toViewProfile k p = Observation.toViewMode (k p) := rfl
+
+end ObservationProfile
+
+end Profile
+end Multiparty
+end Interaction

--- a/VCVio/Interaction/Multiparty/Profile.lean
+++ b/VCVio/Interaction/Multiparty/Profile.lean
@@ -12,14 +12,14 @@ This file packages the most structured native multiparty interface built on top
 of `Interaction.Multiparty.Core`.
 
 A node of move space `X` is decorated not merely by one local view, but by a
-whole profile assigning each party its own `LocalView X`. The endpoint of one
+whole profile assigning each party its own `ViewMode X`. The endpoint of one
 fixed party is then obtained by projecting that profile to the chosen party.
 
 This is the most direct structured way to describe multiparty nodes with:
-* one active controller of the move;
-* parties that observe the full move;
-* parties that observe only a quotient of the move; and
-* parties that observe nothing at all.
+* one party that locally picks the move (`ViewMode.pick`);
+* parties that observe the full move (`ViewMode.observe`);
+* parties that observe only a kernel of the move (`ViewMode.react ⟨..⟩`); and
+* parties that observe nothing at all (`ViewMode.hidden`).
 -/
 
 universe u
@@ -37,7 +37,7 @@ multiparty interaction: one actual global move may give different local
 observations to different parties.
 -/
 abbrev ViewProfile (Party : Type u) : Spec.Node.Context.{u, u + 1} :=
-  fun X => Party → LocalView X
+  fun X => Party → ViewMode X
 
 /--
 A `Decoration Party spec` assigns one local-view profile to every node of

--- a/docs/agents/interaction.md
+++ b/docs/agents/interaction.md
@@ -13,8 +13,8 @@ The framework is organized around a few stable principles:
   All composition, decoration, and strategy types respect this structure.
 - **Control vs observation are orthogonal.**
   Who *chooses* a move (per-node: `NodeAuthority`; per-spec-tree: `Concurrent.Control`)
-  and who *sees* a move (per-node: `NodeObservation`; per-party-per-node:
-  `Multiparty.LocalView`; per-spec-tree: `Concurrent.Profile`) are independent axes.
+  and who *sees* a move (per-node: `NodeView`; per-party-per-node:
+  `Multiparty.ViewMode`; per-spec-tree: `Concurrent.Profile`) are independent axes.
   A party can control a node but see only a quotient of its own move, or observe
   a node fully without controlling it.
 - **Boundary vs composition.**
@@ -40,7 +40,7 @@ The framework is organized around a few stable principles:
 |-------|-----------|----------------|
 | Sequential core | `Basic/` | Specs, transcripts, decorations, strategies, composition |
 | Two-party | `TwoParty/` | Sender/receiver roles, counterparts, Fiat-Shamir replay |
-| Multiparty | `Multiparty/` | Per-party local views (active/observe/hidden/quotient) |
+| Multiparty | `Multiparty/` | Per-party local view modes (pick/observe/hidden/react) and observation kernels |
 | Concurrent | `Concurrent/` | Parallel composition, frontiers, processes, refinement, open systems |
 
 Dependencies flow downward: `Concurrent/` may import `Multiparty/` and `Basic/`;
@@ -76,13 +76,19 @@ tree). Typically there are *many more* nodes than parties: a long protocol may h
 unboundedly many nodes (or a continuation-based infinite stream of them via
 `ProcessOver`), but always the same finite party set.
 
-### LocalView — what a single party sees at a single node
+### ViewMode — what a single party sees at a single node
 
-`Multiparty.LocalView X` (`Multiparty/Core.lean`) records how *one* party locally
+`Multiparty.ViewMode X` (`Multiparty/Core.lean`) records how *one* party locally
 experiences a node whose move space is `X`. The four constructors
-`active` / `observe` / `hidden` / `quotient Obs toObs` are the canonical observation
-modes. A `LocalView` is the smallest atomic node × party × observation triple in the
-framework.
+`pick` / `observe` / `hidden` / `react ⟨Obs, toObs⟩` are the canonical
+observation modes. A `ViewMode` is the smallest atomic node × party ×
+observation triple in the framework.
+
+The information content of a `ViewMode` is captured by `Multiparty.Observation X`
+(`Multiparty/Observation.lean`), a `Σ Obs : Type, X → Obs` realized as
+`PFunctor.Idx (Observation.basePFunctor X)`. `Observation X` carries
+Mathlib's order typeclasses (`⊤`, `⊥`, `≤`, `⊔`) so refinement and join in
+the information lattice use standard notation.
 
 ### NodeProfile — per-node attribution of who-authors-what and who-sees-what
 
@@ -90,15 +96,20 @@ framework.
 and the whole party set. It bundles two orthogonal factor structures:
 
 - `NodeAuthority Party X`: `controllers : X → List Party` — for each possible move,
-  which parties are credited as having authored it.
-- `NodeObservation Party X`: `views : Party → Multiparty.LocalView X` — for each
+  which parties are credited as having authored it (move-dependent and possibly
+  multi-controller).
+- `NodeView Party X`: `views : Party → Multiparty.ViewMode X` — for each
   party, what local view they have at this node.
 
 The structure `extends` both factors, so dot-notation field access
 (`node.controllers x`, `node.views me`) and the structure-literal constructor
 `{ controllers := ..., views := ... }` work transparently. Code that depends only on
 authorship can take a `NodeAuthority Party X` parameter; code that depends only on
-observation can take a `NodeObservation Party X` parameter.
+observation can take a `NodeView Party X` parameter.
+
+The naming `NodeView` (rather than `NodeObservation`) deliberately avoids
+collision with `Multiparty.Observation X`, the kernel-level *information
+content* of a single party's view.
 
 `OpenNodeProfile Party Δ X` (`UC/OpenProcess.lean`) is the open-system extension that
 adds one `BoundaryAction Δ X` field for external traffic.
@@ -107,14 +118,15 @@ adds one `BoundaryAction Δ X` field for external traffic.
 
 The protocol tree is the stage; **nodes** are scenes on the stage; **parties** are
 actors who appear in many scenes; a **`NodeProfile`** is one scene's cast list and
-sightlines. `LocalView` is a single actor's vantage on a single scene.
+sightlines. `ViewMode` is a single actor's vantage on a single scene.
 
 | Concept | Scope | Role |
 |---|---|---|
 | `Spec` | whole protocol tree | branching shape of all possible plays |
 | Node | one location in the tree | one scene: move space + continuation |
 | Party | spans the whole tree | actor; may control or observe at various nodes |
-| `Multiparty.LocalView X` | one node × one party | that party's vantage on that one scene |
+| `Multiparty.ViewMode X` | one node × one party | that party's vantage on that one scene |
+| `Multiparty.Observation X` | one node × one party | information content (kernel) of that vantage |
 | `NodeProfile Party X` | one node × all parties | full cast list + sightlines for that scene |
 
 ## Core types
@@ -177,14 +189,14 @@ These require `LawfulCommMonad` (independent effects may be swapped).
 
 ## Multiparty local views (`Multiparty/`)
 
-`LocalView X` characterizes what a participant sees at a node with move type `X`:
+`ViewMode X` characterizes what a participant sees at a node with move type `X`:
 
 | Constructor | Meaning |
 |-------------|---------|
-| `.active` | Participant locally selects the move (effectful Σ-of-X) |
+| `.pick` | Participant locally selects the move (effectful Σ-of-X) |
 | `.observe` | Participant sees the full move (function-from-X) |
 | `.hidden` | Participant sees nothing |
-| `.quotient f` | Participant sees `f x` (partial information) |
+| `.react ⟨Obs, toObs⟩` | Participant sees `toObs x : Obs` (partial information) |
 
 Three packaged resolver patterns:
 
@@ -192,32 +204,54 @@ Three packaged resolver patterns:
 - **`Directed.Strategy`**: sender/receiver pair per node.
 - **`Profile.Strategy`**: full per-party `ViewProfile` decoration.
 
-### Kernel vs operational shape
+### Information kernel vs operational shape
 
-`LocalView` carries information along **two orthogonal axes**:
+`ViewMode` carries information along **two orthogonal axes**:
 
 - **Information** — what observation does the participant make? Fully captured
   by a single projection `toObs : X → Obs` packaged with its codomain `Obs`.
-  This polynomial-element form is `LocalView.Kernel X := Σ Obs : Type, X → Obs`.
-  Every `LocalView X` collapses to a `Kernel X` via `LocalView.toKernel`.
+  This polynomial-element form is `Multiparty.Observation X`, defined as
+  `PFunctor.Idx (Observation.basePFunctor X)` where
+  `Observation.basePFunctor X := ⟨Type, (X → ·)⟩`. Concretely it unfolds to
+  `Σ Obs : Type, X → Obs`. Every `ViewMode X` collapses to an `Observation X`
+  via `ViewMode.toObservation`.
 - **Operational** — what continuation-passing shape does the participant use
-  for `Action`? `.active` (effectful Σ-of-X), `.observe` (function-from-X),
-  `.hidden` (function-into-Cont, prepared in advance), `.quotient` (function
-  on the observation, prepared in advance).
+  for `Action`? `.pick` (effectful Σ-of-X), `.observe` (function-from-X),
+  `.hidden` (function-into-Cont, prepared in advance), `.react` (function on
+  the observation, prepared in advance).
 
-The four-constructor `LocalView` is the *ergonomically convenient* form; it
+The four-constructor `ViewMode` is the *ergonomically convenient* form; it
 specializes `Action` to a definitionally simpler shape per pattern, which
-keeps protocol examples short. `Kernel` is the *semantically universal* form;
-protocols whose participants make arbitrary observations not captured by
-`active` / `observe` / `hidden` should build kernels directly. The two are
-related by `LocalView.toKernel` (collapse) and `LocalView.fromKernel` (lift
-into the universal `.quotient` constructor); on the operational side,
-`LocalView.Action (.quotient ..) = Kernel.Action ⟨..⟩` definitionally.
+keeps protocol examples short. `Observation` is the *semantically universal*
+form; protocols whose participants make arbitrary observations not captured
+by `.pick` / `.observe` / `.hidden` should build observations directly. The
+two are related by `ViewMode.toObservation` (collapse) and
+`Observation.toViewMode` (lift into the universal `.react` constructor); on
+the operational side, `ViewMode.Action (.react ⟨..⟩) = Observation.Action ⟨..⟩`
+definitionally.
 
-Note that the operational distinction `.active` vs `.observe` is **not** the
+The information lattice on `Observation X` is exposed via Mathlib's order
+typeclasses, so `⊤`, `⊥`, `≤`, `⊔` work directly:
+
+- `⊤ : Observation X` is `Observation.top X = ⟨X, id⟩` — full information.
+  This is exactly the kernel of `ViewMode.observe`.
+- `⊥ : Observation X` is `Observation.bot X = ⟨PUnit, fun _ => .unit⟩` —
+  no information. This is exactly the kernel of `ViewMode.hidden`.
+- `k₁ ≤ k₂` denotes `Observation.Refines k₁ k₂` — `k₁` is no more revealing
+  than `k₂`.
+- `k₁ ⊔ k₂` denotes `Observation.combine k₁ k₂` — the join (Σ-product) of
+  two observations.
+
+`Refines` is only a *preorder* (mutual refinement permits codomain
+bijections), so `Observation X` carries `Preorder`, `OrderTop`, `OrderBot`
+and `Max` instances but not `PartialOrder` / `SemilatticeSup`. Profile-level
+order theory comes through Mathlib's `Pi` instances on
+`ObservationProfile Party X = Party → Observation X` for free.
+
+Note that the operational distinction `.pick` vs `.observe` is **not** the
 canonical authorship attribution. Authorship-of-move is recorded by
 `Concurrent.NodeAuthority.controllers : X → List Party` (move-dependent,
-possibly multi-controller). `LocalView.active` indicates only that the
+possibly multi-controller). `ViewMode.pick` indicates only that the
 participant chooses *locally* in its endpoint; the protocol-level controllers
 of a given move are recorded separately.
 
@@ -286,7 +320,7 @@ it produces a `ProcessOver Δ` with product state space
 ### Control and observation
 
 `Control Party S` assigns ownership of payload moves and scheduling decisions.
-`Profile Party S` assigns `LocalView`s to each party at frontier nodes.
+`Profile Party S` assigns `ViewMode`s to each party at frontier nodes.
 `Current.view` combines both to give a party's current-step interface.
 
 ### Fairness, safety, liveness
@@ -412,7 +446,9 @@ import VCVio.Interaction.Concurrent.Process
 
 | File | Purpose |
 |------|---------|
-| `Core.lean` | `LocalView`, `ObsType`, `Action`, `Kernel`, `toKernel`/`fromKernel`, `Multiparty.Strategy` |
+| `Core.lean` | `ViewMode`, `ObsType`, `Action`, `toObservation`/`fromObservation` (kernel bridges), `Multiparty.Strategy` |
+| `Observation.lean` | `Multiparty.Observation` (= `PFunctor.Idx (Observation.basePFunctor X)`), `top`/`bot`/`Refines`/`combine`/`postcomp`/`Action`, Mathlib order typeclasses (`Top`/`Bot`/`LE`/`Preorder`/`OrderTop`/`OrderBot`/`Max`) |
+| `ObservationProfile.lean` | `Multiparty.ObservationProfile Party X := Party → Observation X` (with pointwise `Pi` order instances), `toViewProfile` |
 | `Broadcast.lean` | `PartyDecoration`, `Broadcast.Strategy` |
 | `Directed.lean` | `EdgeDecoration`, `Directed.Strategy` |
 | `Profile.lean` | `ViewProfile`, `Profile.Decoration`, `Profile.Strategy` |
@@ -430,7 +466,7 @@ import VCVio.Interaction.Concurrent.Process
 | `Control.lean` | `Control`, `scheduler?`, `current?`, `controllers` |
 | `Profile.lean` | `Profile`, `observe`, `residual`, `frontierView` |
 | `Current.lean` | `view`, `observe`, `residualView` |
-| `Process.lean` | `NodeAuthority`, `NodeObservation`, `NodeProfile`, `StepOver`, `ProcessOver`, `Process`, systems, `Functor (StepOver Γ)`, `Coalg` instance, `interleave`, `ProcessOver.{Behavior, behavior, ObsEq}` |
+| `Process.lean` | `NodeAuthority`, `NodeView`, `NodeProfile`, `StepOver`, `ProcessOver`, `Process`, systems, `Functor (StepOver Γ)`, `Coalg` instance, `interleave`, `ProcessOver.{Behavior, behavior, ObsEq}` |
 | `Tree.lean` | Structural concurrent syntax → `Process` |
 | `Machine.lean` | `Machine`, `Machine.toProcess`, `Machine.StepFun`, `Coalg` instance |
 | `Execution.lean` | `Trace`, `ObservedTrace` for processes |

--- a/docs/agents/interaction.md
+++ b/docs/agents/interaction.md
@@ -215,10 +215,11 @@ into the universal `.quotient` constructor); on the operational side,
 `LocalView.Action (.quotient ..) = Kernel.Action ⟨..⟩` definitionally.
 
 Note that the operational distinction `.active` vs `.observe` is **not** the
-canonical authorship predicate. Authorship-of-move is recorded by
-`Concurrent.NodeAuthority.controllers : Party → Bool`. `LocalView.active`
-indicates only that the participant chooses *locally* in its endpoint; the
-protocol-level controller is recorded separately.
+canonical authorship attribution. Authorship-of-move is recorded by
+`Concurrent.NodeAuthority.controllers : X → List Party` (move-dependent,
+possibly multi-controller). `LocalView.active` indicates only that the
+participant chooses *locally* in its endpoint; the protocol-level controllers
+of a given move are recorded separately.
 
 ### Literature
 

--- a/docs/agents/interaction.md
+++ b/docs/agents/interaction.md
@@ -181,8 +181,8 @@ These require `LawfulCommMonad` (independent effects may be swapped).
 
 | Constructor | Meaning |
 |-------------|---------|
-| `.active` | Participant chooses the move |
-| `.observe` | Participant sees the full move |
+| `.active` | Participant locally selects the move (effectful Σ-of-X) |
+| `.observe` | Participant sees the full move (function-from-X) |
 | `.hidden` | Participant sees nothing |
 | `.quotient f` | Participant sees `f x` (partial information) |
 
@@ -191,6 +191,53 @@ Three packaged resolver patterns:
 - **`Broadcast.Strategy`**: one acting party per node, all others observe.
 - **`Directed.Strategy`**: sender/receiver pair per node.
 - **`Profile.Strategy`**: full per-party `ViewProfile` decoration.
+
+### Kernel vs operational shape
+
+`LocalView` carries information along **two orthogonal axes**:
+
+- **Information** — what observation does the participant make? Fully captured
+  by a single projection `toObs : X → Obs` packaged with its codomain `Obs`.
+  This polynomial-element form is `LocalView.Kernel X := Σ Obs : Type, X → Obs`.
+  Every `LocalView X` collapses to a `Kernel X` via `LocalView.toKernel`.
+- **Operational** — what continuation-passing shape does the participant use
+  for `Action`? `.active` (effectful Σ-of-X), `.observe` (function-from-X),
+  `.hidden` (function-into-Cont, prepared in advance), `.quotient` (function
+  on the observation, prepared in advance).
+
+The four-constructor `LocalView` is the *ergonomically convenient* form; it
+specializes `Action` to a definitionally simpler shape per pattern, which
+keeps protocol examples short. `Kernel` is the *semantically universal* form;
+protocols whose participants make arbitrary observations not captured by
+`active` / `observe` / `hidden` should build kernels directly. The two are
+related by `LocalView.toKernel` (collapse) and `LocalView.fromKernel` (lift
+into the universal `.quotient` constructor); on the operational side,
+`LocalView.Action (.quotient ..) = Kernel.Action ⟨..⟩` definitionally.
+
+Note that the operational distinction `.active` vs `.observe` is **not** the
+canonical authorship predicate. Authorship-of-move is recorded by
+`Concurrent.NodeAuthority.controllers : Party → Bool`. `LocalView.active`
+indicates only that the participant chooses *locally* in its endpoint; the
+protocol-level controller is recorded separately.
+
+### Literature
+
+Three independent traditions converge on the kernel form `Σ Obs, X → Obs`:
+
+- *Epistemic logic* (Halpern-Vardi "Reasoning About Knowledge"): agent
+  observation as a projection from global state to local indistinguishability
+  classes.
+- *Noninterference / info-flow* (Goguen-Meseguer; Sabelfeld-Myers
+  "Language-Based Information-Flow Security"): per-security-level projection
+  of observable outputs.
+- *Session types and endpoint projection* (Honda-Yoshida-Carbone "Multiparty
+  Asynchronous Session Types"; Cruz-Filipe-Montesi "A Core Model for
+  Choreographic Programming"): projection of a global type / global play to a
+  single role's local view.
+
+Closest type-theoretic ancestor: Hancock-Setzer "Interactive Programs in
+Dependent Type Theory" — Command/Response interfaces with embedded
+observation modes mirror the four-constructor operational shape.
 
 ## Concurrent processes (`Concurrent/`)
 
@@ -364,7 +411,7 @@ import VCVio.Interaction.Concurrent.Process
 
 | File | Purpose |
 |------|---------|
-| `Core.lean` | `LocalView`, `ObsType`, `Action`, `Multiparty.Strategy` |
+| `Core.lean` | `LocalView`, `ObsType`, `Action`, `Kernel`, `toKernel`/`fromKernel`, `Multiparty.Strategy` |
 | `Broadcast.lean` | `PartyDecoration`, `Broadcast.Strategy` |
 | `Directed.lean` | `EdgeDecoration`, `Directed.Strategy` |
 | `Profile.lean` | `ViewProfile`, `Profile.Decoration`, `Profile.Strategy` |


### PR DESCRIPTION
## Summary

Full cutover of the Multiparty local-view layer into a clean two-axis design:

- **Operational axis** (`Multiparty.ViewMode X`): the four-constructor enumeration `pick` / `observe` / `hidden` / `react ⟨Obs, toObs⟩` that determines `Action`'s definitional shape per pattern. Renamed from `LocalView`.
- **Information axis** (`Multiparty.Observation X`): the maximally general single-projection form `Σ Obs, X → Obs`, realized as `PFunctor.Idx (Observation.basePFunctor X)`. Mathlib lattice typeclasses (`Top`, `Bot`, `LE`, `Preorder`, `OrderTop`, `OrderBot`, `Max`) expose `⊤`, `⊥`, `≤`, `⊔` directly. `SemilatticeSup` is deliberately omitted because `Refines` is a preorder, not a partial order.

This started as the additive Option A + Option B from the `LocalView` design survey (`vcvio-localview-design-survey.md`), but in iteration we converged on a full cutover (the B1 four-constructor `ViewMode`, the `PFunctor.Idx` substrate for the kernel, and the Mathlib order typeclasses for free notation). Every `rfl` reduction in the existing example files survives.

### Replaced / deleted / added

- **Deleted (working-tree only, never landed)**: `VCVio/Interaction/Multiparty/KernelProfile.lean`, `Examples/SealedSender/AspectKernel.lean` (the original additive sketch from the earlier draft commits on this branch).
- **New**:
  - `VCVio/Interaction/Multiparty/Observation.lean` (kernel as `PFunctor.Idx`, lattice algebra, Mathlib order typeclasses)
  - `VCVio/Interaction/Multiparty/ObservationProfile.lean` (per-party profile via `Pi`-instance lifting)
  - `Examples/SealedSender/AspectObservation.lean` (sealed-sender example using `≤` and `⊔` directly)
- **Renamed in place**:
  - `LocalView` → `ViewMode` (constructor `.active` → `.pick`, `.quotient Obs toObs` → `.react ⟨Obs, toObs⟩`)
  - `LocalView.Kernel` → `Multiparty.Observation` (lifted to a first-class top-level type so it can carry instances and live in its own file)
  - `Concurrent.NodeObservation` → `Concurrent.NodeView` (singular-abstract type with plural `views` field, mirroring `NodeAuthority` + `controllers` and Mathlib's `Filter` + `sets`; also avoids collision with the new `Multiparty.Observation`)
  - `Profile.KernelProfile` → `Profile.ObservationProfile` (now leveraging Mathlib `Pi` instances; about 50 lines of explicit `Refines`/`combine` profile lemmas removed)

### Highlights

`Observation X` as `PFunctor.Idx`:

\`\`\`lean
namespace Observation
@[reducible] def basePFunctor (X : Type u) : PFunctor.{u + 1, u} where
  A := Type u
  B := (X → ·)
end Observation

abbrev Observation (X : Type u) : Type (u + 1) :=
  PFunctor.Idx (Observation.basePFunctor X)
\`\`\`

Mathlib lattice notation works directly:

\`\`\`lean
theorem serverSealed_le_serverHonest : serverSealed ≤ serverHonest :=
  ⟨fun v => ⟨v.envTo, v.ciphertext, v.timestamp⟩, fun _ => rfl⟩

def serverNetCoalitionClean : Observation Packet :=
  Observations.serverHonest ⊔ Observations.netHonest
\`\`\`

`ObservationProfile Party X = Party → Observation X` inherits `Top`, `Bot`, `LE`, `Preorder`, `OrderTop`, `OrderBot`, `Max` pointwise via `Pi`-instance lifting:

\`\`\`lean
theorem observationProfile_serverSealed_le_clean :
    observationProfile .serverSealed ≤ observationProfile .clean := by
  intro p; cases p
  · exact le_refl _
  · exact Observations.serverSealed_le_serverHonest
  · exact le_refl _
  · exact le_refl _
\`\`\`

### Naming rationale

- `LocalView → ViewMode`: the four constructors describe a *mode* of viewing (operational shape), not a view itself. Sits naturally next to `Multiparty.Observation` (the information content).
- `LocalView.Kernel → Multiparty.Observation`: lifted to a first-class top-level type so it can live in its own file and carry typeclass instances.
- `NodeObservation → NodeView`: singular abstract type + plural `views` field, the same pattern as `NodeAuthority` + `controllers` and Mathlib's `Filter` + `sets`. Also avoids the post-cutover name clash with `Multiparty.Observation`. The "View" overload between `Multiparty.ViewMode` and `Concurrent.NodeView` is contained: namespace prefix and arity disambiguate, and `NodeView` reads naturally as "the view-structure of/at a node".

### Verification

- `lake build` green across all 3571 jobs (only pre-existing unrelated `sorry`s remain in `CryptoFoundations/{FiatShamir, FujisakiOkamoto, KEMDEM, GPVHashAndSign, HardnessAssumptions/DiffieHellman}.lean` and `ToMathlib/Probability/...RenyiDivergence.lean`; no new ones introduced).
- `#print axioms` reports zero axioms across `Observation.{top, bot, combine, Refines, refines_combine_left}`, `Observation.Refines.trans`, `ViewMode.toObservation`, `Observation.toViewMode`, `Concurrent.{NodeView, NodeProfile}`, and every example refinement theorem in `AspectObservation.lean`.
- Every `rfl` reduction in `Multiparty/Examples.lean` and `Concurrent/Examples.lean` survives.

## Test plan

- [x] `lake build` succeeds (3571 jobs, no new warnings)
- [x] No new `sorry`, no new `axiom`, no new `set_option linter.* false`
- [x] `#print axioms` confirms zero axioms on all new declarations
- [x] All preserved `rfl`-style examples continue to compile

## Stacking

Branched from `origin/main` (the prior #319 `NodeProfile` split has landed). No further stacking required.

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)