### PR TITLE
feat(tactics): populate relational vcspec catalog, add bind normalization, and broaden leaf closure

### DIFF
--- a/Examples/ProgramLogic/RelationalStep.lean
+++ b/Examples/ProgramLogic/RelationalStep.lean
@@ -170,3 +170,31 @@ example {oa₁ oa₂ : OracleComp spec α}
     (hf : ∀ a₁ a₂, S a₁ a₂ → ⟪f₁ a₁ ~ f₂ a₂ | R⟫) :
     ⟪oa₁ >>= f₁ ~ oa₂ >>= f₂ | R⟫ := by
   rvcgen
+
+/-! ## Leaf closure via equality hypotheses
+
+These exercise the augmented leaf closer that calls `subst_vars` and tries the
+canonical pure/refl rules afterward, so syntactically-distinct pure values that
+become equal under local equalities close automatically. -/
+
+example {a b : α} (h : a = b) :
+    ⟪(pure a : OracleComp spec α) ~ (pure b : OracleComp spec α) | EqRel α⟫ := by
+  rvcstep
+
+example {a b : α} (h : b = a) :
+    ⟪(pure a : OracleComp spec α) ~ (pure b : OracleComp spec α) | EqRel α⟫ := by
+  rvcstep
+
+/-! ## Bind normalization
+
+These exercise the monadic-normalization pre-pass: nested `>>=` and `pure`-binds
+get flattened so the relational planner sees aligned bind shapes (or bypasses
+the bind rule entirely when both sides reduce to a leaf). -/
+
+example {a : α} {f : α → OracleComp spec β} :
+    ⟪(do let x ← pure a; f x) ~ f a | EqRel β⟫ := by
+  rvcstep
+
+example {oa : OracleComp spec α} {f : α → OracleComp spec β} {g : β → OracleComp spec γ} :
+    ⟪((oa >>= f) >>= g) ~ (do let x ← oa; let y ← f x; g y) | EqRel γ⟫ := by
+  rvcstep

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -20,14 +20,50 @@ namespace OracleComp.ProgramLogic
 namespace TacticInternals
 namespace Relational
 
+/-! ### Registered VC-spec rules
+
+Centralized `@[vcspec]` registrations for the relational planner. Lemmas added here become
+candidates for the registered-rule branch of `rvcstep`/`rvcgen` (and surface in the
+"Registered `@[vcspec]` candidates" hint when the planner gets stuck), in addition to any
+structural rule that `runRVCGenCore` already tries by goal shape. -/
+
 attribute [vcspec]
+  -- Core relational rules from `Relational/Basic.lean`
+  OracleComp.ProgramLogic.Relational.relTriple_pure_pure
+  OracleComp.ProgramLogic.Relational.relTriple_bind
+  OracleComp.ProgramLogic.Relational.relTriple_map
+  OracleComp.ProgramLogic.Relational.relTriple_if
+  OracleComp.ProgramLogic.Relational.relTriple_replicate
+  OracleComp.ProgramLogic.Relational.relTriple_replicate_eqRel
+  OracleComp.ProgramLogic.Relational.relTriple_list_mapM
+  OracleComp.ProgramLogic.Relational.relTriple_list_mapM_eqRel
+  OracleComp.ProgramLogic.Relational.relTriple_list_foldlM
+  OracleComp.ProgramLogic.Relational.relTriple_list_foldlM_same
+  OracleComp.ProgramLogic.Relational.relTriple_uniformSample_bij
+  OracleComp.ProgramLogic.Relational.relTriple_uniformSample_refl
+  -- Quantitative (eRHL) rules from `Relational/Quantitative.lean`
+  OracleComp.ProgramLogic.Relational.eRelTriple_pure
+  OracleComp.ProgramLogic.Relational.eRelTriple_bind
+  OracleComp.ProgramLogic.Relational.eRelTriple_uniformSample_bij
+  -- `simulateQ`-aware rules from `Relational/SimulateQ.lean`
   OracleComp.ProgramLogic.Relational.relTriple_simulateQ_run_eqRel_of_impl_eq_preservesInv
-attribute [vcspec]
   OracleComp.ProgramLogic.Relational.relTriple_simulateQ_run'_of_query_map_eq
 
 private def mkRVCGenPlannedStep (label replayText : String) (run : TacticM Bool) : PlannedStep :=
   { label, replayText, run }
 
+/-- Attempt to close the current relational/eRHL leaf goal with the canonical fast paths.
+
+Tries, in order:
+* `assumption` (catches a hypothesis matching the relational triple verbatim);
+* `relTriple_refl` (identical computations, equality coupling);
+* `relTriple_eqRel_of_eq rfl` (syntactically identical computations);
+* `relTriple_pure_pure rfl` (`pure x ⨯ pure x` with reflexive postcondition);
+* `relTriple_pure_pure` together with `assumption` (`pure a ⨯ pure b` with `R a b` in scope);
+* `eRelTriple_pure _ _ _` (quantitative pure-pure leaf);
+* the same closers after `subst_vars` (resolves goals where the pure values are
+  syntactically distinct but unified via local equality hypotheses);
+* `relTriple_pure_pure ∘ symm` (`pure a ⨯ pure b` with `R b a` in scope). -/
 def tryCloseRelGoalImmediate : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic| assumption)) <||>
   tryEvalTacticSyntax (← `(tactic|
@@ -37,7 +73,19 @@ def tryCloseRelGoalImmediate : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic|
     exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl)) <||>
   tryEvalTacticSyntax (← `(tactic|
-    apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> assumption))
+    apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> assumption)) <||>
+  tryEvalTacticSyntax (← `(tactic|
+    exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _)) <||>
+  tryEvalTacticSyntax (← `(tactic|
+    (try subst_vars
+     first
+       | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
+       | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
+       | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
+       | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
+       | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> assumption)))) <||>
+  tryEvalTacticSyntax (← `(tactic|
+    apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> (symm; assumption)))
 
 def tryCloseLeadingRelGoalImmediate : TacticM Unit := do
   let goals ← getGoals
@@ -85,6 +133,17 @@ def tryLowerRelGoal : TacticM Bool := withMainContext do
   else
     return false
 
+/-- Normalize the monad structure of both sides of a relational/eRHL goal.
+
+Applies the standard set of monad simplification lemmas (right-association, pure-bind
+elimination, `bind_pure_comp`, `Functor.map_map`, `map_pure`) to flatten nested binds
+and strip pure-bind layers so that downstream rule selection (especially
+`relTriple_bind`) sees aligned structures on both sides. The pass is best-effort:
+`try simp only` always succeeds and leaves the goal unchanged when no lemma applies. -/
+def tryNormalizeRelBindStructure : TacticM Unit := do
+  let _ ← tryEvalTacticSyntax (← `(tactic|
+    try simp only [bind_assoc, pure_bind, bind_pure_comp, Functor.map_map, map_pure]))
+
 def runERelPureRule : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic|
     exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _))
@@ -98,6 +157,9 @@ def runERelBindRuleUsing (cut : TSyntax `term) : TacticM Bool := do
     refine OracleComp.ProgramLogic.Relational.eRelTriple_bind (cut := $cut) ?_ ?_))
 
 def runRelBindRule : TacticM Bool := do
+  tryNormalizeRelBindStructure
+  if ← tryCloseRelGoalImmediate then
+    return true
   if ← tryEvalTacticSyntax (← `(tactic|
       refine OracleComp.ProgramLogic.Relational.relTriple_bind
         (R := OracleComp.ProgramLogic.Relational.EqRel _) ?_ ?_)) then
@@ -235,11 +297,14 @@ def runRelSimDistRule : TacticM Bool := withMainContext do
   | none => return false
 
 def runRVCGenCore : TacticM Bool := withMainContext do
+  tryNormalizeRelBindStructure
   let target ← instantiateMVars (← getMainTarget)
   if let some (pre, oa, ob, _) := eRelTripleGoalParts? target then
     let _ := pre
     let oa ← whnfReducible (← instantiateMVars oa)
     let ob ← whnfReducible (← instantiateMVars ob)
+    if ← tryCloseRelGoalImmediate then
+      return true
     if ← runERelPureRule then
       return true
     if isBindExpr oa && isBindExpr ob then
@@ -379,7 +444,15 @@ private def closeRelTheoremStepGoals : TacticM Unit := do
       | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
       | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
       | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
-      | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption)))
+      | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption)
+      | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
+      | (try subst_vars
+         first
+           | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
+           | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
+           | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
+           | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
+           | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption))))
 
 private def runRVCGenStepWithTheoremDirect
     (thm : TSyntax `term) (requireClosed : Bool := false) : TacticM Bool := do
@@ -787,7 +860,15 @@ def runRVCGenFinish : TacticM Unit := do
         | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
         | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
         | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
-        | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption)))
+        | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption)
+        | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
+        | (try subst_vars
+           first
+             | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
+             | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
+             | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
+             | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
+             | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption))))
   unless (← getGoals).isEmpty do
     discard <| runBoundedPasses "rvcgen finish" runRVCGenCloseConseqPass
 

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -124,7 +124,23 @@ one specific theorem/assumption step manually.
 with `@[vcspec]` to register it for the analogous bounded head-pair lookup on the relational side.
 This is especially useful for automation-oriented `simulateQ` transport lemmas whose outer
 computation heads are stable but whose inner invariants or projection arguments still come from
-the local context.
+the local context. The default registry already covers the structural relational rules
+(`relTriple_pure_pure`, `relTriple_bind`, `relTriple_map`, `relTriple_if`, the `replicate` /
+`mapM` / `foldlM` / `uniformSample_bij` families, the quantitative `eRelTriple_pure` /
+`eRelTriple_bind` / `eRelTriple_uniformSample_bij`, and the two `simulateQ` transport rules),
+so user-defined rules slot into the same lookup pipeline without further wiring.
+
+**Bind normalization**: `rvcstep` (and therefore `rvcgen`) runs a best-effort
+`simp only [bind_assoc, pure_bind, bind_pure_comp, Functor.map_map, map_pure]` pre-pass on the
+relational goal before deciding which structural rule to apply. This flattens nested binds and
+strips pure-bind layers so that the bind decomposition rule fires on aligned shapes, and so that
+goals that simplify to pure-pure or refl close immediately.
+
+**Augmented leaf closure**: the relational leaf closer (`tryCloseRelGoalImmediate`, plus its
+`rvcgen` finishing pass) tries the canonical `relTriple_refl` / `relTriple_eqRel_of_eq rfl` /
+`relTriple_pure_pure` / `eRelTriple_pure` family, then a `subst_vars`-driven retry that resolves
+syntactically-distinct pure values unified by local equality hypotheses, and finally a symmetric
+`relTriple_pure_pure ∘ symm` step for postconditions written in the swapped direction.
 
 **Pass budget**: exhaustive `vcgen` / `rvcgen` runs are bounded by
 `set_option vcvio.vcgen.maxPasses <n>`. The default is conservative so large proofs stay


### PR DESCRIPTION
## Summary

Three coordinated planner improvements that exercise the existing tactic infrastructure in `VCVio/ProgramLogic/Tactics/Relational/Internals.lean` without adding any new tactic surface. They unblock relational proofs that were closing the structural goal but stalling on common `pure_pure` / `pure_bind` shapes that fall just outside the previous closer.

* **Populate the relational `@[vcspec]` catalog.** Centralize 16 attribute registrations covering the structural pRHL rules (`relTriple_pure_pure`, `relTriple_bind`, `relTriple_map`, `relTriple_if`, the `replicate` / `mapM` / `foldlM` / `uniformSample_bij` family), the quantitative `eRelTriple_pure` / `eRelTriple_bind` / `eRelTriple_uniformSample_bij`, and the existing two `simulateQ` transports. The registered-rule branch of `rvcstep`, `rvcstep with <thm>`, and the \"Registered \`@[vcspec]\` candidates\" hint now surface a useful default set rather than two outliers, and user-defined relational rules slot into the same lookup pipeline without further wiring.

* **Bind normalization pre-pass.** `runRVCGenCore` and `runRelBindRule` now run a best-effort `try simp only [bind_assoc, pure_bind, bind_pure_comp, Functor.map_map, map_pure]` on the relational target before deciding which structural rule to apply. Nested binds and pure-bind layers get flattened so the bind decomposition rule fires on aligned shapes, and goals that simplify to a leaf close immediately.

* **Augmented leaf closure.** `tryCloseRelGoalImmediate` (and the matching closers in `closeRelTheoremStepGoals` / `runRVCGenFinish`) now also try `eRelTriple_pure` for the quantitative side, a `subst_vars`-driven retry over the canonical pure / refl rules so syntactically-distinct pure values that unify under a local equality hypothesis close immediately, and a symmetric `relTriple_pure_pure ∘ symm` step for postconditions written in the swapped direction.

## Why no unary registrations?

Registering the unary structural rules (`triple_bind`, `triple_ite`, `triple_replicate*`, etc.) under `@[vcspec]` causes timeouts in `Examples/ProgramLogic/UnaryTriple.lean`: the unary planner's `closeTheoremStepGoals` runs a heavier `solve_by_elim` over `wp_mono` / `le_trans` after every previewed candidate, so adding even a handful of fully redundant candidates per step blows past the default heartbeat budget. The unary planner needs to short-circuit theorem-candidate previews when the structural step is already conclusive before unary rules can land in the registry. Tracked as a follow-up.

## Test plan

* [x] `lake build` is clean (only pre-existing `sorry`s remain).
* [x] `lake build Examples` builds, including `Examples/Schnorr`, `Examples/ProgramLogic/UnaryTriple`, and the new `Examples/ProgramLogic/RelationalStep` cases.
* [x] `Examples/ProgramLogic/RelationalStep.lean` adds four new examples that close in a single `rvcstep`, exercising the augmented closer (pure-pure under `subst_vars`, pure-pure under `symm`) and the bind normalization pass (`pure x >>= f`, nested `(_ >>= _) >>= _`).

## Docs

* `docs/agents/program-logic.md` describes the new default registry coverage, the bind-normalization pre-pass, and the augmented leaf closure list.

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)