### PR TITLE
feat(tactics): smarter relational planner and unified `using` bijection coupling

### DIFF
--- a/Examples/ProgramLogic/ProofMode.lean
+++ b/Examples/ProgramLogic/ProofMode.lean
@@ -151,8 +151,6 @@ example [SampleableType α]
   conv_rhs => rw [← id_map ($ᵗ α : ProbComp α)]
   by_equiv
   rvcgen
-  · exact hf
-  · exact rfl
 
 example {oa₁ oa₂ : OracleComp spec α}
     {f₁ f₂ : α → OracleComp spec β}

--- a/Examples/ProgramLogic/RelationalDerived.lean
+++ b/Examples/ProgramLogic/RelationalDerived.lean
@@ -80,8 +80,9 @@ example :
 /--
 error: rvcstep using hf: the explicit hint did not match the current relational goal shape.
 `using` is interpreted by goal shape as one of:
-- bind cut relation
-- random/query bijection
+- bind cut relation (`α → β → Prop`)
+- bind bijection coupling (`α → α`, on synchronized uniform/query binds)
+- random/query bijection (`α → α`)
 - `List.mapM` / `List.foldlM` input relation
 - `simulateQ` state relation
 

--- a/Examples/ProgramLogic/RelationalStep.lean
+++ b/Examples/ProgramLogic/RelationalStep.lean
@@ -1,4 +1,4 @@
-/- 
+/-
 Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
@@ -195,3 +195,24 @@ example {a : α} {f : α → OracleComp spec β} :
 example {oa : OracleComp spec α} {f : α → OracleComp spec β} {g : β → OracleComp spec γ} :
     ⟪((oa >>= f) >>= g) ~ (do let x ← oa; let y ← f x; g y) | EqRel γ⟫ := by
   rvcstep
+
+/-! ## Regression: multi-goal isolation
+
+Not an idiomatic-usage example. The deliberately unfocused `rvcstep` below
+exercises the corner case where `rvcstep` is invoked with sibling goals visible
+in the goal list (the pattern `linter.style.multiGoal` discourages on style
+grounds, but which must still behave *correctly* when used). Previously, when
+the sample subgoal of `relTriple_bind` auto-closed, an unconditional
+swap-and-close pass could pull a trailing sibling ahead of the bind continuation
+and silently discharge it. The fix in `closeSampleAndReorderBindGoals` keeps
+`rest` untouched at the tail. -/
+
+set_option linter.style.multiGoal false in
+example {oa : OracleComp spec α} {f g : α → OracleComp spec β}
+    (ob : OracleComp spec α)
+    (hf : ∀ a, ⟪f a ~ g a | EqRel β⟫) :
+    (⟪oa >>= f ~ oa >>= g | EqRel β⟫) ∧ (⟪ob ~ ob | EqRel α⟫) := by
+  refine ⟨?_, ?_⟩
+  rvcstep
+  · intro a₁ a₂ h; subst h; exact hf a₁
+  · rvcstep

--- a/Examples/ProgramLogic/RelationalStep.lean
+++ b/Examples/ProgramLogic/RelationalStep.lean
@@ -36,7 +36,6 @@ example {oa₁ oa₂ : OracleComp spec α}
     (hf : ∀ a₁ a₂, EqRel α a₁ a₂ → ⟪f₁ a₁ ~ f₂ a₂ | EqRel β⟫) :
     ⟪oa₁ >>= f₁ ~ oa₂ >>= f₂ | EqRel β⟫ := by
   rvcstep
-  exact hoa
 
 example {oa₁ oa₂ : OracleComp spec α}
     {f₁ : α → OracleComp spec β} {f₂ : α → OracleComp spec γ}
@@ -45,7 +44,6 @@ example {oa₁ oa₂ : OracleComp spec α}
     (hf : ∀ a₁ a₂, S a₁ a₂ → ⟪f₁ a₁ ~ f₂ a₂ | R⟫) :
     ⟪oa₁ >>= f₁ ~ oa₂ >>= f₂ | R⟫ := by
   rvcstep using S
-  · exact hoa
 
 example (f : α → OracleComp spec β) :
     ∀ x, ⟪f x ~ f x | EqRel β⟫ := by
@@ -161,7 +159,6 @@ example {oa₁ oa₂ : OracleComp spec α}
     (hf : ∀ a₁ a₂, S a₁ a₂ → ⟪f₁ a₁ ~ f₂ a₂ | R⟫) :
     ⟪oa₁ >>= f₁ ~ oa₂ >>= f₂ | R⟫ := by
   rvcstep
-  · exact hoa
 
 example {oa₁ oa₂ : OracleComp spec α}
     {f₁ : α → OracleComp spec β} {f₂ : α → OracleComp spec γ}

--- a/Examples/Schnorr.lean
+++ b/Examples/Schnorr.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 import VCVio.CryptoFoundations.SigmaProtocol
 import VCVio.ProgramLogic.Tactics.Unary
+import VCVio.ProgramLogic.Tactics.Relational
 
 /-!
 # Schnorr Sigma Protocol
@@ -98,6 +99,7 @@ def simTranscript (g : G) (pk : G) : ProbComp (G × F × F) := do
   let z ← $ᵗ F
   return (z • g - c • pk, c, z)
 
+open OracleComp.ProgramLogic OracleComp.ProgramLogic.Relational in
 omit [Fintype F] [DecidableEq F] in
 /-- Honest-verifier zero-knowledge: the real transcript distribution equals the simulated one.
 The proof swaps sampling order and uses uniformity of `F` to reindex via the bijection
@@ -116,20 +118,13 @@ theorem sigma_hvzk (g : G) [Finite F] :
   · simp only [SigmaProtocol.realTranscript, sigma]
     vcstep rw
     simp [h_eq, add_smul, mul_smul, add_sub_cancel_right]
-  · refine probOutput_bind_congr' ($ᵗ F) t ?_
-    intro c
-    simpa [simTranscript, map_eq_bind_pure_comp, bind_assoc, pure_bind] using
-      (probOutput_bind_bijective_uniform_cross
-        (α := F) (β := F)
-        (f := fun r => r + c * sk)
-        (hf := by
-          constructor
-          · intro r₁ r₂ h
-            exact add_right_cancel h
-          · intro z
-            refine ⟨z - c * sk, ?_⟩
-            simp [sub_eq_add_neg, add_left_comm, add_comm])
-        (g := fun z => pure ((z • g - c • pk, c, z) : G × F × F))
-        t)
+  · show _ = Pr[= t | simTranscript F G g pk]
+    unfold simTranscript
+    apply probOutput_eq_of_relTriple_eqRel (x := t)
+    rvcstep
+    intro c _ hc; subst hc
+    rvcstep using (· + c * sk)
+    · rvcgen
+    · exact ⟨fun _ _ h => add_right_cancel h, fun z => ⟨z - c * sk, sub_add_cancel z _⟩⟩
 
 end Schnorr

--- a/Examples/SimpleTwoServerPIR.lean
+++ b/Examples/SimpleTwoServerPIR.lean
@@ -208,14 +208,12 @@ theorem pir_private (i₁ i₂ : Fin N) :
   · intro j acc₁ acc₂ hS
     simp only [ProgramLogic.Relational.EqRel] at hS
     rvcstep using (fun b₁ b₂ => b₁ = b₂)
-    · intro b₁ b₂ hb; subst hb
-      cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte,
-        ProgramLogic.Relational.relTriple_iff_relWP, ProgramLogic.Relational.relWP_iff_couplingPost]
-        <;> (split <;> split <;>
-          apply ProgramLogic.Relational.relTriple_pure_pure <;>
-          simp_all [ProgramLogic.Relational.EqRel])
-    · exact ProgramLogic.Relational.relTriple_uniformSample_bij
-        Function.bijective_id _ (fun _ => rfl)
+    intro b₁ b₂ hb; subst hb
+    cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte,
+      ProgramLogic.Relational.relTriple_iff_relWP, ProgramLogic.Relational.relWP_iff_couplingPost]
+      <;> (split <;> split <;>
+        apply ProgramLogic.Relational.relTriple_pure_pure <;>
+        simp_all [ProgramLogic.Relational.EqRel])
 
 /-- Privacy of the second server view: the distribution of the second query set `s'`
 is independent of which index is being queried. Intuitively, each index `j` appears in `s'` with
@@ -241,10 +239,8 @@ theorem pir_private_snd (i₁ i₂ : Fin N) :
     -- Case 1: j = i₁ ∧ j = i₂ — identical, identity coupling
     · subst h₁; subst h₂
       rvcstep using (fun b₁ b₂ => b₁ = b₂)
-      · intro b₁ b₂ hb; subst hb; cases b₁ <;>
-          simp_all [ProgramLogic.Relational.EqRel]
-      · exact ProgramLogic.Relational.relTriple_uniformSample_bij
-          Function.bijective_id _ (fun _ => rfl)
+      intro b₁ b₂ hb; subst hb; cases b₁ <;>
+        simp_all [ProgramLogic.Relational.EqRel]
     -- Case 2: j = i₁ ∧ j ≠ i₂ — negation coupling
     · subst h₁
       rvcstep using (fun b₁ b₂ => b₂ = !b₁)
@@ -261,7 +257,5 @@ theorem pir_private_snd (i₁ i₂ : Fin N) :
           Bool.involutive_not.bijective _ (fun _ => rfl)
     -- Case 4: j ≠ i₁ ∧ j ≠ i₂ — identity coupling
     · rvcstep using (fun b₁ b₂ => b₁ = b₂)
-      · intro b₁ b₂ hb; subst hb; simp [h₁, h₂]; cases b₁ <;>
-          simp_all [ProgramLogic.Relational.EqRel]
-      · exact ProgramLogic.Relational.relTriple_uniformSample_bij
-          Function.bijective_id _ (fun _ => rfl)
+      intro b₁ b₂ hb; subst hb; simp [h₁, h₂]; cases b₁ <;>
+        simp_all [ProgramLogic.Relational.EqRel]

--- a/VCVio/ProgramLogic/Relational/Examples.lean
+++ b/VCVio/ProgramLogic/Relational/Examples.lean
@@ -84,7 +84,6 @@ example {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
     (hfg : ∀ a b, R a b → RelTriple (fa a) (fb b) S) :
     RelTriple (oa >>= fa) (ob >>= fb) S := by
   rvcstep using R
-  exact hxy
 
 example (oa : OracleComp spec₁ α) :
     RelTriple (spec₁ := spec₁) (spec₂ := spec₁) oa oa (EqRel α) := by

--- a/VCVio/ProgramLogic/Tactics/Relational.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational.lean
@@ -52,8 +52,12 @@ goals: synchronized conditionals, `simulateQ`, `Functor.map`, bounded traversals
 bind decomposition, or random/query coupling.
 
 `rvcstep using t` supplies the explicit witness needed for the current shape:
-- bind cut relation
-- random/query bijection
+- bind cut relation, where `t : α → β → Prop`
+- bind bijection coupling, where `t : α → α` and both sides start
+  with a uniform sample / query (the cut is inferred as `fun a b => b = t a`,
+  closing the sample subgoal via `relTriple_uniformSample_bij` /
+  `relTriple_query_bij` and substituting the equality on the continuation)
+- random/query bijection, where `t : α → α`
 - traversal input relation (`List.mapM` / `List.foldlM`)
 - `simulateQ` state relation
 

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -98,25 +98,6 @@ def tryCloseRelGoalImmediate : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic|
     apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> (symm; assumption)))
 
-def tryCloseLeadingRelGoalImmediate : TacticM Unit := do
-  let goals ← getGoals
-  match goals with
-  | [] => pure ()
-  | goal :: rest =>
-      setGoals [goal]
-      if ← tryCloseRelGoalImmediate then
-        let solvedPrefix ← getGoals
-        setGoals (solvedPrefix ++ rest)
-      else
-        setGoals goals
-
-def reorderRelBindGoals : TacticM Unit := do
-  let goals ← getGoals
-  match goals with
-  | first :: second :: rest =>
-      setGoals ([second, first] ++ rest)
-  | _ => pure ()
-
 private def relationalGoalParts? (target : Expr) : Option (Expr × Expr × Expr) :=
   match relTripleGoalParts? target with
   | some parts => some parts
@@ -176,14 +157,30 @@ def tryFlattenRelBindGoal : TacticM Bool := do
     simp only [bind_assoc, pure_bind, bind_pure_comp, map_pure, map_bind,
       OracleComp.bind_pure_comp]))
 
-/-- After `relTriple_bind ?_ ?_` produces `[sample, continuation]`, this helper tries
-to auto-close the sample subgoal (typically `RelTriple oa oa (EqRel _)` closes via
-`relTriple_refl`), then swaps the remaining goals so the continuation lands first
-for the user's natural `intro`-style flow. -/
+/-- After `relTriple_bind ?_ ?_` produces `[sample, continuation, …pre-existing]`,
+this helper tries to auto-close the sample subgoal (typically `RelTriple oa oa
+(EqRel _)` closes via `relTriple_refl`) and the continuation subgoal in isolation,
+then puts any unclosed continuation first for the user's natural `intro`-style flow.
+
+Pre-existing goals (those already in the goal list before `relTriple_bind` produced
+the two new subgoals at the head) are preserved unchanged at the tail; the helper
+never touches or reorders them. This guards against the multi-goal scenario where
+`rvcstep` is invoked on a goal sitting alongside other open goals (for example,
+after `constructor`): a naive close-then-swap would, when the sample closes,
+swap the continuation with an unrelated trailing goal, and a follow-up close pass
+could fire on it. -/
 def closeSampleAndReorderBindGoals : TacticM Unit := do
-  tryCloseLeadingRelGoalImmediate
-  reorderRelBindGoals
-  tryCloseLeadingRelGoalImmediate
+  let goalsBefore ← getGoals
+  match goalsBefore with
+  | sample :: continuation :: rest =>
+      setGoals [sample]
+      let _ ← tryCloseRelGoalImmediate
+      let postSample ← getGoals
+      setGoals [continuation]
+      let _ ← tryCloseRelGoalImmediate
+      let postCont ← getGoals
+      setGoals (postCont ++ postSample ++ rest)
+  | _ => pure ()
 
 def runRelBindRule : TacticM Bool := do
   tryNormalizeRelBindStructure

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -167,6 +167,24 @@ def runERelBindRuleUsing (cut : TSyntax `term) : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic|
     refine OracleComp.ProgramLogic.Relational.eRelTriple_bind (cut := $cut) ?_ ?_))
 
+/-- Monad-law normalization used as a fallback when a direct `relTriple_bind`
+attempt fails. Flattens nested binds (`bind_assoc`) and reduces `pure_bind` so
+that `commit`-style intermediate computations (e.g. `do x ← oa; pure (x, x)`)
+align with the corresponding flat form on the other side. -/
+def tryFlattenRelBindGoal : TacticM Bool := do
+  tryEvalTacticSyntax (← `(tactic|
+    simp only [bind_assoc, pure_bind, bind_pure_comp, map_pure, map_bind,
+      OracleComp.bind_pure_comp]))
+
+/-- After `relTriple_bind ?_ ?_` produces `[sample, continuation]`, this helper tries
+to auto-close the sample subgoal (typically `RelTriple oa oa (EqRel _)` closes via
+`relTriple_refl`), then swaps the remaining goals so the continuation lands first
+for the user's natural `intro`-style flow. -/
+def closeSampleAndReorderBindGoals : TacticM Unit := do
+  tryCloseLeadingRelGoalImmediate
+  reorderRelBindGoals
+  tryCloseLeadingRelGoalImmediate
+
 def runRelBindRule : TacticM Bool := do
   tryNormalizeRelBindStructure
   if ← tryCloseRelGoalImmediate then
@@ -174,21 +192,94 @@ def runRelBindRule : TacticM Bool := do
   if ← tryEvalTacticSyntax (← `(tactic|
       refine OracleComp.ProgramLogic.Relational.relTriple_bind
         (R := OracleComp.ProgramLogic.Relational.EqRel _) ?_ ?_)) then
-    reorderRelBindGoals
-    tryCloseLeadingRelGoalImmediate
+    closeSampleAndReorderBindGoals
     return true
   if ← tryEvalTacticSyntax (← `(tactic|
       refine OracleComp.ProgramLogic.Relational.relTriple_bind ?_ ?_)) then
-    reorderRelBindGoals
-    tryCloseLeadingRelGoalImmediate
+    closeSampleAndReorderBindGoals
+    return true
+  -- Fallback: flatten nested binds via monad laws and retry the EqRel-bind cut.
+  if ← tryEvalTacticSyntax (← `(tactic|
+      (simp only [bind_assoc, pure_bind, bind_pure_comp, map_pure, map_bind,
+        OracleComp.bind_pure_comp]
+       refine OracleComp.ProgramLogic.Relational.relTriple_bind
+         (R := OracleComp.ProgramLogic.Relational.EqRel _) ?_ ?_))) then
+    closeSampleAndReorderBindGoals
+    return true
+  if ← tryEvalTacticSyntax (← `(tactic|
+      (simp only [bind_assoc, pure_bind, bind_pure_comp, map_pure, map_bind,
+        OracleComp.bind_pure_comp]
+       refine OracleComp.ProgramLogic.Relational.relTriple_bind ?_ ?_))) then
+    closeSampleAndReorderBindGoals
     return true
   return false
+
+/-- Bijection-coupling interpretation of an `rvcstep using f` hint when both sides
+of a bind start with a uniform sample / query.
+
+Given a goal `RelTriple ((⋯ : OracleComp _ α) >>= fa) ((⋯ : OracleComp _ α) >>= fb) S`,
+applies `relTriple_bind` with the cut `R := fun a b => b = f a`, closes the sample
+subgoal via `relTriple_uniformSample_bij` (or `relTriple_query_bij`), and on the
+continuation introduces the coupled values together with the equality witness and
+substitutes it.
+
+Resulting goal order:
+1. The continuation `RelTriple (fa a) (fb (f a)) S` for an arbitrary fresh `a`.
+2. The bijectivity side condition `Function.Bijective f`.
+3. Any prior trailing goals.
+
+Returns `true` iff every step of the recipe fired; otherwise restores state and
+returns `false` so a caller can try a different interpretation of the hint. -/
+def runRelBindBijRuleUsing (f : TSyntax `term) : TacticM Bool := do
+  let saved ← saveState
+  -- Best-effort normalization so `<$>` / `bind_pure_comp` shapes are also
+  -- recognized as bind-on-both-sides for the purposes of the recipe.
+  let _ ← tryEvalTacticSyntax (← `(tactic|
+    try simp only [bind_assoc, pure_bind, bind_pure_comp, Functor.map_map, map_pure,
+      map_bind, OracleComp.bind_pure_comp]))
+  unless ← tryEvalTacticSyntax (← `(tactic|
+      refine OracleComp.ProgramLogic.Relational.relTriple_bind
+        (R := fun a b => b = $f a) ?_ ?_)) do
+    saved.restore
+    return false
+  let bindGoals ← getGoals
+  match bindGoals with
+  | sample :: cont :: rest =>
+      setGoals [sample]
+      let sampleClosed ← tryEvalTacticSyntax (← `(tactic|
+        first
+          | refine OracleComp.ProgramLogic.Relational.relTriple_uniformSample_bij
+              (f := $f) ?_ _ (fun _ => rfl)
+          | refine OracleComp.ProgramLogic.Relational.relTriple_query_bij
+              _ (f := $f) ?_ _ (fun _ => rfl)))
+      unless sampleClosed do
+        saved.restore
+        return false
+      let bijGoals ← getGoals
+      setGoals [cont]
+      let _ ← tryEvalTacticSyntax (← `(tactic| intro _ _ heq; subst heq))
+      let contGoals ← getGoals
+      setGoals (contGoals ++ bijGoals ++ rest)
+      return true
+  | _ =>
+      saved.restore
+      return false
 
 def runRelBindRuleUsing (R : TSyntax `term) : TacticM Bool := do
   if ← tryEvalTacticSyntax (← `(tactic|
       refine OracleComp.ProgramLogic.Relational.relTriple_bind (R := $R) ?_ ?_)) then
-    reorderRelBindGoals
-    tryCloseLeadingRelGoalImmediate
+    closeSampleAndReorderBindGoals
+    return true
+  -- Fallback 1: flatten nested binds and retry with the explicit cut.
+  if ← tryEvalTacticSyntax (← `(tactic|
+      (simp only [bind_assoc, pure_bind, bind_pure_comp, map_pure, map_bind,
+        OracleComp.bind_pure_comp]
+       refine OracleComp.ProgramLogic.Relational.relTriple_bind (R := $R) ?_ ?_))) then
+    closeSampleAndReorderBindGoals
+    return true
+  -- Fallback 2: hint may be a bijection `f : α → α` (not a relation).
+  -- Try the bijection-coupling recipe used when both sides bind a uniform sample.
+  if ← runRelBindBijRuleUsing R then
     return true
   return false
 
@@ -383,6 +474,13 @@ def runRVCGenCoreUsing (hint : TSyntax `term) : TacticM Bool := withMainContext 
         if ← runRelBindRuleUsing hint then
           return true
       if ← runRelRndRuleUsing hint then
+        return true
+      -- Generic bijection-coupling-bind fallback. Handles `<$>`-shaped goals (and
+      -- more generally any goal that normalizes to `bind` on both sides) by
+      -- treating the hint as a bijection `f : α → α`, cutting with
+      -- `R := fun a b => b = f a`, and discharging the sample subgoal via
+      -- `relTriple_uniformSample_bij` / `relTriple_query_bij`.
+      if ← runRelBindBijRuleUsing hint then
         return true
       if hasSimulateQRunLike oa && hasSimulateQRunLike ob then
         runRelSimRuleUsing hint
@@ -837,8 +935,9 @@ def throwRVCGenStepUsingError (hint : TSyntax `term) : TacticM Unit := withMainC
   throwError m!
     "rvcstep using {hint}: the explicit hint did not match the current relational goal shape.\n\
     `using` is interpreted by goal shape as one of:\n\
-    - bind cut relation\n\
-    - random/query bijection\n\
+    - bind cut relation (`α → β → Prop`)\n\
+    - bind bijection coupling (`α → α`, on synchronized uniform/query binds)\n\
+    - random/query bijection (`α → α`)\n\
     - `List.mapM` / `List.foldlM` input relation\n\
     - `simulateQ` state relation\n\
     {hintMsg}\n\

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -48,7 +48,13 @@ before generating the remaining subgoals.
 ### Optional arguments
 
 - `rvcstep using R` — on bind goals, provide the intermediate relation explicitly
-- `rvcstep using f` — on random/query goals, provide the coupling bijection explicitly
+- `rvcstep using f` — on random/query goals, provide the coupling bijection explicitly.
+  On a synchronized bind goal whose left/right scrutinees are uniform samples or queries,
+  the same `using f` form is also accepted as a *bijection-coupling bind*: it cuts with
+  `R := fun a b => b = f a`, closes the sample subgoal via
+  `relTriple_uniformSample_bij` (or `relTriple_query_bij`), and substitutes the equality
+  on the continuation, leaving the user with the continuation goal followed by the
+  `Function.Bijective f` side condition
 - `rvcstep using Rin` — on `List.mapM` / `List.foldlM` goals, provide the input relation
 - `rvcstep using R_state` — on `simulateQ` goals, provide the state invariant relation
 - `rvcstep with thm` — force one explicit registered/local relational theorem


### PR DESCRIPTION
## Summary

Three planner upgrades to `rvcstep` / `rvcgen`, all routed through the existing `using` modifier (no new tactics), motivated by simplifying the Schnorr HVZK proof against the recent eRHL rule blocks (#329, #330).

### Upgrades

1. **Bind-flatten fallback** in `runRelBindRule` and `runRelBindRuleUsing`. Adds monad-law normalization (`bind_assoc`, `pure_bind`, `bind_pure_comp`, `map_pure`, `map_bind`, `OracleComp.bind_pure_comp`) as a fallback when the direct `relTriple_bind` cut fails. Handles `commit`-style nested binds (e.g. `do x ← oa; pure (x, x)` aligning with the corresponding flat form on the other side).

2. **Auto-close sample before reorder** via new `closeSampleAndReorderBindGoals` helper. Tries to close the sample subgoal first (e.g. `RelTriple oa oa (EqRel _)` via `relTriple_refl`), then reorders the remaining goals. Eliminates a redundant `· exact` bullet for identity-shape sample triples in `Examples/SimpleTwoServerPIR.lean`, `Examples/ProgramLogic/RelationalStep.lean`, and `VCVio/ProgramLogic/Relational/Examples.lean`.

3. **Bijection-coupling-bind interpretation of `rvcstep using f` / `rvcgen using f`.** When the explicit hint `f` does not elaborate as a cut relation `α → β → Prop`, the planner now also tries treating it as a bijection `f : α → α` for synchronized uniform / query binds. The recipe cuts with `R := fun a b => b = f a`, closes the sample subgoal via `relTriple_uniformSample_bij` (or `relTriple_query_bij`), and on the continuation introduces the coupled values together with the equality witness and substitutes it. The recipe transparently handles `<$>` shapes by normalizing to `>>=` first. The user is left with the continuation goal followed by the `Function.Bijective f` side condition.

   This obviates a standalone `rel_bij` tactic. Folded into the existing `using` machinery so the surface API stays small.

### Effect on `Examples/Schnorr.lean`

`sigma_hvzk` second leg is now an idiomatic eRHL chain:

```lean
apply probOutput_eq_of_relTriple_eqRel (x := t)
rvcstep                                  -- synchronized challenge bind
intro c _ hc; subst hc
rvcstep using (· + c * sk)               -- response bijection-coupling bind
· rvcgen                                 -- leaf closes via subst_vars + pure_pure rfl
· exact ⟨..., ...⟩                       -- bijectivity tail
```

Other examples (`SimpleTwoServerPIR`, `Examples/ProgramLogic/RelationalStep`, `VCVio/ProgramLogic/Relational/Examples`) gain shorter proofs because redundant identity-sample bullets fold into the auto-close.

### Documentation

`docs/agents/program-logic.md` and the `throwRVCGenStepUsingError` shape-mismatch message both advertise the new bijection-coupling-bind interpretation under `rvcstep using f`.

## Test plan

- [x] Rebased on current `main` (PRs #332, #333 already merged); the previously-conflicting `tryCloseRelGoalImmediate` block is now strictly subsumed by #332's stronger `subst_vars` retry.
- [x] `lake build` clean across the repo (existing `sorry`-warnings unchanged).
- [x] `./scripts/check-agent-docs.py` passes (the previously-failing `Undocumented tactic: rel_bij` is gone since `rel_bij` is no longer a top-level tactic).
- [x] `Examples.Schnorr`, `Examples.SimpleTwoServerPIR`, `Examples.ProgramLogic.RelationalStep`, `VCVio.ProgramLogic.Relational.Examples` build with the planner change.

---
Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)