### PR TITLE
feat(tomathlib): Trace foundations + Chart API expansion to parity with Lens

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -25,6 +25,7 @@ import ToMathlib.Control.Monad.Relative
 import ToMathlib.Control.Monad.Transformer
 import ToMathlib.Control.OptionT
 import ToMathlib.Control.StateT
+import ToMathlib.Control.Trace
 import ToMathlib.Control.WriterT
 import ToMathlib.Data.ENNReal.AbsDiff
 import ToMathlib.Data.ENNReal.SumSquares
@@ -40,6 +41,7 @@ import ToMathlib.PFunctor.Cofree
 import ToMathlib.PFunctor.Equiv.Basic
 import ToMathlib.PFunctor.Free
 import ToMathlib.PFunctor.Lens.Basic
+import ToMathlib.PFunctor.Trace
 import ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence
 import ToMathlib.Probability.ProbabilityMassFunction.TailSums
 import ToMathlib.Probability.ProbabilityMassFunction.TotalVariation

--- a/ToMathlib/Control/Trace.lean
+++ b/ToMathlib/Control/Trace.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import Mathlib.Algebra.Group.Pi.Basic
+public import Mathlib.Algebra.Group.Hom.Defs
+
+/-!
+# Traces into a monoid
+
+`Control.Trace ω X` is the type `X → ω` for any monoid `ω`.
+
+It is the universal carrier of "stateless effectful trace" data:
+each input contributes one element of a fixed monoid `ω`, and pointwise
+multiplication (via `Pi.monoid`) gives `Trace ω X` itself the structure of a
+monoid.  Nothing in this file requires a monad.
+
+## Why a monoid, not a monad
+
+Many bookkeeping / observation patterns share this exact shape:
+
+* `QueryLog spec`             — `ω = List ((t : spec.Domain) × spec.Range t)`,
+                                 i.e. the free monoid on indices,
+* `QueryCount ι`              — `ω = ι → ℕ`, a commutative monoid under
+                                 pointwise addition,
+* `QueryCache spec`           — `ω = (t : spec.Domain) → Option (spec.Range t)`
+                                 with at-most-once write semigroup,
+* abstract cost functions     — `ω` any commutative monoid (e.g. `ℝ≥0`).
+
+The monoid axioms are exactly what is needed to turn "one contribution per
+input" into a meaningful aggregate over a sequence of inputs.
+
+The companion file `ToMathlib/PFunctor/Trace.lean` specialises this at
+`ω = FreeMonoid (Idx P)` for a polynomial functor `P`, recovering the
+universal "log of P-events" trace, together with a universal property
+`Trace P X → Control.Trace ω X` (`toMonoid`) coming from the free-monoid
+universal property.
+
+## Conventions
+
+`Trace` is `@[reducible]` so that `Pi.monoid` and `Pi.commMonoid` apply
+directly, and so that downstream definitions like `QueryLog` and `QueryCount`
+can be exhibited as `Trace`-instances by `rfl`-clean abbreviations.
+
+## References
+
+* Bonchi, Di Lavore, Romàn — *Effectful Mealy machines and Kleisli
+  categories*.
+* Hancock, Setzer — *Interactive programs and weakly final coalgebras in
+  dependent type theory*.
+* Spivak, Niu — *Polynomial Functors: A Mathematical Theory of Interaction*,
+  arXiv:2202.00534.
+-/
+
+@[expose] public section
+
+universe u u' u'' v w
+
+namespace Control
+
+/--
+`Trace ω X` is the type `X → ω` of stateless valuations from inputs `X` into
+a monoid `ω`.  It inherits a monoid structure from `Pi.monoid`, with `1`
+the constant trace and `*` the pointwise product.
+
+See the module docstring for motivation and the catalogue of instances
+(`QueryLog`, `QueryCount`, ...) it is intended to subsume.
+-/
+@[reducible] def Trace (ω : Type u) (X : Type v) : Type max u v := X → ω
+
+namespace Trace
+
+variable {ω : Type u} {ω' : Type u'} {ω'' : Type u''} {X Y Z : Type v}
+
+/-- Pre-compose a trace with `f : Y → X`, giving a trace on `Y`. -/
+def precomp (f : Y → X) (t : Trace ω X) : Trace ω Y := t ∘ f
+
+/-- Post-compose a trace with a monoid homomorphism. -/
+def map [MulOneClass ω] [MulOneClass ω'] (φ : ω →* ω') (t : Trace ω X) :
+    Trace ω' X := φ ∘ t
+
+/-! ### Pointwise behaviour of `precomp` -/
+
+@[simp] theorem precomp_apply (f : Y → X) (t : Trace ω X) (y : Y) :
+    precomp f t y = t (f y) := rfl
+
+@[simp] theorem precomp_id (t : Trace ω X) : precomp id t = t := rfl
+
+@[simp] theorem precomp_comp (g : Z → Y) (f : Y → X) (t : Trace ω X) :
+    precomp g (precomp f t) = precomp (f ∘ g) t := rfl
+
+@[simp] theorem precomp_one [One ω] (f : Y → X) :
+    precomp f (1 : Trace ω X) = 1 := rfl
+
+@[simp] theorem precomp_mul [Mul ω] (f : Y → X) (t s : Trace ω X) :
+    precomp f (t * s) = precomp f t * precomp f s := rfl
+
+/-! ### Pointwise behaviour of `map` -/
+
+@[simp] theorem map_apply [MulOneClass ω] [MulOneClass ω']
+    (φ : ω →* ω') (t : Trace ω X) (x : X) :
+    map φ t x = φ (t x) := rfl
+
+@[simp] theorem map_id [MulOneClass ω] (t : Trace ω X) :
+    map (MonoidHom.id ω) t = t := rfl
+
+@[simp] theorem map_comp [MulOneClass ω] [MulOneClass ω'] [MulOneClass ω'']
+    (g : ω' →* ω'') (f : ω →* ω') (t : Trace ω X) :
+    map (g.comp f) t = map g (map f t) := rfl
+
+@[simp] theorem map_precomp [MulOneClass ω] [MulOneClass ω']
+    (φ : ω →* ω') (f : Y → X) (t : Trace ω X) :
+    map φ (precomp f t) = precomp f (map φ t) := rfl
+
+@[simp] theorem map_one [MulOneClass ω] [MulOneClass ω'] (φ : ω →* ω') :
+    map φ (1 : Trace ω X) = 1 := by
+  funext x; exact φ.map_one
+
+@[simp] theorem map_mul [MulOneClass ω] [MulOneClass ω'] (φ : ω →* ω')
+    (t s : Trace ω X) :
+    map φ (t * s) = map φ t * map φ s := by
+  funext x; exact φ.map_mul _ _
+
+/--
+Bundle `map φ` as a monoid homomorphism on the trace monoid.
+
+This is the manifest algebraic content of `map`: post-composing a trace with
+a monoid hom is itself a monoid hom on the pointwise-monoid `Trace ω X`.
+-/
+@[simps]
+def mapHom [Monoid ω] [Monoid ω'] (φ : ω →* ω') :
+    Trace ω X →* Trace ω' X where
+  toFun := map φ
+  map_one' := map_one φ
+  map_mul' := map_mul φ
+
+end Trace
+
+end Control

--- a/ToMathlib/PFunctor/Chart/Basic.lean
+++ b/ToMathlib/PFunctor/Chart/Basic.lean
@@ -104,6 +104,24 @@ theorem ext {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (c₁ c�
   subst hB
   rfl
 
+/-! ### Action on indices
+
+A chart `φ : P → Q` acts on `Idx P = Σ a : P.A, P.B a` by sending
+`⟨a, b⟩ ↦ ⟨φ.toFunA a, φ.toFunB a b⟩`. This is the underlying function on
+positions; `Trace.mapChart` (in `ToMathlib.PFunctor.Trace`) uses it to push
+event traces along charts. -/
+
+variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+
+/-- Push an `Idx P` along a chart `P → Q` to an `Idx Q`. -/
+def mapIdx (φ : Chart P Q) (i : Idx P) : Idx Q :=
+  ⟨φ.toFunA i.1, φ.toFunB i.1 i.2⟩
+
+@[simp] theorem mapIdx_id (i : Idx P) : mapIdx (Chart.id P) i = i := rfl
+
+@[simp] theorem mapIdx_comp (g : Chart Q R) (f : Chart P Q) (i : Idx P) :
+    mapIdx (g ∘c f) i = mapIdx g (mapIdx f i) := rfl
+
 end Chart
 
 namespace Equiv

--- a/ToMathlib/PFunctor/Chart/Basic.lean
+++ b/ToMathlib/PFunctor/Chart/Basic.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 module
 
 public import ToMathlib.PFunctor.Basic
+public import ToMathlib.PFunctor.Equiv.Basic
 
 /-!
 # Charts between polynomial functors
@@ -346,6 +347,12 @@ theorem sumPair_inl_inr :
     Chart.sumPair Chart.inl Chart.inr = Chart.id.{max uA₁ uA₂, uB} (P + Q) := by
   ext a <;> rcases a <;> rfl
 
+theorem sumMap_comp_sumMap {S : PFunctor.{uA₅, uB₅}} {T : PFunctor.{uA₆, uB₅}}
+    (c₁ : Chart P R) (c₂ : Chart Q W)
+    (c₁' : Chart R S) (c₂' : Chart W T) :
+    (c₁' ⊎c c₂') ∘c (c₁ ⊎c c₂) = (c₁' ∘c c₁) ⊎c (c₂' ∘c c₂) := by
+  ext a <;> rcases a <;> rfl
+
 namespace Equiv
 
 /-- Commutativity of coproduct -/
@@ -406,6 +413,18 @@ def zeroSum :
     · rfl
   right_inv := by ext <;> rfl
 
+/-- Coproduct preserves equivalences: `P ≃c P' → Q ≃c Q' → P + Q ≃c P' + Q'`. -/
+def sumCongr {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+    {P' : PFunctor.{uA₃, uB}} {Q' : PFunctor.{uA₄, uB}}
+    (e₁ : P ≃c P') (e₂ : Q ≃c Q') :
+    Chart.Equiv.{max uA₁ uA₂, uB, max uA₃ uA₄, uB} (P + Q) (P' + Q') where
+  toChart := e₁.toChart ⊎c e₂.toChart
+  invChart := e₁.invChart ⊎c e₂.invChart
+  left_inv := by
+    rw [Chart.sumMap_comp_sumMap, e₁.left_inv, e₂.left_inv, Chart.sumMap_id]
+  right_inv := by
+    rw [Chart.sumMap_comp_sumMap, e₁.right_inv, e₂.right_inv, Chart.sumMap_id]
+
 end Equiv
 
 end Sum
@@ -453,6 +472,11 @@ theorem tensorMap_comp
     {P' : PFunctor.{uA₅, uB₅}} {Q' : PFunctor.{uA₆, uB₆}}
     (c₁ : Chart P P') (c₂ : Chart Q Q') (c₁' : Chart P' R) (c₂' : Chart Q' W) :
     (c₁' ∘c c₁) ⊗c (c₂' ∘c c₂) = (c₁' ⊗c c₂') ∘c (c₁ ⊗c c₂) := rfl
+
+theorem tensorMap_comp_tensorMap
+    {P' : PFunctor.{uA₅, uB₅}} {Q' : PFunctor.{uA₆, uB₆}}
+    (c₁ : Chart P R) (c₂ : Chart Q W) (c₁' : Chart R P') (c₂' : Chart W Q') :
+    (c₁' ⊗c c₂') ∘c (c₁ ⊗c c₂) = (c₁' ∘c c₁) ⊗c (c₂' ∘c c₂) := rfl
 
 @[simp]
 theorem tensorPair_fst_snd : Chart.tensorPair Chart.fst Chart.snd =
@@ -510,11 +534,89 @@ def tensorZero : P ⊗ 0 ≃c 0 where
   left_inv := by ext ⟨_, b⟩ <;> exact PEmpty.elim b
   right_inv := by ext a <;> exact PEmpty.elim a
 
+/-- Tensor product preserves equivalences: `P ≃c P' → Q ≃c Q' → P ⊗ Q ≃c P' ⊗ Q'`. -/
+def tensorCongr {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
+    {P' : PFunctor.{uA₃, uB₃}} {Q' : PFunctor.{uA₄, uB₄}}
+    (e₁ : P ≃c P') (e₂ : Q ≃c Q') :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄}
+      (P ⊗ Q) (P' ⊗ Q') where
+  toChart := e₁.toChart ⊗c e₂.toChart
+  invChart := e₁.invChart ⊗c e₂.invChart
+  left_inv := by
+    rw [Chart.tensorMap_comp_tensorMap, e₁.left_inv, e₂.left_inv,
+      Chart.tensorMap_id]
+  right_inv := by
+    rw [Chart.tensorMap_comp_tensorMap, e₁.right_inv, e₂.right_inv,
+      Chart.tensorMap_id]
+
+/-- Left distributivity of tensor product over coproduct.
+
+`P ⊗ (Q + R) ≃c (P ⊗ Q) + (P ⊗ R)`. -/
+def tensorSumDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
+      (P ⊗ (Q + R)) ((P ⊗ Q) + (P ⊗ R)) where
+  toChart :=
+    (fun ⟨p, qr⟩ => match qr with
+      | Sum.inl q => Sum.inl (p, q)
+      | Sum.inr r => Sum.inr (p, r)) ⇉
+    (fun ⟨_, qr⟩ pb => match qr with
+      | Sum.inl _ => pb
+      | Sum.inr _ => pb)
+  invChart :=
+    (Sum.elim
+      (fun ⟨p, q⟩ => (p, Sum.inl q))
+      (fun ⟨p, r⟩ => (p, Sum.inr r))) ⇉
+    (fun pqpr pb => match pqpr with
+      | Sum.inl _ => pb
+      | Sum.inr _ => pb)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a with ⟨_, _ | _⟩ <;> rfl
+    · intro a; funext _; rcases a with ⟨_, _ | _⟩ <;> rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a <;> rfl
+    · intro a; funext _; rcases a <;> rfl
+
+/-- Right distributivity of tensor product over coproduct.
+
+`(Q + R) ⊗ P ≃c (Q ⊗ P) + (R ⊗ P)`. -/
+def sumTensorDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
+      ((Q + R) ⊗ P) ((Q ⊗ P) + (R ⊗ P)) where
+  toChart :=
+    (fun ⟨qr, p⟩ => match qr with
+      | Sum.inl q => Sum.inl (q, p)
+      | Sum.inr r => Sum.inr (r, p)) ⇉
+    (fun ⟨qr, _⟩ pb => match qr with
+      | Sum.inl _ => pb
+      | Sum.inr _ => pb)
+  invChart :=
+    (Sum.elim
+      (fun ⟨q, p⟩ => (Sum.inl q, p))
+      (fun ⟨r, p⟩ => (Sum.inr r, p))) ⇉
+    (fun qprp pb => match qprp with
+      | Sum.inl _ => pb
+      | Sum.inr _ => pb)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a with ⟨_ | _, _⟩ <;> rfl
+    · intro a; funext _; rcases a with ⟨_ | _, _⟩ <;> rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a <;> rfl
+    · intro a; funext _; rcases a <;> rfl
+
 end Equiv
 
 end Tensor
 
-/-! ### Polynomial-product coherence -/
+/-! ### Polynomial-product coherence
+
+Even though `*` is *not* the categorical product in the chart category, it
+is still a functor and admits coherent equivalences (commutativity,
+associativity, units, zeros, congruence, distributivity over `+`). These
+mirror the `PFunctor.Equiv.prod*` lemmas. -/
 
 section Prod
 
@@ -527,6 +629,149 @@ theorem prodMap_id :
   ext _ x
   · rfl
   · cases x <;> rfl
+
+theorem prodMap_comp_prodMap {S : PFunctor.{uA₅, uB₅}} {T : PFunctor.{uA₆, uB₆}}
+    (c₁ : Chart P R) (c₂ : Chart Q W) (c₁' : Chart R S) (c₂' : Chart W T) :
+    (c₁' ×c c₂') ∘c (c₁ ×c c₂) = (c₁' ∘c c₁) ×c (c₂' ∘c c₂) := by
+  refine Chart.ext _ _ ?_ ?_
+  · intro _; rfl
+  · intro _; funext psum; rcases psum <;> rfl
+
+namespace Equiv
+
+/-- Polynomial-product preserves equivalences: `P ≃c P' → Q ≃c Q' → P * Q ≃c P' * Q'`. -/
+def prodCongr {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
+    {P' : PFunctor.{uA₃, uB₃}} {Q' : PFunctor.{uA₄, uB₄}}
+    (e₁ : P ≃c P') (e₂ : Q ≃c Q') :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄}
+      (P * Q) (P' * Q') where
+  toChart := e₁.toChart ×c e₂.toChart
+  invChart := e₁.invChart ×c e₂.invChart
+  left_inv := by
+    rw [Chart.prodMap_comp_prodMap, e₁.left_inv, e₂.left_inv, Chart.prodMap_id]
+  right_inv := by
+    rw [Chart.prodMap_comp_prodMap, e₁.right_inv, e₂.right_inv, Chart.prodMap_id]
+
+/-- Commutativity of the polynomial product. -/
+def prodComm (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂} (P * Q) (Q * P) where
+  toChart := Prod.swap ⇉ (fun _ d => d.swap)
+  invChart := Prod.swap ⇉ (fun _ d => d.swap)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro _; rfl
+    · intro _; funext d; rcases d <;> rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro _; rfl
+    · intro _; funext d; rcases d <;> rfl
+
+/-- Associativity of the polynomial product. -/
+def prodAssoc :
+    Chart.Equiv.{max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃, max uA₁ uA₂ uA₃, max uB₁ uB₂ uB₃}
+      ((P * Q) * R) (P * (Q * R)) where
+  toChart := (_root_.Equiv.prodAssoc _ _ _).toFun ⇉
+    (fun _ d => (_root_.Equiv.sumAssoc _ _ _).toFun d)
+  invChart := (_root_.Equiv.prodAssoc _ _ _).invFun ⇉
+    (fun _ d => (_root_.Equiv.sumAssoc _ _ _).invFun d)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro _; rfl
+    · intro _; funext d; rcases d with d | d
+      · rcases d with d | d <;> rfl
+      · rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro _; rfl
+    · intro _; funext d; rcases d with d | d
+      · rfl
+      · rcases d with d | d <;> rfl
+
+/-- Polynomial-product with `0` is `0` (right). -/
+def prodZero : P * 0 ≃c 0 where
+  toChart := (fun a => PEmpty.elim a.2) ⇉ (fun a _ => PEmpty.elim a.2)
+  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  left_inv := by ext ⟨_, b⟩ <;> exact PEmpty.elim b
+  right_inv := by ext a <;> exact PEmpty.elim a
+
+/-- Polynomial-product with `0` is `0` (left). -/
+def zeroProd : 0 * P ≃c 0 where
+  toChart := (fun a => PEmpty.elim a.1) ⇉ (fun a _ => PEmpty.elim a.1)
+  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  left_inv := by ext ⟨a, _⟩ <;> exact PEmpty.elim a
+  right_inv := by ext a <;> exact PEmpty.elim a
+
+/-- Left distributivity of polynomial product over coproduct.
+
+`P * (Q + R) ≃c (P * Q) + (P * R)`. -/
+def prodSumDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
+      (P * (Q + R)) ((P * Q) + (P * R)) where
+  toChart :=
+    (fun ⟨p, qr⟩ => match qr with
+      | Sum.inl q => Sum.inl (p, q)
+      | Sum.inr r => Sum.inr (p, r)) ⇉
+    (fun ⟨_, qr⟩ d => match qr, d with
+      | Sum.inl _, Sum.inl pb => Sum.inl pb
+      | Sum.inl _, Sum.inr qb => Sum.inr qb
+      | Sum.inr _, Sum.inl pb => Sum.inl pb
+      | Sum.inr _, Sum.inr rb => Sum.inr rb)
+  invChart :=
+    (Sum.elim
+      (fun ⟨p, q⟩ => (p, Sum.inl q))
+      (fun ⟨p, r⟩ => (p, Sum.inr r))) ⇉
+    (fun pqpr d => match pqpr, d with
+      | Sum.inl _, Sum.inl pb => Sum.inl pb
+      | Sum.inl _, Sum.inr qb => Sum.inr qb
+      | Sum.inr _, Sum.inl pb => Sum.inl pb
+      | Sum.inr _, Sum.inr rb => Sum.inr rb)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a with ⟨_, _ | _⟩ <;> rfl
+    · intro a; funext d
+      rcases a with ⟨_, _ | _⟩ <;> rcases d <;> rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a <;> rfl
+    · intro a; funext d
+      rcases a <;> rcases d <;> rfl
+
+/-- Right distributivity of polynomial product over coproduct.
+
+`(Q + R) * P ≃c (Q * P) + (R * P)`. -/
+def sumProdDistrib {P : PFunctor.{uA₁, uB₁}} {Q R : PFunctor.{uA₂, uB₂}} :
+    Chart.Equiv.{max uA₁ uA₂, max uB₁ uB₂, max uA₁ uA₂, max uB₁ uB₂}
+      ((Q + R) * P) ((Q * P) + (R * P)) where
+  toChart :=
+    (fun ⟨qr, p⟩ => match qr with
+      | Sum.inl q => Sum.inl (q, p)
+      | Sum.inr r => Sum.inr (r, p)) ⇉
+    (fun ⟨qr, _⟩ d => match qr, d with
+      | Sum.inl _, Sum.inl qb => Sum.inl qb
+      | Sum.inl _, Sum.inr pb => Sum.inr pb
+      | Sum.inr _, Sum.inl rb => Sum.inl rb
+      | Sum.inr _, Sum.inr pb => Sum.inr pb)
+  invChart :=
+    (Sum.elim
+      (fun ⟨q, p⟩ => (Sum.inl q, p))
+      (fun ⟨r, p⟩ => (Sum.inr r, p))) ⇉
+    (fun qprp d => match qprp, d with
+      | Sum.inl _, Sum.inl qb => Sum.inl qb
+      | Sum.inl _, Sum.inr pb => Sum.inr pb
+      | Sum.inr _, Sum.inl rb => Sum.inl rb
+      | Sum.inr _, Sum.inr pb => Sum.inr pb)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a with ⟨_ | _, _⟩ <;> rfl
+    · intro a; funext d
+      rcases a with ⟨_ | _, _⟩ <;> rcases d <;> rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro a; rcases a <;> rfl
+    · intro a; funext d
+      rcases a <;> rcases d <;> rfl
+
+end Equiv
 
 end Prod
 
@@ -549,11 +794,153 @@ namespace Equiv
 
 variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
 
-/-- Convert an equivalence between two polynomial functors `P` and `Q` to a chart equivalence. -/
+/-- Convert an equivalence between two polynomial functors `P` and `Q` to a chart. -/
 def toChart (e : P ≃ₚ Q) : Chart P Q where
   toFunA := e.equivA
   toFunB := fun a => e.equivB a
 
+/-! ### Bridge `PFunctor.Equiv → Chart.Equiv`
+
+Every polynomial-functor equivalence yields a chart equivalence: the forward
+chart uses `e.equivA` / `e.equivB`, and the inverse chart uses their symmetric
+counterparts. The proofs of `left_inv` / `right_inv` need the cast
+machinery from `forward_equivB_roundtrip` / `reverse_equivB_roundtrip` because
+`e.symm.equivA (e.equivA a)` and `a` are only propositionally equal.
+
+This is the chart analogue of `Equiv.toLensEquiv` and is the standard way to
+derive sigma / distributivity equivalences from their `PFunctor.Equiv`
+counterparts. -/
+
+private theorem eqRec_id_apply_codomain
+    {α : Sort*} {β : α → Sort*} {a₀ a₁ : α}
+    (h : a₀ = a₁) (x : β a₀) :
+    Eq.rec (motive := fun x _ => β a₀ → β x) id h x =
+      _root_.cast (congrArg β h) x := by
+  subst h; rfl
+
+@[simp]
+theorem symm_toChart_comp_toChart (e : P ≃ₚ Q) :
+    e.symm.toChart ∘c e.toChart = Chart.id P := by
+  refine Chart.ext _ _ (fun a => e.equivA.symm_apply_apply a) (fun a => ?_)
+  funext b
+  simp only [Chart.comp, Chart.id, toChart, Function.comp_apply]
+  rw [forward_equivB_roundtrip]
+  exact (eqRec_id_apply_codomain (e.equivA.symm_apply_apply a).symm b).symm
+
+@[simp]
+theorem toChart_comp_symm_toChart (e : P ≃ₚ Q) :
+    e.toChart ∘c e.symm.toChart = Chart.id Q := by
+  refine Chart.ext _ _ (fun a => e.equivA.apply_symm_apply a) (fun a => ?_)
+  funext b
+  simp only [Chart.comp, Chart.id, toChart, Function.comp_apply]
+  change e.equivB (e.equivA.symm a) (e.symm.equivB a b) = _
+  rw [reverse_equivB_roundtrip]
+  exact (eqRec_id_apply_codomain (e.equivA.apply_symm_apply a).symm b).symm
+
+/-- Convert an equivalence between two polynomial functors to a chart equivalence.
+
+Chart-side analogue of `Equiv.toLensEquiv`. Together with `Chart.Equiv.refl`,
+`symm`, and `trans`, this establishes a faithful functor
+`PFunctor.Equiv → Chart.Equiv`. -/
+def toChartEquiv (e : P ≃ₚ Q) : P ≃c Q where
+  toChart := e.toChart
+  invChart := e.symm.toChart
+  left_inv := symm_toChart_comp_toChart e
+  right_inv := toChart_comp_symm_toChart e
+
 end Equiv
+
+/-! ### Sigma equivalences
+
+These are derived from `PFunctor.Equiv.toChartEquiv` applied to the
+corresponding `PFunctor.Equiv` constructions. They mirror the
+`PFunctor.Lens.Equiv.sigma*` family. -/
+
+namespace Chart.Equiv
+
+variable {I : Type v}
+
+/-- Sigma of an empty family is the zero functor. -/
+def sigmaEmpty [IsEmpty I] {F : I → PFunctor.{uA, uB}} : sigma F ≃c 0 :=
+  PFunctor.Equiv.toChartEquiv (PFunctor.Equiv.emptySigma (F := F))
+
+/-- Sigma of a `PUnit`-indexed family is equivalent to the functor itself
+    (up to `ulift`). -/
+def sigmaUnit {F : PUnit → PFunctor.{uA, uB}} : sigma F ≃c (F PUnit.unit).ulift :=
+  PFunctor.Equiv.toChartEquiv
+    (PFunctor.Equiv.trans
+      (PFunctor.Equiv.punitSigma (F := F))
+      (PFunctor.Equiv.uliftEquiv (P := F PUnit.unit)))
+
+/-- Sigma of a unique-indexed family is equivalent to the default fiber
+    (up to `ulift`). -/
+def sigmaOfUnique [Unique I] {F : I → PFunctor.{uA, uB}} : sigma F ≃c (F default).ulift :=
+  PFunctor.Equiv.toChartEquiv
+    (PFunctor.Equiv.trans
+      (PFunctor.Equiv.uniqueSigma (F := F))
+      (PFunctor.Equiv.uliftEquiv (P := F default)))
+
+/-- Left distributivity of polynomial product over sigma. -/
+def prodSigmaDistrib {P : PFunctor.{uA₁, uB₁}} {F : I → PFunctor.{uA₂, uB₂}} :
+    Chart.Equiv.{max uA₁ uA₂ v, max uB₁ uB₂, max uA₁ uA₂ v, max uB₁ uB₂}
+      (P * sigma F) (sigma (fun i => (P * F i : PFunctor.{max uA₁ uA₂, max uB₁ uB₂}))) :=
+  PFunctor.Equiv.toChartEquiv (PFunctor.Equiv.prodSigmaDistrib (P := P) (F := F))
+
+/-- Right distributivity of polynomial product over sigma. -/
+def sigmaProdDistrib {P : PFunctor.{uA₁, uB₁}} {F : I → PFunctor.{uA₂, uB₂}} :
+    Chart.Equiv.{max uA₁ uA₂ v, max uB₁ uB₂, max uA₁ uA₂ v, max uB₁ uB₂}
+      (sigma F * P) (sigma (fun i => (F i * P : PFunctor.{max uA₁ uA₂, max uB₁ uB₂}))) :=
+  PFunctor.Equiv.toChartEquiv (PFunctor.Equiv.sigmaProdDistrib (P := P) (F := F))
+
+/-- Left distributivity of tensor product over sigma. -/
+def tensorSigmaDistrib {P : PFunctor.{uA₁, uB₁}} {F : I → PFunctor.{uA₂, uB₂}} :
+    P ⊗ sigma F ≃c sigma (fun i => P ⊗ F i) :=
+  PFunctor.Equiv.toChartEquiv (PFunctor.Equiv.tensorSigmaDistrib (P := P) (F := F))
+
+/-- Right distributivity of tensor product over sigma. -/
+def sigmaTensorDistrib {P : PFunctor.{uA₂, uB₂}} {F : I → PFunctor.{uA₁, uB₁}} :
+    sigma F ⊗ P ≃c sigma (fun i => F i ⊗ P) :=
+  PFunctor.Equiv.toChartEquiv (PFunctor.Equiv.sigmaTensorDistrib (F := F) (P := P))
+
+/-! ### Pi equivalences
+
+`piMap` lives in the operations section, but unlike lenses, charts admit
+no `piForall` (Pi-elimination requires direction-contravariance). What we
+get cleanly here is `piUnit` and `piZero`. -/
+
+/-- Pi over a `PUnit`-indexed family is equivalent to the functor itself. -/
+def piUnit {P : PFunctor.{uA, uB}} : pi (fun (_ : PUnit) => P) ≃c P where
+  toChart := (fun f => f PUnit.unit) ⇉ (fun _ s => s.2)
+  invChart := (fun pa _ => pa) ⇉ (fun _ pb => ⟨PUnit.unit, pb⟩)
+  left_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro f; funext u; cases u; rfl
+    · intro f; funext ⟨u, pb⟩; cases u; rfl
+  right_inv := by
+    refine Chart.ext _ _ ?_ ?_
+    · intro _; rfl
+    · intro _; funext _; rfl
+
+/-- Pi of a family of zero functors over an inhabited type is the zero functor. -/
+def piZero [Inhabited I] {F : I → PFunctor.{uA, uB}} (F_zero : ∀ i, F i = 0) :
+    pi F ≃c 0 := by
+  letI : IsEmpty (pi F).A := by
+    refine ⟨fun f => ?_⟩
+    have : PEmpty := by
+      simpa [F_zero (default : I)] using (f default)
+    exact this.elim
+  refine
+    { toChart := isEmptyElim ⇉ (fun a _ => isEmptyElim a)
+      invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+      left_inv := by
+        refine Chart.ext _ _ ?_ ?_
+        · intro a; exact isEmptyElim a
+        · intro a; exact isEmptyElim a
+      right_inv := by
+        refine Chart.ext _ _ ?_ ?_
+        · intro a; exact PEmpty.elim a
+        · intro a; exact PEmpty.elim a }
+
+end Chart.Equiv
 
 end PFunctor

--- a/ToMathlib/PFunctor/Chart/Basic.lean
+++ b/ToMathlib/PFunctor/Chart/Basic.lean
@@ -9,15 +9,73 @@ public import ToMathlib.PFunctor.Basic
 
 /-!
 # Charts between polynomial functors
+
+A `Chart P Q` is a pair `(toFunA, toFunB)` where
+
+* `toFunA : P.A → Q.A` is a forward map on positions, and
+* `toFunB : ∀ a, P.B a → Q.B (toFunA a)` is a forward map on directions.
+
+While **lenses** make `Poly` into a 2-category whose categorical product is
+`*` (positions ×, directions Σ), **charts** make `Poly` into a different
+category that is isomorphic to the arrow category `Set^→` (squares
+`B → A → B' → A'`). A consequence is that the chart category has a
+*different* monoidal structure from the lens category.
+
+## Comparison with `Lens`
+
+|              | Lens                                     | Chart                            |
+|--------------|------------------------------------------|----------------------------------|
+| Coproduct    | `+`                                      | `+` (same)                       |
+| Product      | `*` (positions ×, directions ⊕)          | `⊗` (positions ×, directions ×)  |
+| Terminal     | `1` (positions = 1, no directions)       | `X = y` (positions = 1, dir = 1) |
+| Composition  | `compMap` is natural                     | `compMap` is **not** natural     |
+| Sigma        | `sigmaExists`, `sigmaMap`                | `sigmaExists`, `sigmaMap`        |
+| Pi           | `piForall`, `piMap`                      | only `piMap`                     |
+
+The operations missing from charts (`compMap`, `piForall`, projections from
+`*`, `sigmaForall`) all require contravariance and so are intrinsically
+lens-side. What charts do have, they have cleanly: `+` is the coproduct
+with `inl`/`inr`/`sumPair`, and `⊗` is the categorical product with
+`fst`/`snd`/`tensorPair`.
+
+## Layout
+
+This file mirrors `ToMathlib/PFunctor/Lens/Basic.lean` for ease of
+cross-reference. Each section header that overlaps with `Lens` is named
+identically; the chart-specific sections (`Tensor` for the categorical
+product, `Prod` for the polynomial product) are documented inline.
+
+## Downstream consumers
+
+`Interface.Hom`, `Interface.Hom.mapPacket`, and the boundary-side composition
+operators are intentionally thin wrappers around this file. New downstream
+operators on packet/index transport (e.g. parallel composition, sum routing)
+should be defined as wrappers, not re-implemented.
 -/
 
 @[expose] public section
 
-universe uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃ uA₄ uB₄
+universe u v uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃ uA₄ uB₄ uA₅ uB₅ uA₆ uB₆
 
 namespace PFunctor
 
 namespace Chart
+
+@[ext (iff := false)]
+theorem ext {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (c₁ c₂ : Chart P Q)
+    (h₁ : ∀ a, c₁.toFunA a = c₂.toFunA a) (h₂ : ∀ a, c₁.toFunB a = (h₁ a) ▸ c₂.toFunB a) :
+    c₁ = c₂ := by
+  rcases c₁ with ⟨toFunA₁, toFunB₁⟩
+  rcases c₂ with ⟨toFunA₂, toFunB₂⟩
+  have h : toFunA₁ = toFunA₂ := funext h₁
+  subst h
+  have hB : toFunB₁ = toFunB₂ := by
+    funext a
+    simpa using h₂ a
+  subst hB
+  rfl
+
+/-! ### Identity and composition -/
 
 /-- The identity chart -/
 protected def id (P : PFunctor.{uA, uB}) : Chart P P := id ⇉ fun _ => id
@@ -43,14 +101,16 @@ theorem comp_assoc {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {
     {S : PFunctor.{uA₄, uB₄}} (c : Chart R S) (c' : Chart Q R) (c'' : Chart P Q) :
     (c ∘c c') ∘c c'' = c ∘c (c' ∘c c'') := rfl
 
+/-! ### Equivalences -/
+
 /-- An equivalence between two polynomial functors `P` and `Q`, using charts.
     This corresponds to an isomorphism in the category `PFunctor` with `Chart` morphisms. -/
 @[ext]
 protected structure Equiv (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) where
   toChart : Chart P Q
   invChart : Chart Q P
-  left_inv : comp invChart toChart = Chart.id P
-  right_inv : comp toChart invChart = Chart.id Q
+  left_inv : comp invChart toChart = Chart.id P := by simp
+  right_inv : comp toChart invChart = Chart.id Q := by simp
 
 /-- Infix notation for chart equivalence `P ≃c Q` -/
 infix:50 " ≃c " => Chart.Equiv
@@ -65,6 +125,7 @@ def refl (P : PFunctor.{uA, uB}) : P ≃c P :=
 def symm {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (e : P ≃c Q) : Q ≃c P :=
   ⟨e.invChart, e.toChart, e.right_inv, e.left_inv⟩
 
+@[trans]
 def trans {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
     (e₁ : P ≃c Q) (e₂ : Q ≃c R) : P ≃c R :=
   ⟨e₂.toChart ∘c e₁.toChart, e₁.invChart ∘c e₂.invChart,
@@ -79,30 +140,133 @@ def trans {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunc
 
 end Equiv
 
+/-! ### Initial and terminal -/
+
 /-- The (unique) initial chart from the zero functor to any functor `P`. -/
 def initial {P : PFunctor.{uA, uB}} : Chart 0 P :=
   PEmpty.elim ⇉ fun _ => PEmpty.elim
 
-/-- The (unique) terminal chart from any functor `P` to the functor `X`. -/
+/-- The (unique) terminal chart from any functor `P` to `X = y`.
+
+`X` is the terminal object of the chart category — a single position with a
+single direction — corresponding to the identity arrow `1 → 1` in `Set^→`.
+This differs from the lens-side terminal `1` (positions `1`, no directions). -/
 def terminal {P : PFunctor.{uA, uB}} : Chart P X :=
   (fun _ => PUnit.unit) ⇉ (fun _ _ => PUnit.unit)
 
 alias fromZero := initial
 alias toOne := terminal
 
-@[ext (iff := false)]
-theorem ext {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} (c₁ c₂ : Chart P Q)
-    (h₁ : ∀ a, c₁.toFunA a = c₂.toFunA a) (h₂ : ∀ a, c₁.toFunB a = (h₁ a) ▸ c₂.toFunB a) :
-    c₁ = c₂ := by
-  rcases c₁ with ⟨toFunA₁, toFunB₁⟩
-  rcases c₂ with ⟨toFunA₂, toFunB₂⟩
-  have h : toFunA₁ = toFunA₂ := funext h₁
-  subst h
-  have hB : toFunB₁ = toFunB₂ := by
-    funext a
-    simpa using h₂ a
-  subst hB
-  rfl
+/-! ### Coproduct (`+`)
+
+`+` is the coproduct in the chart category (as it is in the lens category).
+The two inclusions `inl`/`inr` plus the copairing `sumPair` realise the
+universal property of `+`. The parallel-sum `sumMap` is then a derived
+construction. -/
+
+/-- Left injection chart `inl : P → P + Q`. -/
+def inl {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
+    Chart.{uA₁, uB, max uA₁ uA₂, uB} P (P + Q) :=
+  Sum.inl ⇉ (fun _ d => d)
+
+/-- Right injection chart `inr : Q → P + Q`. -/
+def inr {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
+    Chart.{uA₂, uB, max uA₁ uA₂, uB} Q (P + Q) :=
+  Sum.inr ⇉ (fun _ d => d)
+
+/-- Copairing of charts `[c₁, c₂]c : P + Q → R`. -/
+def sumPair {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} {R : PFunctor.{uA₃, uB₃}}
+    (c₁ : Chart P R) (c₂ : Chart Q R) :
+    Chart.{max uA₁ uA₂, uB, uA₃, uB₃} (P + Q) R :=
+  (Sum.elim c₁.toFunA c₂.toFunA) ⇉
+    (fun a d => match a with
+      | Sum.inl pa => c₁.toFunB pa d
+      | Sum.inr qa => c₂.toFunB qa d)
+
+/-- Parallel application of charts for coproduct `c₁ ⊎c c₂ : P + Q → R + W`. -/
+def sumMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₁}} {R : PFunctor.{uA₃, uB₃}}
+    {W : PFunctor.{uA₄, uB₃}} (c₁ : Chart P R) (c₂ : Chart Q W) :
+    Chart.{max uA₁ uA₂, uB₁, max uA₃ uA₄, uB₃} (P + Q) (R + W) :=
+  (Sum.map c₁.toFunA c₂.toFunA) ⇉
+    (fun psum => match psum with
+      | Sum.inl pa => c₁.toFunB pa
+      | Sum.inr qa => c₂.toFunB qa)
+
+/-! ### Tensor (`⊗`) — the chart category's binary product
+
+`⊗` is the **categorical** binary product in the chart category, with
+projections `fst`/`snd` and pairing `tensorPair`. (For lenses, the
+categorical product is `*`, not `⊗`.) -/
+
+/-- Projection chart `fst : P ⊗ Q → P`. -/
+def fst {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} :
+    Chart.{max uA₁ uA₂, max uB₁ uB₂, uA₁, uB₁} (P ⊗ Q) P :=
+  Prod.fst ⇉ (fun _ => Prod.fst)
+
+/-- Projection chart `snd : P ⊗ Q → Q`. -/
+def snd {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} :
+    Chart.{max uA₁ uA₂, max uB₁ uB₂, uA₂, uB₂} (P ⊗ Q) Q :=
+  Prod.snd ⇉ (fun _ => Prod.snd)
+
+/-- Pairing of charts `⟨c₁, c₂⟩c : P → Q ⊗ R`. -/
+def tensorPair {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+    (c₁ : Chart P Q) (c₂ : Chart P R) :
+    Chart.{uA₁, uB₁, max uA₂ uA₃, max uB₂ uB₃} P (Q ⊗ R) :=
+  (fun pa => (c₁.toFunA pa, c₂.toFunA pa)) ⇉
+    (fun pa pb => (c₁.toFunB pa pb, c₂.toFunB pa pb))
+
+/-- Parallel application of charts for tensor `c₁ ⊗c c₂ : P ⊗ Q → R ⊗ W`. -/
+def tensorMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+    {W : PFunctor.{uA₄, uB₄}} (c₁ : Chart P R) (c₂ : Chart Q W) :
+    Chart.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄} (P ⊗ Q) (R ⊗ W) :=
+  (Prod.map c₁.toFunA c₂.toFunA) ⇉
+    (fun pq pb => (c₁.toFunB pq.1 pb.1, c₂.toFunB pq.2 pb.2))
+
+/-! ### Polynomial product (`*`) — *not* the chart categorical product
+
+The polynomial product `*` is **not** the categorical product in the chart
+category: there is no natural chart `P * Q → P` because the source has
+direction type `P.B a₁ ⊕ Q.B a₂` and we cannot project a `Q.B a₂` to a
+`P.B a₁`. We provide only the parallel-map operation.
+
+For categorical projections / pairing, use `⊗` instead. -/
+
+/-- Parallel application of charts for polynomial product `c₁ ×c c₂ : P * Q → R * W`. -/
+def prodMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+    {W : PFunctor.{uA₄, uB₄}} (c₁ : Chart P R) (c₂ : Chart Q W) :
+    Chart.{max uA₁ uA₂, max uB₁ uB₂, max uA₃ uA₄, max uB₃ uB₄} (P * Q) (R * W) :=
+  (Prod.map c₁.toFunA c₂.toFunA) ⇉
+    (fun pq psum => match psum with
+      | Sum.inl pb => Sum.inl (c₁.toFunB pq.1 pb)
+      | Sum.inr qb => Sum.inr (c₂.toFunB pq.2 qb))
+
+/-! ### Indexed colimits and limits
+
+The chart category has Sigma-eliminations (`sigmaExists`/`sigmaMap`) but
+only the parametric Pi-map (`piMap`); `piForall` is intrinsically a
+lens-side construction because it requires "choosing an index" in the
+chart direction, which has no canonical choice in `Set^→`. -/
+
+/-- Dependent copairing of charts over `sigma`: `(Σ i, F i) → R`. -/
+def sigmaExists {I : Type v} {F : I → PFunctor.{uA₁, uB₁}} {R : PFunctor.{uA₂, uB₂}}
+    (c : ∀ i, Chart (F i) R) :
+    Chart (sigma F) R :=
+  (fun ⟨i, fa⟩ => (c i).toFunA fa) ⇉
+    (fun ⟨i, fa⟩ => (c i).toFunB fa)
+
+/-- Pointwise mapping of charts over `sigma`. -/
+def sigmaMap {I : Type v} {F : I → PFunctor.{uA₁, uB₁}} {G : I → PFunctor.{uA₂, uB₂}}
+    (c : ∀ i, Chart (F i) (G i)) :
+    Chart (sigma F) (sigma G) :=
+  (fun ⟨i, fa⟩ => ⟨i, (c i).toFunA fa⟩) ⇉
+    (fun ⟨i, fa⟩ => (c i).toFunB fa)
+
+/-- Pointwise mapping of charts over `pi`. -/
+def piMap {I : Type v} {F : I → PFunctor.{uA₁, uB₁}} {G : I → PFunctor.{uA₂, uB₂}}
+    (c : ∀ i, Chart (F i) (G i)) :
+    Chart (pi F) (pi G) :=
+  (fun fa i => (c i).toFunA (fa i)) ⇉
+    (fun fa ⟨i, fb⟩ => ⟨i, (c i).toFunB (fa i) fb⟩)
 
 /-! ### Action on indices
 
@@ -121,6 +285,263 @@ def mapIdx (φ : Chart P Q) (i : Idx P) : Idx Q :=
 
 @[simp] theorem mapIdx_comp (g : Chart Q R) (f : Chart P Q) (i : Idx P) :
     mapIdx (g ∘c f) i = mapIdx g (mapIdx f i) := rfl
+
+/-! ### Special charts -/
+
+/-- The type of charts from a polynomial functor `P` to `X`.
+
+A chart `P → X` is equivalent to a function `(a : P.A) → P.B a → PUnit`,
+i.e. a boundary valuation that picks out a single direction at every
+position. Analogous to `Lens.enclose`. -/
+def enclose (P : PFunctor.{uA, uB}) : Type max uA uA₁ uB uB₁ :=
+  Chart P X.{uA₁, uB₁}
+
+/-! ### Notations for binary operations -/
+
+@[inherit_doc] infixl:75 " ⊎c " => sumMap
+@[inherit_doc] infixl:75 " ⊗c " => tensorMap
+@[inherit_doc] infixl:75 " ×c " => prodMap
+notation "[" c₁ "," c₂ "]c" => sumPair c₁ c₂
+notation "⟨" c₁ "," c₂ "⟩c" => tensorPair c₁ c₂
+
+/-! ### Coproduct coherence -/
+
+section Sum
+
+variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+  {R : PFunctor.{uA₃, uB₃}} {W : PFunctor.{uA₄, uB₃}} {S : PFunctor.{uA₅, uB₅}}
+
+@[simp]
+theorem sumMap_comp_inl (c₁ : Chart P R) (c₂ : Chart Q W) :
+    ((c₁ ⊎c c₂) ∘c Chart.inl) = (Chart.inl ∘c c₁) := rfl
+
+@[simp]
+theorem sumMap_comp_inr (c₁ : Chart P R) (c₂ : Chart Q W) :
+    ((c₁ ⊎c c₂) ∘c Chart.inr) = (Chart.inr ∘c c₂) := rfl
+
+theorem sumPair_comp_sumMap (c₁ : Chart P R) (c₂ : Chart Q W)
+    (f : Chart R S) (g : Chart W S) :
+    Chart.sumPair f g ∘c (c₁ ⊎c c₂) = Chart.sumPair (f ∘c c₁) (g ∘c c₂) := by
+  ext a <;> rcases a with a | a <;> rfl
+
+@[simp]
+theorem sumPair_comp_inl (f : Chart P R) (g : Chart Q R) :
+    Chart.sumPair f g ∘c Chart.inl = f := rfl
+
+@[simp]
+theorem sumPair_comp_inr (f : Chart P R) (g : Chart Q R) :
+    Chart.sumPair f g ∘c Chart.inr = g := rfl
+
+theorem comp_inl_inr (h : Chart.{max uA₁ uA₂, uB, uA₃, uB₃} (P + Q) R) :
+    Chart.sumPair (h ∘c Chart.inl) (h ∘c Chart.inr) = h := by
+  ext a <;> rcases a <;> rfl
+
+@[simp]
+theorem sumMap_id :
+    Chart.sumMap (Chart.id P) (Chart.id Q) = Chart.id.{max uA₁ uA₂, uB} (P + Q) := by
+  ext a <;> rcases a <;> rfl
+
+@[simp]
+theorem sumPair_inl_inr :
+    Chart.sumPair Chart.inl Chart.inr = Chart.id.{max uA₁ uA₂, uB} (P + Q) := by
+  ext a <;> rcases a <;> rfl
+
+namespace Equiv
+
+/-- Commutativity of coproduct -/
+def sumComm (P : PFunctor.{uA₁, uB}) (Q : PFunctor.{uA₂, uB}) :
+    Chart.Equiv.{max uA₁ uA₂, uB, max uA₁ uA₂, uB} (P + Q) (Q + P) where
+  toChart := Chart.sumPair Chart.inr Chart.inl
+  invChart := Chart.sumPair Chart.inr Chart.inl
+  left_inv := by ext a <;> rcases a with a | a <;> rfl
+  right_inv := by ext a <;> rcases a with a | a <;> rfl
+
+variable {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} {R : PFunctor.{uA₃, uB}}
+
+@[simp]
+theorem sumComm_symm :
+    (sumComm P Q).symm = sumComm Q P := rfl
+
+/-- Associativity of coproduct -/
+def sumAssoc :
+    Chart.Equiv.{max uA₁ uA₂ uA₃, uB, max uA₁ uA₂ uA₃, uB} ((P + Q) + R) (P + (Q + R)) where
+  toChart :=
+    Chart.sumPair
+      (Chart.sumPair
+        Chart.inl
+        (Chart.inr ∘c Chart.inl))
+      (Chart.inr ∘c Chart.inr)
+  invChart :=
+    Chart.sumPair
+      (Chart.inl ∘c Chart.inl)
+      (Chart.sumPair
+        (Chart.inl ∘c Chart.inr)
+        Chart.inr)
+  left_inv := by ext a <;> rcases a with (a | a) | a <;> rfl
+  right_inv := by ext a <;> rcases a with a | (a | a) <;> rfl
+
+/-- Coproduct with `0` is identity (right) -/
+def sumZero :
+    Chart.Equiv.{max uA uA₁, uB, uA₁, uB} (P + (0 : PFunctor.{uA, uB})) P where
+  toChart := Chart.sumPair (Chart.id P) Chart.initial
+  invChart := Chart.inl
+  left_inv := by
+    ext a <;> rcases a with a | a
+    · rfl
+    · exact PEmpty.elim a
+    · rfl
+    · exact PEmpty.elim a
+  right_inv := by ext <;> rfl
+
+/-- Coproduct with `0` is identity (left) -/
+def zeroSum :
+    Chart.Equiv.{max uA uA₁, uB, uA₁, uB} ((0 : PFunctor.{uA, uB}) + P) P where
+  toChart := Chart.sumPair Chart.initial (Chart.id P)
+  invChart := Chart.inr
+  left_inv := by
+    ext a <;> rcases a with a | a
+    · exact PEmpty.elim a
+    · rfl
+    · exact PEmpty.elim a
+    · rfl
+  right_inv := by ext <;> rfl
+
+end Equiv
+
+end Sum
+
+/-! ### Tensor coherence -/
+
+section Tensor
+
+variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+  {W : PFunctor.{uA₄, uB₄}} {S : PFunctor.{uA₅, uB₅}}
+
+@[simp]
+theorem fst_comp_tensorMap (c₁ : Chart P R) (c₂ : Chart Q W) :
+    Chart.fst ∘c (c₁ ⊗c c₂) = c₁ ∘c Chart.fst := rfl
+
+@[simp]
+theorem snd_comp_tensorMap (c₁ : Chart P R) (c₂ : Chart Q W) :
+    Chart.snd ∘c (c₁ ⊗c c₂) = c₂ ∘c Chart.snd := rfl
+
+theorem tensorMap_comp_tensorPair (c₁ : Chart Q W) (c₂ : Chart R S)
+    (f : Chart P Q) (g : Chart P R) :
+    (c₁ ⊗c c₂) ∘c Chart.tensorPair f g = Chart.tensorPair (c₁ ∘c f) (c₂ ∘c g) := by
+  ext _ _
+  · rfl
+  · rfl
+
+@[simp]
+theorem fst_comp_tensorPair (f : Chart P Q) (g : Chart P R) :
+    Chart.fst ∘c Chart.tensorPair f g = f := rfl
+
+@[simp]
+theorem snd_comp_tensorPair (f : Chart P Q) (g : Chart P R) :
+    Chart.snd ∘c Chart.tensorPair f g = g := rfl
+
+theorem comp_fst_snd (h : Chart.{uA₁, uB₁, max uA₂ uA₃, max uB₂ uB₃} P (Q ⊗ R)) :
+    Chart.tensorPair (Chart.fst ∘c h) (Chart.snd ∘c h) = h := by
+  ext _ _
+  · rfl
+  · rfl
+
+@[simp]
+theorem tensorMap_id : (Chart.id P) ⊗c (Chart.id Q) = Chart.id (P ⊗ Q) := rfl
+
+theorem tensorMap_comp
+    {P' : PFunctor.{uA₅, uB₅}} {Q' : PFunctor.{uA₆, uB₆}}
+    (c₁ : Chart P P') (c₂ : Chart Q Q') (c₁' : Chart P' R) (c₂' : Chart Q' W) :
+    (c₁' ∘c c₁) ⊗c (c₂' ∘c c₂) = (c₁' ⊗c c₂') ∘c (c₁ ⊗c c₂) := rfl
+
+@[simp]
+theorem tensorPair_fst_snd : Chart.tensorPair Chart.fst Chart.snd =
+    Chart.id.{max uA₁ uA₂, max uB₁ uB₂} (P ⊗ Q) := by
+  ext _ _
+  · rfl
+  · rfl
+
+namespace Equiv
+
+/-- Commutativity of tensor product -/
+def tensorComm (P : PFunctor.{uA₁, uB₁}) (Q : PFunctor.{uA₂, uB₂}) : P ⊗ Q ≃c Q ⊗ P where
+  toChart := Prod.swap ⇉ (fun _ => Prod.swap)
+  invChart := Prod.swap ⇉ (fun _ => Prod.swap)
+  left_inv := rfl
+  right_inv := rfl
+
+@[simp]
+theorem tensorComm_symm : (tensorComm P Q).symm = tensorComm Q P := rfl
+
+/-- Associativity of tensor product -/
+def tensorAssoc : (P ⊗ Q) ⊗ R ≃c P ⊗ (Q ⊗ R) where
+  toChart := (_root_.Equiv.prodAssoc _ _ _).toFun ⇉
+              (fun _ => (_root_.Equiv.prodAssoc _ _ _).toFun)
+  invChart := (_root_.Equiv.prodAssoc _ _ _).invFun ⇉
+              (fun _ => (_root_.Equiv.prodAssoc _ _ _).invFun)
+  left_inv := rfl
+  right_inv := rfl
+
+/-- Tensor product with `X` is identity (right) -/
+def tensorX : P ⊗ X ≃c P where
+  toChart := Prod.fst ⇉ (fun _ => Prod.fst)
+  invChart := (fun p => (p, PUnit.unit)) ⇉ (fun _ b => (b, PUnit.unit))
+  left_inv := rfl
+  right_inv := rfl
+
+/-- Tensor product with `X` is identity (left) -/
+def xTensor : X ⊗ P ≃c P where
+  toChart := Prod.snd ⇉ (fun _ => Prod.snd)
+  invChart := (fun p => (PUnit.unit, p)) ⇉ (fun _ b => (PUnit.unit, b))
+  left_inv := rfl
+  right_inv := rfl
+
+/-- Tensor product with `0` is zero (left) -/
+def zeroTensor : 0 ⊗ P ≃c 0 where
+  toChart := (fun a => PEmpty.elim a.1) ⇉ (fun a _ => PEmpty.elim a.1)
+  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  left_inv := by ext ⟨a, _⟩ <;> exact PEmpty.elim a
+  right_inv := by ext a <;> exact PEmpty.elim a
+
+/-- Tensor product with `0` is zero (right) -/
+def tensorZero : P ⊗ 0 ≃c 0 where
+  toChart := (fun a => PEmpty.elim a.2) ⇉ (fun a _ => PEmpty.elim a.2)
+  invChart := PEmpty.elim ⇉ (fun a _ => PEmpty.elim a)
+  left_inv := by ext ⟨_, b⟩ <;> exact PEmpty.elim b
+  right_inv := by ext a <;> exact PEmpty.elim a
+
+end Equiv
+
+end Tensor
+
+/-! ### Polynomial-product coherence -/
+
+section Prod
+
+variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+  {W : PFunctor.{uA₄, uB₄}}
+
+@[simp]
+theorem prodMap_id :
+    (Chart.id P) ×c (Chart.id Q) = Chart.id.{max uA₁ uA₂, max uB₁ uB₂} (P * Q) := by
+  ext _ x
+  · rfl
+  · cases x <;> rfl
+
+end Prod
+
+/-! ### ULift -/
+
+namespace Equiv
+
+/-- ULift equivalence for charts. -/
+def ulift {P : PFunctor.{uA, uB}} : P.ulift ≃c P where
+  toChart := (fun a => ULift.down a) ⇉ (fun _ b => ULift.down b)
+  invChart := (fun a => ULift.up a) ⇉ (fun _ b => ULift.up b)
+  left_inv := rfl
+  right_inv := rfl
+
+end Equiv
 
 end Chart
 

--- a/ToMathlib/PFunctor/Trace.lean
+++ b/ToMathlib/PFunctor/Trace.lean
@@ -1,0 +1,206 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import Mathlib.Algebra.FreeMonoid.Basic
+public import ToMathlib.Control.Trace
+public import ToMathlib.PFunctor.Chart.Basic
+
+/-!
+# Traces of polynomial-functor events
+
+For a polynomial functor `P`, the universal "log of `P`-events" is the free
+monoid on indices `Idx P = Σ a : P.A, P.B a`.  This file packages that monoid
+together with the abstract `Control.Trace` machinery from
+`ToMathlib/Control/Trace.lean`.
+
+## Main definitions
+
+* `PFunctor.TraceList P` — the carrier `FreeMonoid (Idx P)`,
+  definitionally `List (Σ a, P.B a)`.
+* `PFunctor.Trace P X` — the type of `X`-indexed `P`-event traces,
+  i.e. `X → TraceList P`, with monoid structure inherited pointwise.
+* `PFunctor.Trace.mapPartial`, `mapChart`,
+  `restrictLeft`, `restrictRight` — the standard push / filter operations
+  along chart morphisms and direct-sum projections.
+* `PFunctor.Trace.toMonoid` — the universal property: every valuation
+  `Idx P → ω` extends uniquely to a monoid hom `TraceList P →* ω`, and so to
+  a trace map `Trace P X → Control.Trace ω X`.
+
+## Boundary-emitter intuition
+
+Reading `Trace P X` as "for each input `x : X`, the finite, ordered list of
+`P`-events that get emitted on the boundary": this is precisely the boundary
+shape of a stateless effectful Mealy machine in the `List`-Writer Kleisli
+category.  Stateful executors (e.g. running over an `OracleComp`) are handled
+separately in `VCVio/OracleComp/QueryTracking/`.
+
+## Companion bridge
+
+`Chart.mapIdx` is added here as the small helper that lifts a polynomial
+chart `P → Q` to a function `Idx P → Idx Q`.  It is the `Idx`-level avatar of
+`PFunctor.Chart` and underlies `Trace.mapChart`.
+
+## References
+
+* Bonchi, Di Lavore, Romàn — *Effectful Mealy machines and Kleisli
+  categories*.
+* Hancock, Setzer — *Interactive programs and weakly final coalgebras in
+  dependent type theory*.
+* Spivak, Niu — *Polynomial Functors: A Mathematical Theory of Interaction*,
+  arXiv:2202.00534.
+-/
+
+@[expose] public section
+
+universe uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃ v w
+
+namespace PFunctor
+
+namespace Chart
+
+variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
+  {R : PFunctor.{uA₃, uB₃}}
+
+/-- Push an `Idx P` along a chart `P → Q` to an `Idx Q`. -/
+def mapIdx (φ : Chart P Q) (i : Idx P) : Idx Q :=
+  ⟨φ.toFunA i.1, φ.toFunB i.1 i.2⟩
+
+@[simp] theorem mapIdx_id (i : Idx P) : mapIdx (Chart.id P) i = i := rfl
+
+@[simp] theorem mapIdx_comp (g : Chart Q R) (f : Chart P Q) (i : Idx P) :
+    mapIdx (g ∘c f) i = mapIdx g (mapIdx f i) := rfl
+
+end Chart
+
+/--
+The free monoid on `P`-events.  Definitionally `FreeMonoid (Idx P)`, which
+in turn is reducibly `List (Idx P)`.  This is the universal carrier for
+"finite ordered logs of `P`-events".
+-/
+@[reducible] def TraceList (P : PFunctor.{uA, uB}) : Type max uA uB :=
+  FreeMonoid (Idx P)
+
+/--
+An `X`-indexed trace of `P`-events: for each input `x : X`, a finite ordered
+list of `P`-events.  Specialisation of `Control.Trace` at
+`ω = TraceList P`, inheriting a pointwise monoid structure.
+-/
+@[reducible] def Trace (P : PFunctor.{uA, uB}) (X : Type v) : Type max uA uB v :=
+  Control.Trace (TraceList P) X
+
+namespace Trace
+
+variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
+  {R : PFunctor.{uA₃, uB₃}} {X Y : Type v}
+
+/--
+Relabel-and-filter a trace along a partial map of indices.  This is the
+single primitive for moving traces between polynomial functors: total chart
+pushforward and summand restriction are both specialisations of it.
+-/
+def mapPartial (f : Idx P → Option (Idx Q)) (t : Trace P X) : Trace Q X :=
+  fun x => List.filterMap f (t x)
+
+/-- Push a `P`-trace forward along a chart `P → Q`. -/
+def mapChart (φ : Chart P Q) : Trace P X → Trace Q X :=
+  mapPartial (fun i => some (Chart.mapIdx φ i))
+
+/-- Pre-compose a `P`-trace with `f : Y → X` (input variance). -/
+def precomp (f : Y → X) (t : Trace P X) : Trace P Y := Control.Trace.precomp f t
+
+/--
+The universal map into any monoid-valued trace via the free-monoid universal
+property.  Every valuation `φ : Idx P → ω` extends uniquely to a monoid
+homomorphism `FreeMonoid (Idx P) →* ω`; `toMonoid φ` post-composes a `P`-trace
+with that hom.
+-/
+def toMonoid {ω : Type w} [Monoid ω] (φ : Idx P → ω) :
+    Trace P X → Control.Trace ω X :=
+  Control.Trace.map (FreeMonoid.lift φ)
+
+/-! ### Pointwise behaviour -/
+
+@[simp] theorem mapPartial_apply (f : Idx P → Option (Idx Q)) (t : Trace P X)
+    (x : X) :
+    mapPartial f t x = List.filterMap f (t x) := rfl
+
+@[simp] theorem mapChart_apply (φ : Chart P Q) (t : Trace P X) (x : X) :
+    mapChart φ t x = (t x).filterMap (fun i => some (Chart.mapIdx φ i)) := rfl
+
+@[simp] theorem toMonoid_apply {ω : Type w} [Monoid ω] (φ : Idx P → ω)
+    (t : Trace P X) (x : X) :
+    toMonoid φ t x = FreeMonoid.lift φ (t x) := rfl
+
+/-! ### Functoriality of `mapPartial` and `mapChart` -/
+
+@[simp] theorem mapPartial_some (t : Trace P X) :
+    mapPartial (fun i => some i) t = t := by
+  funext x
+  exact List.filterMap_some
+
+theorem mapPartial_comp (g : Idx Q → Option (Idx R))
+    (f : Idx P → Option (Idx Q)) (t : Trace P X) :
+    mapPartial g (mapPartial f t) = mapPartial (fun i => (f i).bind g) t := by
+  funext x
+  exact List.filterMap_filterMap
+
+@[simp] theorem mapChart_id (t : Trace P X) : mapChart (Chart.id P) t = t := by
+  change mapPartial (fun i => some (Chart.mapIdx (Chart.id P) i)) t = t
+  exact mapPartial_some t
+
+@[simp] theorem mapChart_comp (g : Chart Q R) (f : Chart P Q) (t : Trace P X) :
+    mapChart (g ∘c f) t = mapChart g (mapChart f t) := by
+  change mapPartial (fun i => some (Chart.mapIdx (g ∘c f) i)) t =
+    mapPartial (fun i => some (Chart.mapIdx g i))
+      (mapPartial (fun i => some (Chart.mapIdx f i)) t)
+  rw [mapPartial_comp]
+  rfl
+
+/-! ### Naturality of `toMonoid`
+
+Pushing a `P`-trace along a chart `φ : P → Q` and then evaluating against a
+`Q`-valuation `ψ` is the same as evaluating against the precomposed
+`P`-valuation `ψ ∘ Chart.mapIdx φ`.  This is exactly the free-monoid
+naturality square. -/
+
+@[simp] theorem toMonoid_mapChart {ω : Type w} [Monoid ω] (ψ : Idx Q → ω)
+    (φ : Chart P Q) (t : Trace P X) :
+    toMonoid ψ (mapChart φ t) = toMonoid (ψ ∘ Chart.mapIdx φ) t := by
+  funext x
+  change FreeMonoid.lift ψ
+      (FreeMonoid.ofList ((t x).filterMap (some ∘ Chart.mapIdx φ))) =
+        FreeMonoid.lift (ψ ∘ Chart.mapIdx φ) (t x)
+  rw [List.filterMap_eq_map (f := Chart.mapIdx φ),
+    FreeMonoid.lift_ofList, FreeMonoid.lift_apply, List.map_map]
+  rfl
+
+end Trace
+
+/-! ### Restriction along direct-sum projections
+
+The summand restriction operations need `P` and `Q` to share the `B` universe
+so that `P + Q` typechecks. -/
+
+namespace Trace
+
+variable {P Q : PFunctor.{uA, uB}} {X : Type v}
+
+/-- Restrict a trace on `P + Q` to its `P`-summand. -/
+def restrictLeft : Trace (P + Q) X → Trace P X :=
+  mapPartial (fun i => match i with
+    | ⟨Sum.inl a, b⟩ => some ⟨a, b⟩
+    | ⟨Sum.inr _, _⟩ => none)
+
+/-- Restrict a trace on `P + Q` to its `Q`-summand. -/
+def restrictRight : Trace (P + Q) X → Trace Q X :=
+  mapPartial (fun i => match i with
+    | ⟨Sum.inl _, _⟩ => none
+    | ⟨Sum.inr a, b⟩ => some ⟨a, b⟩)
+
+end Trace
+
+end PFunctor

--- a/ToMathlib/PFunctor/Trace.lean
+++ b/ToMathlib/PFunctor/Trace.lean
@@ -38,11 +38,6 @@ shape of a stateless effectful Mealy machine in the `List`-Writer Kleisli
 category.  Stateful executors (e.g. running over an `OracleComp`) are handled
 separately in `VCVio/OracleComp/QueryTracking/`.
 
-## Companion bridge
-
-`Chart.mapIdx` is added here as the small helper that lifts a polynomial
-chart `P → Q` to a function `Idx P → Idx Q`.  It is the `Idx`-level avatar of
-`PFunctor.Chart` and underlies `Trace.mapChart`.
 
 ## References
 
@@ -59,22 +54,6 @@ chart `P → Q` to a function `Idx P → Idx Q`.  It is the `Idx`-level avatar o
 universe uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃ v w
 
 namespace PFunctor
-
-namespace Chart
-
-variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}}
-  {R : PFunctor.{uA₃, uB₃}}
-
-/-- Push an `Idx P` along a chart `P → Q` to an `Idx Q`. -/
-def mapIdx (φ : Chart P Q) (i : Idx P) : Idx Q :=
-  ⟨φ.toFunA i.1, φ.toFunB i.1 i.2⟩
-
-@[simp] theorem mapIdx_id (i : Idx P) : mapIdx (Chart.id P) i = i := rfl
-
-@[simp] theorem mapIdx_comp (g : Chart Q R) (f : Chart P Q) (i : Idx P) :
-    mapIdx (g ∘c f) i = mapIdx g (mapIdx f i) := rfl
-
-end Chart
 
 /--
 The free monoid on `P`-events.  Definitionally `FreeMonoid (Idx P)`, which

--- a/VCVio/Interaction/UC/Interface.lean
+++ b/VCVio/Interaction/UC/Interface.lean
@@ -1185,58 +1185,14 @@ abbrev swapSwap
     Equiv (PortBoundary.swap (PortBoundary.swap Δ)) Δ :=
   refl Δ
 
-private theorem eqRec_id_apply_codomain
-    {α : Sort*} {β : α → Sort*} {a₀ a₁ : α}
-    (h : a₀ = a₁) (x : β a₀) :
-    Eq.rec (motive := fun x _ => β a₀ → β x) id h x =
-      _root_.cast (congrArg β h) x := by
-  subst h; rfl
-
-private theorem chart_comp_symm_eq_id
-    {P : PFunctor} {Q : PFunctor} (e : PFunctor.Equiv P Q) :
-    PFunctor.Chart.comp e.symm.toChart e.toChart =
-      PFunctor.Chart.id P := by
-  refine PFunctor.Chart.ext _ _
-    (fun a => e.equivA.symm_apply_apply a) (fun a => ?_)
-  funext b
-  simp only [PFunctor.Chart.comp, PFunctor.Chart.id,
-    PFunctor.Equiv.toChart, Function.comp_apply]
-  change (((_root_.Equiv.cast _).trans
-    (e.equivB (e.equivA.symm (e.equivA a))).symm)
-    (e.equivB a b)) = _
-  simp only [_root_.Equiv.trans_apply]
-  trans _root_.cast
-    (congrArg P.B (e.equivA.symm_apply_apply a).symm) b
-  · exact PFunctor.Equiv.equivB_symm_apply_of_eq e
-      (e.equivA.apply_symm_apply (e.equivA a)) b
-  · exact (eqRec_id_apply_codomain
-      (e.equivA.symm_apply_apply a).symm b).symm
-
-private theorem chart_comp_inv_eq_id
-    {P : PFunctor} {Q : PFunctor} (e : PFunctor.Equiv P Q) :
-    PFunctor.Chart.comp e.toChart e.symm.toChart =
-      PFunctor.Chart.id Q := by
-  refine PFunctor.Chart.ext _ _
-    (fun a => e.equivA.apply_symm_apply a) (fun a => ?_)
-  funext b
-  simp only [PFunctor.Chart.comp, PFunctor.Chart.id,
-    PFunctor.Equiv.toChart, Function.comp_apply]
-  change ((e.equivB (e.equivA.symm a)))
-    (((_root_.Equiv.cast _).trans
-      (e.equivB (e.equivA.symm a)).symm) b) = _
-  simp only [_root_.Equiv.trans_apply,
-    _root_.Equiv.apply_symm_apply]
-  exact (eqRec_id_apply_codomain
-    (e.equivA.apply_symm_apply a).symm b).symm
-
 @[simp]
 theorem symm_toHom_comp_toHom
     {Δ₁ Δ₂ : PortBoundary}
     (e : PortBoundary.Equiv Δ₁ Δ₂) :
     Hom.comp e.symm.toHom e.toHom = Hom.id Δ₁ := by
   apply Hom.ext
-  · exact chart_comp_inv_eq_id e.onIn
-  · exact chart_comp_symm_eq_id e.onOut
+  · exact PFunctor.Equiv.toChart_comp_symm_toChart e.onIn
+  · exact PFunctor.Equiv.symm_toChart_comp_toChart e.onOut
 
 @[simp]
 theorem toHom_comp_symm_toHom
@@ -1244,8 +1200,8 @@ theorem toHom_comp_symm_toHom
     (e : PortBoundary.Equiv Δ₁ Δ₂) :
     Hom.comp e.toHom e.symm.toHom = Hom.id Δ₂ := by
   apply Hom.ext
-  · exact chart_comp_symm_eq_id e.onIn
-  · exact chart_comp_inv_eq_id e.onOut
+  · exact PFunctor.Equiv.symm_toChart_comp_toChart e.onIn
+  · exact PFunctor.Equiv.toChart_comp_symm_toChart e.onOut
 
 @[simp]
 theorem tensorComm_comp_tensorComm

--- a/VCVio/Interaction/UC/Interface.lean
+++ b/VCVio/Interaction/UC/Interface.lean
@@ -257,12 +257,14 @@ abbrev comp
 
 /--
 Translate one concrete packet along an interface morphism.
+
+Boundary-oriented alias for `PFunctor.Chart.mapIdx`.
 -/
-def mapPacket
+abbrev mapPacket
     {I : Interface.{uA, uB}}
     {J : Interface.{vA, vB}}
-    (f : Hom I J) : Packet I → Packet J
-  | ⟨a, m⟩ => ⟨f.onPort a, f.onMsg m⟩
+    (f : Hom I J) : Packet I → Packet J :=
+  PFunctor.Chart.mapIdx f
 
 @[simp]
 theorem id_comp
@@ -292,10 +294,8 @@ theorem comp_assoc
 @[simp]
 theorem mapPacket_id
     {I : Interface.{uA, uB}} :
-    mapPacket (id I) = fun p => p := by
-  funext p
-  cases p
-  rfl
+    mapPacket (id I) = fun p => p :=
+  funext (PFunctor.Chart.mapIdx_id (P := I))
 
 @[simp]
 theorem mapPacket_comp
@@ -303,10 +303,8 @@ theorem mapPacket_comp
     {J : Interface.{vA, vB}}
     {K : Interface.{wA, wB}}
     (g : Hom J K) (f : Hom I J) :
-    mapPacket (comp g f) = mapPacket g ∘ mapPacket f := by
-  funext p
-  cases p
-  rfl
+    mapPacket (comp g f) = mapPacket g ∘ mapPacket f :=
+  funext (PFunctor.Chart.mapIdx_comp g f)
 
 end Hom
 
@@ -392,7 +390,7 @@ theorem mapPacket_comp
     (g : Hom J K) (f : Hom I J) (rp : RoutedPacket I M) :
     mapPacket g (mapPacket f rp) = mapPacket (Hom.comp g f) rp := by
   cases rp
-  simp [mapPacket, Hom.mapPacket_comp]
+  simp [mapPacket]
 
 @[simp]
 theorem mapSender_id


### PR DESCRIPTION
## Summary

Originally PR-T1 of the **Trace foundations + cutover** plan from
`vcvio-interaction-redesign-council-synthesis.md` §0.7 (lives outside the
repo, in `~/Documents/Notes/`). The scope grew organically to cover the
`PFunctor.Chart` API expansion that the Trace cutover and downstream
interaction layer both want, plus a small refactor of
`VCVio/Interaction/UC/Interface.lean` that the new bridge enables.

Net additive: ~1185 / ~78 lines, all of it new lemmas / structural API,
plus a tiny cleanup of `Interface.lean`. No core semantics changes.

### `ToMathlib/Control/Trace.lean` (new)

Abstract trace `Trace ω X := X → ω` for any monoid `ω`. Pointwise monoid
inherited from `Pi.monoid` (`@[reducible]`), so `1` is the constant trace
and `*` the pointwise product. Provides:

- `precomp f t` — pre-compose with `f : Y → X` (input variance).
- `map φ t` — post-compose with a monoid hom.
- `mapHom φ` — `map` bundled as a monoid hom on the trace monoid.
- Functoriality / naturality / monoid-hom lemmas (`map_id`, `map_comp`,
  `map_one`, `map_mul`, `map_precomp`, `precomp_one`, `precomp_mul`, ...).

### `ToMathlib/PFunctor/Trace.lean` (new)

The polynomial-events specialization
`Trace P X := Control.Trace (FreeMonoid (Idx P)) X`:

- `Trace.mapPartial f t` — relabel-and-filter along
  `Idx P → Option (Idx Q)` (single primitive).
- `Trace.mapChart φ t` — chart pushforward (specialization of `mapPartial`).
- `Trace.restrictLeft` / `restrictRight` — sum-restriction along
  `Trace (P + Q) X`.
- `Trace.precomp f t` — input-variance, inherited from `Control.Trace`.
- `Trace.toMonoid φ` — universal property: any valuation
  `Idx P → ω` extends uniquely to `Trace P X → Control.Trace ω X` via
  `FreeMonoid.lift`.

Includes standard functoriality / naturality lemmas (e.g.
`toMonoid_mapChart`).

### `ToMathlib/PFunctor/Chart/Basic.lean` (expanded)

The Chart API is brought to parity with `Lens` for everything that's
chart-natural (i.e. covariant on directions). Net +862 lines.

**Bridge from `PFunctor.Equiv`:**

- `Equiv.toChart` and `Equiv.toChartEquiv` — chart-side analogue of
  `Equiv.toLensEquiv`. Backed by `symm_toChart_comp_toChart` and
  `toChart_comp_symm_toChart`, which promote the previously private
  cast-machinery proofs from `VCVio/Interaction/UC/Interface.lean` (those
  are deleted there). Establishes a faithful functor `≃ₚ → ≃c`.

**Operations:**

- `mapIdx` (moved here from `PFunctor/Trace.lean`) — push `Idx P` along a
  chart, with `mapIdx_id` / `mapIdx_comp` simp lemmas.
- Coproduct `+`: `inl`, `inr`, `sumPair` (`[_,_]c`), `sumMap` (`⊎c`) and
  coherence lemmas (`sumMap_comp_inl/inr`, `sumPair_comp_sumMap`,
  `sumPair_comp_inl/inr`, `comp_inl_inr`, `sumMap_id`, `sumMap_comp_sumMap`,
  `sumPair_inl_inr`).
- Tensor `⊗` (the chart-categorical product): `fst`, `snd`, `tensorPair`
  (`⟨_,_⟩c`), `tensorMap` (`⊗c`), and the analogous coherence laws
  (`fst/snd_comp_tensorMap`, `tensorMap_comp_tensorPair`,
  `fst/snd_comp_tensorPair`, `comp_fst_snd`, `tensorMap_id`,
  `tensorMap_comp`, `tensorMap_comp_tensorMap`, `tensorPair_fst_snd`).
- Polynomial product `*`: `prodMap` (`×c`), `prodMap_id`,
  `prodMap_comp_prodMap` (no natural projections, by design — that's a
  lens-side property, called out in the docstring).
- Indexed: `sigmaExists`, `sigmaMap`, `piMap`. Documents why `piForall` /
  `sigmaForall` are absent on charts.
- Misc: `enclose` (chart from `P` to `X`), `Equiv.ulift`.
- `initial` and `terminal` objects (`X` is the terminal object for
  charts).
- New infix notations `⊎c`, `⊗c`, `×c`, `[_,_]c`, `⟨_,_⟩c`.

**Equivalences (`Chart.Equiv`):**

- Coproduct: `sumComm`, `sumAssoc`, `sumZero`, `zeroSum`, `sumCongr`.
- Tensor: `tensorComm`, `tensorAssoc`, `tensorX`, `xTensor`, `zeroTensor`,
  `tensorZero`, `tensorCongr`, `tensorSumDistrib`, `sumTensorDistrib`.
- Polynomial product: `prodCongr`, `prodComm`, `prodAssoc`, `prodZero`,
  `zeroProd`, `prodSumDistrib`, `sumProdDistrib`.
- Sigma: `sigmaEmpty`, `sigmaUnit`, `sigmaOfUnique`, `prodSigmaDistrib`,
  `sigmaProdDistrib`, `tensorSigmaDistrib`, `sigmaTensorDistrib` — all
  derived through `toChartEquiv` from their `PFunctor.Equiv` counterparts.
- Pi: `piUnit`, `piZero` (no `piForall` since chart-side Pi-elimination
  requires direction-contravariance).

The module docstring documents the categorical differences from `Lens` in
a comparison table, so downstream readers can see at a glance which
operations are intrinsically lens-side.

### `VCVio/Interaction/UC/Interface.lean` (cleanup)

- Drops the local `private theorem chart_comp_symm_eq_id` /
  `chart_comp_inv_eq_id` helpers and the `eqRec_id_apply_codomain`
  cast-helper. `symm_toHom_comp_toHom` / `toHom_comp_symm_toHom` now call
  the new `PFunctor.Equiv.symm_toChart_comp_toChart` /
  `toChart_comp_symm_toChart` directly.
- `Hom.mapPacket` becomes an `abbrev` over `PFunctor.Chart.mapIdx`, and
  `mapPacket_id` / `mapPacket_comp` are one-line corollaries of
  `Chart.mapIdx_id` / `Chart.mapIdx_comp`.

Net `−74 / +0` lines on this file (no API surface change).

### Why this matters (forward-looking)

The synthesis memo §0.7 identifies that

- `QueryLog spec` is definitionally `List ((t : spec.Domain) × spec.Range t)`
  = `FreeMonoid (Idx spec.toPFunctor)` = `TraceList spec.toPFunctor`,
- `QueryCount ι` is `ι → ℕ` with the additive monoid,
- `QueryImpl.withCost` is already parameterised by `[Monoid ω]`,
- `BoundaryAction.emit` is morally `X → List (Idx Δ.Out)` =
  `PFunctor.Trace Δ.Out X`,

all of which fit into one shared abstraction. The Chart API expansion is
needed alongside Trace because the cutover for `BoundaryAction` and
`OpenNodeContext` (PR-T2) will refactor several hand-rolled chart-style
operations into one-liners over the new Chart API.

PR-T2 will land the cutover: collapse the seven hand-rolled
`BoundaryAction` operations into one-liners over `PFunctor.Trace`,
redefine `QueryLog` / `QueryCount` as `Trace` instances, and introduce
`QueryImpl.withTrace` / `withTraceBefore` as the primitive base for
`withCost` and `withLogging`.

### Verification

- ✅ `lake build` clean for the full project (3570 jobs, only the
  unrelated pre-existing `sorry` warning in
  `FiatShamir/Sigma/Security.lean`).
- ✅ `bash scripts/lint-style.sh` clean for all touched files.
- ✅ Axiom check: every new declaration depends only on `propext`,
  `Classical.choice`, `Quot.sound`. No project-specific axioms.

## Test plan

- [x] `lake build ToMathlib.Control.Trace`
- [x] `lake build ToMathlib.PFunctor.Trace`
- [x] `lake build ToMathlib.PFunctor.Chart.Basic`
- [x] `lake build VCVio.Interaction.UC.Interface`
- [x] `lake build` (whole project)
- [x] Style lint: no violations on touched files
- [x] Axiom check: only `propext`, `Classical.choice`, `Quot.sound`

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)