### PR TITLE
feat(VCVio): Improve grind performance and trappings

### DIFF
--- a/Examples/CommitmentScheme/Hiding/Main.lean
+++ b/Examples/CommitmentScheme/Hiding/Main.lean
@@ -94,8 +94,7 @@ theorem hiding_bound_finite [Finite M] {AUX : Type} {t : ℕ}
               ((HidingAvgSpec M S C).query (Sum.inl ()) :
                 OracleComp (HidingAvgSpec M S C) S)].toReal *
             tvDist (hidingReal A s) (hidingSim A s) := by
-            refine tsum_congr fun s => ?_
-            rw [tvDist_liftComp_hidingAvgSpec]
+            simp_rw [tvDist_liftComp_hidingAvgSpec]
     _ = ∑ s : S, ((Fintype.card S : ℝ≥0∞)⁻¹).toReal * tvDist (hidingReal A s) (hidingSim A s) := by
           rw [tsum_fintype]
           refine Finset.sum_congr rfl ?_

--- a/Examples/ElGamal/Basic.lean
+++ b/Examples/ElGamal/Basic.lean
@@ -284,16 +284,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
       simp_rw [hbool]
       have hsum : ∑' x : G, Pr[= x | ($ᵗ G)] = 1 :=
         HasEvalPMF.tsum_probOutput_eq_one ($ᵗ G)
-      calc
-        ∑' x, Pr[= x | ($ᵗ G)] * (1 / 2 : ℝ≥0∞) =
-            ∑' x, (1 / 2 : ℝ≥0∞) * Pr[= x | ($ᵗ G)] := by
-              refine tsum_congr ?_
-              intro x
-              rw [mul_comm]
-        _ = (1 / 2 : ℝ≥0∞) * ∑' x, Pr[= x | ($ᵗ G)] := by
-              rw [ENNReal.tsum_mul_left]
-        _ = (1 / 2 : ℝ≥0∞) * 1 := by rw [hsum]
-        _ = 1 / 2 := by simp
+      rw [ENNReal.tsum_mul_right, hsum, one_mul]
 
 omit [DecidableEq G] in
 /-- The absolute one-time signed IND-CPA advantage of ElGamal is exactly twice the DDH guess

--- a/Examples/ElGamal/Hash.lean
+++ b/Examples/ElGamal/Hash.lean
@@ -432,16 +432,7 @@ theorem esIdeal_eq_half
       simp_rw [hbool]
       have hsum : ∑' x : HK, Pr[= x | ($ᵗ HK)] = 1 :=
         HasEvalPMF.tsum_probOutput_eq_one ($ᵗ HK)
-      calc
-        ∑' x, Pr[= x | ($ᵗ HK)] * (1 / 2 : ℝ≥0∞) =
-            ∑' x, (1 / 2 : ℝ≥0∞) * Pr[= x | ($ᵗ HK)] := by
-              refine tsum_congr ?_
-              intro x
-              rw [mul_comm]
-        _ = (1 / 2 : ℝ≥0∞) * ∑' x, Pr[= x | ($ᵗ HK)] := by
-              rw [ENNReal.tsum_mul_left]
-        _ = (1 / 2 : ℝ≥0∞) * 1 := by rw [hsum]
-        _ = 1 / 2 := by simp
+      rw [ENNReal.tsum_mul_right, hsum, one_mul]
 
 /-! ## Main theorem -/
 

--- a/Examples/OneTimePad/Basic.lean
+++ b/Examples/OneTimePad/Basic.lean
@@ -67,13 +67,7 @@ lemma perfectSecrecyAt (sp : ℕ) : (oneTimePad sp).perfectSecrecyAt := by
     simpa [SymmEncAlg.PerfectSecrecyExp, oneTimePad,
       bind_assoc, pure_bind] using
       probOutput_pair_xor_uniform sp (mx := mgen) msg σ
-  calc
-    Pr[= (msg, σ) | (oneTimePad sp).PerfectSecrecyExp mgen] =
-        Pr[= msg | mgen] *
-          (Fintype.card (BitVec sp) : ℝ≥0∞)⁻¹ := hpair
-    _ = Pr[= msg | mgen] *
-        Pr[= σ | (oneTimePad sp).PerfectSecrecyCipherExp mgen] := by
-          rw [probOutput_cipher_uniform]
+  rw [hpair, ← probOutput_cipher_uniform]
 
 /-- The one-time pad is perfectly secret for all security parameters. -/
 lemma perfectSecrecy : ∀ sp, (oneTimePad sp).perfectSecrecyAt := perfectSecrecyAt

--- a/Examples/Pedersen.lean
+++ b/Examples/Pedersen.lean
@@ -175,24 +175,14 @@ theorem binding_le_dlog (hg : Function.Bijective (· • g : F → G))
         else 0) = x
   have hbinding :
       Pr[= true | (pedersenCommit g).bindingExp binder] = Pr[ bindingWin | base] := by
-    rw [← probEvent_eq_eq_probOutput]
     rw [show (pedersenCommit g).bindingExp binder = (fun z => decide (bindingWin z)) <$> base by
       simp [CommitmentScheme.bindingExp, pedersenCommit, base, bindingWin, Bool.and_assoc]]
-    rw [probEvent_map]
-    refine probEvent_ext ?_
-    intro z hz
-    rcases z with ⟨x, ⟨c, m₁, d₁, m₂, d₂⟩⟩
-    simp [bindingWin, Bool.and_eq_true, decide_eq_true_eq]
+    grind
   have hdlog :
       Pr[= true | dlogExp g (dlogReduction binder)] = Pr[ dlogWin | base] := by
-    rw [← probEvent_eq_eq_probOutput]
     rw [show dlogExp g (dlogReduction binder) = (fun z => decide (dlogWin z)) <$> base by
       simp [DiffieHellman.dlogExp, dlogReduction, base, dlogWin]]
-    rw [probEvent_map]
-    refine probEvent_ext ?_
-    intro z hz
-    rcases z with ⟨x, ⟨c, m₁, d₁, m₂, d₂⟩⟩
-    simp [dlogWin, decide_eq_true_eq]
+    grind
   rw [hbinding, hdlog]
   exact OracleComp.ProgramLogic.probEvent_mono base (fun z hwin => by
     rcases z with ⟨x, ⟨c, m₁, d₁, m₂, d₂⟩⟩

--- a/Examples/Signature.lean
+++ b/Examples/Signature.lean
@@ -104,7 +104,7 @@ end
 
 end extractor
 
-omit [DecidableEq F] [Fintype F] in
+omit [Fintype F] in
 /-- Completeness of the Schnorr signature follows from completeness of the
 underlying Schnorr Σ-protocol via the generic Fiat-Shamir completeness theorem. -/
 theorem signature_complete (g : G) (hg : Function.Bijective (· • g : F → G))

--- a/LatticeCrypto/Falcon/Scheme.lean
+++ b/LatticeCrypto/Falcon/Scheme.lean
@@ -105,7 +105,7 @@ theorem validKeyPair_eq_true_iff (pk : PublicKey p) (sk : SecretKey p) :
     validKeyPair p pk sk = true ↔
       ntruEquation p sk.f sk.g sk.capF sk.capG ∧
       negacyclicMul (IntPoly.toRq sk.f) pk.h = IntPoly.toRq sk.g := by
-  simp [validKeyPair, Bool.and_eq_true, decide_eq_true_eq]
+  simp [validKeyPair]
 
 /-! ### Core Algorithms -/
 

--- a/LatticeCrypto/MLDSA/Security.lean
+++ b/LatticeCrypto/MLDSA/Security.lean
@@ -149,8 +149,7 @@ theorem idsWithAbort_commitment_recoverable :
       (prims.sampleInBall cTilde) z pk.t1), ?_⟩
   rintro s w' c ⟨z, h⟩ hverify
   unfold identificationScheme at hverify
-  simp only [Bool.and_eq_true, decide_eq_true_eq] at hverify
-  exact hverify.1.2
+  grind
 
 end Properties
 

--- a/LatticeCrypto/MLDSA/Security.lean
+++ b/LatticeCrypto/MLDSA/Security.lean
@@ -81,7 +81,7 @@ theorem idsWithAbort_complete' :
     (identificationScheme p prims nttOps).Complete := by
   classical
   intro pk sk hvalid
-  rw [← probEvent_eq_eq_probOutput, probEvent_eq_one_iff]
+  rw [probOutput_eq_one_iff_forall]
   refine ⟨HasEvalPMF.probFailure_eq_zero _, ?_⟩
   intro b hb
   rw [support_bind] at hb

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -1030,12 +1030,7 @@ theorem euf_nma_bound
             eufNmaReduction σ hr M nmaAdv qH pkw.1] := by
     unfold hardRelationExp
     rw [← probEvent_eq_eq_probOutput]
-    simp only [bind_pure_comp, probEvent_bind_eq_tsum]
-    refine tsum_congr fun pkw => ?_
-    rcases pkw with ⟨pk, sk⟩
-    congr 1
-    rw [probEvent_map]
-    rfl
+    simp only [bind_pure_comp, probEvent_bind_eq_tsum, probEvent_map, Function.comp_def]
   -- ── Step (c): per-pk forking bound via `Fork.replayForkingBound` applied with the
   -- strengthened support invariant `forkSupportInvariant`.
   have hPerPk : ∀ pk : Stmt,

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -1014,13 +1014,9 @@ theorem euf_nma_bound
         ∑' pkw : Stmt × Wit, Pr[= pkw | hr.gen] * acc pkw.1 := by
     change Pr[= true | Fork.exp σ hr M nmaAdv qH] = _
     unfold Fork.exp
-    rw [← probEvent_eq_eq_probOutput, probEvent_simulateQ_unifChalImpl,
-      probEvent_bind_eq_tsum]
-    refine tsum_congr fun pkw => ?_
-    rw [probOutput_liftComp]
-    congr 1
-    rcases pkw with ⟨pk, sk⟩
-    simp only [bind_pure_comp, probEvent_map, Function.comp_def, acc]
+    simp only [← probEvent_eq_eq_probOutput, probEvent_simulateQ_unifChalImpl,
+      probEvent_bind_eq_tsum, bind_pure_comp, probEvent_map, Function.comp_def,
+      probEvent_liftComp, acc]
   -- ── Step (b): rewrite `Pr[= true | hardRelationExp]` as a keygen-marginalized sum of
   -- per-pk relation-recovery probabilities.
   have hRHS_eq_tsum :

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -1025,8 +1025,8 @@ theorem euf_nma_bound
           Pr[ fun w : Wit => rel pkw.1 w = true |
             eufNmaReduction σ hr M nmaAdv qH pkw.1] := by
     unfold hardRelationExp
-    rw [← probEvent_eq_eq_probOutput]
-    simp only [bind_pure_comp, probEvent_bind_eq_tsum, probEvent_map, Function.comp_def]
+    simp only [← probEvent_eq_eq_probOutput, bind_pure_comp, probEvent_bind_eq_tsum,
+      probEvent_map, Function.comp_def]
   -- ── Step (c): per-pk forking bound via `Fork.replayForkingBound` applied with the
   -- strengthened support invariant `forkSupportInvariant`.
   have hPerPk : ∀ pk : Stmt,

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -388,24 +388,20 @@ private lemma evalDist_simulateQ_unifChalImpl {α : Type}
         rw [evalDist_uniformSample, evalDist_query]; rfl
       exact heq ▸ rfl
 
-/-- Corollary: `probEvent` is preserved by the `ofLift + uniformSampleImpl` simulation. -/
-private lemma probEvent_simulateQ_unifChalImpl {α : Type}
-    (oa : OracleComp (unifSpec + (Unit →ₒ Chal)) α) (p : α → Prop) :
-    Pr[ p | simulateQ (QueryImpl.ofLift unifSpec ProbComp +
-      (uniformSampleImpl (spec := (Unit →ₒ Chal)))) oa] = Pr[ p | oa] := by
-  simp only [probEvent_eq_tsum_indicator]
-  refine tsum_congr fun x => ?_
-  unfold Set.indicator
-  split_ifs with hpx
-  · exact congrFun (congrArg DFunLike.coe (evalDist_simulateQ_unifChalImpl oa)) x
-  · rfl
-
 /-- Corollary: `probOutput` is preserved by the `ofLift + uniformSampleImpl` simulation. -/
 private lemma probOutput_simulateQ_unifChalImpl {α : Type}
     (oa : OracleComp (unifSpec + (Unit →ₒ Chal)) α) (x : α) :
     Pr[= x | simulateQ (QueryImpl.ofLift unifSpec ProbComp +
       (uniformSampleImpl (spec := (Unit →ₒ Chal)))) oa] = Pr[= x | oa] :=
   congrFun (congrArg DFunLike.coe (evalDist_simulateQ_unifChalImpl oa)) x
+
+/-- Corollary: `probEvent` is preserved by the `ofLift + uniformSampleImpl` simulation. -/
+private lemma probEvent_simulateQ_unifChalImpl {α : Type}
+    (oa : OracleComp (unifSpec + (Unit →ₒ Chal)) α) (p : α → Prop) :
+    Pr[ p | simulateQ (QueryImpl.ofLift unifSpec ProbComp +
+      (uniformSampleImpl (spec := (Unit →ₒ Chal)))) oa] = Pr[ p | oa] := by
+  simp_rw [probEvent_eq_tsum_indicator, Set.indicator,
+    probOutput_simulateQ_unifChalImpl]
 
 end evalDistBridge
 section jensenIntegration

--- a/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
@@ -324,11 +324,7 @@ variable (g : G)
 def dlogGenerable :
     GenerableRelation G F (fun pk sk => decide (sk • g = pk)) where
   gen := do let sk ← $ᵗ F; return (sk • g, sk)
-  gen_sound := fun pk sk hmem => by
-    rw [decide_eq_true_eq]
-    simp only [support_bind, support_pure, Set.mem_iUnion, Set.mem_singleton_iff,
-               Prod.mk.injEq] at hmem
-    obtain ⟨_, -, rfl, rfl⟩ := hmem; rfl
+  gen_sound := fun _ _ _ => by grind
 
 end DLogGenerable
 

--- a/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
@@ -181,10 +181,8 @@ private lemma ddhExp_probOutput_eq_branch (g : G) (adversary : DDHAdversary F G)
                else ddhExpRand g adversary
       pure (bit == z)] := by
   unfold ddhExp
-  simp only [← probEvent_eq_eq_probOutput]
-  rw [probEvent_bind_congr fun a _ => probEvent_bind_bind_swap _ _ _ _,
-      probEvent_bind_bind_swap]
-  simp only [probEvent_eq_eq_probOutput]
+  rw [probOutput_bind_congr fun a _ => probOutput_bind_bind_swap _ _ _ _,
+      probOutput_bind_bind_swap]
   refine probOutput_bind_congr' ($ᵗ Bool) true ?_
   intro bit
   cases bit <;> simp [ddhExpReal, ddhExpRand]

--- a/VCVio/CryptoFoundations/HashCommitment.lean
+++ b/VCVio/CryptoFoundations/HashCommitment.lean
@@ -77,27 +77,8 @@ theorem bindingAdvantage_toCommitment_le_keyedCRAdvantage
   unfold bindingAdvantage CommitmentScheme.bindingExp
     keyedCRAdvantage keyedCRExp bindingAdv_toCRAdv KeyedHashFamily.toCommitment
   simp only [bind_assoc, pure_bind]
-  rw [← probEvent_eq_eq_probOutput
-        (H.keygen >>= fun k => A k >>= fun x =>
-          pure (decide (x.2.1 ≠ x.2.2.2.1) && decide (H.hash k (x.2.1, x.2.2.1) = x.1) &&
-            decide (H.hash k (x.2.2.2.1, x.2.2.2.2) = x.1))) true,
-      ← probEvent_eq_eq_probOutput
-        (H.keygen >>= fun k => A k >>= fun x =>
-          pure (decide ((x.2.1, x.2.2.1) ≠ (x.2.2.2.1, x.2.2.2.2) ∧
-            H.hash k (x.2.1, x.2.2.1) = H.hash k (x.2.2.2.1, x.2.2.2.2)))) true]
-  refine probEvent_bind_mono fun k _ => ?_
-  refine probEvent_bind_mono fun ⟨c, m₁, s₁, m₂, s₂⟩ _ => ?_
-  rw [probEvent_pure, probEvent_pure]
-  -- Both sides reduce to indicator `if pred then 1 else 0`; show binding-pred → cr-pred.
-  by_cases hbind :
-      (decide (m₁ ≠ m₂) && decide (H.hash k (m₁, s₁) = c) &&
-        decide (H.hash k (m₂, s₂) = c)) = true
-  · simp only [Bool.and_eq_true, decide_eq_true_eq] at hbind
-    obtain ⟨⟨hne_m, hh₁⟩, hh₂⟩ := hbind
-    have hne_pair : (m₁, s₁) ≠ (m₂, s₂) := fun h => hne_m (Prod.ext_iff.mp h).1
-    have hhash : H.hash k (m₁, s₁) = H.hash k (m₂, s₂) := hh₁.trans hh₂.symm
-    simp [hne_m, hh₁, hh₂, hne_pair]
-  · simp only [hbind]
-    exact zero_le _
+  refine probOutput_bind_mono fun k _ => ?_
+  refine probOutput_bind_mono fun ⟨c, m₁, s₁, m₂, s₂⟩ _ => ?_
+  grind
 
 end CollisionResistance

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -3464,10 +3464,9 @@ private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
       simp_rw [← ENNReal.tsum_mul_right]
       rw [ENNReal.tsum_comm]
       simp_rw [mul_assoc, ENNReal.tsum_mul_left]
-      refine tsum_congr fun u => ?_
-      refine congrArg _ ?_
-      exact tsum_probOutput_map_mul (replayFirstRun (mx u))
-        (fun p : α × QueryLog spec => (p.1, (⟨t, u⟩ : (i' : ι) × spec.Range i') :: p.2)) g
+      exact tsum_congr fun u => congrArg _ <|
+        tsum_probOutput_map_mul (replayFirstRun (mx u))
+          (fun p : α × QueryLog spec => (p.1, (⟨t, u⟩ : (i' : ι) × spec.Range i') :: p.2)) g
     -- Step 3: apply `swap` to both sides.
     rw [swap fun p => h (QueryLog.takeBeforeForkAt p.2 i s) *
         Pr[= y | (f <$> (pure p.1 : OracleComp spec α) : OracleComp spec β)]]
@@ -3611,9 +3610,8 @@ private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
           simp only [map_bind]
         simp_rw [hPr_rhs]
         -- Apply IH with shifted `h`.
-        refine tsum_congr fun u => ?_
-        refine congrArg _ ?_
-        exact ih u k (fun τ => h ((⟨t, u⟩ : (i' : ι) × spec.Range i') :: τ))
+        exact tsum_congr fun u => congrArg _ <|
+          ih u k (fun τ => h ((⟨t, u⟩ : (i' : ι) × spec.Range i') :: τ))
     · -- Case `t ≠ i`: truncation preserves the `⟨t,u⟩` entry; reduce via
       -- `fst_map_replayRunWithTraceValue_query_bind_cons_ne` and IH.
       have htrunc : ∀ (u : spec.Range t) (p' : α × QueryLog spec),
@@ -3662,9 +3660,8 @@ private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
         rw [heq]
         simp only [map_bind]
       simp_rw [hPr_rhs]
-      refine tsum_congr fun u => ?_
-      refine congrArg _ ?_
-      exact ih u s (fun τ => h ((⟨t, u⟩ : (i' : ι) × spec.Range i') :: τ))
+      exact tsum_congr fun u => congrArg _ <|
+        ih u s (fun τ => h ((⟨t, u⟩ : (i' : ι) × spec.Range i') :: τ))
 
 /-- Replay-side Jensen / Cauchy-Schwarz step. Squaring the probability that the first
 run satisfies `cf x₁ = some s` is bounded by the joint probability that *both* the
@@ -3726,16 +3723,14 @@ private lemma sq_probOutput_main_le_noGuardReplayComp
         = ∑' p, w p * I p.1 := hMain
       _ = ∑' p, Pr[= p | replayFirstRun main] *
             Pr[= y | (cf <$> (pure p.1 : OracleComp spec α) :
-              OracleComp spec (Option (Fin (qb i + 1))))] := by
-              refine tsum_congr fun p => ?_; rfl
+              OracleComp spec (Option (Fin (qb i + 1))))] := rfl
       _ = ∑' p, Pr[= p | replayFirstRun main] *
             Pr[= y | cf <$> Prod.fst <$> (do
               let u ← liftComp ($ᵗ spec.Range i) spec
               replayRunWithTraceValue main i
                 (QueryLog.takeBeforeForkAt p.2 i ↑s) ↑s u :
                   OracleComp spec (α × _))] := hB1h
-      _ = ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) := by
-              refine tsum_congr fun p => ?_; rfl
+      _ = ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) := rfl
   -- `hEq`: the two expansions of `Pr[= y | cf <$> main]` coincide.
   have hEq : ∑' p, w p * I p.1 =
       ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) := hMain.symm.trans hMainTake
@@ -3770,14 +3765,12 @@ private lemma sq_probOutput_main_le_noGuardReplayComp
                 let u ← liftComp ($ᵗ spec.Range i) spec
                 replayRunWithTraceValue main i
                   (QueryLog.takeBeforeForkAt p.2 i ↑s) ↑s u :
-                    OracleComp spec (α × _))]) := by
-            refine tsum_congr fun p => ?_; exact hsq_eq p
+                    OracleComp spec (α × _))]) := tsum_congr hsq_eq
       _ = ∑' p, Pr[= p | replayFirstRun main] *
             (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) *
               Pr[= y | (cf <$> (pure p.1 : OracleComp spec α) :
                 OracleComp spec (Option (Fin (qb i + 1))))]) := hB1h.symm
-      _ = ∑' p, w p * (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) * I p.1) := by
-            refine tsum_congr fun p => ?_; rfl
+      _ = ∑' p, w p * (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) * I p.1) := rfl
   -- `hFactor`: expand `Pr[= z | noGuardReplayComp]` as `E[I p.1 * Q(p.2)]`.
   have hFactor : Pr[= z | noGuardReplayComp main qb i cf s] =
       ∑' p, w p * (I p.1 * Q p.2) := by
@@ -3844,8 +3837,7 @@ private lemma sq_probOutput_main_le_noGuardReplayComp
       _ ≤ ∑' p, w p * Q (QueryLog.takeBeforeForkAt p.2 i ↑s) ^ 2 := hJensen
       _ = ∑' p, w p * (Q (QueryLog.takeBeforeForkAt p.2 i ↑s) * I p.1) := hEq2
       _ = ∑' p, w p * (I p.1 * Q (QueryLog.takeBeforeForkAt p.2 i ↑s)) := by
-            refine tsum_congr fun p => ?_
-            ring
+            simp_rw [mul_comm (Q _) (I _)]
       _ = Pr[= z | noGuardReplayComp main qb i cf s] := hFactorTrunc.symm
   change (Pr[= s | cf <$> main] : ℝ≥0∞) ^ 2 ≤ Pr[= z | noGuardReplayComp main qb i cf s]
   have : (Pr[= s | cf <$> main] : ℝ≥0∞) = Pr[= y | cf <$> main] := by

--- a/VCVio/CryptoFoundations/SeededFork.lean
+++ b/VCVio/CryptoFoundations/SeededFork.lean
@@ -529,10 +529,7 @@ private lemma probOutput_collision_le_main_div (s : Fin (qb i + 1)) :
           Pr[= (some s : Option (Fin (qb i + 1))) |
             cf <$> (simulateQ seededOracle main).run' seed]) /
           ↑(Fintype.card (spec.Range i)) := by
-    simp_rw [div_eq_mul_inv]
-    rw [← ENNReal.tsum_mul_right]
-    refine tsum_congr fun seed => ?_
-    rw [mul_assoc]
+    simp_rw [div_eq_mul_inv, ← mul_assoc, ENNReal.tsum_mul_right]
   have hStep3 :
       (∑' seed : QuerySeed spec,
         Pr[= seed | liftComp (generateSeed spec qb js) spec] *

--- a/VCVio/EvalDist/Bool.lean
+++ b/VCVio/EvalDist/Bool.lean
@@ -12,7 +12,7 @@ import VCVio.EvalDist.Defs.NeverFails
 Specialization lemmas for `HasEvalSPMF` computations returning `Bool`.
 -/
 
-variable {m : Type _ → Type _} [Monad m] [HasEvalSPMF m] {α : Type _}
+variable {m : Type _ → Type _} [Monad m] [HasEvalSPMF m] {α β : Type _}
 
 @[simp]
 lemma probOutput_true_add_false (mx : m Bool) :
@@ -45,14 +45,22 @@ lemma probOutput_not_map' [LawfulMonad m] (mx : m Bool) :
     Pr[= false | (! ·) <$> mx] = Pr[= true | mx] :=
   probOutput_map_injective mx (fun a b h => by cases a <;> cases b <;> simp_all) true
 
-@[simp]
+@[grind =]
 lemma probOutput_true_add_false_of_neverFail {mx : m Bool} [NeverFail mx] :
     Pr[= true | mx] + Pr[= false | mx] = 1 := by simp
 
-@[simp]
+@[simp, grind =]
 lemma probEvent_true_eq_probOutput (mx : m Bool) :
     Pr[ (· = true) | mx] = Pr[= true | mx] := probEvent_eq_eq_probOutput mx true
 
-@[simp]
+@[simp, grind =]
 lemma probEvent_not_eq_probOutput (mx : m Bool) :
     Pr[ (· = false) | mx] = Pr[= false | mx] := probEvent_eq_eq_probOutput mx false
+
+lemma probOutput_true_bind_map_eq_probEvent [LawfulMonad m]
+    (mx : m α) (my : α → m β) (p : α → β → Bool) :
+    Pr[= true | mx >>= fun x => p x <$> my x] =
+      Pr[fun (x, y) => p x y | do let x ← mx; return (x, ← my x)] := by
+  simp only [probOutput_bind_eq_tsum, probOutput_map_eq_tsum_ite, Bool.true_eq, bind_pure_comp,
+    probEvent_bind_eq_tsum, probEvent_map]
+  grind

--- a/VCVio/EvalDist/Bool.lean
+++ b/VCVio/EvalDist/Bool.lean
@@ -14,13 +14,13 @@ Specialization lemmas for `HasEvalSPMF` computations returning `Bool`.
 
 variable {m : Type _ → Type _} [Monad m] [HasEvalSPMF m] {α β : Type _}
 
-@[simp]
+@[simp, grind =]
 lemma probOutput_true_add_false (mx : m Bool) :
     Pr[= true | mx] + Pr[= false | mx] = 1 - Pr[⊥ | mx] := by
   have h := tsum_probOutput_eq_sub mx
   rwa [tsum_fintype (L := .unconditional _), Fintype.sum_bool] at h
 
-@[simp]
+@[simp, grind =]
 lemma probOutput_false_add_true (mx : m Bool) :
     Pr[= false | mx] + Pr[= true | mx] = 1 - Pr[⊥ | mx] := by
   rw [add_comm, probOutput_true_add_false]

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -196,6 +196,7 @@ lemma probEvent_eq_zero_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] = 0 ↔ ∀ x ∈ finSupport mx, ¬ p x := by grind
 alias ⟨_, probEvent_eq_zero'⟩ := probEvent_eq_zero_iff'
 
+@[simp, grind =]
 lemma probEvent_ne_zero_iff : Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ support mx, p x := by  grind
 alias ⟨_, probEvent_ne_zero⟩ := probEvent_ne_zero_iff
 
@@ -549,6 +550,7 @@ lemma sum_finSupport_probOutput_eq_one [HasEvalFinset m] [DecidableEq α]
 
 end sum_probOutput
 
+@[grind =]
 lemma probFailure_eq_sub_tsum [HasEvalSPMF m] (mx : m α) :
     Pr[⊥ | mx] = 1 - ∑' x : α, Pr[= x | mx] := by
   refine ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top tsum_probOutput_le_one)

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -105,11 +105,11 @@ variable (mx : m α) (x : α)
   rw [eq_comm, probOutput_eq_zero_iff]
 alias ⟨_, zero_eq_probOutput⟩ := zero_eq_probOutput_iff
 
-@[simp] lemma probOutput_eq_zero_iff' [HasEvalFinset m] [DecidableEq α] :
+@[simp, grind =] lemma probOutput_eq_zero_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[= x | mx] = 0 ↔ x ∉ finSupport mx := by rw [mem_finSupport_iff_mem_support]; aesop
 alias ⟨not_mem_fin_support_of_probOutput_eq_zero, probOutput_eq_zero'⟩ := probOutput_eq_zero_iff'
 
-@[simp] lemma zero_eq_probOutput_iff' [HasEvalFinset m] [DecidableEq α] :
+@[simp, grind =] lemma zero_eq_probOutput_iff' [HasEvalFinset m] [DecidableEq α] :
     0 = Pr[= x | mx] ↔ x ∉ finSupport mx := by rw [eq_comm, probOutput_eq_zero_iff']
 alias ⟨_, zero_eq_probOutput'⟩ := zero_eq_probOutput_iff'
 
@@ -118,7 +118,7 @@ lemma probOutput_pos_iff : 0 < Pr[= x | mx] ↔ x ∈ support mx := by
   rw [pos_iff_ne_zero, ne_eq, probOutput_eq_zero_iff, not_not]
 alias ⟨mem_support_of_probOutput_pos, probOutput_pos⟩ := probOutput_pos_iff
 
-@[simp]
+@[simp, grind =]
 lemma probOutput_pos_iff' [HasEvalFinset m] [DecidableEq α] :
     0 < Pr[= x | mx] ↔ x ∈ finSupport mx := by grind
 alias ⟨mem_finSupport_of_probOutput_pos, probOutput_pos'⟩ := probOutput_pos_iff'
@@ -191,7 +191,7 @@ lemma probEvent_eq_zero_iff :
   rw [probEvent_eq_tsum_indicator]; aesop
 alias ⟨_, probEvent_eq_zero⟩ := probEvent_eq_zero_iff
 
-@[simp]
+@[simp, grind =]
 lemma probEvent_eq_zero_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] = 0 ↔ ∀ x ∈ finSupport mx, ¬ p x := by grind
 alias ⟨_, probEvent_eq_zero'⟩ := probEvent_eq_zero_iff'
@@ -200,6 +200,7 @@ alias ⟨_, probEvent_eq_zero'⟩ := probEvent_eq_zero_iff'
 lemma probEvent_ne_zero_iff : Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ support mx, p x := by  grind
 alias ⟨_, probEvent_ne_zero⟩ := probEvent_ne_zero_iff
 
+@[simp, grind =]
 lemma probEvent_ne_zero_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ finSupport mx, p x := by aesop
 alias ⟨_, probEvent_ne_zero'⟩ := probEvent_ne_zero_iff'
@@ -209,7 +210,7 @@ lemma probEvent_pos_iff : 0 < Pr[ p | mx] ↔ ∃ x ∈ support mx, p x := by
   simp [pos_iff_ne_zero]
 alias ⟨_, probEvent_pos⟩ := probEvent_pos_iff
 
-@[simp]
+@[simp, grind =]
 lemma probEvent_pos_iff' [HasEvalFinset m] [DecidableEq α] :
     0 < Pr[ p | mx] ↔ ∃ x ∈ finSupport mx, p x := by grind
 alias ⟨_, probEvent_pos'⟩ := probEvent_pos_iff'
@@ -730,21 +731,30 @@ lemma probEvent_eq_one_iff :
 
 alias ⟨_, probEvent_eq_one⟩ := probEvent_eq_one_iff
 
-@[simp low]
+/-- Pointwise variant of `probOutput_eq_one_iff`: `Pr[= x | mx] = 1` iff the support is
+a subset of `{x}` (phrased as a forall over the support) and the computation never fails.
+
+More usable than `probOutput_eq_one_iff` when the caller wants to iterate over arbitrary
+support elements rather than prove a set equality. -/
+lemma probOutput_eq_one_iff_forall (mx : m α) (x : α) :
+    Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ y ∈ support mx, y = x := by
+  rw [← probEvent_eq_eq_probOutput, probEvent_eq_one_iff]
+
+@[simp low, grind =]
 lemma one_eq_probEvent_iff :
     1 = Pr[ p | mx] ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, p x := by
   rw [eq_comm, probEvent_eq_one_iff]
 
 alias ⟨_, one_eq_probEvent⟩ := one_eq_probEvent_iff
 
-@[simp]
+@[simp, grind =]
 lemma probEvent_eq_one_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ finSupport mx, p x := by
   simp_rw [probEvent_eq_one_iff, mem_finSupport_iff_mem_support]
 
 alias ⟨_, probEvent_eq_one'⟩ := probEvent_eq_one_iff'
 
-@[simp]
+@[simp, grind =]
 lemma one_eq_probEvent_iff' [HasEvalFinset m] [DecidableEq α] :
     1 = Pr[ p | mx] ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ finSupport mx, p x := by
   rw [eq_comm, probEvent_eq_one_iff']

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -84,6 +84,7 @@ lemma probOutput_map_eq_tsum_subtype_ite [DecidableEq β] (y : β) :
   simp only [map_eq_bind_pure_comp, probOutput_bind_eq_tsum_subtype, Function.comp_apply,
     probOutput_pure, mul_ite, mul_one, mul_zero]
 
+@[grind =]
 lemma probOutput_map_eq_tsum_ite [DecidableEq β] (y : β) :
     Pr[= y | f <$> mx] = ∑' x : α, if y = f x then Pr[= x | mx] else 0 := by
   simp only [map_eq_bind_pure_comp, probOutput_bind_eq_tsum, Function.comp_apply, probOutput_pure,

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -52,7 +52,7 @@ lemma probOutput_seq_eq_tsum_ite [HasEvalSPMF m] [LawfulMonad m] [DecidableEq β
   simp [seq_eq_bind_map, probOutput_bind_eq_tsum,
     probOutput_map_eq_tsum_ite, ← ENNReal.tsum_mul_left]
 
-@[simp]
+@[simp, grind =_]
 lemma probFailure_seq [HasEvalSPMF m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
     Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by
   rw [seq_eq_bind_map]
@@ -83,7 +83,8 @@ section seqLeft
     evalDist (mx <* my) = evalDist mx <* evalDist my := by
   simp [seqLeft_eq]
 
-@[simp] lemma probOutput_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) (x : α) :
+@[simp, grind =_]
+lemma probOutput_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) (x : α) :
     Pr[= x | mx <* my] = (1 - Pr[⊥ | my]) * Pr[= x | mx] := by
   rw [seqLeft_eq, seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc]
   simp only [Function.comp_apply, pure_bind, probOutput_bind_eq_tsum]
@@ -92,11 +93,13 @@ section seqLeft
     mul_left_comm _ (1 - Pr[⊥ | my])]
   rw [ENNReal.tsum_mul_left, ← probOutput_bind_eq_tsum, bind_pure]
 
-@[simp] lemma probFailure_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
+@[simp, grind =_]
+lemma probFailure_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
     Pr[⊥ | mx <* my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by
   rw [seqLeft_eq, probFailure_seq, probFailure_map]
 
-@[simp] lemma probEvent_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
+@[simp, grind =_]
+lemma probEvent_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
     (p : α → Prop) :
     Pr[ p | mx <* my] = (1 - Pr[⊥ | my]) * Pr[ p | mx] := by
   rw [seqLeft_eq, seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc]
@@ -119,16 +122,19 @@ section seqRight
     evalDist (mx *> my) = evalDist mx *> evalDist my := by
   simp [seqRight_eq]
 
-@[simp] lemma probOutput_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) (y : β) :
+@[simp, grind =_]
+lemma probOutput_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) (y : β) :
     Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by
   have h : mx *> my = mx >>= fun _ => my := by simp [seqRight_eq, seq_eq_bind_map]
   rw [h, probOutput_bind_const]
 
-@[simp] lemma probFailure_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
+@[simp, grind =_]
+lemma probFailure_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
     Pr[⊥ | mx *> my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by
   rw [seqRight_eq, probFailure_seq, probFailure_map]
 
-@[simp] lemma probEvent_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
+@[simp, grind =_]
+lemma probEvent_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
     (p : β → Prop) :
     Pr[ p | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[ p | my] := by
   have h : mx *> my = mx >>= fun _ => my := by simp [seqRight_eq, seq_eq_bind_map]

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -235,10 +235,8 @@ lemma relTriple_eqRel_of_probOutput_eq {oa : OracleComp spec₁ α} {ob : Oracle
 lemma probOutput_eq_of_relTriple_eqRel {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ α}
     (h : RelTriple oa ob (EqRel α)) (x : α) : Pr[= x | oa] = Pr[= x | ob] := by
   rcases (relTriple_iff_relWP (oa := oa) (ob := ob) (R := EqRel α)).1 h with ⟨c, hc⟩
-  have hfst : Pr[= x | Prod.fst <$> c.1] = Pr[= x | oa] := by
-    simpa [probOutput_def] using congrArg (fun p : SPMF α => p x) c.2.map_fst
-  have hsnd : Pr[= x | Prod.snd <$> c.1] = Pr[= x | ob] := by
-    simpa [probOutput_def] using congrArg (fun p : SPMF α => p x) c.2.map_snd
+  have hfst : Pr[= x | Prod.fst <$> c.1] = Pr[= x | oa] := by grind [c.2.map_fst]
+  have hsnd : Pr[= x | Prod.snd <$> c.1] = Pr[= x | ob] := by grind [c.2.map_snd]
   have hevent : Pr[ (fun z : α × α => z.1 = x) | c.1] = Pr[ (fun z : α × α => z.2 = x) | c.1] := by
     refine probEvent_ext (mx := c.1) fun z hz => ?_
     have hzEq : z.1 = z.2 := hc z hz; grind

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -171,11 +171,8 @@ theorem relTriple'_iff_couplingPost
                 exact probEvent_map (mx := evalDist oa) (f := packA) (q := fun a : A => a.1 = x)
           _ = Pr[ fun y : α => (packA y).1 = x | evalDist oa] := rfl
           _ = Pr[ fun y : α => y = x | evalDist oa] := by
-                apply probEvent_ext
-                intro y hy
-                have hyfin : y ∈ finSupport oa :=
-                  mem_finSupport_of_mem_support_evalDist (oa := oa) (x := y) hy
-                simp [packA, hyfin]
+                refine probEvent_ext fun y hy => ?_
+                simp [packA, mem_finSupport_of_mem_support_evalDist (oa := oa) (x := y) hy]
           _ = Pr[= x | evalDist oa] := by simp
       have hvalB : Subtype.val <$> pb = evalDist ob := by
         apply SPMF.ext
@@ -190,11 +187,8 @@ theorem relTriple'_iff_couplingPost
                 exact probEvent_map (mx := evalDist ob) (f := packB) (q := fun b : B => b.1 = y)
           _ = Pr[ fun x : β => (packB x).1 = y | evalDist ob] := rfl
           _ = Pr[ fun x : β => x = y | evalDist ob] := by
-                apply probEvent_ext
-                intro x hx
-                have hxfin : x ∈ finSupport ob :=
-                  mem_finSupport_of_mem_support_evalDist (oa := ob) (x := x) hx
-                simp [packB, hxfin]
+                refine probEvent_ext fun x hx => ?_
+                simp [packB, mem_finSupport_of_mem_support_evalDist (oa := ob) (x := x) hx]
           _ = Pr[= y | evalDist ob] := by simp
       have hsub_nonempty : Nonempty (SPMF.Coupling pa pb) := by
         rcases hne with ⟨c₀⟩
@@ -455,22 +449,8 @@ private lemma probOutput_diag_le_min_marginals
     (c : SPMF.Coupling (evalDist oa) (evalDist ob)) (a : α) :
     Pr[= (a, a) | c.1] ≤ min (Pr[= a | evalDist oa]) (Pr[= a | evalDist ob]) := by
   refine le_min ?_ ?_
-  · calc Pr[= (a, a) | c.1]
-        = Pr[ (· = (a, a)) | c.1] := (probEvent_eq_eq_probOutput c.1 (a, a)).symm
-      _ ≤ Pr[ (· = a) ∘ Prod.fst | c.1] :=
-          probEvent_mono fun z _ h => h ▸ rfl
-      _ = Pr[ (· = a) | Prod.fst <$> c.1] :=
-          (probEvent_map c.1 Prod.fst (· = a)).symm
-      _ = Pr[= a | evalDist oa] := by
-          rw [probEvent_eq_eq_probOutput, c.2.map_fst]
-  · calc Pr[= (a, a) | c.1]
-        = Pr[ (· = (a, a)) | c.1] := (probEvent_eq_eq_probOutput c.1 (a, a)).symm
-      _ ≤ Pr[ (· = a) ∘ Prod.snd | c.1] :=
-          probEvent_mono fun z _ h => h ▸ rfl
-      _ = Pr[ (· = a) | Prod.snd <$> c.1] :=
-          (probEvent_map c.1 Prod.snd (· = a)).symm
-      _ = Pr[= a | evalDist ob] := by
-          rw [probEvent_eq_eq_probOutput, c.2.map_snd]
+  · have := c.2.map_fst; grind [probEvent_mono]
+  · have := c.2.map_snd; grind [probEvent_mono]
 
 private lemma eRelWP_indicator_eqRel_le
     {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ α} :


### PR DESCRIPTION
This PR mainly adds/removes/modifies grind tags on lemmas to both reduce search space explosion in certain cases (that mean `grind` times out  currently in a lot of contexts) and to improve coverage in cases where it makes sense. A few cases of simplifications in examples included to show the improvements.