### PR TITLE
feat(program-logic): add selective bad-flag TV bounds

### DIFF
--- a/VCVio/OracleComp/QueryTracking/QueryBound.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryBound.lean
@@ -117,6 +117,36 @@ lemma isQueryBound_congr
     oa.IsQueryBound b canQuery₁ cost₁ ↔ oa.IsQueryBound b canQuery₂ cost₂ :=
   isQueryBound_congr_aux oa canQuery₁ canQuery₂ cost₁ cost₂ hcan hcost
 
+/-- Project an `IsQueryBound` along a budget projection `proj : B → B'`.
+
+If the source bound at budget `b` validates queries at every step, the projected
+bound at `proj b` is also validated, provided:
+* `h_can`  — whenever a step is allowed in the source (`canQuery t b'`), it is
+  allowed in the projection (`canQuery' t (proj b')`);
+* `h_cost` — the projection commutes with the cost step on the allowed branch
+  (`proj (cost t b') = cost' t (proj b')`).
+
+Typical use: extract a single-coordinate query bound (e.g. `qS`-only) from a
+multi-coordinate bound (e.g. `(qS, qH)` from `signHashQueryBound`) by setting
+`proj := Prod.fst`. -/
+lemma IsQueryBound.proj
+    {B' : Type*} (proj : B → B')
+    {oa : OracleComp spec α} {b : B}
+    {canQuery : ι → B → Prop} {cost : ι → B → B}
+    {canQuery' : ι → B' → Prop} {cost' : ι → B' → B'}
+    (h_can : ∀ (t : ι) (b' : B), canQuery t b' → canQuery' t (proj b'))
+    (h_cost : ∀ (t : ι) (b' : B), canQuery t b' → proj (cost t b') = cost' t (proj b'))
+    (h : IsQueryBound oa b canQuery cost) :
+    IsQueryBound oa (proj b) canQuery' cost' := by
+  induction oa using OracleComp.inductionOn generalizing b with
+  | pure x => simp
+  | query_bind t mx ih =>
+      rw [isQueryBound_query_bind_iff] at h ⊢
+      refine ⟨h_can t b h.1, fun u => ?_⟩
+      have hu : IsQueryBound (mx u) (proj (cost t b)) canQuery' cost' :=
+        ih u (h.2 u)
+      rwa [h_cost t b h.1] at hu
+
 /-- Transfer a structural query bound through `simulateQ` into a stateful target semantics,
 provided each simulated source query has a target-side step bound and the target-side bind
 rule composes those step budgets with the recursive continuation budget. -/

--- a/VCVio/OracleComp/SimSemantics/StateT.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT.lean
@@ -40,6 +40,45 @@ def piStateT {τ : Type} [DecidableEq τ] {ι : τ → Type _}
     QueryImpl (OracleSpec.sigma spec) (StateT ((t : τ) → σ t) m)
   | ⟨t, q⟩ => StateT.mk fun s => Prod.map id (Function.update s t) <$> (impl t q).run (s t)
 
+/-- Lift a stateful query implementation to a `(state × Bool)`-stateful version that threads
+the boolean (bad) flag unchanged. The output value and updated state come from the
+underlying `impl`; the second `Bool` component is preserved verbatim across each query. -/
+def withBadFlag {ι : Type _} {spec : OracleSpec ι}
+    {m : Type _ → Type _} [Functor m] {σ : Type _}
+    (impl : QueryImpl spec (StateT σ m)) :
+    QueryImpl spec (StateT (σ × Bool) m) := fun t =>
+  StateT.mk fun | (s, b) => Prod.map id (·, b) <$> (impl t).run s
+
+/-- Lift a stateful query implementation to a `(state × Bool)`-stateful version that OR-updates
+the boolean (bad) flag with a predicate `f` evaluated on the pre-state and produced output.
+The flag is monotone: if it was already `true`, it stays `true`. -/
+def withBadUpdate {ι : Type _} {spec : OracleSpec ι}
+    {m : Type _ → Type _} [Functor m] {σ : Type _}
+    (impl : QueryImpl spec (StateT σ m))
+    (f : (t : spec.Domain) → σ → spec.Range t → Bool) :
+    QueryImpl spec (StateT (σ × Bool) m) := fun t =>
+  StateT.mk fun | (s, b) => (fun (vs : spec.Range t × σ) => (vs.1, vs.2, b || f t s vs.1)) <$>
+    (impl t).run s
+
+/-- Run-shape of `withBadFlag`: the lifted implementation maps the underlying run by tagging
+each `(value, state)` pair with the unchanged bad flag `b`. -/
+@[simp] lemma withBadFlag_apply_run {ι : Type _} {spec : OracleSpec ι}
+    {m : Type _ → Type _} [Functor m] {σ : Type _}
+    (impl : QueryImpl spec (StateT σ m)) (t : spec.Domain) (s : σ) (b : Bool) :
+    (impl.withBadFlag t).run (s, b) =
+      (fun (vs : spec.Range t × σ) => (vs.1, vs.2, b)) <$> (impl t).run s := rfl
+
+/-- Run-shape of `withBadUpdate`: the lifted implementation maps the underlying run by
+appending the OR-updated bad flag `b || f t s vs.1`. -/
+@[simp] lemma withBadUpdate_apply_run {ι : Type _} {spec : OracleSpec ι}
+    {m : Type _ → Type _} [Functor m] {σ : Type _}
+    (impl : QueryImpl spec (StateT σ m))
+    (f : (t : spec.Domain) → σ → spec.Range t → Bool)
+    (t : spec.Domain) (s : σ) (b : Bool) :
+    (impl.withBadUpdate f t).run (s, b) =
+      (fun (vs : spec.Range t × σ) =>
+        (vs.1, vs.2, b || f t s vs.1)) <$> (impl t).run s := rfl
+
 end QueryImpl
 
 namespace OracleComp

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -885,4 +885,515 @@ theorem identical_until_bad_with_flag
           (simulateQ impl₁ oa).run (s₀, false)].toReal :=
   tvDist_simulateQ_le_probEvent_output_bad impl₁ impl₂ oa s₀ h_agree_good h_mono₁ h_mono₂
 
+/-! ## ε-perturbed "identical until bad" with output bad flag
+
+These lemmas generalize `tvDist_simulateQ_le_probEvent_output_bad` from EXACT agreement on
+the no-bad path to ε-CLOSE agreement: the per-step TV distance between the two oracle
+implementations may be at most `ε` (instead of zero) on the no-bad path. Combined with a
+query bound `q` on the computation, the total bound becomes `q*ε + Pr[bad]`.
+
+The standard "identical until bad" bound (`Pr[bad]`) is recovered as the special case `ε = 0`.
+
+**Application**: HVZK simulation in Fiat-Shamir, where the simulated transcript is only
+`ε`-close to the real transcript per query (not exactly equal), but a "programming
+collision" event captures the catastrophic failure mode (collision between programmed hash
+entries). The total reduction loss is `qS·ε + Pr[collision]`. -/
+
+section IdenticalUntilBadEpsilon
+
+variable {ι : Type} {spec : OracleSpec ι}
+variable {ι' : Type} {spec' : OracleSpec ι'} [spec'.Fintype] [spec'.Inhabited]
+variable {α : Type} {σ : Type}
+
+omit [spec'.Fintype] [spec'.Inhabited] in
+/-- "Bad propagation": starting from a bad state, every output of the simulation has the
+bad flag set. This generalizes the per-step `h_mono` hypothesis to the full simulation. -/
+private lemma mem_support_simulateQ_run_of_bad
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (h_mono : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (p : σ × Bool) (hp : p.2 = true) :
+    ∀ z ∈ support ((simulateQ impl oa).run p), z.2.2 = true := by
+  induction oa using OracleComp.inductionOn generalizing p with
+  | pure x =>
+      intro z hz
+      simp only [simulateQ_pure, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hz
+      subst hz
+      exact hp
+  | query_bind t cont ih =>
+      intro z hz
+      simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+        OracleQuery.cont_query, id_map, StateT.run_bind, support_bind, Set.mem_iUnion,
+        exists_prop] at hz
+      obtain ⟨⟨u, p'⟩, h_mem, h_z⟩ := hz
+      have hp' : p'.2 = true := h_mono t p hp (u, p') h_mem
+      exact ih u p' hp' z h_z
+
+/-- Under bad-monotonicity, a simulation started from a bad state has bad output probability
+exactly `1` (using `OracleComp.HasEvalPMF` to ensure no failure mass). -/
+private lemma probEvent_simulateQ_run_bad_eq_one_of_bad
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (h_mono : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (p : σ × Bool) (hp : p.2 = true) :
+    Pr[fun z : α × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p] = 1 := by
+  rw [probEvent_eq_one_iff]
+  refine ⟨by simp, ?_⟩
+  exact mem_support_simulateQ_run_of_bad impl h_mono oa p hp
+
+/-! ### ε-perturbed identical-until-bad: helper lemmas (in dependency order) -/
+
+/-- Bound `∑' z, p_z.toReal * tvDist (f₁ z) (f₂ z)` by `c + Pr[bad | mx >>= f₁]`,
+given that each summand is bounded by `p_z * (c + Pr[bad | f₁ z])`. The constant `c`
+is intended to be `(q - 1) · ε` from the inductive hypothesis. -/
+private theorem tsum_probOutput_mul_tvDist_le_const_plus_probEvent_bad
+    {β : Type} (mx : OracleComp spec' β) (f₁ f₂ : β → OracleComp spec' (α × σ × Bool))
+    {c : ℝ} (hc : 0 ≤ c)
+    (h_summand_le : ∀ z : β,
+      Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) ≤
+        Pr[= z | mx].toReal * (c +
+          Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal)) :
+    (∑' z : β, Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z))
+      ≤ c + Pr[fun w : α × σ × Bool => w.2.2 = true | mx >>= f₁].toReal := by
+  have h_p_sum_le_one : (∑' z : β, Pr[= z | mx]) ≤ 1 := tsum_probOutput_le_one
+  have h_p_sum_ne_top : (∑' z : β, Pr[= z | mx]) ≠ ⊤ :=
+    ne_top_of_le_ne_top one_ne_top h_p_sum_le_one
+  have h_p_summable : Summable (fun z : β => Pr[= z | mx].toReal) :=
+    ENNReal.summable_toReal h_p_sum_ne_top
+  have h_lhs_summand_nn : ∀ z : β, 0 ≤ Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) :=
+    fun z => mul_nonneg ENNReal.toReal_nonneg (tvDist_nonneg _ _)
+  have h_lhs_summand_le : ∀ z : β,
+      Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) ≤ Pr[= z | mx].toReal :=
+    fun z => mul_le_of_le_one_right ENNReal.toReal_nonneg (tvDist_le_one _ _)
+  have h_lhs_summable : Summable
+      (fun z : β => Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z)) :=
+    Summable.of_nonneg_of_le h_lhs_summand_nn h_lhs_summand_le h_p_summable
+  have h_b_z_le_one : ∀ z : β,
+      Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal ≤ 1 := fun z => by
+    simpa using ENNReal.toReal_mono one_ne_top probEvent_le_one
+  have h_rhs_summand_nn : ∀ z : β, 0 ≤ Pr[= z | mx].toReal *
+      (c + Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal) :=
+    fun z => mul_nonneg ENNReal.toReal_nonneg
+      (add_nonneg hc ENNReal.toReal_nonneg)
+  have h_rhs_summand_le : ∀ z : β,
+      Pr[= z | mx].toReal * (c + Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal) ≤
+      Pr[= z | mx].toReal * (c + 1) := fun z => by
+    apply mul_le_mul_of_nonneg_left _ ENNReal.toReal_nonneg
+    linarith [h_b_z_le_one z]
+  have h_rhs_summable : Summable (fun z : β => Pr[= z | mx].toReal *
+      (c + Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal)) :=
+    Summable.of_nonneg_of_le h_rhs_summand_nn h_rhs_summand_le
+      (h_p_summable.mul_right (c + 1))
+  have h_le_rhs :
+      (∑' z : β, Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z))
+        ≤ ∑' z : β, Pr[= z | mx].toReal *
+          (c + Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal) :=
+    Summable.tsum_le_tsum h_summand_le h_lhs_summable h_rhs_summable
+  refine le_trans h_le_rhs ?_
+  have h_distrib_summable_a : Summable
+      (fun z : β => Pr[= z | mx].toReal * c) :=
+    h_p_summable.mul_right _
+  have h_distrib_summable_b : Summable
+      (fun z : β => Pr[= z | mx].toReal *
+        Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal) :=
+    Summable.of_nonneg_of_le
+      (fun z => mul_nonneg ENNReal.toReal_nonneg ENNReal.toReal_nonneg)
+      (fun z => mul_le_of_le_one_right ENNReal.toReal_nonneg (h_b_z_le_one z))
+      h_p_summable
+  have h_split :
+      (∑' z : β, Pr[= z | mx].toReal *
+        (c + Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal))
+        = (∑' z : β, Pr[= z | mx].toReal * c) +
+          (∑' z : β, Pr[= z | mx].toReal *
+            Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal) := by
+    rw [← Summable.tsum_add h_distrib_summable_a h_distrib_summable_b]
+    refine tsum_congr fun z => ?_
+    ring
+  rw [h_split]
+  have h_first_sum :
+      (∑' z : β, Pr[= z | mx].toReal * c) = c := by
+    rw [tsum_mul_right]
+    have h_one : (∑' z : β, Pr[= z | mx].toReal) = 1 := by
+      rw [show (∑' z : β, Pr[= z | mx].toReal) = ((∑' z : β, Pr[= z | mx])).toReal from
+        (ENNReal.tsum_toReal_eq fun z => by
+          have h := probOutput_le_one (mx := mx) (x := z)
+          exact ne_top_of_le_ne_top one_ne_top h).symm]
+      rw [HasEvalPMF.tsum_probOutput_eq_one]
+      simp
+    rw [h_one, one_mul]
+  have h_second_sum :
+      (∑' z : β, Pr[= z | mx].toReal *
+        Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z].toReal)
+        = Pr[fun w : α × σ × Bool => w.2.2 = true | mx >>= f₁].toReal := by
+    have h_term_ne_top : ∀ z : β, Pr[= z | mx] *
+        Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z] ≠ ⊤ := fun z => by
+      have h₁ : Pr[= z | mx] ≤ 1 := probOutput_le_one
+      have h₂ : Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z] ≤ 1 := probEvent_le_one
+      have h_le : Pr[= z | mx] * Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z] ≤ 1 :=
+        mul_le_one' h₁ h₂
+      exact ne_top_of_le_ne_top one_ne_top h_le
+    rw [show
+      Pr[fun w : α × σ × Bool => w.2.2 = true | mx >>= f₁] =
+        ∑' z : β, Pr[= z | mx] *
+          Pr[fun w : α × σ × Bool => w.2.2 = true | f₁ z] from
+        probEvent_bind_eq_tsum mx f₁ _,
+      ENNReal.tsum_toReal_eq h_term_ne_top]
+    refine tsum_congr fun z => ?_
+    exact ENNReal.toReal_mul.symm
+  rw [h_first_sum, h_second_sum]
+
+/-- The `query_bind` (`p.2 = false`) inductive step: given the per-continuation IH bound
+(parameterized by `q - 1`), combine the triangle inequality, the two `tvDist_bind_*_le`
+bounds, and the algebraic distribution to get the `q · ε + Pr[bad]` bound. -/
+private theorem tvDist_simulateQ_run_query_bind_le
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (h_step_tv : ∀ (t : spec.Domain) (s : σ),
+      tvDist ((impl₁ t).run (s, false)) ((impl₂ t).run (s, false)) ≤ ε)
+    (t : spec.Domain) (cont : spec.Range t → OracleComp spec α)
+    {q : ℕ} (hq_pos : 0 < q)
+    (ih : ∀ (u : spec.Range t) (p' : σ × Bool),
+      tvDist ((simulateQ impl₁ (cont u)).run p')
+          ((simulateQ impl₂ (cont u)).run p')
+        ≤ ↑(q - 1) * ε + Pr[ fun w : α × σ × Bool => w.2.2 = true |
+            (simulateQ impl₁ (cont u)).run p'].toReal)
+    (s : σ) :
+    tvDist ((simulateQ impl₁ (query t >>= cont)).run (s, false))
+        ((simulateQ impl₂ (query t >>= cont)).run (s, false))
+      ≤ ↑q * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ (query t >>= cont)).run (s, false)].toReal := by
+  set sim₁ : OracleComp spec' (α × σ × Bool) :=
+    (simulateQ impl₁ (query t >>= cont)).run (s, false) with hsim₁_def
+  set sim₂ : OracleComp spec' (α × σ × Bool) :=
+    (simulateQ impl₂ (query t >>= cont)).run (s, false) with hsim₂_def
+  set f₁ : spec.Range t × σ × Bool → OracleComp spec' (α × σ × Bool) :=
+    fun z => (simulateQ impl₁ (cont z.1)).run z.2 with hf₁_def
+  set f₂ : spec.Range t × σ × Bool → OracleComp spec' (α × σ × Bool) :=
+    fun z => (simulateQ impl₂ (cont z.1)).run z.2 with hf₂_def
+  set mx : OracleComp spec' (spec.Range t × σ × Bool) := (impl₁ t).run (s, false) with hmx_def
+  set my : OracleComp spec' (spec.Range t × σ × Bool) := (impl₂ t).run (s, false) with hmy_def
+  have hsim₁_eq : sim₁ = mx >>= f₁ := by
+    simp [hsim₁_def, hmx_def, hf₁_def, simulateQ_bind, simulateQ_query,
+      OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind]
+  have hsim₂_eq : sim₂ = my >>= f₂ := by
+    simp [hsim₂_def, hmy_def, hf₂_def, simulateQ_bind, simulateQ_query,
+      OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind]
+  set mid : OracleComp spec' (α × σ × Bool) := mx >>= f₂ with hmid_def
+  have h_tri : tvDist sim₁ sim₂ ≤ tvDist sim₁ mid + tvDist mid sim₂ :=
+    tvDist_triangle _ _ _
+  have h_second : tvDist mid sim₂ ≤ ε := by
+    rw [hmid_def, hsim₂_eq]
+    exact le_trans (tvDist_bind_right_le _ _ _) (h_step_tv t s)
+  have h_first_raw :
+      tvDist sim₁ mid ≤ ∑' z : spec.Range t × σ × Bool,
+        Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) := by
+    rw [hsim₁_eq, hmid_def]
+    exact tvDist_bind_left_le _ _ _
+  have h_summand_le : ∀ z : spec.Range t × σ × Bool,
+      Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) ≤
+        Pr[= z | mx].toReal * (↑(q - 1) * ε + Pr[fun w : α × σ × Bool => w.2.2 = true |
+            f₁ z].toReal) := fun z => by
+    apply mul_le_mul_of_nonneg_left _ ENNReal.toReal_nonneg
+    simpa [hf₁_def, hf₂_def] using ih z.1 z.2
+  have h_const_nonneg : (0 : ℝ) ≤ ↑(q - 1) * ε := mul_nonneg (Nat.cast_nonneg _) hε
+  have h_first :
+      tvDist sim₁ mid ≤ ↑(q - 1) * ε +
+        Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁].toReal := by
+    refine le_trans h_first_raw ?_
+    have h_helper := tsum_probOutput_mul_tvDist_le_const_plus_probEvent_bad
+      (mx := mx) (f₁ := f₁) (f₂ := f₂) (c := ↑(q - 1) * ε) h_const_nonneg h_summand_le
+    rw [hsim₁_eq]
+    exact h_helper
+  have hq_arith : ((q - 1 : ℕ) : ℝ) + 1 = (q : ℝ) := by
+    have h1 : 1 ≤ q := hq_pos
+    have h2 : ((q - 1 : ℕ) + 1 : ℕ) = q := Nat.sub_add_cancel h1
+    have h3 : (((q - 1 : ℕ) + 1 : ℕ) : ℝ) = (q : ℝ) := by exact_mod_cast h2
+    simpa using h3
+  calc tvDist sim₁ sim₂
+      ≤ tvDist sim₁ mid + tvDist mid sim₂ := h_tri
+    _ ≤ (↑(q - 1) * ε + Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁].toReal) + ε :=
+        add_le_add h_first h_second
+    _ = (↑(q - 1) + 1) * ε + Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁].toReal := by
+        ring
+    _ = ↑q * ε + Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁].toReal := by
+        rw [hq_arith]
+
+/-- Auxiliary inductive lemma for `tvDist_simulateQ_le_qeps_plus_probEvent_output_bad`. Bounds
+the TV distance on the **joint** (state-included) distribution, for arbitrary starting state
+`p` (whether the bad flag is set or not).
+
+The proof inducts on `oa`:
+- `pure x`: both simulations equal `pure (x, p)`, so `tvDist = 0` and the RHS is non-negative.
+- `query t >>= cont`: case on `p.2`.
+  - `true`: by bad-monotonicity, `Pr[bad | sim₁] = 1`, and `tvDist ≤ 1` always.
+  - `false`: see `tvDist_simulateQ_run_query_bind_le`. -/
+private theorem tvDist_simulateQ_run_le_qeps_plus_probEvent_output_bad_aux
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (h_step_tv : ∀ (t : spec.Domain) (s : σ),
+      tvDist ((impl₁ t).run (s, false)) ((impl₂ t).run (s, false)) ≤ ε)
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) {q : ℕ}
+    (h_qb : OracleComp.IsTotalQueryBound oa q) (p : σ × Bool) :
+    tvDist ((simulateQ impl₁ oa).run p) ((simulateQ impl₂ oa).run p)
+      ≤ q * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run p].toReal := by
+  induction oa using OracleComp.inductionOn generalizing q p with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, tvDist_self]
+      exact add_nonneg (mul_nonneg (Nat.cast_nonneg _) hε) ENNReal.toReal_nonneg
+  | query_bind t cont ih =>
+      rcases p with ⟨s, b⟩
+      cases b with
+      | true =>
+          have h_bad₁ : Pr[fun z : α × σ × Bool => z.2.2 = true |
+              (simulateQ impl₁ (query t >>= cont)).run (s, true)] = 1 :=
+            probEvent_simulateQ_run_bad_eq_one_of_bad impl₁ h_mono₁
+              (query t >>= cont) (s, true) rfl
+          have h_tv_le_one :
+              tvDist ((simulateQ impl₁ (query t >>= cont)).run (s, true))
+                  ((simulateQ impl₂ (query t >>= cont)).run (s, true)) ≤ 1 :=
+            tvDist_le_one _ _
+          have h_target_ge_one :
+              (1 : ℝ) ≤ ↑q * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+                (simulateQ impl₁ (query t >>= cont)).run (s, true)].toReal := by
+            rw [h_bad₁]
+            simp only [ENNReal.toReal_one]
+            have hqε : (0 : ℝ) ≤ ↑q * ε := mul_nonneg (Nat.cast_nonneg _) hε
+            linarith
+          exact le_trans h_tv_le_one h_target_ge_one
+      | false =>
+          have hq_pos : 0 < q := h_qb.1
+          have hq_cont : ∀ u, OracleComp.IsTotalQueryBound (cont u) (q - 1) := h_qb.2
+          exact tvDist_simulateQ_run_query_bind_le impl₁ impl₂ hε h_step_tv t cont hq_pos
+            (fun u p' => ih u (hq_cont u) p') s
+
+/-- **ε-perturbed identical-until-bad with output bad flag.**
+
+If two stateful oracle implementations are ε-CLOSE in TV distance per step on the no-bad
+path (instead of exactly equal as in `tvDist_simulateQ_le_probEvent_output_bad`), and the
+computation makes at most `q` queries, then the TV distance between the two simulations
+is bounded by `q*ε + Pr[bad]`.
+
+Only `impl₁` requires bad-flag monotonicity (since the bound uses `Pr[bad | sim₁]`); the
+"true" branch in the inductive proof exploits monotonicity to push `Pr[bad | sim₁] = 1`
+which dominates the trivial `tvDist ≤ 1` bound.
+
+The `ε = 0` case recovers the existing identical-until-bad bound (modulo the upgraded
+agreement hypothesis from definitional equality to TV-distance equality, which is
+equivalent for distributions over the same type). -/
+theorem tvDist_simulateQ_le_qeps_plus_probEvent_output_bad
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (h_step_tv : ∀ (t : spec.Domain) (s : σ),
+      tvDist ((impl₁ t).run (s, false)) ((impl₂ t).run (s, false)) ≤ ε)
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) {q : ℕ}
+    (h_qb : OracleComp.IsTotalQueryBound oa q) (s₀ : σ) :
+    tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+        ((simulateQ impl₂ oa).run' (s₀, false))
+      ≤ q * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run (s₀, false)].toReal := by
+  have h_joint :
+      tvDist ((simulateQ impl₁ oa).run (s₀, false)) ((simulateQ impl₂ oa).run (s₀, false))
+        ≤ q * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+            (simulateQ impl₁ oa).run (s₀, false)].toReal :=
+    tvDist_simulateQ_run_le_qeps_plus_probEvent_output_bad_aux
+      impl₁ impl₂ hε h_step_tv h_mono₁ oa h_qb (s₀, false)
+  have h_map :
+      tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+          ((simulateQ impl₂ oa).run' (s₀, false))
+        ≤ tvDist ((simulateQ impl₁ oa).run (s₀, false))
+            ((simulateQ impl₂ oa).run (s₀, false)) := by
+    simpa [StateT.run'] using
+      (tvDist_map_le (m := OracleComp spec') (α := α × σ × Bool) (β := α) Prod.fst
+        ((simulateQ impl₁ oa).run (s₀, false)) ((simulateQ impl₂ oa).run (s₀, false)))
+  exact le_trans h_map h_joint
+
+end IdenticalUntilBadEpsilon
+
+/-! ### Selective ε-perturbed identical-until-bad
+
+A refinement of `tvDist_simulateQ_le_qeps_plus_probEvent_output_bad` where the per-step ε
+bound applies only to a designated subset `S` of queries (the "costly" or "perturbed"
+queries), and the impls are pointwise equal on the complement (the "free" queries). The
+bound counts only the S-queries, giving a tight `qS · ε` instead of `q_total · ε`.
+
+This is essential for cryptographic reductions where, e.g., signing-oracle queries are
+ε-close to a simulator (HVZK guarantee) but uniform / RO queries are exactly equal (both
+sides forward through the same RO cache). Direct application of the uniform-ε lemma would
+give `(qS + qH) · ε`, but for tight bounds we want `qS · ε`. -/
+
+section IdenticalUntilBadEpsilonSelective
+
+variable {ι : Type} {spec : OracleSpec ι}
+variable {ι' : Type} {spec' : OracleSpec ι'} [spec'.Fintype] [spec'.Inhabited]
+variable {α : Type} {σ : Type}
+
+/-- The `query_bind` step for a "free" query (impls pointwise equal on the no-bad branch).
+The budget `qS` is preserved (no decrement), since a free query doesn't count toward the
+S-query bound. -/
+private theorem tvDist_simulateQ_run_free_query_bind_le
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (t : spec.Domain) (h_step_eq : ∀ (p : σ × Bool), (impl₁ t).run p = (impl₂ t).run p)
+    (cont : spec.Range t → OracleComp spec α) {qS : ℕ}
+    (ih : ∀ (u : spec.Range t) (p' : σ × Bool),
+      tvDist ((simulateQ impl₁ (cont u)).run p')
+          ((simulateQ impl₂ (cont u)).run p')
+        ≤ ↑qS * ε + Pr[ fun w : α × σ × Bool => w.2.2 = true |
+            (simulateQ impl₁ (cont u)).run p'].toReal)
+    (s : σ) :
+    tvDist ((simulateQ impl₁ (query t >>= cont)).run (s, false))
+        ((simulateQ impl₂ (query t >>= cont)).run (s, false))
+      ≤ ↑qS * ε + Pr[ fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ (query t >>= cont)).run (s, false)].toReal := by
+  set mx : OracleComp spec' (spec.Range t × σ × Bool) := (impl₁ t).run (s, false) with hmx_def
+  have hmy_eq : (impl₂ t).run (s, false) = mx := (h_step_eq (s, false)).symm
+  set f₁ : spec.Range t × σ × Bool → OracleComp spec' (α × σ × Bool) :=
+    fun z => (simulateQ impl₁ (cont z.1)).run z.2 with hf₁_def
+  set f₂ : spec.Range t × σ × Bool → OracleComp spec' (α × σ × Bool) :=
+    fun z => (simulateQ impl₂ (cont z.1)).run z.2 with hf₂_def
+  have hsim₁_eq : (simulateQ impl₁ (query t >>= cont)).run (s, false) = mx >>= f₁ := by
+    simp [hmx_def, hf₁_def, simulateQ_bind, simulateQ_query,
+      OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind]
+  have hsim₂_eq : (simulateQ impl₂ (query t >>= cont)).run (s, false) = mx >>= f₂ := by
+    simp [hmy_eq, hf₂_def, simulateQ_bind, simulateQ_query,
+      OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind]
+  have h_bd : tvDist (mx >>= f₁) (mx >>= f₂)
+      ≤ ∑' z : spec.Range t × σ × Bool, Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) :=
+    tvDist_bind_left_le _ _ _
+  have h_summand_le : ∀ z : spec.Range t × σ × Bool,
+      Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) ≤
+        Pr[= z | mx].toReal * (↑qS * ε + Pr[fun w : α × σ × Bool => w.2.2 = true |
+            f₁ z].toReal) := fun z => by
+    apply mul_le_mul_of_nonneg_left _ ENNReal.toReal_nonneg
+    simpa [hf₁_def, hf₂_def] using ih z.1 z.2
+  have h_qSε_nonneg : (0 : ℝ) ≤ ↑qS * ε := mul_nonneg (Nat.cast_nonneg _) hε
+  rw [hsim₁_eq, hsim₂_eq]
+  exact le_trans h_bd
+    (tsum_probOutput_mul_tvDist_le_const_plus_probEvent_bad
+      (mx := mx) (f₁ := f₁) (f₂ := f₂) (c := ↑qS * ε) h_qSε_nonneg h_summand_le)
+
+/-- Auxiliary inductive lemma for the selective ε-perturbed bound. Inducts on `oa` and
+case-splits each query on whether it's in the costly set `S` (existing per-step argument
+with budget decrement) or free (`tvDist_simulateQ_run_free_query_bind_le` with budget
+preserved). -/
+private theorem tvDist_simulateQ_run_le_qSeps_plus_probEvent_output_bad_aux
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (S : ι → Prop) [DecidablePred S]
+    (h_step_tv_S : ∀ (t : ι), S t → ∀ (s : σ),
+      tvDist ((impl₁ t).run (s, false)) ((impl₂ t).run (s, false)) ≤ ε)
+    (h_step_eq_nS : ∀ (t : ι), ¬ S t → ∀ (p : σ × Bool),
+      (impl₁ t).run p = (impl₂ t).run p)
+    (h_mono₁ : ∀ (t : ι) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) {qS : ℕ}
+    (h_qb : OracleComp.IsQueryBound oa qS
+      (fun t b => if S t then 0 < b else True)
+      (fun t b => if S t then b - 1 else b))
+    (p : σ × Bool) :
+    tvDist ((simulateQ impl₁ oa).run p) ((simulateQ impl₂ oa).run p)
+      ≤ qS * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run p].toReal := by
+  -- Construct a global per-step bound `tvDist ≤ ε` that holds for ALL queries:
+  -- for S-queries by `h_step_tv_S`, for non-S-queries since the impls are pointwise equal.
+  have h_step_tv_global : ∀ (t' : ι) (s' : σ),
+      tvDist ((impl₁ t').run (s', false)) ((impl₂ t').run (s', false)) ≤ ε := by
+    intro t' s'
+    by_cases hSt' : S t'
+    · exact h_step_tv_S t' hSt' s'
+    · rw [h_step_eq_nS t' hSt' (s', false), tvDist_self]; exact hε
+  induction oa using OracleComp.inductionOn generalizing qS p with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, tvDist_self]
+      exact add_nonneg (mul_nonneg (Nat.cast_nonneg _) hε) ENNReal.toReal_nonneg
+  | query_bind t cont ih =>
+      rcases p with ⟨s, b⟩
+      cases b with
+      | true =>
+          have h_bad₁ : Pr[fun z : α × σ × Bool => z.2.2 = true |
+              (simulateQ impl₁ (query t >>= cont)).run (s, true)] = 1 :=
+            probEvent_simulateQ_run_bad_eq_one_of_bad impl₁ h_mono₁
+              (query t >>= cont) (s, true) rfl
+          have h_tv_le_one :
+              tvDist ((simulateQ impl₁ (query t >>= cont)).run (s, true))
+                  ((simulateQ impl₂ (query t >>= cont)).run (s, true)) ≤ 1 :=
+            tvDist_le_one _ _
+          have h_target_ge_one :
+              (1 : ℝ) ≤ ↑qS * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+                (simulateQ impl₁ (query t >>= cont)).run (s, true)].toReal := by
+            rw [h_bad₁]
+            simp only [ENNReal.toReal_one]
+            have hqε : (0 : ℝ) ≤ ↑qS * ε := mul_nonneg (Nat.cast_nonneg _) hε
+            linarith
+          exact le_trans h_tv_le_one h_target_ge_one
+      | false =>
+          rw [isQueryBound_query_bind_iff] at h_qb
+          obtain ⟨h_can, h_cont⟩ := h_qb
+          by_cases hSt : S t
+          · -- Costly query: use the existing helper with budget `qS`, decrementing to `qS - 1`.
+            simp only [hSt, if_true] at h_can h_cont
+            have hqS_pos : 0 < qS := h_can
+            exact tvDist_simulateQ_run_query_bind_le impl₁ impl₂ hε h_step_tv_global
+              t cont hqS_pos
+              (fun u p' => ih u (h_cont u) p') s
+          · -- Free query: impls equal here; preserve the `qS` budget through the recursion.
+            simp only [hSt, if_false] at h_can h_cont
+            exact tvDist_simulateQ_run_free_query_bind_le impl₁ impl₂ hε t
+              (h_step_eq_nS t hSt) cont
+              (fun u p' => ih u (h_cont u) p') s
+
+/-- **Selective ε-perturbed identical-until-bad with output bad flag.**
+
+Like `tvDist_simulateQ_le_qeps_plus_probEvent_output_bad`, but the per-step ε bound
+applies only to queries `t` satisfying a designated predicate `S` (the "costly" queries),
+and the impls are pointwise equal on `¬ S` (the "free" queries). The bound counts only
+the S-queries (via `IsQueryBound` parameterized to decrement only on S), giving the tight
+`qS · ε` instead of the trivial `q_total · ε` from the uniform-ε lemma.
+
+The intended use is for cryptographic reductions: e.g., for Fiat-Shamir signing-oracle
+swaps, the "costly" queries are signing queries (HVZK gives per-query ε bound) and the
+"free" queries are the underlying spec queries (uniform sampling and RO caching, where
+both sides forward through the same `baseSim`). -/
+theorem tvDist_simulateQ_le_qSeps_plus_probEvent_output_bad
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (S : ι → Prop) [DecidablePred S]
+    (h_step_tv_S : ∀ (t : ι), S t → ∀ (s : σ),
+      tvDist ((impl₁ t).run (s, false)) ((impl₂ t).run (s, false)) ≤ ε)
+    (h_step_eq_nS : ∀ (t : ι), ¬ S t → ∀ (p : σ × Bool),
+      (impl₁ t).run p = (impl₂ t).run p)
+    (h_mono₁ : ∀ (t : ι) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) {qS : ℕ}
+    (h_qb : OracleComp.IsQueryBound oa qS
+      (fun t b => if S t then 0 < b else True)
+      (fun t b => if S t then b - 1 else b))
+    (s₀ : σ) :
+    tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+        ((simulateQ impl₂ oa).run' (s₀, false))
+      ≤ qS * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run (s₀, false)].toReal := by
+  have h_joint :
+      tvDist ((simulateQ impl₁ oa).run (s₀, false)) ((simulateQ impl₂ oa).run (s₀, false))
+        ≤ qS * ε + Pr[fun z : α × σ × Bool => z.2.2 = true |
+            (simulateQ impl₁ oa).run (s₀, false)].toReal :=
+    tvDist_simulateQ_run_le_qSeps_plus_probEvent_output_bad_aux
+      impl₁ impl₂ hε S h_step_tv_S h_step_eq_nS h_mono₁ oa h_qb (s₀, false)
+  have h_map :
+      tvDist ((simulateQ impl₁ oa).run' (s₀, false))
+          ((simulateQ impl₂ oa).run' (s₀, false))
+        ≤ tvDist ((simulateQ impl₁ oa).run (s₀, false))
+            ((simulateQ impl₂ oa).run (s₀, false)) := by
+    simpa [StateT.run'] using
+      (tvDist_map_le (m := OracleComp spec') (α := α × σ × Bool) (β := α) Prod.fst
+        ((simulateQ impl₁ oa).run (s₀, false)) ((simulateQ impl₂ oa).run (s₀, false)))
+  exact le_trans h_map h_joint
+
+end IdenticalUntilBadEpsilonSelective
+
 end OracleComp.ProgramLogic.Relational


### PR DESCRIPTION
Posted by Cursor assistant (model: GPT-5.4) on behalf of the user (Quang Dao) with approval.

## Summary
- add `QueryImpl.withBadFlag` and `QueryImpl.withBadUpdate` for threading a monotone bad flag through stateful query implementations
- add `OracleComp.IsQueryBound.proj` to project a single budget coordinate out of a composite query bound
- add uniform and selective epsilon-perturbed identical-until-bad lemmas for `simulateQ`
- extract the reusable proof infrastructure from the larger Fiat-Shamir security branch into a standalone PR

## Test plan
- [x] `lake build VCVio.OracleComp.SimSemantics.StateT VCVio.OracleComp.QueryTracking.QueryBound VCVio.ProgramLogic.Relational.SimulateQ`


Made with [Cursor](https://cursor.com)