### PR TITLE
feat(uc, query-tracking): unify trace bookkeeping under PFunctor.Trace and WriterT-Trace primitives (PR-T2)

### DIFF
--- a/ToMathlib/Control/Trace.lean
+++ b/ToMathlib/Control/Trace.lean
@@ -28,6 +28,8 @@ Many bookkeeping / observation patterns share this exact shape:
                                  pointwise addition,
 * `QueryCache spec`           — `ω = (t : spec.Domain) → Option (spec.Range t)`
                                  with at-most-once write semigroup,
+* `BoundaryAction.emit`       — `ω = TraceList Δ.Out` (the polynomial-trace
+                                 specialisation in `PFunctor/Trace.lean`),
 * abstract cost functions     — `ω` any commutative monoid (e.g. `ℝ≥0`).
 
 The monoid axioms are exactly what is needed to turn "one contribution per

--- a/ToMathlib/PFunctor/Trace.lean
+++ b/ToMathlib/PFunctor/Trace.lean
@@ -38,6 +38,14 @@ shape of a stateless effectful Mealy machine in the `List`-Writer Kleisli
 category.  Stateful executors (e.g. running over an `OracleComp`) are handled
 separately in `VCVio/OracleComp/QueryTracking/`.
 
+The canonical user inside this repository is `BoundaryAction.emit` in
+`VCVio/Interaction/UC/OpenProcess.lean`, where `Trace Δ.Out X` records the
+list of output-port packets a node emits when the local state transitions
+to `x : X`. Operations such as `mapBoundary`, `wireLeft`, `wireRight`, and
+the tensor embeddings of open processes are implemented directly by
+`PFunctor.Trace.mapChart` and `PFunctor.Trace.mapPartial` against
+appropriate boundary morphisms.
+
 
 ## References
 
@@ -138,6 +146,18 @@ theorem mapPartial_comp (g : Idx Q → Option (Idx R))
       (mapPartial (fun i => some (Chart.mapIdx f i)) t)
   rw [mapPartial_comp]
   rfl
+
+/-! ### Trivial-trace lemmas
+
+The unit trace `1 : Trace P X = fun _ => []` is annihilated by all relabel /
+filter operations.  These are needed downstream to reason about
+boundary actions whose default emission is the empty trace. -/
+
+@[simp] theorem mapPartial_one (f : Idx P → Option (Idx Q)) :
+    mapPartial f (1 : Trace P X) = 1 := rfl
+
+@[simp] theorem mapChart_one (φ : Chart P Q) :
+    mapChart φ (1 : Trace P X) = 1 := rfl
 
 /-! ### Naturality of `toMonoid`
 

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -162,6 +162,7 @@ import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
 import VCVio.OracleComp.QueryTracking.ResourceProfile
 import VCVio.OracleComp.QueryTracking.SeededOracle
 import VCVio.OracleComp.QueryTracking.Structures
+import VCVio.OracleComp.QueryTracking.Tracing
 import VCVio.OracleComp.QueryTracking.Unpredictability
 import VCVio.OracleComp.RunIO
 import VCVio.OracleComp.SimSemantics.Append

--- a/VCVio/Interaction/UC/OpenProcess.lean
+++ b/VCVio/Interaction/UC/OpenProcess.lean
@@ -3,6 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+import ToMathlib.PFunctor.Trace
 import VCVio.Interaction.Concurrent.Process
 import VCVio.Interaction.UC.Interface
 
@@ -38,6 +39,14 @@ Boundary actions are structurally mappable along `PortBoundary.Hom` via
 boundary adaptation (only `emit` transforms), which ensures functoriality.
 The query-level decoding of how input messages determine node moves belongs
 in the runtime/execution layer, not the structural boundary action.
+
+The `emit` field is presented as a `PFunctor.Trace Δ.Out X` (the free-monoid
+trace on `Δ.Out`-events indexed by the node's move space `X`). This makes the
+structural boundary operations land directly in the generic `Trace` API:
+`mapBoundary` is `Trace.mapChart` on the output chart, and `wireLeft` /
+`wireRight` are `Trace.mapPartial` on the appropriate sum projections. The
+empty-emission default is the trace-monoid unit `1`, which is definitionally
+the constant-`[]` trace.
 -/
 
 universe u v w
@@ -55,8 +64,10 @@ Fields:
 
 * `isActivated` flags whether this node is driven by external boundary
   input (`true`) or by the internal protocol dynamics (`false`).
-* `emit` maps each chosen move to the list of outbound packets it
-  contributes on `Δ.Out`.
+* `emit` is the `PFunctor.Trace Δ.Out X` recording, for each chosen move
+  `x : X`, the finite ordered list of outbound packets contributed on
+  `Δ.Out`. The default is the monoid unit `1`, which is definitionally
+  the constant-`[]` trace.
 
 The activation flag is a structural marker. The query-level information
 about *how* an input message determines the node's move belongs in the
@@ -70,7 +81,7 @@ concerns (buffering, duplication, scheduling, delivery) belong in a separate
 -/
 structure BoundaryAction (Δ : PortBoundary) (X : Type w) where
   isActivated : Bool := false
-  emit : X → List (Interface.Packet Δ.Out) := fun _ => []
+  emit : PFunctor.Trace Δ.Out X := 1
 
 namespace BoundaryAction
 
@@ -79,7 +90,7 @@ A purely internal node: not externally activated and no outbound packets.
 -/
 def internal (Δ : PortBoundary) (X : Type w) : BoundaryAction Δ X where
   isActivated := false
-  emit := fun _ => []
+  emit := 1
 
 /--
 A boundary-activated node that emits no outbound packets.
@@ -91,27 +102,27 @@ def activated (Δ : PortBoundary) (X : Type w) : BoundaryAction Δ X where
 An internally driven node that emits outbound packets.
 -/
 def outputOnly {Δ : PortBoundary} {X : Type w}
-    (e : X → List (Interface.Packet Δ.Out)) : BoundaryAction Δ X where
+    (e : PFunctor.Trace Δ.Out X) : BoundaryAction Δ X where
   emit := e
 
 /--
 Transform a boundary action along a boundary adaptation.
 
 The activation flag is preserved (it does not depend on the boundary
-presentation). The emitted packets are translated forward along
-`φ.onOut`.
+presentation). The emitted-trace is pushed forward along the output chart
+`φ.onOut` via `PFunctor.Trace.mapChart`.
 -/
 def mapBoundary {Δ₁ Δ₂ : PortBoundary} {X : Type w}
     (φ : PortBoundary.Hom Δ₁ Δ₂) (b : BoundaryAction Δ₁ X) :
     BoundaryAction Δ₂ X where
   isActivated := b.isActivated
-  emit x := (b.emit x).map (Interface.Hom.mapPacket φ.onOut)
+  emit := PFunctor.Trace.mapChart φ.onOut b.emit
 
 @[simp]
 theorem mapBoundary_id {Δ : PortBoundary} {X : Type w}
     (b : BoundaryAction Δ X) :
     mapBoundary (PortBoundary.Hom.id Δ) b = b := by
-  simp [mapBoundary, PortBoundary.Hom.id, Interface.Hom.mapPacket_id]
+  simp [mapBoundary, PortBoundary.Hom.id, Interface.Hom.id]
 
 @[simp]
 theorem mapBoundary_comp {Δ₁ Δ₂ Δ₃ : PortBoundary} {X : Type w}
@@ -119,72 +130,88 @@ theorem mapBoundary_comp {Δ₁ Δ₂ Δ₃ : PortBoundary} {X : Type w}
     (b : BoundaryAction Δ₁ X) :
     mapBoundary g (mapBoundary f b) =
       mapBoundary (PortBoundary.Hom.comp g f) b := by
-  simp [mapBoundary, PortBoundary.Hom.comp, List.map_map,
-    Interface.Hom.mapPacket_comp]
+  simp [mapBoundary, PortBoundary.Hom.comp, Interface.Hom.comp,
+    PFunctor.Trace.mapChart_comp]
 
 /--
 Embed a boundary action on the left factor into the tensor boundary.
 
-Emitted packets are injected into the left summand of the combined output
-interface. The activation flag is preserved.
+The trace is pushed forward along the left-injection chart
+`Interface.Hom.inl Δ₁.Out Δ₂.Out` via `PFunctor.Trace.mapChart`. The
+activation flag is preserved.
 -/
 def embedInlTensor {Δ₁ : PortBoundary} (Δ₂ : PortBoundary) {X : Type w}
     (b : BoundaryAction Δ₁ X) :
     BoundaryAction (PortBoundary.tensor Δ₁ Δ₂) X where
   isActivated := b.isActivated
-  emit x := (b.emit x).map (Interface.Hom.mapPacket (Interface.Hom.inl Δ₁.Out Δ₂.Out))
+  emit := PFunctor.Trace.mapChart (Interface.Hom.inl Δ₁.Out Δ₂.Out) b.emit
 
 /--
 Embed a boundary action on the right factor into the tensor boundary.
 
-Emitted packets are injected into the right summand of the combined output
-interface. The activation flag is preserved.
+The trace is pushed forward along the right-injection chart
+`Interface.Hom.inr Δ₁.Out Δ₂.Out` via `PFunctor.Trace.mapChart`. The
+activation flag is preserved.
 -/
 def embedInrTensor (Δ₁ : PortBoundary) {Δ₂ : PortBoundary} {X : Type w}
     (b : BoundaryAction Δ₂ X) :
     BoundaryAction (PortBoundary.tensor Δ₁ Δ₂) X where
   isActivated := b.isActivated
-  emit x := (b.emit x).map (Interface.Hom.mapPacket (Interface.Hom.inr Δ₁.Out Δ₂.Out))
+  emit := PFunctor.Trace.mapChart (Interface.Hom.inr Δ₁.Out Δ₂.Out) b.emit
 
 /--
 Transform a boundary action on `tensor Δ₁ Γ` into one on `tensor Δ₁ Δ₂`
 by keeping only the left-summand (Δ₁) packets and re-injecting them
 into the left summand of the combined output. Right-summand (Γ) packets
 are dropped (they become internal traffic handled by the runtime).
+
+Implemented as `PFunctor.Trace.mapPartial` on the appropriate index-level
+partial map.
 -/
 def wireLeft {Δ₁ Γ : PortBoundary} (Δ₂ : PortBoundary) {X : Type w}
     (b : BoundaryAction (PortBoundary.tensor Δ₁ Γ) X) :
     BoundaryAction (PortBoundary.tensor Δ₁ Δ₂) X where
   isActivated := b.isActivated
-  emit x := (b.emit x).filterMap fun
-    | ⟨Sum.inl a₁, m⟩ => some ⟨Sum.inl a₁, m⟩
-    | ⟨Sum.inr _, _⟩ => none
+  emit := PFunctor.Trace.mapPartial
+    (P := (PortBoundary.tensor Δ₁ Γ).Out)
+    (Q := (PortBoundary.tensor Δ₁ Δ₂).Out)
+    (fun
+      | ⟨Sum.inl a₁, m⟩ => some ⟨Sum.inl a₁, m⟩
+      | ⟨Sum.inr _, _⟩ => none) b.emit
 
 /--
 Transform a boundary action on `tensor (swap Γ) Δ₂` into one on
 `tensor Δ₁ Δ₂` by keeping only the right-summand (Δ₂) packets and
 re-injecting them into the right summand of the combined output.
 Left-summand (swap Γ) packets are dropped (internal traffic).
+
+Implemented as `PFunctor.Trace.mapPartial` on the appropriate index-level
+partial map.
 -/
 def wireRight (Δ₁ : PortBoundary) {Γ Δ₂ : PortBoundary} {X : Type w}
     (b : BoundaryAction (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂) X) :
     BoundaryAction (PortBoundary.tensor Δ₁ Δ₂) X where
   isActivated := b.isActivated
-  emit x := (b.emit x).filterMap fun
-    | ⟨Sum.inl _, _⟩ => none
-    | ⟨Sum.inr a₂, m⟩ => some ⟨Sum.inr a₂, m⟩
+  emit := PFunctor.Trace.mapPartial
+    (P := (PortBoundary.tensor (PortBoundary.swap Γ) Δ₂).Out)
+    (Q := (PortBoundary.tensor Δ₁ Δ₂).Out)
+    (fun
+      | ⟨Sum.inl _, _⟩ => none
+      | ⟨Sum.inr a₂, m⟩ => some ⟨Sum.inr a₂, m⟩) b.emit
 
 /--
 Close a boundary action by dropping all external traffic.
 
 The result lives on `PortBoundary.empty` and has no activation or emission.
-This is used by `plug` to internalize all boundary interactions.
+This is used by `plug` to internalize all boundary interactions. The
+emitted-trace is the monoid unit `1`, which is definitionally the constant-`[]`
+trace.
 -/
 def closed {Δ : PortBoundary} {X : Type w}
     (b : BoundaryAction Δ X) :
     BoundaryAction PortBoundary.empty X where
   isActivated := b.isActivated
-  emit _ := []
+  emit := 1
 
 @[simp]
 theorem mapBoundary_embedInlTensor
@@ -193,8 +220,11 @@ theorem mapBoundary_embedInlTensor
     (b : BoundaryAction Δ₁ X) :
     (b.embedInlTensor Δ₂).mapBoundary (PortBoundary.Hom.tensor f₁ f₂) =
       (b.mapBoundary f₁).embedInlTensor Δ₂' := by
-  simp only [mapBoundary, embedInlTensor, PortBoundary.Hom.tensor, List.map_map]
+  simp only [mapBoundary, embedInlTensor, PortBoundary.Hom.tensor]
   congr 1
+  rw [← PFunctor.Trace.mapChart_comp, ← PFunctor.Trace.mapChart_comp]
+  exact congrArg (PFunctor.Trace.mapChart · b.emit)
+    (Interface.Hom.comp_sum_inl f₁.onOut f₂.onOut)
 
 @[simp]
 theorem mapBoundary_embedInrTensor
@@ -203,16 +233,18 @@ theorem mapBoundary_embedInrTensor
     (b : BoundaryAction Δ₂ X) :
     (b.embedInrTensor Δ₁).mapBoundary (PortBoundary.Hom.tensor f₁ f₂) =
       (b.mapBoundary f₂).embedInrTensor Δ₁' := by
-  simp only [mapBoundary, embedInrTensor, PortBoundary.Hom.tensor, List.map_map]
+  simp only [mapBoundary, embedInrTensor, PortBoundary.Hom.tensor]
   congr 1
+  rw [← PFunctor.Trace.mapChart_comp, ← PFunctor.Trace.mapChart_comp]
+  exact congrArg (PFunctor.Trace.mapChart · b.emit)
+    (Interface.Hom.comp_sum_inr f₁.onOut f₂.onOut)
 
 @[simp]
 theorem closed_mapBoundary
     {Δ₁ Δ₂ : PortBoundary} {X : Type w}
     (φ : PortBoundary.Hom Δ₁ Δ₂)
     (b : BoundaryAction Δ₁ X) :
-    (b.mapBoundary φ).closed = b.closed := by
-  simp [closed, mapBoundary]
+    (b.mapBoundary φ).closed = b.closed := rfl
 
 @[simp]
 theorem mapBoundary_wireLeft
@@ -223,12 +255,13 @@ theorem mapBoundary_wireLeft
       (b.mapBoundary
         (PortBoundary.Hom.tensor f₁ (PortBoundary.Hom.id Γ))).wireLeft Δ₂' := by
   simp only [wireLeft, mapBoundary, PortBoundary.Hom.tensor, PortBoundary.Hom.id]
-  congr 1; funext x
-  rw [List.map_filterMap, List.filterMap_map]
-  congr 1; funext ⟨pkt_port, pkt_msg⟩
-  cases pkt_port with
-  | inl _ => dsimp [Interface.Hom.mapPacket, Interface.Hom.sum]; rfl
-  | inr _ => dsimp [Interface.Hom.mapPacket, Interface.Hom.sum]; rfl
+  congr 1
+  funext x
+  simp only [PFunctor.Trace.mapChart_apply, PFunctor.Trace.mapPartial_apply,
+    List.filterMap_filterMap]
+  congr 1
+  funext ⟨pkt_port, pkt_msg⟩
+  cases pkt_port <;> rfl
 
 @[simp]
 theorem mapBoundary_wireRight
@@ -240,12 +273,13 @@ theorem mapBoundary_wireRight
         (PortBoundary.Hom.tensor
           (PortBoundary.Hom.id (PortBoundary.swap Γ)) f₂)).wireRight Δ₁' := by
   simp only [wireRight, mapBoundary, PortBoundary.Hom.tensor, PortBoundary.Hom.id]
-  congr 1; funext x
-  rw [List.map_filterMap, List.filterMap_map]
-  congr 1; funext ⟨pkt_port, pkt_msg⟩
-  cases pkt_port with
-  | inl _ => dsimp [Interface.Hom.mapPacket, Interface.Hom.sum]; rfl
-  | inr _ => dsimp [Interface.Hom.mapPacket, Interface.Hom.sum]; rfl
+  congr 1
+  funext x
+  simp only [PFunctor.Trace.mapChart_apply, PFunctor.Trace.mapPartial_apply,
+    List.filterMap_filterMap]
+  congr 1
+  funext ⟨pkt_port, pkt_msg⟩
+  cases pkt_port <;> rfl
 
 end BoundaryAction
 

--- a/VCVio/OracleComp/QueryTracking/CountingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CountingOracle.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.OracleComp.QueryTracking.Structures
+import VCVio.OracleComp.QueryTracking.Tracing
 import VCVio.OracleComp.EvalDist
 
 /-!
@@ -15,6 +16,11 @@ counts, allowing each oracle to be tracked individually.
 
 Tracking individually is not necessary, but gives tighter security bounds in some cases.
 It also allows for generating things like seed values for a computation more tightly.
+
+`QueryImpl.withCost` and `QueryImpl.withCounting` are response-independent traces, defined as
+specialisations of `QueryImpl.withTraceBefore` (see `Tracing.lean`): the cost is accumulated
+*before* the underlying handler runs, so failed queries still incur their cost. The counting
+case picks `QueryCount.single` as the trace function.
 -/
 
 open OracleSpec OracleComp
@@ -33,7 +39,10 @@ variable {ω : Type u} [Monoid ω]
 
 /-- Wrap an oracle implementation to accumulate cost in a `WriterT ω` layer.
 The cost function `costFn` assigns a cost value to each oracle query.
-Cost is accumulated before the implementation runs, so failed queries are still costed.
+Cost is accumulated *before* the implementation runs, so failed queries are still costed.
+
+This is the response-independent specialisation of `QueryImpl.withTraceBefore`:
+the trace value depends only on the query, not on the response.
 
 **Side-channel trace instrumentation.**
 `withCost` doubles as automatic side-channel instrumentation: given any
@@ -51,7 +60,10 @@ query is visible." For observations at non-query points (e.g. pure-computation
 timing), use the explicit `observe` / `runObs` API from `ObservationOracle`. -/
 def withCost (so : QueryImpl spec m) (costFn : spec.Domain → ω) :
     QueryImpl spec (WriterT ω m) :=
-  fun t => do tell (costFn t); so t
+  so.withTraceBefore costFn
+
+lemma withCost_eq_withTraceBefore (so : QueryImpl spec m) (costFn : spec.Domain → ω) :
+    so.withCost costFn = so.withTraceBefore costFn := rfl
 
 @[simp, grind =]
 lemma withCost_apply (so : QueryImpl spec m) (costFn : spec.Domain → ω)
@@ -60,24 +72,20 @@ lemma withCost_apply (so : QueryImpl spec m) (costFn : spec.Domain → ω)
 
 lemma fst_map_run_withCost [LawfulMonad m]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
-    Prod.fst <$> (simulateQ (so.withCost costFn) mx).run = simulateQ so mx := by
-  induction mx using OracleComp.inductionOn with
-  | pure x => simp
-  | query_bind t oa h => simp [h]
+    Prod.fst <$> (simulateQ (so.withCost costFn) mx).run = simulateQ so mx :=
+  fst_map_run_withTraceBefore so costFn mx
 
 /-- Cost-tracking preserves failure probability: for any base monad `m` with `HasEvalSPMF`,
 wrapping an oracle implementation with `withCost` does not change the probability of failure. -/
 lemma probFailure_run_simulateQ_withCost [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
-    Pr[⊥ | (simulateQ (so.withCost costFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
-  rw [show Pr[⊥ | (simulateQ (so.withCost costFn) mx).run] =
-    Pr[⊥ | Prod.fst <$> (simulateQ (so.withCost costFn) mx).run] from
-    (probFailure_map _ _).symm, fst_map_run_withCost]
+    Pr[⊥ | (simulateQ (so.withCost costFn) mx).run] = Pr[⊥ | simulateQ so mx] :=
+  probFailure_run_simulateQ_withTraceBefore so costFn mx
 
 lemma NeverFail_run_simulateQ_withCost_iff [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
-    NeverFail (simulateQ (so.withCost costFn) mx).run ↔ NeverFail (simulateQ so mx) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withCost]
+    NeverFail (simulateQ (so.withCost costFn) mx).run ↔ NeverFail (simulateQ so mx) :=
+  NeverFail_run_simulateQ_withTraceBefore_iff so costFn mx
 
 /-- When every query costs the monoid identity `1`, the trace is always `1`,
 so `withCost` is a no-op up to pairing with `1`. -/
@@ -85,10 +93,8 @@ so `withCost` is a no-op up to pairing with `1`. -/
 lemma run_simulateQ_withCost_const_one [LawfulMonad m]
     (so : QueryImpl spec m) (mx : OracleComp spec α) :
     (simulateQ (so.withCost (fun _ => (1 : ω))) mx).run =
-      (·, 1) <$> simulateQ so mx := by
-  induction mx using OracleComp.inductionOn with
-  | pure x => simp
-  | query_bind t oa ih => simp [ih]
+      (·, 1) <$> simulateQ so mx :=
+  run_simulateQ_withTraceBefore_const_one so mx
 
 /-! ### EvalDist Bridge for `withCost`
 
@@ -100,19 +106,19 @@ lemma evalDist_fst_run_withCost [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
     evalDist (Prod.fst <$> (simulateQ (so.withCost costFn) mx).run) =
       evalDist (simulateQ so mx) :=
-  congrArg evalDist (fst_map_run_withCost so costFn mx)
+  evalDist_fst_run_withTraceBefore so costFn mx
 
 lemma probOutput_fst_run_withCost [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (so.withCost costFn) mx).run] =
-      Pr[= x | simulateQ so mx] := by
-  rw [fst_map_run_withCost]
+      Pr[= x | simulateQ so mx] :=
+  probOutput_fst_run_withTraceBefore so costFn mx x
 
 lemma support_fst_run_withCost [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (so.withCost costFn) mx).run) =
-      support (simulateQ so mx) := by
-  rw [fst_map_run_withCost]
+      support (simulateQ so mx) :=
+  support_fst_run_withTraceBefore so costFn mx
 
 end withCost
 

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -5,11 +5,23 @@ Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.QueryTracking.Structures
+import VCVio.OracleComp.QueryTracking.Tracing
 import ToMathlib.Control.WriterT
 
 /-!
 # Logging Queries Made by a Computation
 
+`QueryImpl.withLogging` records every query/response pair `⟨t, u⟩` to a
+`WriterT (QueryLog spec)` writer layer. It is a response-dependent trace,
+defined as a specialisation of `QueryImpl.withTraceAppend` (see
+`Tracing.lean`): the log is appended *after* the underlying handler returns,
+so a handler failure leaves no log entry for the failed query.
+
+We use the `Append`-flavoured `withTraceAppend` (rather than the `Monoid`
+flavoured `withTrace`) because `QueryLog spec = List _` only carries an
+`[EmptyCollection, Append, LawfulAppend]` structure, not a `Monoid`. This
+matches the pre-existing `Monad (WriterT (QueryLog spec) m)` instance the
+rest of `WriterTBridge` / `mvcgen` infrastructure already targets.
 -/
 
 universe u v w
@@ -24,9 +36,16 @@ variable {m : Type u → Type v} [Monad m]
 
 /-- Given that `so` implements the oracles in `spec` using the monad `m`,
 `withLogging so` gives the same implementation in the extension `WriterT (QueryLog spec) m`,
-by logging all the queries to the writer monad before forwarding the response. -/
+by appending a single-entry log `[⟨t, u⟩]` *after* the handler returns response `u`.
+
+This is the response-dependent specialisation of `QueryImpl.withTraceAppend` with the
+trace function `fun t u => [⟨t, u⟩]` (a single-element list, the free-monoid
+generator of `QueryLog spec = List ((t : spec.Domain) × spec.Range t)`). -/
 def withLogging (so : QueryImpl spec m) : QueryImpl spec (WriterT (QueryLog spec) m) :=
-  fun t : spec.Domain => do let u ← so t; tell [⟨t, u⟩]; return u
+  so.withTraceAppend (fun t u => [⟨t, u⟩])
+
+lemma withLogging_eq_withTraceAppend (so : QueryImpl spec m) :
+    so.withLogging = so.withTraceAppend (fun t u => [⟨t, u⟩]) := rfl
 
 @[simp, grind =]
 lemma withLogging_apply (so : QueryImpl spec m) (t : spec.Domain) :
@@ -34,10 +53,8 @@ lemma withLogging_apply (so : QueryImpl spec m) (t : spec.Domain) :
 
 lemma fst_map_run_withLogging [LawfulMonad m] (so : QueryImpl spec m) (mx : OracleComp spec α) :
     Prod.fst <$> (simulateQ (so.withLogging) mx).run =
-    simulateQ so mx := by
-  induction mx using OracleComp.inductionOn with
-  | pure x => simp
-  | query_bind t oa h => simp [h]
+    simulateQ so mx :=
+  fst_map_run_withTraceAppend so (fun (t : spec.Domain) u => ([⟨t, u⟩] : QueryLog spec)) mx
 
 /-- Logging preserves failure probability: for any base monad `m` with `HasEvalSPMF`,
 wrapping an oracle implementation with `withLogging` does not change the probability of failure.
@@ -45,15 +62,15 @@ When `m = OracleComp spec`, both sides are `0` (trivially true). When `m` can ge
 (e.g. `OptionT (OracleComp spec)`), this is a non-trivial faithfulness property. -/
 lemma probFailure_run_simulateQ_withLogging [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (mx : OracleComp spec α) :
-    Pr[⊥ | (simulateQ (so.withLogging) mx).run] = Pr[⊥ | simulateQ so mx] := by
-  rw [show Pr[⊥ | (simulateQ (so.withLogging) mx).run] =
-    Pr[⊥ | Prod.fst <$> (simulateQ (so.withLogging) mx).run] from
-    (probFailure_map _ _).symm, fst_map_run_withLogging]
+    Pr[⊥ | (simulateQ (so.withLogging) mx).run] = Pr[⊥ | simulateQ so mx] :=
+  probFailure_run_simulateQ_withTraceAppend so
+    (fun (t : spec.Domain) u => ([⟨t, u⟩] : QueryLog spec)) mx
 
 lemma NeverFail_run_simulateQ_withLogging_iff [LawfulMonad m] [HasEvalSPMF m]
     (so : QueryImpl spec m) (mx : OracleComp spec α) :
-    NeverFail (simulateQ (so.withLogging) mx).run ↔ NeverFail (simulateQ so mx) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withLogging]
+    NeverFail (simulateQ (so.withLogging) mx).run ↔ NeverFail (simulateQ so mx) :=
+  NeverFail_run_simulateQ_withTraceAppend_iff so
+    (fun (t : spec.Domain) u => ([⟨t, u⟩] : QueryLog spec)) mx
 
 end QueryImpl
 
@@ -124,7 +141,7 @@ lemma run_simulateQ_loggingOracle_query_bind
       (query t : OracleComp spec _) >>= fun u =>
         (fun p : α × QueryLog spec => (p.1, (⟨t, u⟩ : (i : spec.Domain) × spec.Range i) :: p.2))
           <$> (simulateQ loggingOracle (mx u)).run := by
-  simp [loggingOracle, QueryImpl.withLogging, OracleQuery.cont_query,
+  simp [loggingOracle, QueryImpl.withLogging_apply, OracleQuery.cont_query,
     Function.id_def]
 
 /-- `loggingOracle` preserves `IsTotalQueryBound`: the query structure of

--- a/VCVio/OracleComp/QueryTracking/Structures.lean
+++ b/VCVio/OracleComp/QueryTracking/Structures.lean
@@ -210,7 +210,13 @@ end QueryCache
 
 /-- Simple wrapper in order to introduce the `Monoid` structure for `countingOracle`.
 Marked as reducible and can generally be treated as just a function.
-`idx` gives the "index" for a given input -/
+`idx` gives the "index" for a given input.
+
+A `QueryCount ι` is a commutative monoid under pointwise addition; it is
+exactly the trace-monoid value type used by `QueryImpl.withCost`, which
+attaches a `WriterT (QueryCount ι) m` writer effect via the generic
+`QueryImpl.withTraceBefore` primitive in
+`VCVio/OracleComp/QueryTracking/Tracing.lean`. -/
 @[reducible] def QueryCount (ι : Type*) := ι → ℕ
 
 namespace QueryCount
@@ -252,11 +258,16 @@ end QueryCount
 keep track of query ordering between different oracles.
 
 A `QueryLog spec` is morally a free monoid on `Idx spec.toPFunctor`, with
-identity `[]` and product `(++)`. We do *not* declare a global
-`Monoid (QueryLog spec)` instance: doing so would conflict with the
-`[EmptyCollection ω] [Append ω] → Monad (WriterT ω M)` instance Mathlib
-already provides for `WriterT (QueryLog spec) M`, which the existing
-`WriterTBridge`/`mvcgen` proof infrastructure relies on. The
+identity `[]` and product `(++)`. By Mathlib reducibility this is exactly
+`FreeMonoid (Idx spec.toPFunctor) = TraceList spec.toPFunctor`, so a
+trace-valued boundary description such as `BoundaryAction.emit` (in
+`VCVio/Interaction/UC/OpenProcess.lean`) and a per-call `QueryLog`-valued
+writer share the same underlying free-monoid carrier.
+
+We do *not* declare a global `Monoid (QueryLog spec)` instance: doing so
+would conflict with the `[EmptyCollection ω] [Append ω] → Monad (WriterT ω M)`
+instance Mathlib already provides for `WriterT (QueryLog spec) M`, which the
+existing `WriterTBridge`/`mvcgen` proof infrastructure relies on. The
 `QueryImpl.withTrace`/`withLogging` API instead uses the Append-based
 `Monad (WriterT _ _)` directly via `QueryImpl.withTraceAppend`. -/
 @[reducible] def QueryLog (spec : OracleSpec.{u, v} ι) : Type (max u v) :=

--- a/VCVio/OracleComp/QueryTracking/Structures.lean
+++ b/VCVio/OracleComp/QueryTracking/Structures.lean
@@ -249,7 +249,16 @@ end QueryCount
 
 /-- Log of queries represented by a list of dependent product's tagging the oracle's index.
 `(t : spec.Domain) × (spec.Range t)` is slightly more restricted as it doesn't
-keep track of query ordering between different oracles. -/
+keep track of query ordering between different oracles.
+
+A `QueryLog spec` is morally a free monoid on `Idx spec.toPFunctor`, with
+identity `[]` and product `(++)`. We do *not* declare a global
+`Monoid (QueryLog spec)` instance: doing so would conflict with the
+`[EmptyCollection ω] [Append ω] → Monad (WriterT ω M)` instance Mathlib
+already provides for `WriterT (QueryLog spec) M`, which the existing
+`WriterTBridge`/`mvcgen` proof infrastructure relies on. The
+`QueryImpl.withTrace`/`withLogging` API instead uses the Append-based
+`Monad (WriterT _ _)` directly via `QueryImpl.withTraceAppend`. -/
 @[reducible] def QueryLog (spec : OracleSpec.{u, v} ι) : Type (max u v) :=
   List ((t : spec.Domain) × spec.Range t)
 

--- a/VCVio/OracleComp/QueryTracking/Tracing.lean
+++ b/VCVio/OracleComp/QueryTracking/Tracing.lean
@@ -1,0 +1,360 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.OracleComp.QueryTracking.Structures
+import VCVio.OracleComp.EvalDist
+import ToMathlib.Control.Trace
+import ToMathlib.Control.WriterT
+
+/-!
+# Generic Trace Instrumentation for Query Implementations
+
+Two primitive ways to attach a writer-valued trace to a `QueryImpl`. Each
+comes in two flavours, mirroring Mathlib's two `Monad (WriterT ω M)` instances:
+
+* `[Monoid ω]` flavour (`withTrace` / `withTraceBefore`): the trace lives in
+  an arbitrary monoid `ω` and accumulates via `1` and `*`. This is what
+  `QueryImpl.withCost` (`CountingOracle.lean`) uses, with `ω = QueryCount ι`
+  (pointwise additive monoid).
+
+* `[EmptyCollection ω] [Append ω]` flavour (`withTraceAppend` /
+  `withTraceAppendBefore`): the trace accumulates via `∅` and `++`, matching
+  the Append-based `Monad (WriterT ω m)` instance. This is what
+  `QueryImpl.withLogging` (`LoggingOracle.lean`) uses, with
+  `ω = QueryLog spec` (a list of query/response pairs).
+
+The two flavours are mathematically the same (a free monoid view vs. an
+append-list view), but they correspond to *different* `Monad (WriterT ω m)`
+instances and Lean's resolver picks whichever one is unambiguously available.
+We expose both so neither of `QueryCount`/`QueryLog` has to switch its
+underlying writer interpretation.
+
+For each flavour, "Before" emits `traceFn t` *before* running the handler
+(so a handler failure still records the trace), while the bare version emits
+`traceFn t u` *after* the handler returns response `u` (so a failure skips
+the trace).
+
+Concretely:
+
+* `withCost = withTraceBefore` (the cost ignores the response).
+* `withLogging so = withTraceAppend so (fun t u => [⟨t, u⟩])` (the log records
+  the response, hence "after" semantics).
+
+The generic lemmas (output marginal, failure probability, `NeverFail`
+equivalence, `evalDist` / `support` / `probOutput` bridges) flow downstream
+automatically.
+
+## Connection to `Control.Trace`
+
+The trace function `traceFn : (t : spec.Domain) → spec.Range t → ω` is a curried
+form of `Idx spec.toPFunctor → ω`, which is precisely
+`Control.Trace ω (Idx spec.toPFunctor)`. The `Tracing` API is therefore the
+oracle-level counterpart of the abstract `Control.Trace` / `PFunctor.Trace`
+infrastructure in `ToMathlib`.
+-/
+
+open OracleSpec OracleComp
+
+universe u v w
+
+variable {ι : Type u} {spec : OracleSpec ι} {α β γ : Type u}
+
+namespace QueryImpl
+
+variable {m : Type u → Type v} [Monad m]
+
+/-! ### `withTraceBefore`: response-independent trace, recorded before handler -/
+
+section withTraceBefore
+
+variable {ω : Type u} [Monoid ω]
+
+/-- Wrap an oracle implementation so that each query records `traceFn t` in
+the writer `ω` *before* running the handler. The trace value depends only on
+the query, so a failure inside the handler still leaves the trace recorded. -/
+def withTraceBefore (so : QueryImpl spec m) (traceFn : spec.Domain → ω) :
+    QueryImpl spec (WriterT ω m) :=
+  fun t => do tell (traceFn t); so t
+
+@[simp, grind =]
+lemma withTraceBefore_apply (so : QueryImpl spec m) (traceFn : spec.Domain → ω)
+    (t : spec.Domain) :
+    so.withTraceBefore traceFn t = (do tell (traceFn t); so t) := rfl
+
+lemma fst_map_run_withTraceBefore [LawfulMonad m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run = simulateQ so mx := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t oa h => simp [h]
+
+/-- A "before"-style trace preserves failure probability for any base monad with
+`HasEvalSPMF`: instrumenting with `withTraceBefore` does not change the
+probability of failure. -/
+lemma probFailure_run_simulateQ_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    Pr[⊥ | (simulateQ (so.withTraceBefore traceFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
+  rw [show Pr[⊥ | (simulateQ (so.withTraceBefore traceFn) mx).run] =
+    Pr[⊥ | Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run] from
+    (probFailure_map _ _).symm, fst_map_run_withTraceBefore]
+
+lemma NeverFail_run_simulateQ_withTraceBefore_iff [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    NeverFail (simulateQ (so.withTraceBefore traceFn) mx).run ↔ NeverFail (simulateQ so mx) := by
+  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTraceBefore]
+
+/-- When every query traces to the monoid identity `1`, `withTraceBefore` is a
+no-op up to pairing with `1`. -/
+@[simp]
+lemma run_simulateQ_withTraceBefore_const_one [LawfulMonad m]
+    (so : QueryImpl spec m) (mx : OracleComp spec α) :
+    (simulateQ (so.withTraceBefore (fun _ => (1 : ω))) mx).run =
+      (·, 1) <$> simulateQ so mx := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t oa ih => simp [ih]
+
+/-! #### `evalDist` / `probOutput` / `support` bridges for `withTraceBefore` -/
+
+lemma evalDist_fst_run_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    evalDist (Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run) =
+      evalDist (simulateQ so mx) :=
+  congrArg evalDist (fst_map_run_withTraceBefore so traceFn mx)
+
+lemma probOutput_fst_run_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) (x : α) :
+    Pr[= x | Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run] =
+      Pr[= x | simulateQ so mx] := by
+  rw [fst_map_run_withTraceBefore]
+
+lemma support_fst_run_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    support (Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run) =
+      support (simulateQ so mx) := by
+  rw [fst_map_run_withTraceBefore]
+
+end withTraceBefore
+
+/-! ### `withTrace`: response-dependent trace, recorded after handler -/
+
+section withTrace
+
+variable {ω : Type u} [Monoid ω]
+
+/-- Wrap an oracle implementation so that each query records
+`traceFn t u` in the writer `ω` *after* the handler returns response `u`.
+A handler failure skips the trace (the response never materialised). -/
+def withTrace (so : QueryImpl spec m)
+    (traceFn : (t : spec.Domain) → spec.Range t → ω) :
+    QueryImpl spec (WriterT ω m) :=
+  fun t => do let u ← so t; tell (traceFn t u); return u
+
+@[simp, grind =]
+lemma withTrace_apply (so : QueryImpl spec m)
+    (traceFn : (t : spec.Domain) → spec.Range t → ω) (t : spec.Domain) :
+    so.withTrace traceFn t = (do let u ← so t; tell (traceFn t u); return u) := rfl
+
+lemma fst_map_run_withTrace [LawfulMonad m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run = simulateQ so mx := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t oa h => simp [h]
+
+/-- An "after"-style trace preserves failure probability for any base monad with
+`HasEvalSPMF`: instrumenting with `withTrace` does not change the probability
+of failure. When `m = OracleComp spec`, both sides are `0` (trivially true);
+when `m` can genuinely fail (e.g. `OptionT (OracleComp spec)`), this is a
+non-trivial faithfulness property. -/
+lemma probFailure_run_simulateQ_withTrace [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    Pr[⊥ | (simulateQ (so.withTrace traceFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
+  rw [show Pr[⊥ | (simulateQ (so.withTrace traceFn) mx).run] =
+    Pr[⊥ | Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run] from
+    (probFailure_map _ _).symm, fst_map_run_withTrace]
+
+lemma NeverFail_run_simulateQ_withTrace_iff [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    NeverFail (simulateQ (so.withTrace traceFn) mx).run ↔ NeverFail (simulateQ so mx) := by
+  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTrace]
+
+/-- When every query/response pair traces to the monoid identity `1`,
+`withTrace` is a no-op up to pairing with `1`. -/
+@[simp]
+lemma run_simulateQ_withTrace_const_one [LawfulMonad m]
+    (so : QueryImpl spec m) (mx : OracleComp spec α) :
+    (simulateQ (so.withTrace (fun _ _ => (1 : ω))) mx).run =
+      (·, 1) <$> simulateQ so mx := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t oa ih => simp [ih]
+
+/-! #### `evalDist` / `probOutput` / `support` bridges for `withTrace` -/
+
+lemma evalDist_fst_run_withTrace [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    evalDist (Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run) =
+      evalDist (simulateQ so mx) :=
+  congrArg evalDist (fst_map_run_withTrace so traceFn mx)
+
+lemma probOutput_fst_run_withTrace [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) (x : α) :
+    Pr[= x | Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run] =
+      Pr[= x | simulateQ so mx] := by
+  rw [fst_map_run_withTrace]
+
+lemma support_fst_run_withTrace [LawfulMonad m] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    support (Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run) =
+      support (simulateQ so mx) := by
+  rw [fst_map_run_withTrace]
+
+end withTrace
+
+/-! ### `withTraceAppendBefore`: response-independent trace, recorded before
+handler, accumulating via `∅` / `++` -/
+
+section withTraceAppendBefore
+
+variable {ω : Type u} [EmptyCollection ω] [Append ω]
+
+/-- Append-flavoured analogue of `withTraceBefore`: each query records
+`traceFn t` in the writer `ω` *before* running the handler, and `WriterT`
+uses the `[EmptyCollection ω] [Append ω]` `Monad` instance (`tell` is a single
+push, `bind` concatenates with `++`). The trace value depends only on the
+query, so a failure inside the handler still leaves the trace recorded. -/
+def withTraceAppendBefore (so : QueryImpl spec m) (traceFn : spec.Domain → ω) :
+    QueryImpl spec (WriterT ω m) :=
+  fun t => do tell (traceFn t); so t
+
+@[simp, grind =]
+lemma withTraceAppendBefore_apply (so : QueryImpl spec m) (traceFn : spec.Domain → ω)
+    (t : spec.Domain) :
+    so.withTraceAppendBefore traceFn t = (do tell (traceFn t); so t) := rfl
+
+lemma fst_map_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run = simulateQ so mx := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t oa h => simp [h]
+
+lemma probFailure_run_simulateQ_withTraceAppendBefore [LawfulMonad m]
+    [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    Pr[⊥ | (simulateQ (so.withTraceAppendBefore traceFn) mx).run] =
+      Pr[⊥ | simulateQ so mx] := by
+  rw [show Pr[⊥ | (simulateQ (so.withTraceAppendBefore traceFn) mx).run] =
+    Pr[⊥ | Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run] from
+    (probFailure_map _ _).symm, fst_map_run_withTraceAppendBefore]
+
+lemma NeverFail_run_simulateQ_withTraceAppendBefore_iff [LawfulMonad m]
+    [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    NeverFail (simulateQ (so.withTraceAppendBefore traceFn) mx).run ↔
+      NeverFail (simulateQ so mx) := by
+  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTraceAppendBefore]
+
+/-! #### `evalDist` / `probOutput` / `support` bridges for `withTraceAppendBefore` -/
+
+lemma evalDist_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    evalDist (Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run) =
+      evalDist (simulateQ so mx) :=
+  congrArg evalDist (fst_map_run_withTraceAppendBefore so traceFn mx)
+
+lemma probOutput_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) (x : α) :
+    Pr[= x | Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run] =
+      Pr[= x | simulateQ so mx] := by
+  rw [fst_map_run_withTraceAppendBefore]
+
+lemma support_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
+    support (Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run) =
+      support (simulateQ so mx) := by
+  rw [fst_map_run_withTraceAppendBefore]
+
+end withTraceAppendBefore
+
+/-! ### `withTraceAppend`: response-dependent trace, recorded after handler,
+accumulating via `∅` / `++` -/
+
+section withTraceAppend
+
+variable {ω : Type u} [EmptyCollection ω] [Append ω]
+
+/-- Append-flavoured analogue of `withTrace`: each query records
+`traceFn t u` in the writer `ω` *after* the handler returns response `u`,
+using the `[EmptyCollection ω] [Append ω]` `Monad (WriterT ω m)` instance.
+A handler failure skips the trace (the response never materialised). -/
+def withTraceAppend (so : QueryImpl spec m)
+    (traceFn : (t : spec.Domain) → spec.Range t → ω) :
+    QueryImpl spec (WriterT ω m) :=
+  fun t => do let u ← so t; tell (traceFn t u); return u
+
+@[simp, grind =]
+lemma withTraceAppend_apply (so : QueryImpl spec m)
+    (traceFn : (t : spec.Domain) → spec.Range t → ω) (t : spec.Domain) :
+    so.withTraceAppend traceFn t = (do let u ← so t; tell (traceFn t u); return u) := rfl
+
+lemma fst_map_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run = simulateQ so mx := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t oa h => simp [h]
+
+lemma probFailure_run_simulateQ_withTraceAppend [LawfulMonad m]
+    [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    Pr[⊥ | (simulateQ (so.withTraceAppend traceFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
+  rw [show Pr[⊥ | (simulateQ (so.withTraceAppend traceFn) mx).run] =
+    Pr[⊥ | Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run] from
+    (probFailure_map _ _).symm, fst_map_run_withTraceAppend]
+
+lemma NeverFail_run_simulateQ_withTraceAppend_iff [LawfulMonad m]
+    [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    NeverFail (simulateQ (so.withTraceAppend traceFn) mx).run ↔
+      NeverFail (simulateQ so mx) := by
+  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTraceAppend]
+
+/-! #### `evalDist` / `probOutput` / `support` bridges for `withTraceAppend` -/
+
+lemma evalDist_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    evalDist (Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run) =
+      evalDist (simulateQ so mx) :=
+  congrArg evalDist (fst_map_run_withTraceAppend so traceFn mx)
+
+lemma probOutput_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) (x : α) :
+    Pr[= x | Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run] =
+      Pr[= x | simulateQ so mx] := by
+  rw [fst_map_run_withTraceAppend]
+
+lemma support_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+    (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
+    (mx : OracleComp spec α) :
+    support (Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run) =
+      support (simulateQ so mx) := by
+  rw [fst_map_run_withTraceAppend]
+
+end withTraceAppend
+
+end QueryImpl

--- a/VCVio/ProgramLogic/Unary/HandlerSpecs.lean
+++ b/VCVio/ProgramLogic/Unary/HandlerSpecs.lean
@@ -456,7 +456,7 @@ theorem loggingOracle_triple (t : spec.Domain) (log₀ : QueryLog spec) :
         WriterT (QueryLog spec) (OracleComp spec) (spec.Range t))
       (spred(fun log => ⌜log = log₀⌝))
       (⇓ v log' => ⌜log' = log₀ ++ [⟨t, v⟩]⌝) := by
-  unfold loggingOracle QueryImpl.withLogging QueryImpl.ofLift
+  unfold loggingOracle QueryImpl.withLogging QueryImpl.withTraceAppend QueryImpl.ofLift
   mvcgen
   rename_i s _ heq
   subst heq
@@ -473,7 +473,7 @@ theorem loggingOracle_triple_prefix (t : spec.Domain) (log₀ : QueryLog spec) :
         WriterT (QueryLog spec) (OracleComp spec) (spec.Range t))
       (spred(fun log => ⌜log = log₀⌝))
       (⇓ _ log' => ⌜log₀ <+: log'⌝) := by
-  unfold loggingOracle QueryImpl.withLogging QueryImpl.ofLift
+  unfold loggingOracle QueryImpl.withLogging QueryImpl.withTraceAppend QueryImpl.ofLift
   mvcgen
   rename_i s _ heq
   subst heq


### PR DESCRIPTION
Stacked on top of #321 (`PR-T1`, trace foundations, already merged). This PR
("`PR-T2`") performs the cutover to the new abstractions inside core VCVio.

## Summary

* **Generic trace instrumentation for `QueryImpl`**
  (`VCVio/OracleComp/QueryTracking/Tracing.lean`, new). Four primitives
  mirroring Mathlib's two `Monad (WriterT ω M)` instances:
  * `[Monoid ω]` flavour: `withTrace` / `withTraceBefore` (used by
    `withCost`, `ω = QueryCount ι`).
  * `[EmptyCollection ω] [Append ω]` flavour: `withTraceAppend` /
    `withTraceAppendBefore` (used by `withLogging`,
    `ω = QueryLog spec = List _`).
  Each flavour comes in "before" (failure-resilient) and bare (failure-
  skipping) variants. Generic lemmas for `fst_map_run`, `probFailure`,
  `NeverFail`, and `evalDist` / `support` / `probOutput` bridges.

* **`withCost` and `withLogging` become `rfl`-thin specialisations** of the
  generic primitives (no semantic change), with a `Monoid` design note on
  `QueryLog` explaining why we keep the Append-flavoured `WriterT` instance
  rather than promoting `QueryLog` to a `Monoid` (the latter would shadow
  the existing `mvcgen` / `WriterTBridge` proof infrastructure).

* **`BoundaryAction.emit` over `PFunctor.Trace`**
  (`VCVio/Interaction/UC/OpenProcess.lean`). The boundary-emit field moves
  from `X → List (Interface.Packet Δ.Out)` to the equivalent
  `PFunctor.Trace Δ.Out X = X → FreeMonoid (Idx Δ.Out)`. All structural
  boundary operations are now expressed directly in the generic `Trace`
  API:
  * `internal` / `outputOnly` / `closed` use the monoid unit `1`.
  * `mapBoundary` is `Trace.mapChart φ.onOut`.
  * `embedInlTensor` / `embedInrTensor` are `Trace.mapChart` along the
    sum-injection charts.
  * `wireLeft` / `wireRight` are `Trace.mapPartial` along the appropriate
    index-level partial maps.

  Associated `@[simp]` lemmas (`mapBoundary_id`, `mapBoundary_comp`,
  `mapBoundary_embedInlTensor`, `mapBoundary_embedInrTensor`,
  `closed_mapBoundary`, `mapBoundary_wireLeft`, `mapBoundary_wireRight`)
  are reformulated against `mapChart_comp`, `mapPartial_comp`, and the
  new `mapChart_one` / `mapPartial_one` lemmas (added to
  `ToMathlib/PFunctor/Trace.lean` because the unit trace is now `1`, not
  the literal `fun _ => []`).

* **Cross-references**. `ToMathlib/Control/Trace.lean`,
  `ToMathlib/PFunctor/Trace.lean`, and
  `VCVio/OracleComp/QueryTracking/Structures.lean` now point at each other
  so that `QueryLog`, `QueryCount`, and `BoundaryAction.emit` are
  presented as the canonical users of the trace stack.

## Verification

* `lake build` clean (3573 jobs). All warnings are pre-existing `sorry`
  declarations unrelated to this PR.
* `./scripts/lint-style.sh`: no new violations on the touched files
  (`Tracing.lean`, `Structures.lean`, `OpenProcess.lean`, `PFunctor/Trace.lean`,
  `Control/Trace.lean`, `CountingOracle.lean`, `LoggingOracle.lean`,
  `HandlerSpecs.lean`).
* `#print axioms` on the new public surface:
  `withTrace*` / `withTraceAppend*` and
  `BoundaryAction.{mapBoundary, wireLeft, wireRight}` use **no axioms**.
  `mapPartial_one` / `mapChart_one` use only `propext` and `Quot.sound`
  (Lean 4 standard).

## Files

```
ToMathlib/Control/Trace.lean                       |   2 +
ToMathlib/PFunctor/Trace.lean                      |  20 ++
VCVio.lean                                         |   1 +
VCVio/Interaction/UC/OpenProcess.lean              | 116 +++---
VCVio/OracleComp/QueryTracking/CountingOracle.lean |  48 +--
VCVio/OracleComp/QueryTracking/LoggingOracle.lean  |  43 +-
VCVio/OracleComp/QueryTracking/Structures.lean     |  24 +-
VCVio/OracleComp/QueryTracking/Tracing.lean        | 360 +++++++
VCVio/ProgramLogic/Unary/HandlerSpecs.lean         |   4 +-
9 files changed, 539 insertions(+), 79 deletions(-)
```

---
Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user
(Quang Dao) with approval.

Made with [Cursor](https://cursor.com)