### PR TITLE
feat(relational): MAlgRelOrdered.Anchored class + honest exception/option WPs

### DIFF
--- a/Examples.lean
+++ b/Examples.lean
@@ -26,6 +26,7 @@ import Examples.Pedersen
 import Examples.ProgramLogic.Probability
 import Examples.ProgramLogic.ProofMode
 import Examples.ProgramLogic.Relational
+import Examples.ProgramLogic.RelationalAnchored
 import Examples.ProgramLogic.RelationalDerived
 import Examples.ProgramLogic.RelationalStep
 import Examples.ProgramLogic.Unary

--- a/Examples/ProgramLogic/RelationalAnchored.lean
+++ b/Examples/ProgramLogic/RelationalAnchored.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import VCVio.ProgramLogic.Relational.Quantitative
+import ToMathlib.Control.Monad.RelationalAlgebraAnchored
+
+/-!
+# Honest Exception Relational WP Examples
+
+Demonstrates the derived combinators `rwpExc`, `rwpExcLeft`, `rwpExcRight`, `rwpOpt`,
+`rwpOptLeft`, and `rwpOptRight` from `ToMathlib.Control.Monad.RelationalAlgebraAnchored`.
+These honest variants distinguish exception/`none` outcomes per side, in contrast to the
+default `instExceptTLeft` / `instOptionTLeft` couplings, which collapse all failure mass
+to `⊥`.
+
+The `MAlgRelOrdered.Anchored` instance for two `OracleComp` monads (proved in
+`VCVio.ProgramLogic.Relational.Quantitative` for `ℝ≥0∞`) is what makes the cross-corner
+reductions and the bind laws available.
+-/
+
+universe u
+
+namespace OracleComp.ProgramLogic.AnchoredExamples
+
+open ENNReal MAlgRelOrdered MAlgRelOrdered.Anchored
+
+variable {ι₁ ι₂ : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+
+/-! ## Pure-pure base cases -/
+
+/-- Two `pure ok` programs hit the `(ok, ok)` corner exactly. -/
+example {α β ε₁ ε₂ : Type} (a : α) (b : β)
+    (postOO : α → β → ℝ≥0∞) (postEO : ε₁ → β → ℝ≥0∞)
+    (postOE : α → ε₂ → ℝ≥0∞) (postEE : ε₁ → ε₂ → ℝ≥0∞) :
+    rwpExc (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (pure a : ExceptT ε₁ (OracleComp spec₁) α)
+        (pure b : ExceptT ε₂ (OracleComp spec₂) β)
+        postOO postEO postOE postEE = postOO a b := by
+  simp
+
+/-- A `throw` on the left lands in the `(error, ok)` corner. -/
+example {α β ε₁ ε₂ : Type} (e : ε₁) (b : β)
+    (postOO : α → β → ℝ≥0∞) (postEO : ε₁ → β → ℝ≥0∞)
+    (postOE : α → ε₂ → ℝ≥0∞) (postEE : ε₁ → ε₂ → ℝ≥0∞) :
+    rwpExc (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (throw e : ExceptT ε₁ (OracleComp spec₁) α)
+        (pure b : ExceptT ε₂ (OracleComp spec₂) β)
+        postOO postEO postOE postEE = postEO e b := by
+  simp
+
+/-- Both sides throw: hits the `(error, error)` corner. -/
+example {α β ε₁ ε₂ : Type} (e₁ : ε₁) (e₂ : ε₂)
+    (postOO : α → β → ℝ≥0∞) (postEO : ε₁ → β → ℝ≥0∞)
+    (postOE : α → ε₂ → ℝ≥0∞) (postEE : ε₁ → ε₂ → ℝ≥0∞) :
+    rwpExc (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (throw e₁ : ExceptT ε₁ (OracleComp spec₁) α)
+        (throw e₂ : ExceptT ε₂ (OracleComp spec₂) β)
+        postOO postEO postOE postEE = postEE e₁ e₂ := by
+  simp
+
+/-! ## Anchored pure-side reductions -/
+
+/-- When the left side is a literal `pure ok`, the relational WP reduces to a unary
+honest exception WP on the right side. -/
+example {α β ε₁ ε₂ : Type} (a : α) (y : ExceptT ε₂ (OracleComp spec₂) β)
+    (postOO : α → β → ℝ≥0∞) (postEO : ε₁ → β → ℝ≥0∞)
+    (postOE : α → ε₂ → ℝ≥0∞) (postEE : ε₁ → ε₂ → ℝ≥0∞) :
+    rwpExc (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (pure a : ExceptT ε₁ (OracleComp spec₁) α) y postOO postEO postOE postEE =
+      MAlgOrdered.wpExc y (postOO a) (postOE a) :=
+  rwpExc_pure_left a y postOO postEO postOE postEE
+
+/-- A `throw` on the left collapses the relational WP to a unary WP that ignores the
+left's `α` outcome and only sees the (left error, right outcome) postconditions. -/
+example {α β ε₁ ε₂ : Type} (e : ε₁) (y : ExceptT ε₂ (OracleComp spec₂) β)
+    (postOO : α → β → ℝ≥0∞) (postEO : ε₁ → β → ℝ≥0∞)
+    (postOE : α → ε₂ → ℝ≥0∞) (postEE : ε₁ → ε₂ → ℝ≥0∞) :
+    rwpExc (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (throw e : ExceptT ε₁ (OracleComp spec₁) α) y postOO postEO postOE postEE =
+      MAlgOrdered.wpExc y (postEO e) (postEE e) :=
+  rwpExc_throw_left e y postOO postEO postOE postEE
+
+/-! ## One-sided combinators -/
+
+/-- `rwpExcLeft` distinguishes left ok / left error per the right's value. -/
+example {α β ε : Type} (a : α) (y : OracleComp spec₂ β)
+    (postOk : α → β → ℝ≥0∞) (postErr : ε → β → ℝ≥0∞) :
+    rwpExcLeft (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (pure a : ExceptT ε (OracleComp spec₁) α) y postOk postErr =
+      MAlgOrdered.wp y (postOk a) :=
+  rwpExcLeft_pure_left a y postOk postErr
+
+/-- A `throw` on the left in `rwpExcLeft` collapses to a unary WP using the error
+postcondition. -/
+example {α β ε : Type} (e : ε) (y : OracleComp spec₂ β)
+    (postOk : α → β → ℝ≥0∞) (postErr : ε → β → ℝ≥0∞) :
+    rwpExcLeft (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (throw e : ExceptT ε (OracleComp spec₁) α) y postOk postErr =
+      MAlgOrdered.wp y (postErr e) :=
+  rwpExcLeft_throw_left e y postOk postErr
+
+/-! ## OptionT combinators -/
+
+/-- A `pure none` (i.e., `failure`) on the left of `rwpOpt` collapses to a unary `wpOpt`
+on the right side using the `(none, ?)` corner postconditions. -/
+example {α β : Type} (y : OptionT (OracleComp spec₂) β)
+    (postSS : α → β → ℝ≥0∞) (postSN : α → ℝ≥0∞)
+    (postNS : β → ℝ≥0∞) (postNN : ℝ≥0∞) :
+    rwpOpt (m₁ := OracleComp spec₁) (m₂ := OracleComp spec₂) (l := ℝ≥0∞)
+        (OptionT.mk (pure none) : OptionT (OracleComp spec₁) α) y postSS postSN postNS postNN =
+      MAlgOrdered.wpOpt y postNS postNN :=
+  rwpOpt_fail_left y postSS postSN postNS postNN
+
+end OracleComp.ProgramLogic.AnchoredExamples

--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -21,6 +21,7 @@ import ToMathlib.Control.Monad.Indexed
 import ToMathlib.Control.Monad.Ordered
 import ToMathlib.Control.Monad.Relation
 import ToMathlib.Control.Monad.RelationalAlgebra
+import ToMathlib.Control.Monad.RelationalAlgebraAnchored
 import ToMathlib.Control.Monad.Relative
 import ToMathlib.Control.Monad.Transformer
 import ToMathlib.Control.OptionT

--- a/ToMathlib/Control/Monad/Algebra.lean
+++ b/ToMathlib/Control/Monad/Algebra.lean
@@ -264,3 +264,167 @@ attribute [instance] instExceptT
 attribute [instance] instOptionT
 
 end MAlgOrdered
+
+/-! ## Honest exception WP
+
+`wpExc` is a derived weakest-precondition combinator for `ExceptT` that records *both*
+a success postcondition `postOk : α → l` and a failure postcondition `postErr : ε → l`,
+rather than collapsing failures to `⊥`. Symmetrically, `wpOpt` is the analogue for
+`OptionT`.
+
+These are derived: they use only the unary algebra `MAlgOrdered m l` of the underlying
+monad. The standard `MAlgOrdered (ExceptT ε m)` / `MAlgOrdered (OptionT m)` lifts then
+correspond to `wpExc · · (fun _ => ⊥)` and `wpOpt · · ⊥` respectively, which is the
+"lossy" case. The honest combinators come with their own `pure`/`throw`/`bind`/
+`tryCatch` rules that enable side-by-side reasoning about success and failure paths.
+-/
+
+namespace MAlgOrdered
+
+variable {m : Type u → Type v} {l : Type u}
+variable [Monad m] [CompleteLattice l] [MAlgOrdered m l]
+variable {α β ε : Type u}
+
+/-- Honest weakest precondition for `ExceptT`: takes a success postcondition `postOk`
+and a failure postcondition `postErr`, and returns the unary `wp` over the underlying
+monad with the postcondition split by case. -/
+def wpExc (x : ExceptT ε m α) (postOk : α → l) (postErr : ε → l) : l :=
+  MAlgOrdered.wp (m := m) x.run (fun ea =>
+    match ea with
+    | Except.ok a => postOk a
+    | Except.error e => postErr e)
+
+/-- Honest weakest precondition for `OptionT`: takes a `some` postcondition and a
+`none` postcondition. -/
+def wpOpt (x : OptionT m α) (postSome : α → l) (postNone : l) : l :=
+  MAlgOrdered.wp (m := m) x.run (fun oa =>
+    match oa with
+    | some a => postSome a
+    | none => postNone)
+
+variable [LawfulMonad m]
+
+/-- Generic case-split postcondition for `Except`-valued returns, used internally
+by `wpExc`. -/
+private def excPost (postOk : α → l) (postErr : ε → l) : Except ε α → l := fun ea =>
+  match ea with
+  | Except.ok a => postOk a
+  | Except.error e => postErr e
+
+omit [LawfulMonad m] in
+private theorem wpExc_def (x : ExceptT ε m α) (postOk : α → l) (postErr : ε → l) :
+    wpExc x postOk postErr = MAlgOrdered.wp (m := m) x.run (excPost postOk postErr) :=
+  rfl
+
+@[simp]
+theorem wpExc_pure (a : α) (postOk : α → l) (postErr : ε → l) :
+    wpExc (pure a : ExceptT ε m α) postOk postErr = postOk a := by
+  rw [wpExc_def, ExceptT.run_pure, wp_pure]
+  rfl
+
+/-- `throw e` is `ExceptT.mk (pure (Except.error e))`. -/
+@[simp]
+theorem wpExc_throw (e : ε) (postOk : α → l) (postErr : ε → l) :
+    wpExc (ExceptT.mk (pure (Except.error e)) : ExceptT ε m α) postOk postErr = postErr e := by
+  change MAlgOrdered.wp (m := m) (pure (Except.error e)) (excPost postOk postErr) = _
+  rw [wp_pure]
+  rfl
+
+/-- Bind law for `wpExc`: only the success branch threads through the post-bind
+continuation; the failure postcondition is preserved at every step. -/
+theorem wpExc_bind (x : ExceptT ε m α) (f : α → ExceptT ε m β)
+    (postOk : β → l) (postErr : ε → l) :
+    wpExc (x >>= f) postOk postErr =
+      wpExc x (fun a => wpExc (f a) postOk postErr) postErr := by
+  rw [wpExc_def, wpExc_def, ExceptT.run_bind, wp_bind]
+  congr 1
+  funext ea
+  cases ea with
+  | ok a => rfl
+  | error e =>
+      rw [wp_pure]
+      rfl
+
+/-- Catch law for `wpExc`: `tryCatch x h` exchanges its failure postcondition for the
+honest WP of the handler. -/
+theorem wpExc_tryCatch (x : ExceptT ε m α) (h : ε → ExceptT ε m α)
+    (postOk : α → l) (postErr : ε → l) :
+    wpExc (ExceptT.tryCatch x h) postOk postErr =
+      wpExc x postOk (fun e => wpExc (h e) postOk postErr) := by
+  unfold wpExc
+  unfold ExceptT.tryCatch ExceptT.run ExceptT.mk
+  rw [wp_bind]
+  congr 1
+  funext ea
+  cases ea with
+  | ok a => rw [wp_pure]
+  | error e => rfl
+
+omit [LawfulMonad m] in
+/-- `wpExc` is monotone in both postconditions. -/
+theorem wpExc_mono (x : ExceptT ε m α)
+    {postOk postOk' : α → l} {postErr postErr' : ε → l}
+    (hOk : ∀ a, postOk a ≤ postOk' a) (hErr : ∀ e, postErr e ≤ postErr' e) :
+    wpExc x postOk postErr ≤ wpExc x postOk' postErr' := by
+  rw [wpExc_def, wpExc_def]
+  apply wp_mono
+  intro ea
+  cases ea with
+  | ok a => exact hOk a
+  | error e => exact hErr e
+
+/-- Generic case-split postcondition for `Option`-valued returns. -/
+private def optPost (postSome : α → l) (postNone : l) : Option α → l := fun oa =>
+  match oa with
+  | some a => postSome a
+  | none => postNone
+
+omit [LawfulMonad m] in
+private theorem wpOpt_def (x : OptionT m α) (postSome : α → l) (postNone : l) :
+    wpOpt x postSome postNone = MAlgOrdered.wp (m := m) x.run (optPost postSome postNone) :=
+  rfl
+
+@[simp]
+theorem wpOpt_pure (a : α) (postSome : α → l) (postNone : l) :
+    wpOpt (pure a : OptionT m α) postSome postNone = postSome a := by
+  change MAlgOrdered.wp (m := m) (pure (some a)) (optPost postSome postNone) = _
+  rw [wp_pure]
+  rfl
+
+@[simp]
+theorem wpOpt_fail (postSome : α → l) (postNone : l) :
+    wpOpt (OptionT.mk (pure none) : OptionT m α) postSome postNone = postNone := by
+  change MAlgOrdered.wp (m := m) (pure none) (optPost postSome postNone) = _
+  rw [wp_pure]
+  rfl
+
+theorem wpOpt_bind (x : OptionT m α) (f : α → OptionT m β)
+    (postSome : β → l) (postNone : l) :
+    wpOpt (x >>= f) postSome postNone =
+      wpOpt x (fun a => wpOpt (f a) postSome postNone) postNone := by
+  rw [wpOpt_def, wpOpt_def, OptionT.run_bind]
+  change MAlgOrdered.wp (m := m) (x.run >>= fun oa =>
+      Option.elim oa (pure none) (fun a => (f a).run)) (optPost postSome postNone) = _
+  rw [wp_bind]
+  congr 1
+  funext oa
+  cases oa with
+  | some a => rfl
+  | none =>
+      change MAlgOrdered.wp (m := m) (pure none) _ = _
+      rw [wp_pure]
+      rfl
+
+omit [LawfulMonad m] in
+theorem wpOpt_mono (x : OptionT m α)
+    {postSome postSome' : α → l} {postNone postNone' : l}
+    (hSome : ∀ a, postSome a ≤ postSome' a) (hNone : postNone ≤ postNone') :
+    wpOpt x postSome postNone ≤ wpOpt x postSome' postNone' := by
+  rw [wpOpt_def, wpOpt_def]
+  apply wp_mono
+  intro oa
+  cases oa with
+  | some a => exact hSome a
+  | none => exact hNone
+
+end MAlgOrdered

--- a/ToMathlib/Control/Monad/RelationalAlgebra.lean
+++ b/ToMathlib/Control/Monad/RelationalAlgebra.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 module
 
 public import Mathlib.Order.CompleteLattice.Basic
+public import ToMathlib.Control.Monad.Algebra
 
 /-!
 # Relational monad algebras
@@ -607,5 +608,65 @@ instance instStrictBindStateTBoth [StrictBind m₁ m₂ l] (σ₁ σ₂ : Type u
     simpa [StateT.run_bind] using h
 
 end StrictBindInstances
+
+/-! ## Anchored subclass
+
+A relational logic is *anchored* (with respect to a unary algebra on each side) when
+relational reasoning collapses to unary reasoning whenever one of the two computations
+is a `pure` value. The two coherence axioms
+
+* `rwp_pure_left a y post = wp y (post a)`
+* `rwp_pure_right x b post = wp x (fun a => post a b)`
+
+freeze the relational `rwp` to the underlying unary `wp` at one of the two corners,
+recovering Maillard et al.'s "two unary triples + a relational triple" pattern from
+[*The Next 700 Relational Program Logics*, POPL 2020] without committing to the full
+relative-monad machinery. They are precisely the ingredient missing from the lossy
+exception lifts (see `instExceptTLeft` / `instExceptTRight` above): once anchored, one
+can derive *honest exception* combinators `wpExc` (unary) and `rwpExc` (relational)
+that track success and failure separately rather than collapsing failures to `⊥`.
+
+Anchoring is independent of `StrictBind`. The coupling-based `OracleComp` instance is
+anchored (Dirac couplings are unique) but is not strict, while a deterministic
+specification monad is strict and anchored.
+-/
+
+/-- A `MAlgRelOrdered` instance that *anchors* the relational WP to the unary WPs of
+the two sides at `pure`. The two axioms are the relational analogues of the coupling
+identities `IsCoupling c (pure a) q ↔ c = (a, ·) <$> q` (and symmetrically on the
+right): once one side is a Dirac, the relational WP collapses to the unary WP of the
+other side, specialized at the Dirac point. -/
+class Anchored (m₁ : Type u → Type v₁) (m₂ : Type u → Type v₂) (l : Type u)
+    [Monad m₁] [Monad m₂] [CompleteLattice l]
+    [MAlgOrdered m₁ l] [MAlgOrdered m₂ l] [MAlgRelOrdered m₁ m₂ l] : Prop where
+  /-- Left anchoring: when the left computation is `pure a`, the relational WP equals
+  the unary WP of the right computation evaluated at the postcondition specialized at
+  `a`. -/
+  rwp_pure_left {α β : Type u} (a : α) (y : m₂ β) (post : α → β → l) :
+    MAlgRelOrdered.rwp (pure a : m₁ α) y post = MAlgOrdered.wp y (post a)
+  /-- Right anchoring: when the right computation is `pure b`, the relational WP equals
+  the unary WP of the left computation evaluated at the postcondition specialized at
+  `b`. -/
+  rwp_pure_right {α β : Type u} (x : m₁ α) (b : β) (post : α → β → l) :
+    MAlgRelOrdered.rwp x (pure b : m₂ β) post = MAlgOrdered.wp x (fun a => post a b)
+
+namespace Anchored
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [CompleteLattice l]
+variable [MAlgOrdered m₁ l] [MAlgOrdered m₂ l] [MAlgRelOrdered m₁ m₂ l]
+variable {α β : Type u}
+
+/-- `RelWP`-flavoured restatement of the left anchoring axiom. -/
+theorem relWP_pure_left [Anchored m₁ m₂ l] (a : α) (y : m₂ β) (post : α → β → l) :
+    RelWP (pure a : m₁ α) y post = MAlgOrdered.wp y (post a) :=
+  Anchored.rwp_pure_left a y post
+
+/-- `RelWP`-flavoured restatement of the right anchoring axiom. -/
+theorem relWP_pure_right [Anchored m₁ m₂ l] (x : m₁ α) (b : β) (post : α → β → l) :
+    RelWP x (pure b : m₂ β) post = MAlgOrdered.wp x (fun a => post a b) :=
+  Anchored.rwp_pure_right x b post
+
+end Anchored
 
 end MAlgRelOrdered

--- a/ToMathlib/Control/Monad/RelationalAlgebraAnchored.lean
+++ b/ToMathlib/Control/Monad/RelationalAlgebraAnchored.lean
@@ -1,0 +1,969 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import ToMathlib.Control.Monad.RelationalAlgebra
+
+/-!
+# Honest exception relational WPs
+
+This file derives "honest" relational weakest-precondition combinators for `ExceptT` and
+`OptionT` from `MAlgRelOrdered.Anchored`, mirroring the unary `MAlgOrdered.wpExc` /
+`MAlgOrdered.wpOpt` derivations in `ToMathlib/Control/Monad/Algebra.lean`.
+
+Unlike the lossy lifts `MAlgRelOrdered.instExceptTLeft` / `instExceptTRight` /
+`instOptionTLeft` / `instOptionTRight`, which collapse exceptions and `none` to `⊥`,
+these combinators record case-split postconditions for both the success and the
+failure branches. The two-sided combinators carry one postcondition for each of the
+four (success/failure × success/failure) corners; the one-sided combinators carry a
+success and a failure postcondition for the side that has the transformer.
+
+The combinators are:
+
+* `rwpExc x y postOO postEO postOE postEE` — both sides are `ExceptT`; postconditions
+  for each of the four ok/error case combinations.
+* `rwpExcLeft x y postOk postErr` — only the left side is `ExceptT`.
+* `rwpExcRight x y postOk postErr` — only the right side is `ExceptT`.
+* `rwpOpt x y postSS postSN postNS postNN` — analogue for `OptionT`.
+* `rwpOptLeft`, `rwpOptRight` — one-sided `OptionT` analogues.
+
+Pure / `throw` / `fail` / `mono` rules hold under just `MAlgRelOrdered`. The bind laws
+and the "pure on one side reduces to unary `wpExc` / `wpOpt`" reductions additionally
+require `MAlgRelOrdered.Anchored`: the `(error, ok)`, `(ok, error)`, and `(none, some)`
+mixed cases collapse to a unary expectation on the still-running side via the
+anchoring axioms.
+-/
+
+@[expose] public section
+
+universe u v₁ v₂ v₃ v₄
+
+namespace MAlgRelOrdered
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [Preorder l] [MAlgRelOrdered m₁ m₂ l]
+variable {α β γ δ : Type u} {ε ε₁ ε₂ : Type u}
+
+/-! ## Honest two-sided exception WP -/
+
+/-- Two-sided 2×2 exception postcondition: the relational postcondition that case-splits
+on whether each side returned `Except.ok` or `Except.error`. Used internally by `rwpExc`
+to package its four corner postconditions into a single relational postcondition over
+`Except ε₁ α × Except ε₂ β`. -/
+def excPostBoth
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    Except ε₁ α → Except ε₂ β → l := fun ea eb =>
+  match ea, eb with
+  | Except.ok a, Except.ok b => postOO a b
+  | Except.error e, Except.ok b => postEO e b
+  | Except.ok a, Except.error e => postOE a e
+  | Except.error e₁, Except.error e₂ => postEE e₁ e₂
+
+/-- Honest two-sided exception relational weakest precondition: takes one postcondition
+per (left ok/error × right ok/error) corner and tracks them all separately, rather than
+collapsing failure cases to `⊥` as `instExceptTLeft` / `instExceptTRight` do. -/
+def rwpExc
+    (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y.run
+    (excPostBoth postOO postEO postOE postEE)
+
+/-! ## Honest one-sided exception WPs -/
+
+/-- Left-only exception postcondition: case-splits on whether the left's `Except`
+returned `ok` or `error`, leaving the right's `β` untouched. -/
+def excPostLeft (postOk : α → β → l) (postErr : ε → β → l) :
+    Except ε α → β → l := fun ea b =>
+  match ea with
+  | Except.ok a => postOk a b
+  | Except.error e => postErr e b
+
+/-- Honest left-side exception relational WP: only the left side carries an `ExceptT`,
+and we record separate success and failure postconditions for the left side while
+leaving the right side as a plain monadic computation in `m₂`. -/
+def rwpExcLeft (x : ExceptT ε m₁ α) (y : m₂ β)
+    (postOk : α → β → l) (postErr : ε → β → l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y (excPostLeft postOk postErr)
+
+/-- Right-only exception postcondition: symmetric to `excPostLeft`, case-splitting on
+the right's `Except`. -/
+def excPostRight (postOk : α → β → l) (postErr : α → ε → l) :
+    α → Except ε β → l := fun a eb =>
+  match eb with
+  | Except.ok b => postOk a b
+  | Except.error e => postErr a e
+
+/-- Honest right-side exception relational WP: only the right side carries an
+`ExceptT`. -/
+def rwpExcRight (x : m₁ α) (y : ExceptT ε m₂ β)
+    (postOk : α → β → l) (postErr : α → ε → l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x y.run (excPostRight postOk postErr)
+
+/-! ## Honest two-sided option WP -/
+
+/-- Two-sided `Option` postcondition. -/
+def optPostBoth
+    (postSS : α → β → l) (postSN : α → l)
+    (postNS : β → l) (postNN : l) :
+    Option α → Option β → l := fun oa ob =>
+  match oa, ob with
+  | some a, some b => postSS a b
+  | some a, none => postSN a
+  | none, some b => postNS b
+  | none, none => postNN
+
+/-- Honest two-sided `Option` relational WP. -/
+def rwpOpt
+    (x : OptionT m₁ α) (y : OptionT m₂ β)
+    (postSS : α → β → l) (postSN : α → l)
+    (postNS : β → l) (postNN : l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y.run
+    (optPostBoth postSS postSN postNS postNN)
+
+/-! ## Honest one-sided option WPs -/
+
+/-- Left-only `Option` postcondition. -/
+def optPostLeft (postSome : α → β → l) (postNone : β → l) :
+    Option α → β → l := fun oa b =>
+  match oa with
+  | some a => postSome a b
+  | none => postNone b
+
+/-- Honest left-side `Option` relational WP. -/
+def rwpOptLeft (x : OptionT m₁ α) (y : m₂ β)
+    (postSome : α → β → l) (postNone : β → l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y (optPostLeft postSome postNone)
+
+/-- Right-only `Option` postcondition. -/
+def optPostRight (postSome : α → β → l) (postNone : α → l) :
+    α → Option β → l := fun a ob =>
+  match ob with
+  | some b => postSome a b
+  | none => postNone a
+
+/-- Honest right-side `Option` relational WP. -/
+def rwpOptRight (x : m₁ α) (y : OptionT m₂ β)
+    (postSome : α → β → l) (postNone : α → l) : l :=
+  MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x y.run (optPostRight postSome postNone)
+
+end MAlgRelOrdered
+
+/-! ## Pure and monotonicity rules
+
+These hold under just `MAlgRelOrdered`. The pure rules cover the (Ok, Ok),
+(Error, Ok), (Ok, Error), (Error, Error) corners when both sides are syntactic
+`pure` / `throw`; mixed pure / non-pure cases need anchoring (further down).
+-/
+
+namespace MAlgRelOrdered
+
+section Lawful
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂] [Preorder l]
+variable [MAlgRelOrdered m₁ m₂ l]
+variable {α β γ δ : Type u} {ε ε₁ ε₂ : Type u}
+
+/-! ### `rwpExc` pure rules -/
+
+@[simp]
+theorem rwpExc_pure_pure (a : α) (b : β)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc (pure a : ExceptT ε₁ m₁ α) (pure b : ExceptT ε₂ m₂ β)
+        postOO postEO postOE postEE = postOO a b := by
+  unfold rwpExc
+  rw [show (pure a : ExceptT ε₁ m₁ α).run = pure (Except.ok a) from
+      ExceptT.run_pure a, show (pure b : ExceptT ε₂ m₂ β).run = pure (Except.ok b) from
+      ExceptT.run_pure b]
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+@[simp]
+theorem rwpExc_throw_pure (e : ε₁) (b : β)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc (throw e : ExceptT ε₁ m₁ α) (pure b : ExceptT ε₂ m₂ β)
+        postOO postEO postOE postEE = postEO e b := by
+  unfold rwpExc
+  rw [show (throw e : ExceptT ε₁ m₁ α).run = pure (Except.error e) from
+      ExceptT.run_throw, show (pure b : ExceptT ε₂ m₂ β).run = pure (Except.ok b) from
+      ExceptT.run_pure b]
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+@[simp]
+theorem rwpExc_pure_throw (a : α) (e : ε₂)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc (pure a : ExceptT ε₁ m₁ α) (throw e : ExceptT ε₂ m₂ β)
+        postOO postEO postOE postEE = postOE a e := by
+  unfold rwpExc
+  rw [show (pure a : ExceptT ε₁ m₁ α).run = pure (Except.ok a) from
+      ExceptT.run_pure a, show (throw e : ExceptT ε₂ m₂ β).run = pure (Except.error e) from
+      ExceptT.run_throw]
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+@[simp]
+theorem rwpExc_throw_throw (e₁ : ε₁) (e₂ : ε₂)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc (throw e₁ : ExceptT ε₁ m₁ α) (throw e₂ : ExceptT ε₂ m₂ β)
+        postOO postEO postOE postEE = postEE e₁ e₂ := by
+  unfold rwpExc
+  rw [show (throw e₁ : ExceptT ε₁ m₁ α).run = pure (Except.error e₁) from
+      ExceptT.run_throw, show (throw e₂ : ExceptT ε₂ m₂ β).run = pure (Except.error e₂) from
+      ExceptT.run_throw]
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+/-! ### `rwpExcLeft` pure rules -/
+
+@[simp]
+theorem rwpExcLeft_pure (a : α) (y : m₂ β)
+    (postOk : α → β → l) (postErr : ε → β → l) :
+    rwpExcLeft (pure a : ExceptT ε m₁ α) y postOk postErr =
+      MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure (Except.ok a)) y
+        (excPostLeft postOk postErr) := by
+  unfold rwpExcLeft
+  rw [show (pure a : ExceptT ε m₁ α).run = pure (Except.ok a) from ExceptT.run_pure a]
+
+@[simp]
+theorem rwpExcLeft_throw (e : ε) (y : m₂ β)
+    (postOk : α → β → l) (postErr : ε → β → l) :
+    rwpExcLeft (throw e : ExceptT ε m₁ α) y postOk postErr =
+      MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure (Except.error e)) y
+        (excPostLeft postOk postErr) := by
+  unfold rwpExcLeft
+  rw [show (throw e : ExceptT ε m₁ α).run = pure (Except.error e) from ExceptT.run_throw]
+
+/-! ### `rwpExcRight` pure rules -/
+
+@[simp]
+theorem rwpExcRight_pure (x : m₁ α) (b : β)
+    (postOk : α → β → l) (postErr : α → ε → l) :
+    rwpExcRight x (pure b : ExceptT ε m₂ β) postOk postErr =
+      MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x (pure (Except.ok b))
+        (excPostRight postOk postErr) := by
+  unfold rwpExcRight
+  rw [show (pure b : ExceptT ε m₂ β).run = pure (Except.ok b) from ExceptT.run_pure b]
+
+@[simp]
+theorem rwpExcRight_throw (x : m₁ α) (e : ε)
+    (postOk : α → β → l) (postErr : α → ε → l) :
+    rwpExcRight x (throw e : ExceptT ε m₂ β) postOk postErr =
+      MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x (pure (Except.error e))
+        (excPostRight postOk postErr) := by
+  unfold rwpExcRight
+  rw [show (throw e : ExceptT ε m₂ β).run = pure (Except.error e) from ExceptT.run_throw]
+
+/-! ### `rwpOpt` pure rules -/
+
+@[simp]
+theorem rwpOpt_pure_pure (a : α) (b : β)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt (pure a : OptionT m₁ α) (pure b : OptionT m₂ β)
+        postSS postSN postNS postNN = postSS a b := by
+  unfold rwpOpt
+  rw [show (pure a : OptionT m₁ α).run = pure (some a) from OptionT.run_pure a,
+      show (pure b : OptionT m₂ β).run = pure (some b) from OptionT.run_pure b]
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+@[simp]
+theorem rwpOpt_fail_pure (b : β)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt (OptionT.mk (pure none) : OptionT m₁ α) (pure b : OptionT m₂ β)
+        postSS postSN postNS postNN = postNS b := by
+  unfold rwpOpt
+  rw [show (pure b : OptionT m₂ β).run = pure (some b) from OptionT.run_pure b]
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) (pure (some b))
+    (optPostBoth postSS postSN postNS postNN) = _
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+@[simp]
+theorem rwpOpt_pure_fail (a : α)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt (pure a : OptionT m₁ α) (OptionT.mk (pure none) : OptionT m₂ β)
+        postSS postSN postNS postNN = postSN a := by
+  unfold rwpOpt
+  rw [show (pure a : OptionT m₁ α).run = pure (some a) from OptionT.run_pure a]
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure (some a)) (pure none)
+    (optPostBoth postSS postSN postNS postNN) = _
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+@[simp]
+theorem rwpOpt_fail_fail
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt (OptionT.mk (pure none) : OptionT m₁ α) (OptionT.mk (pure none) : OptionT m₂ β)
+        postSS postSN postNS postNN = postNN := by
+  unfold rwpOpt
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) (pure none)
+    (optPostBoth postSS postSN postNS postNN) = _
+  rw [MAlgRelOrdered.rwp_pure]
+  rfl
+
+/-! ### Monotonicity -/
+
+theorem rwpExc_mono (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
+    {postOO postOO' : α → β → l} {postEO postEO' : ε₁ → β → l}
+    {postOE postOE' : α → ε₂ → l} {postEE postEE' : ε₁ → ε₂ → l}
+    (hOO : ∀ a b, postOO a b ≤ postOO' a b)
+    (hEO : ∀ e b, postEO e b ≤ postEO' e b)
+    (hOE : ∀ a e, postOE a e ≤ postOE' a e)
+    (hEE : ∀ e₁ e₂, postEE e₁ e₂ ≤ postEE' e₁ e₂) :
+    rwpExc x y postOO postEO postOE postEE ≤ rwpExc x y postOO' postEO' postOE' postEE' := by
+  unfold rwpExc
+  apply MAlgRelOrdered.rwp_mono
+  intro ea eb
+  cases ea with
+  | ok a =>
+      cases eb with
+      | ok b => exact hOO a b
+      | error e => exact hOE a e
+  | error e =>
+      cases eb with
+      | ok b => exact hEO e b
+      | error e' => exact hEE e e'
+
+theorem rwpExcLeft_mono (x : ExceptT ε m₁ α) (y : m₂ β)
+    {postOk postOk' : α → β → l} {postErr postErr' : ε → β → l}
+    (hOk : ∀ a b, postOk a b ≤ postOk' a b)
+    (hErr : ∀ e b, postErr e b ≤ postErr' e b) :
+    rwpExcLeft x y postOk postErr ≤ rwpExcLeft x y postOk' postErr' := by
+  unfold rwpExcLeft
+  apply MAlgRelOrdered.rwp_mono
+  intro ea b
+  cases ea with
+  | ok a => exact hOk a b
+  | error e => exact hErr e b
+
+theorem rwpExcRight_mono (x : m₁ α) (y : ExceptT ε m₂ β)
+    {postOk postOk' : α → β → l} {postErr postErr' : α → ε → l}
+    (hOk : ∀ a b, postOk a b ≤ postOk' a b)
+    (hErr : ∀ a e, postErr a e ≤ postErr' a e) :
+    rwpExcRight x y postOk postErr ≤ rwpExcRight x y postOk' postErr' := by
+  unfold rwpExcRight
+  apply MAlgRelOrdered.rwp_mono
+  intro a eb
+  cases eb with
+  | ok b => exact hOk a b
+  | error e => exact hErr a e
+
+theorem rwpOpt_mono (x : OptionT m₁ α) (y : OptionT m₂ β)
+    {postSS postSS' : α → β → l} {postSN postSN' : α → l}
+    {postNS postNS' : β → l} {postNN postNN' : l}
+    (hSS : ∀ a b, postSS a b ≤ postSS' a b)
+    (hSN : ∀ a, postSN a ≤ postSN' a)
+    (hNS : ∀ b, postNS b ≤ postNS' b)
+    (hNN : postNN ≤ postNN') :
+    rwpOpt x y postSS postSN postNS postNN ≤ rwpOpt x y postSS' postSN' postNS' postNN' := by
+  unfold rwpOpt
+  apply MAlgRelOrdered.rwp_mono
+  intro oa ob
+  cases oa with
+  | some a =>
+      cases ob with
+      | some b => exact hSS a b
+      | none => exact hSN a
+  | none =>
+      cases ob with
+      | some b => exact hNS b
+      | none => exact hNN
+
+theorem rwpOptLeft_mono (x : OptionT m₁ α) (y : m₂ β)
+    {postSome postSome' : α → β → l} {postNone postNone' : β → l}
+    (hSome : ∀ a b, postSome a b ≤ postSome' a b)
+    (hNone : ∀ b, postNone b ≤ postNone' b) :
+    rwpOptLeft x y postSome postNone ≤ rwpOptLeft x y postSome' postNone' := by
+  unfold rwpOptLeft
+  apply MAlgRelOrdered.rwp_mono
+  intro oa b
+  cases oa with
+  | some a => exact hSome a b
+  | none => exact hNone b
+
+theorem rwpOptRight_mono (x : m₁ α) (y : OptionT m₂ β)
+    {postSome postSome' : α → β → l} {postNone postNone' : α → l}
+    (hSome : ∀ a b, postSome a b ≤ postSome' a b)
+    (hNone : ∀ a, postNone a ≤ postNone' a) :
+    rwpOptRight x y postSome postNone ≤ rwpOptRight x y postSome' postNone' := by
+  unfold rwpOptRight
+  apply MAlgRelOrdered.rwp_mono
+  intro a ob
+  cases ob with
+  | some b => exact hSome a b
+  | none => exact hNone a
+
+end Lawful
+
+end MAlgRelOrdered
+
+/-! ## Anchored reductions and bind laws
+
+These rules require `MAlgRelOrdered.Anchored m₁ m₂ l`: the mixed `(error, ok)`,
+`(ok, error)`, and `(none, some)` cases collapse to a unary `wpExc` / `wpOpt` of the
+still-running side via the anchoring axioms.
+-/
+
+namespace MAlgRelOrdered.Anchored
+
+variable {m₁ : Type u → Type v₁} {m₂ : Type u → Type v₂} {l : Type u}
+variable [Monad m₁] [Monad m₂]
+variable [CompleteLattice l]
+variable [MAlgOrdered m₁ l] [MAlgOrdered m₂ l] [MAlgRelOrdered m₁ m₂ l] [Anchored m₁ m₂ l]
+variable {α β γ δ : Type u} {ε ε₁ ε₂ : Type u}
+
+/-! ### `rwpExc` pure-side reductions to unary `wpExc` -/
+
+/-- When the left side is a `pure ok`, the two-sided honest exception WP collapses to
+the unary honest exception WP of the right side, specialized at the left's value. -/
+theorem rwpExc_pure_left (a : α) (y : ExceptT ε₂ m₂ β)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc (pure a : ExceptT ε₁ m₁ α) y postOO postEO postOE postEE =
+      MAlgOrdered.wpExc y (postOO a) (postOE a) := by
+  unfold rwpExc MAlgOrdered.wpExc
+  rw [show (pure a : ExceptT ε₁ m₁ α).run = pure (Except.ok a) from ExceptT.run_pure a]
+  rw [Anchored.rwp_pure_left]
+  congr 1
+  funext eb
+  cases eb with
+  | ok b => rfl
+  | error e => rfl
+
+/-- When the left side is a `throw e`, the two-sided honest exception WP collapses to
+the unary honest exception WP of the right side, with postconditions specialized at
+the left's error `e`. -/
+theorem rwpExc_throw_left (e : ε₁) (y : ExceptT ε₂ m₂ β)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc (throw e : ExceptT ε₁ m₁ α) y postOO postEO postOE postEE =
+      MAlgOrdered.wpExc y (postEO e) (postEE e) := by
+  unfold rwpExc MAlgOrdered.wpExc
+  rw [show (throw e : ExceptT ε₁ m₁ α).run = pure (Except.error e) from ExceptT.run_throw]
+  rw [Anchored.rwp_pure_left]
+  congr 1
+  funext eb
+  cases eb with
+  | ok b => rfl
+  | error e' => rfl
+
+/-- Symmetric to `rwpExc_pure_left` on the right side. -/
+theorem rwpExc_pure_right (x : ExceptT ε₁ m₁ α) (b : β)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc x (pure b : ExceptT ε₂ m₂ β) postOO postEO postOE postEE =
+      MAlgOrdered.wpExc x (fun a => postOO a b) (fun e => postEO e b) := by
+  unfold rwpExc MAlgOrdered.wpExc
+  rw [show (pure b : ExceptT ε₂ m₂ β).run = pure (Except.ok b) from ExceptT.run_pure b]
+  rw [Anchored.rwp_pure_right]
+  congr 1
+  funext ea
+  cases ea with
+  | ok a => rfl
+  | error e => rfl
+
+/-- Symmetric to `rwpExc_throw_left` on the right side. -/
+theorem rwpExc_throw_right (x : ExceptT ε₁ m₁ α) (e : ε₂)
+    (postOO : α → β → l) (postEO : ε₁ → β → l)
+    (postOE : α → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc x (throw e : ExceptT ε₂ m₂ β) postOO postEO postOE postEE =
+      MAlgOrdered.wpExc x (fun a => postOE a e) (fun e₁ => postEE e₁ e) := by
+  unfold rwpExc MAlgOrdered.wpExc
+  rw [show (throw e : ExceptT ε₂ m₂ β).run = pure (Except.error e) from ExceptT.run_throw]
+  rw [Anchored.rwp_pure_right]
+  congr 1
+  funext ea
+  cases ea with
+  | ok a => rfl
+  | error e' => rfl
+
+/-! ### `rwpExcLeft` / `rwpExcRight` pure-side reductions -/
+
+/-- When the left's `ExceptT` is `pure a`, the left-only honest exception WP collapses
+to the unary `MAlgOrdered.wp` of the right side at `postOk a`. -/
+theorem rwpExcLeft_pure_left (a : α) (y : m₂ β)
+    (postOk : α → β → l) (postErr : ε → β → l) :
+    rwpExcLeft (pure a : ExceptT ε m₁ α) y postOk postErr =
+      MAlgOrdered.wp y (postOk a) := by
+  unfold rwpExcLeft
+  rw [show (pure a : ExceptT ε m₁ α).run = pure (Except.ok a) from ExceptT.run_pure a]
+  rw [Anchored.rwp_pure_left]
+  rfl
+
+/-- When the left's `ExceptT` is `throw e`, the left-only honest exception WP collapses
+to the unary `MAlgOrdered.wp` of the right side at `postErr e`. -/
+theorem rwpExcLeft_throw_left (e : ε) (y : m₂ β)
+    (postOk : α → β → l) (postErr : ε → β → l) :
+    rwpExcLeft (throw e : ExceptT ε m₁ α) y postOk postErr =
+      MAlgOrdered.wp y (postErr e) := by
+  unfold rwpExcLeft
+  rw [show (throw e : ExceptT ε m₁ α).run = pure (Except.error e) from ExceptT.run_throw]
+  rw [Anchored.rwp_pure_left]
+  rfl
+
+/-- Symmetric to `rwpExcLeft_pure_left` on the right side. -/
+theorem rwpExcRight_pure_right (x : m₁ α) (b : β)
+    (postOk : α → β → l) (postErr : α → ε → l) :
+    rwpExcRight x (pure b : ExceptT ε m₂ β) postOk postErr =
+      MAlgOrdered.wp x (fun a => postOk a b) := by
+  unfold rwpExcRight
+  rw [show (pure b : ExceptT ε m₂ β).run = pure (Except.ok b) from ExceptT.run_pure b]
+  rw [Anchored.rwp_pure_right]
+  rfl
+
+/-- Symmetric to `rwpExcLeft_throw_left` on the right side. -/
+theorem rwpExcRight_throw_right (x : m₁ α) (e : ε)
+    (postOk : α → β → l) (postErr : α → ε → l) :
+    rwpExcRight x (throw e : ExceptT ε m₂ β) postOk postErr =
+      MAlgOrdered.wp x (fun a => postErr a e) := by
+  unfold rwpExcRight
+  rw [show (throw e : ExceptT ε m₂ β).run = pure (Except.error e) from ExceptT.run_throw]
+  rw [Anchored.rwp_pure_right]
+  rfl
+
+/-! ### `rwpOpt` pure-side reductions -/
+
+/-- When the left side is a `pure a`, the two-sided honest option WP collapses to the
+unary honest option WP of the right side, specialized at the left's value. -/
+theorem rwpOpt_pure_left (a : α) (y : OptionT m₂ β)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt (pure a : OptionT m₁ α) y postSS postSN postNS postNN =
+      MAlgOrdered.wpOpt y (postSS a) (postSN a) := by
+  unfold rwpOpt MAlgOrdered.wpOpt
+  rw [show (pure a : OptionT m₁ α).run = pure (some a) from OptionT.run_pure a]
+  rw [Anchored.rwp_pure_left]
+  congr 1
+  funext ob
+  cases ob with
+  | some b => rfl
+  | none => rfl
+
+/-- When the left side is `OptionT.mk (pure none)`, the two-sided honest option WP
+collapses to the unary honest option WP of the right side, with postconditions
+specialized to the failure case. -/
+theorem rwpOpt_fail_left (y : OptionT m₂ β)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt (OptionT.mk (pure none) : OptionT m₁ α) y postSS postSN postNS postNN =
+      MAlgOrdered.wpOpt y postNS postNN := by
+  unfold rwpOpt MAlgOrdered.wpOpt
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) y.run
+    (optPostBoth postSS postSN postNS postNN) = _
+  rw [Anchored.rwp_pure_left]
+  congr 1
+  funext ob
+  cases ob with
+  | some b => rfl
+  | none => rfl
+
+/-- Symmetric to `rwpOpt_pure_left` on the right side. -/
+theorem rwpOpt_pure_right (x : OptionT m₁ α) (b : β)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt x (pure b : OptionT m₂ β) postSS postSN postNS postNN =
+      MAlgOrdered.wpOpt x (fun a => postSS a b) (postNS b) := by
+  unfold rwpOpt MAlgOrdered.wpOpt
+  rw [show (pure b : OptionT m₂ β).run = pure (some b) from OptionT.run_pure b]
+  rw [Anchored.rwp_pure_right]
+  congr 1
+  funext oa
+  cases oa with
+  | some a => rfl
+  | none => rfl
+
+/-- Symmetric to `rwpOpt_fail_left` on the right side. -/
+theorem rwpOpt_fail_right (x : OptionT m₁ α)
+    (postSS : α → β → l) (postSN : α → l) (postNS : β → l) (postNN : l) :
+    rwpOpt x (OptionT.mk (pure none) : OptionT m₂ β) postSS postSN postNS postNN =
+      MAlgOrdered.wpOpt x postSN postNN := by
+  unfold rwpOpt MAlgOrdered.wpOpt
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run (pure none)
+    (optPostBoth postSS postSN postNS postNN) = _
+  rw [Anchored.rwp_pure_right]
+  congr 1
+  funext oa
+  cases oa with
+  | some a => rfl
+  | none => rfl
+
+/-! ### `rwpOptLeft` / `rwpOptRight` pure-side reductions -/
+
+theorem rwpOptLeft_pure_left (a : α) (y : m₂ β)
+    (postSome : α → β → l) (postNone : β → l) :
+    rwpOptLeft (pure a : OptionT m₁ α) y postSome postNone =
+      MAlgOrdered.wp y (postSome a) := by
+  unfold rwpOptLeft
+  rw [show (pure a : OptionT m₁ α).run = pure (some a) from OptionT.run_pure a]
+  rw [Anchored.rwp_pure_left]
+  rfl
+
+theorem rwpOptLeft_fail_left (y : m₂ β)
+    (postSome : α → β → l) (postNone : β → l) :
+    rwpOptLeft (OptionT.mk (pure none) : OptionT m₁ α) y postSome postNone =
+      MAlgOrdered.wp y postNone := by
+  unfold rwpOptLeft
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) y
+    (optPostLeft postSome postNone) = _
+  rw [Anchored.rwp_pure_left]
+  rfl
+
+theorem rwpOptRight_pure_right (x : m₁ α) (b : β)
+    (postSome : α → β → l) (postNone : α → l) :
+    rwpOptRight x (pure b : OptionT m₂ β) postSome postNone =
+      MAlgOrdered.wp x (fun a => postSome a b) := by
+  unfold rwpOptRight
+  rw [show (pure b : OptionT m₂ β).run = pure (some b) from OptionT.run_pure b]
+  rw [Anchored.rwp_pure_right]
+  rfl
+
+theorem rwpOptRight_fail_right (x : m₁ α)
+    (postSome : α → β → l) (postNone : α → l) :
+    rwpOptRight x (OptionT.mk (pure none) : OptionT m₂ β) postSome postNone =
+      MAlgOrdered.wp x postNone := by
+  unfold rwpOptRight
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x (pure none)
+    (optPostRight postSome postNone) = _
+  rw [Anchored.rwp_pure_right]
+  rfl
+
+/-! ### Bind laws
+
+The two-sided `rwpExc` bind law is the key payoff of anchoring: each of the four cases
+in the inner relational WP either chains relationally (when both sides succeed) or
+collapses to the unary `wpExc` of the still-running side (when one side fails). The
+one-sided `rwpExcLeft` / `rwpExcRight` bind laws are the simpler analogues. The same
+pattern applies to `rwpOpt` / `rwpOptLeft` / `rwpOptRight`.
+-/
+
+/-- Bind law for the honest left-only exception WP. The (ok) branch chains
+relationally; the (error) branch collapses to a unary `wp` on the right side via
+anchoring. -/
+theorem rwpExcLeft_bind_le (x : ExceptT ε m₁ α) (y : m₂ β)
+    (f : α → ExceptT ε m₁ γ) (g : β → m₂ δ)
+    (postOk : γ → δ → l) (postErr : ε → δ → l) :
+    rwpExcLeft x y
+        (fun a b => rwpExcLeft (f a) (g b) postOk postErr)
+        (fun e b => MAlgOrdered.wp (g b) (postErr e)) ≤
+      rwpExcLeft (x >>= f) (y >>= g) postOk postErr := by
+  simp only [rwpExcLeft]
+  let MID : Except ε α → β → l := fun ea b =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (ExceptT.bindCont f ea) (g b)
+      (excPostLeft postOk postErr)
+  let LHSpost : Except ε α → β → l := fun ea b =>
+    match ea with
+    | Except.ok a =>
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a).run (g b) (excPostLeft postOk postErr)
+    | Except.error e => MAlgOrdered.wp (g b) (postErr e)
+  have hpost : LHSpost = MID := by
+    funext ea b
+    cases ea with
+    | ok a => rfl
+    | error e =>
+        change MAlgOrdered.wp (g b) (postErr e) =
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure (Except.error e)) (g b)
+            (excPostLeft postOk postErr)
+        rw [Anchored.rwp_pure_left]
+        rfl
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y LHSpost ≤
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (x >>= f).run (y >>= g) (excPostLeft postOk postErr)
+  rw [hpost]
+  have hbind := MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run) (y := y)
+    (f := ExceptT.bindCont f) (g := g)
+    (post := excPostLeft postOk postErr)
+  refine le_trans hbind ?_
+  rw [show (x >>= f).run = x.run >>= ExceptT.bindCont f from rfl]
+
+/-- Bind law for the honest right-only exception WP. -/
+theorem rwpExcRight_bind_le (x : m₁ α) (y : ExceptT ε m₂ β)
+    (f : α → m₁ γ) (g : β → ExceptT ε m₂ δ)
+    (postOk : γ → δ → l) (postErr : γ → ε → l) :
+    rwpExcRight x y
+        (fun a b => rwpExcRight (f a) (g b) postOk postErr)
+        (fun a e => MAlgOrdered.wp (f a) (fun c => postErr c e)) ≤
+      rwpExcRight (x >>= f) (y >>= g) postOk postErr := by
+  simp only [rwpExcRight]
+  let MID : α → Except ε β → l := fun a eb =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (ExceptT.bindCont g eb)
+      (excPostRight postOk postErr)
+  let LHSpost : α → Except ε β → l := fun a eb =>
+    match eb with
+    | Except.ok b =>
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (g b).run (excPostRight postOk postErr)
+    | Except.error e => MAlgOrdered.wp (f a) (fun c => postErr c e)
+  have hpost : LHSpost = MID := by
+    funext a eb
+    cases eb with
+    | ok b => rfl
+    | error e =>
+        change MAlgOrdered.wp (f a) (fun c => postErr c e) =
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (pure (Except.error e))
+            (excPostRight postOk postErr)
+        rw [Anchored.rwp_pure_right]
+        rfl
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x y.run LHSpost ≤
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (x >>= f) (y >>= g).run (excPostRight postOk postErr)
+  rw [hpost]
+  have hbind := MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x) (y := y.run)
+    (f := f) (g := ExceptT.bindCont g)
+    (post := excPostRight postOk postErr)
+  refine le_trans hbind ?_
+  rw [show (y >>= g).run = y.run >>= ExceptT.bindCont g from rfl]
+
+/-- Bind law for the honest two-sided exception WP. The four cases are:
+
+* `(ok, ok)`: chain relationally via `rwpExc`.
+* `(error, ok)`: collapse to the unary honest exception WP of the right's `g`.
+* `(ok, error)`: collapse to the unary honest exception WP of the left's `f`.
+* `(error, error)`: trivially `postEE e₁ e₂`.
+-/
+theorem rwpExc_bind_le
+    (x : ExceptT ε₁ m₁ α) (y : ExceptT ε₂ m₂ β)
+    (f : α → ExceptT ε₁ m₁ γ) (g : β → ExceptT ε₂ m₂ δ)
+    (postOO : γ → δ → l) (postEO : ε₁ → δ → l)
+    (postOE : γ → ε₂ → l) (postEE : ε₁ → ε₂ → l) :
+    rwpExc x y
+        (fun a b => rwpExc (f a) (g b) postOO postEO postOE postEE)
+        (fun e b => MAlgOrdered.wpExc (g b) (postEO e) (postEE e))
+        (fun a e => MAlgOrdered.wpExc (f a) (fun c => postOE c e) (fun e₁ => postEE e₁ e))
+        postEE ≤
+      rwpExc (x >>= f) (y >>= g) postOO postEO postOE postEE := by
+  simp only [rwpExc]
+  let MID : Except ε₁ α → Except ε₂ β → l := fun ea eb =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (ExceptT.bindCont f ea) (ExceptT.bindCont g eb)
+      (excPostBoth postOO postEO postOE postEE)
+  let LHSpost : Except ε₁ α → Except ε₂ β → l := fun ea eb =>
+    match ea, eb with
+    | Except.ok a, Except.ok b =>
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a).run (g b).run
+          (excPostBoth postOO postEO postOE postEE)
+    | Except.error e, Except.ok b => MAlgOrdered.wpExc (g b) (postEO e) (postEE e)
+    | Except.ok a, Except.error e =>
+        MAlgOrdered.wpExc (f a) (fun c => postOE c e) (fun e₁ => postEE e₁ e)
+    | Except.error e₁, Except.error e₂ => postEE e₁ e₂
+  have hpost : LHSpost = MID := by
+    funext ea eb
+    cases ea with
+    | ok a =>
+        cases eb with
+        | ok b => rfl
+        | error e =>
+            change MAlgOrdered.wpExc (f a) (fun c => postOE c e) (fun e₁ => postEE e₁ e) =
+              MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (pure (Except.error e))
+                (excPostBoth postOO postEO postOE postEE)
+            rw [Anchored.rwp_pure_right]
+            unfold MAlgOrdered.wpExc
+            congr 1
+            funext ec
+            cases ec with
+            | ok c => rfl
+            | error e₁ => rfl
+    | error e =>
+        cases eb with
+        | ok b =>
+            change MAlgOrdered.wpExc (g b) (postEO e) (postEE e) =
+              MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure (Except.error e)) (g b)
+                (excPostBoth postOO postEO postOE postEE)
+            rw [Anchored.rwp_pure_left]
+            unfold MAlgOrdered.wpExc
+            congr 1
+            funext ed
+            cases ed with
+            | ok d => rfl
+            | error e₂ => rfl
+        | error e' =>
+            change postEE e e' =
+              MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂)
+                (pure (Except.error e)) (pure (Except.error e'))
+                (excPostBoth postOO postEO postOE postEE)
+            rw [MAlgRelOrdered.rwp_pure]
+            rfl
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y.run LHSpost ≤
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (x >>= f).run (y >>= g).run
+      (excPostBoth postOO postEO postOE postEE)
+  rw [hpost]
+  have hbind := MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run) (y := y.run)
+    (f := ExceptT.bindCont f) (g := ExceptT.bindCont g)
+    (post := excPostBoth postOO postEO postOE postEE)
+  refine le_trans hbind ?_
+  rw [show (x >>= f).run = x.run >>= ExceptT.bindCont f from rfl,
+      show (y >>= g).run = y.run >>= ExceptT.bindCont g from rfl]
+
+/-! ## Bind laws for the `OptionT` derived combinators -/
+
+/-- Bind law for the honest left-only `Option` WP. The (some) branch chains
+relationally; the (none) branch collapses to a unary `wp` on the right side
+via anchoring. -/
+theorem rwpOptLeft_bind_le (x : OptionT m₁ α) (y : m₂ β)
+    (f : α → OptionT m₁ γ) (g : β → m₂ δ)
+    (postSome : γ → δ → l) (postNone : δ → l) :
+    rwpOptLeft x y
+        (fun a b => rwpOptLeft (f a) (g b) postSome postNone)
+        (fun b => MAlgOrdered.wp (g b) postNone) ≤
+      rwpOptLeft (x >>= f) (y >>= g) postSome postNone := by
+  simp only [rwpOptLeft]
+  let bindCont : Option α → m₁ (Option γ) := fun oa =>
+    Option.elim oa (pure none) (fun a => (f a).run)
+  let MID : Option α → β → l := fun oa b =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (bindCont oa) (g b)
+      (optPostLeft postSome postNone)
+  let LHSpost : Option α → β → l := fun oa b =>
+    match oa with
+    | some a =>
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a).run (g b) (optPostLeft postSome postNone)
+    | none => MAlgOrdered.wp (g b) postNone
+  have hpost : LHSpost = MID := by
+    funext oa b
+    cases oa with
+    | some a => rfl
+    | none =>
+        change MAlgOrdered.wp (g b) postNone =
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) (g b)
+            (optPostLeft postSome postNone)
+        rw [Anchored.rwp_pure_left]
+        rfl
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y LHSpost ≤
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (x >>= f).run (y >>= g) (optPostLeft postSome postNone)
+  rw [hpost]
+  have hbind := MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run) (y := y)
+    (f := bindCont) (g := g)
+    (post := optPostLeft postSome postNone)
+  refine le_trans hbind ?_
+  rw [show (x >>= f).run = x.run >>= bindCont by
+    simp only [OptionT.run_bind, Option.elimM, bindCont]]
+
+/-- Bind law for the honest right-only `Option` WP. -/
+theorem rwpOptRight_bind_le (x : m₁ α) (y : OptionT m₂ β)
+    (f : α → m₁ γ) (g : β → OptionT m₂ δ)
+    (postSome : γ → δ → l) (postNone : γ → l) :
+    rwpOptRight x y
+        (fun a b => rwpOptRight (f a) (g b) postSome postNone)
+        (fun a => MAlgOrdered.wp (f a) postNone) ≤
+      rwpOptRight (x >>= f) (y >>= g) postSome postNone := by
+  simp only [rwpOptRight]
+  let bindCont : Option β → m₂ (Option δ) := fun ob =>
+    Option.elim ob (pure none) (fun b => (g b).run)
+  let MID : α → Option β → l := fun a ob =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (bindCont ob)
+      (optPostRight postSome postNone)
+  let LHSpost : α → Option β → l := fun a ob =>
+    match ob with
+    | some b =>
+        MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (g b).run (optPostRight postSome postNone)
+    | none => MAlgOrdered.wp (f a) postNone
+  have hpost : LHSpost = MID := by
+    funext a ob
+    cases ob with
+    | some b => rfl
+    | none =>
+        change MAlgOrdered.wp (f a) postNone =
+          MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (pure none)
+            (optPostRight postSome postNone)
+        rw [Anchored.rwp_pure_right]
+        rfl
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x y.run LHSpost ≤
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (x >>= f) (y >>= g).run
+      (optPostRight postSome postNone)
+  rw [hpost]
+  have hbind := MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x) (y := y.run)
+    (f := f) (g := bindCont)
+    (post := optPostRight postSome postNone)
+  refine le_trans hbind ?_
+  rw [show (y >>= g).run = y.run >>= bindCont by
+    simp only [OptionT.run_bind, Option.elimM, bindCont]]
+
+/-- Bind law for the honest two-sided `Option` WP. The four cases are:
+
+* `(some, some)`: chain relationally via `rwpOpt`.
+* `(none, some)`: collapse to the unary honest `Option` WP of the right's `g`.
+* `(some, none)`: collapse to the unary honest `Option` WP of the left's `f`.
+* `(none, none)`: trivially `postNN`.
+-/
+theorem rwpOpt_bind_le
+    (x : OptionT m₁ α) (y : OptionT m₂ β)
+    (f : α → OptionT m₁ γ) (g : β → OptionT m₂ δ)
+    (postSS : γ → δ → l) (postSN : γ → l)
+    (postNS : δ → l) (postNN : l) :
+    rwpOpt x y
+        (fun a b => rwpOpt (f a) (g b) postSS postSN postNS postNN)
+        (fun a => MAlgOrdered.wpOpt (f a) postSN postNN)
+        (fun b => MAlgOrdered.wpOpt (g b) postNS postNN)
+        postNN ≤
+      rwpOpt (x >>= f) (y >>= g) postSS postSN postNS postNN := by
+  simp only [rwpOpt]
+  let bindContF : Option α → m₁ (Option γ) := fun oa =>
+    Option.elim oa (pure none) (fun a => (f a).run)
+  let bindContG : Option β → m₂ (Option δ) := fun ob =>
+    Option.elim ob (pure none) (fun b => (g b).run)
+  let MID : Option α → Option β → l := fun oa ob =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (bindContF oa) (bindContG ob)
+      (optPostBoth postSS postSN postNS postNN)
+  let postSS' : α → β → l := fun a b =>
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a).run (g b).run
+      (optPostBoth postSS postSN postNS postNN)
+  let postSN' : α → l := fun a => MAlgOrdered.wpOpt (f a) postSN postNN
+  let postNS' : β → l := fun b => MAlgOrdered.wpOpt (g b) postNS postNN
+  have hpost : optPostBoth postSS' postSN' postNS' postNN = MID := by
+    funext oa ob
+    cases oa with
+    | some a =>
+        cases ob with
+        | some b => rfl
+        | none =>
+            change MAlgOrdered.wpOpt (f a) postSN postNN =
+              MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (f a) (pure none)
+                (optPostBoth postSS postSN postNS postNN)
+            rw [Anchored.rwp_pure_right]
+            unfold MAlgOrdered.wpOpt
+            congr 1
+            funext oc
+            cases oc with
+            | some c => rfl
+            | none => rfl
+    | none =>
+        cases ob with
+        | some b =>
+            change MAlgOrdered.wpOpt (g b) postNS postNN =
+              MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) (g b)
+                (optPostBoth postSS postSN postNS postNN)
+            rw [Anchored.rwp_pure_left]
+            unfold MAlgOrdered.wpOpt
+            congr 1
+            funext od
+            cases od with
+            | some d => rfl
+            | none => rfl
+        | none =>
+            change postNN =
+              MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (pure none) (pure none)
+                (optPostBoth postSS postSN postNS postNN)
+            rw [MAlgRelOrdered.rwp_pure]
+            rfl
+  change MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) x.run y.run
+      (optPostBoth postSS' postSN' postNS' postNN) ≤
+    MAlgRelOrdered.rwp (m₁ := m₁) (m₂ := m₂) (x >>= f).run (y >>= g).run
+      (optPostBoth postSS postSN postNS postNN)
+  rw [hpost]
+  have hbind := MAlgRelOrdered.rwp_bind_le (m₁ := m₁) (m₂ := m₂) (l := l)
+    (x := x.run) (y := y.run)
+    (f := bindContF) (g := bindContG)
+    (post := optPostBoth postSS postSN postNS postNN)
+  refine le_trans hbind ?_
+  rw [show (x >>= f).run = x.run >>= bindContF by
+        simp only [OptionT.run_bind, Option.elimM, bindContF],
+      show (y >>= g).run = y.run >>= bindContG by
+        simp only [OptionT.run_bind, Option.elimM, bindContG]]
+
+end MAlgRelOrdered.Anchored

--- a/ToMathlib/ProbabilityTheory/Coupling.lean
+++ b/ToMathlib/ProbabilityTheory/Coupling.lean
@@ -17,6 +17,8 @@ public import ToMathlib.ProbabilityTheory.SPMF
 
 @[expose] public section
 
+open ENNReal
+
 universe u
 
 noncomputable section
@@ -195,6 +197,162 @@ theorem IsCoupling.prod {α β : Type u} {p : SPMF α} {q : SPMF β}
 noncomputable def Coupling.prod {α β : Type u} {p : SPMF α} {q : SPMF β}
     (hp : p.toPMF none = 0) (hq : q.toPMF none = 0) : Coupling p q :=
   ⟨p >>= fun a => q >>= fun b => pure (a, b), IsCoupling.prod hp hq⟩
+
+/-! ## Dirac couplings: when one marginal is `pure`
+
+When the left marginal is `pure a` (and analogously on the right), the coupling collapses
+to the Dirac product `(a, ·) <$> q`. This is the key combinatorial ingredient behind
+*anchoring*: the relational logic must agree with the unary logic in this corner. -/
+
+/-- Dirac coupling on the left: `(a, ·) <$> q` is a coupling between `pure a` and `q`,
+provided `q` has no failure mass. -/
+theorem IsCoupling.dirac_left {α β : Type u} (a : α) {q : SPMF β}
+    (hq : q.toPMF none = 0) :
+    IsCoupling (((a, ·) : β → α × β) <$> q) (pure a) q := by
+  have hmap : (((a, ·) : β → α × β) <$> q) = q >>= fun b => pure (a, b) :=
+    (bind_pure_comp _ _).symm
+  rw [hmap]
+  refine ⟨?_, ?_⟩
+  · rw [map_bind]
+    have : (fun b : β => (Prod.fst <$> pure (a, b) : SPMF α)) = fun _ => pure a := by
+      funext b; rw [map_pure]
+    rw [this]
+    exact bind_const_of_toPMF_none_eq_zero hq (pure a)
+  · rw [map_bind]
+    have : (fun b : β => (Prod.snd <$> pure (a, b) : SPMF β)) = pure := by
+      funext b; rw [map_pure]
+    rw [this]
+    exact bind_pure q
+
+/-- Dirac coupling on the right: `(·, b) <$> p` is a coupling between `p` and `pure b`,
+provided `p` has no failure mass. -/
+theorem IsCoupling.dirac_right {α β : Type u} {p : SPMF α} (b : β)
+    (hp : p.toPMF none = 0) :
+    IsCoupling (((·, b) : α → α × β) <$> p) p (pure b) := by
+  have hmap : (((·, b) : α → α × β) <$> p) = p >>= fun a => pure (a, b) :=
+    (bind_pure_comp _ _).symm
+  rw [hmap]
+  refine ⟨?_, ?_⟩
+  · rw [map_bind]
+    have : (fun a : α => (Prod.fst <$> pure (a, b) : SPMF α)) = pure := by
+      funext a; rw [map_pure]
+    rw [this]
+    exact bind_pure p
+  · rw [map_bind]
+    have : (fun a : α => (Prod.snd <$> pure (a, b) : SPMF β)) = fun _ => pure b := by
+      funext a; rw [map_pure]
+    rw [this]
+    exact bind_const_of_toPMF_none_eq_zero hp (pure b)
+
+/-- Pointwise characterization of any coupling whose left marginal is `pure a`:
+mass off the slice `{a} × β` is zero. -/
+theorem IsCoupling.apply_eq_zero_of_pure_left {α β : Type u} {a : α} {q : SPMF β}
+    {c : SPMF (α × β)} (hc : IsCoupling c (pure a) q) {x : α} (b : β) (hxa : x ≠ a) :
+    c (x, b) = 0 := by
+  have h1 := hc.map_fst
+  rw [SPMF.fmap_eq_map] at h1
+  change PMF.map (Option.map Prod.fst) c.toPMF = PMF.pure (some a) at h1
+  exact PMF.map_eq_pure_zero _ c.toPMF (some a) h1 (some (x, b)) (by simp [hxa])
+
+/-- Pointwise characterization of any coupling whose right marginal is `pure b`:
+mass off the slice `α × {b}` is zero. -/
+theorem IsCoupling.apply_eq_zero_of_pure_right {α β : Type u} {p : SPMF α} {b : β}
+    {c : SPMF (α × β)} (hc : IsCoupling c p (pure b)) (a : α) {y : β} (hyb : y ≠ b) :
+    c (a, y) = 0 := by
+  have h2 := hc.map_snd
+  rw [SPMF.fmap_eq_map] at h2
+  change PMF.map (Option.map Prod.snd) c.toPMF = PMF.pure (some b) at h2
+  exact PMF.map_eq_pure_zero _ c.toPMF (some b) h2 (some (a, y)) (by simp [hyb])
+
+/-- For a coupling whose left marginal is `pure a`, the value at `(a, b)` matches
+the right marginal `q b`. -/
+theorem IsCoupling.apply_pure_left_eq {α β : Type u} {a : α} {q : SPMF β}
+    {c : SPMF (α × β)} (hc : IsCoupling c (pure a) q) (b : β) :
+    c (a, b) = q b := by
+  have h2 := hc.map_snd
+  rw [SPMF.fmap_eq_map] at h2
+  change PMF.map (Option.map Prod.snd) c.toPMF = q.toPMF at h2
+  rw [SPMF.apply_eq_toPMF_some, SPMF.apply_eq_toPMF_some]
+  refine Eq.symm ?_
+  rw [← h2, PMF.map_apply]
+  refine (tsum_eq_single (some (a, b)) ?_).trans ?_
+  · intro o ho
+    cases o with
+    | none => simp
+    | some p =>
+      obtain ⟨x, b'⟩ := p
+      have hne : x ≠ a ∨ b' ≠ b := by
+        by_contra h
+        push Not at h
+        exact ho (by rw [h.1, h.2])
+      cases hne with
+      | inl hxa =>
+        have hzero : c.toPMF (some (x, b')) = 0 :=
+          hc.apply_eq_zero_of_pure_left b' hxa
+        simp [Option.map, hzero]
+      | inr hb =>
+        have hne_some : (some b : Option β) ≠ some b' := fun h => hb (Option.some.inj h).symm
+        simp [Option.map, if_neg hne_some]
+  · simp
+
+/-- For a coupling whose right marginal is `pure b`, the value at `(a, b)` matches
+the left marginal `p a`. -/
+theorem IsCoupling.apply_pure_right_eq {α β : Type u} {p : SPMF α} {b : β}
+    {c : SPMF (α × β)} (hc : IsCoupling c p (pure b)) (a : α) :
+    c (a, b) = p a := by
+  have h1 := hc.map_fst
+  rw [SPMF.fmap_eq_map] at h1
+  change PMF.map (Option.map Prod.fst) c.toPMF = p.toPMF at h1
+  rw [SPMF.apply_eq_toPMF_some, SPMF.apply_eq_toPMF_some]
+  refine Eq.symm ?_
+  rw [← h1, PMF.map_apply]
+  refine (tsum_eq_single (some (a, b)) ?_).trans ?_
+  · intro o ho
+    cases o with
+    | none => simp
+    | some q =>
+      obtain ⟨a', y⟩ := q
+      have hne : a' ≠ a ∨ y ≠ b := by
+        by_contra h
+        push Not at h
+        exact ho (by rw [h.1, h.2])
+      cases hne with
+      | inl ha =>
+        have hne_some : (some a : Option α) ≠ some a' := fun h => ha (Option.some.inj h).symm
+        simp [Option.map, if_neg hne_some]
+      | inr hyb =>
+        have hzero : c.toPMF (some (a', y)) = 0 :=
+          hc.apply_eq_zero_of_pure_right a' hyb
+        simp [Option.map, hzero]
+  · simp
+
+/-- Anchoring identity for tsum-style expectations on the left:
+the expected value of `g` under any coupling between `pure a` and `q` is
+the marginal expectation `∑' b, q b * g a b`. -/
+theorem IsCoupling.tsum_pure_left {α β : Type u} {a : α} {q : SPMF β}
+    {c : SPMF (α × β)} (hc : IsCoupling c (pure a) q) (g : α → β → ℝ≥0∞) :
+    ∑' z : α × β, c z * g z.1 z.2 = ∑' b, q b * g a b := by
+  rw [ENNReal.tsum_prod']
+  refine (tsum_eq_single a ?_).trans ?_
+  · intro x hx
+    have hzero : ∀ b, c (x, b) = 0 := fun b => hc.apply_eq_zero_of_pure_left b hx
+    simp_rw [hzero, zero_mul]
+    exact tsum_zero
+  · refine tsum_congr fun b => ?_
+    rw [hc.apply_pure_left_eq]
+
+/-- Anchoring identity for tsum-style expectations on the right:
+the expected value of `g` under any coupling between `p` and `pure b` is
+the marginal expectation `∑' a, p a * g a b`. -/
+theorem IsCoupling.tsum_pure_right {α β : Type u} {p : SPMF α} {b : β}
+    {c : SPMF (α × β)} (hc : IsCoupling c p (pure b)) (g : α → β → ℝ≥0∞) :
+    ∑' z : α × β, c z * g z.1 z.2 = ∑' a, p a * g a b := by
+  rw [ENNReal.tsum_prod']
+  refine tsum_congr fun a => ?_
+  refine (tsum_eq_single b ?_).trans ?_
+  · intro y hy
+    rw [hc.apply_eq_zero_of_pure_right a hy, zero_mul]
+  · rw [hc.apply_pure_right_eq]
 
 end SPMF
 

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -209,6 +209,7 @@ import VCVio.ProgramLogic.Tactics.Unary
 import VCVio.ProgramLogic.Tactics.Unary.Internals
 import VCVio.ProgramLogic.Unary.Examples
 import VCVio.ProgramLogic.Unary.HandlerSpecs
+import VCVio.ProgramLogic.Unary.HoarePropTriple
 import VCVio.ProgramLogic.Unary.HoareTriple
 import VCVio.ProgramLogic.Unary.SimulateQ
 import VCVio.ProgramLogic.Unary.StdDoBridge

--- a/VCVio/EvalDist/Defs/Support.lean
+++ b/VCVio/EvalDist/Defs/Support.lean
@@ -83,6 +83,42 @@ lemma not_mem_support_of_not_mem_finSupport [HasEvalSet m] [HasEvalFinset m] [De
 
 end support
 
+section forall_support
+
+variable {m : Type u → Type v} [Monad m] [HasEvalSet m] {α : Type u}
+
+/-- A predicate holds on every output reachable from a monadic computation `mx`,
+i.e. `∀ x ∈ support mx, p x`. This is the "almost-sure" assertion at the qualitative
+denotational level provided by `HasEvalSet`.
+
+For `OracleComp`, see also the structural-recursion variant
+`OracleComp.allOutputsSatisfyWhen` in `VCVio/OracleComp/Traversal.lean`, which is
+parameterized by a set of possible oracle outputs. -/
+def allOutputsSatisfy (p : α → Prop) (mx : m α) : Prop :=
+  ∀ x ∈ support mx, p x
+
+/-- A predicate holds on some output reachable from a monadic computation `mx`,
+i.e. `∃ x ∈ support mx, p x`. -/
+def someOutputSatisfies (p : α → Prop) (mx : m α) : Prop :=
+  ∃ x ∈ support mx, p x
+
+lemma allOutputsSatisfy_iff_forall_support (p : α → Prop) (mx : m α) :
+    allOutputsSatisfy p mx ↔ ∀ x ∈ support mx, p x := Iff.rfl
+
+lemma someOutputSatisfies_iff_exists_support (p : α → Prop) (mx : m α) :
+    someOutputSatisfies p mx ↔ ∃ x ∈ support mx, p x := Iff.rfl
+
+lemma allOutputsSatisfy_mono {p q : α → Prop} (hpq : ∀ a, p a → q a) (mx : m α) :
+    allOutputsSatisfy p mx → allOutputsSatisfy q mx :=
+  fun h x hx => hpq x (h x hx)
+
+lemma someOutputSatisfies_mono {p q : α → Prop} (hpq : ∀ a, p a → q a) (mx : m α) :
+    someOutputSatisfies p mx → someOutputSatisfies q mx := by
+  rintro ⟨x, hx, hpx⟩
+  exact ⟨x, hx, hpq x hpx⟩
+
+end forall_support
+
 variable (p : Prop) [Decidable p]
 
 @[simp] lemma support_ite [HasEvalSet m] (mx mx' : m α) :

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -321,6 +321,39 @@ lemma probFailure_bind_of_probFailure_eq_zero [HasEvalSPMF m] {mx : m α}
 end bind
 
 
+section forall_support
+
+variable [HasEvalSet m]
+
+@[simp] lemma allOutputsSatisfy_pure (p : α → Prop) (x : α) :
+    allOutputsSatisfy p (pure x : m α) ↔ p x := by
+  simp [allOutputsSatisfy]
+
+@[simp] lemma someOutputSatisfies_pure (p : α → Prop) (x : α) :
+    someOutputSatisfies p (pure x : m α) ↔ p x := by
+  simp [someOutputSatisfies]
+
+@[simp] lemma allOutputsSatisfy_bind
+    (mx : m α) (my : α → m β) (p : β → Prop) :
+    allOutputsSatisfy p (mx >>= my) ↔
+      allOutputsSatisfy (fun a => allOutputsSatisfy p (my a)) mx := by
+  simp only [allOutputsSatisfy, support_bind, Set.mem_iUnion, exists_prop]
+  exact ⟨fun h a ha b hb => h b ⟨a, ha, hb⟩, fun h b ⟨a, ha, hb⟩ => h a ha b hb⟩
+
+@[simp] lemma someOutputSatisfies_bind
+    (mx : m α) (my : α → m β) (p : β → Prop) :
+    someOutputSatisfies p (mx >>= my) ↔
+      someOutputSatisfies (fun a => someOutputSatisfies p (my a)) mx := by
+  simp only [someOutputSatisfies, support_bind, Set.mem_iUnion, exists_prop]
+  refine ⟨?_, ?_⟩
+  · rintro ⟨b, ⟨a, ha, hb⟩, hp⟩
+    exact ⟨a, ha, b, hb, hp⟩
+  · rintro ⟨a, ha, b, hb, hp⟩
+    exact ⟨b, ⟨a, ha, hb⟩, hp⟩
+
+end forall_support
+
+
 section congr_mono
 
 variable [HasEvalSPMF m]

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -7,11 +7,13 @@ Authors: Quang Dao
 import ToMathlib.Control.Monad.RelationalAlgebra
 import ToMathlib.ProbabilityTheory.Coupling
 import VCVio.EvalDist.Defs.Instances
+import VCVio.EvalDist.Defs.NeverFails
 import VCVio.EvalDist.Monad.Basic
 import VCVio.OracleComp.Constructions.Replicate
 import VCVio.OracleComp.Constructions.SampleableType
 import VCVio.EvalDist.Monad.Map
 import VCVio.OracleComp.EvalDist
+import VCVio.ProgramLogic.Unary.HoarePropTriple
 
 /-!
 # Relational program-logic baseline
@@ -104,6 +106,74 @@ noncomputable instance instMAlgRelOrdered :
       have hz'' : z ∈ support (Classical.choose hcut).1 := by
         simpa [d, hcut] using hz'
       exact (Classical.choose_spec hcut) z hz''
+
+/-- Anchoring instance for the qualitative `Prop`-valued relational logic on `OracleComp`.
+
+When one of the two computations is `pure`, the relational coupling logic collapses to the
+unary support-based logic of the other side. This is the relational analogue of the
+*Dirac coupling* identity `c (a, b) = (evalDist y) b` whenever `c` couples `pure a` with `y`.
+
+Together with the unary `Prop` algebra in `VCVio/ProgramLogic/Unary/HoarePropTriple.lean`,
+this lets `wpExc` / `rwpExc`-style honest exception combinators (in
+`ToMathlib/Control/Monad/RelationalAlgebraAnchored.lean`) be derived uniformly. -/
+instance instAnchored :
+    MAlgRelOrdered.Anchored (OracleComp spec₁) (OracleComp spec₂) Prop where
+  rwp_pure_left {α β} a y post := by
+    apply propext
+    constructor
+    · -- (→) Use `apply_pure_left_eq` to extract the unary postcondition.
+      rintro ⟨c, hc⟩
+      rw [OracleComp.ProgramLogic.PropLogic.wp_iff_forall_support]
+      intro b hb
+      have hcPure : _root_.SPMF.IsCoupling c.1 (pure a) (evalDist y) := by
+        simpa [evalDist_pure] using c.2
+      have hpos : (evalDist y) b ≠ 0 :=
+        (mem_support_iff_evalDist_apply_ne_zero y b).1 hb
+      have hmass : c.1 (a, b) ≠ 0 := by
+        rw [hcPure.apply_pure_left_eq b]; exact hpos
+      have hmem : (a, b) ∈ support c.1 := (mem_support_iff c.1 (a, b)).2 hmass
+      exact hc (a, b) hmem
+    · -- (←) Construct the canonical Dirac coupling.
+      intro hwp
+      rw [OracleComp.ProgramLogic.PropLogic.wp_iff_forall_support] at hwp
+      have hnf : (evalDist y).toPMF none = 0 := probFailure_eq_zero (mx := y)
+      refine ⟨⟨((a, ·) : β → α × β) <$> evalDist y, ?_⟩, ?_⟩
+      · simpa [evalDist_pure] using
+          (_root_.SPMF.IsCoupling.dirac_left a hnf)
+      · intro z hz
+        rw [support_map] at hz
+        rcases hz with ⟨b, hb, hzeq⟩
+        rw [← hzeq]
+        refine hwp b ?_
+        exact (mem_support_iff_evalDist_apply_ne_zero y b).2
+          ((mem_support_iff_evalDist_apply_ne_zero (evalDist y) b).1 hb)
+  rwp_pure_right {α β} x b post := by
+    apply propext
+    constructor
+    · rintro ⟨c, hc⟩
+      rw [OracleComp.ProgramLogic.PropLogic.wp_iff_forall_support]
+      intro a ha
+      have hcPure : _root_.SPMF.IsCoupling c.1 (evalDist x) (pure b) := by
+        simpa [evalDist_pure] using c.2
+      have hpos : (evalDist x) a ≠ 0 :=
+        (mem_support_iff_evalDist_apply_ne_zero x a).1 ha
+      have hmass : c.1 (a, b) ≠ 0 := by
+        rw [hcPure.apply_pure_right_eq a]; exact hpos
+      have hmem : (a, b) ∈ support c.1 := (mem_support_iff c.1 (a, b)).2 hmass
+      exact hc (a, b) hmem
+    · intro hwp
+      rw [OracleComp.ProgramLogic.PropLogic.wp_iff_forall_support] at hwp
+      have hnf : (evalDist x).toPMF none = 0 := probFailure_eq_zero (mx := x)
+      refine ⟨⟨((·, b) : α → α × β) <$> evalDist x, ?_⟩, ?_⟩
+      · simpa [evalDist_pure] using
+          (_root_.SPMF.IsCoupling.dirac_right b hnf)
+      · intro z hz
+        rw [support_map] at hz
+        rcases hz with ⟨a, ha, hzeq⟩
+        rw [← hzeq]
+        refine hwp a ?_
+        exact (mem_support_iff_evalDist_apply_ne_zero x a).2
+          ((mem_support_iff_evalDist_apply_ne_zero (evalDist x) a).1 ha)
 
 /-- Relational weakest precondition induced by `MAlgRelOrdered` for `OracleComp`. -/
 abbrev RelWP (oa : OracleComp spec₁ α) (ob : OracleComp spec₂ β)

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 
 import VCVio.ProgramLogic.Relational.QuantitativeDefs
 import VCVio.EvalDist.TVDist
+import VCVio.ProgramLogic.Unary.HoareTriple
 import ToMathlib.ProbabilityTheory.OptimalCoupling
 
 /-!
@@ -958,6 +959,71 @@ noncomputable instance instMAlgRelOrdered_eRelWP :
   rwp_mono := fun hpost => eRelWP_mono (spec₁ := spec₁) (spec₂ := spec₂) hpost
   rwp_bind_le := fun oa ob fa fb post =>
     eRelWP_bind_le (spec₁ := spec₁) (spec₂ := spec₂) oa ob fa fb post
+
+/-- Anchoring instance for the quantitative `ℝ≥0∞`-valued relational logic on `OracleComp`.
+
+When one of the two computations is `pure`, the supremum over couplings collapses to the
+single Dirac coupling (existence: `IsCoupling.dirac_left`; uniqueness on the supports follows
+from `IsCoupling.apply_pure_left_eq`), and the relational expectation reduces to the unary
+expectation `wp y (post a)` (resp. `wp x (fun a => post a b)`). This is the genuinely
+quantitative analogue of the qualitative `Anchored Prop` instance in
+`VCVio/ProgramLogic/Relational/Basic.lean`. -/
+noncomputable instance instAnchored_eRelWP :
+    MAlgRelOrdered.Anchored (OracleComp spec₁) (OracleComp spec₂) ℝ≥0∞ where
+  rwp_pure_left {α β} a y post := by
+    change eRelWP (pure a : OracleComp spec₁ α) y post = wp y (post a)
+    rw [wp_eq_tsum]
+    apply le_antisymm
+    · -- (≤): every coupling collapses to the marginal expectation by `tsum_pure_left`.
+      refine iSup_le fun c => ?_
+      have hcPure : SPMF.IsCoupling c.1 (pure a) (evalDist y) := by
+        simpa [evalDist_pure] using c.2
+      have heq := hcPure.tsum_pure_left post
+      change ∑' z, c.1 z * post z.1 z.2 ≤ ∑' b, Pr[= b | y] * post a b
+      simp only [probOutput_def]
+      exact le_of_eq heq
+    · -- (≥): the canonical Dirac coupling exhibits this expectation.
+      have hnf : (evalDist y).toPMF none = 0 := probFailure_eq_zero (mx := y)
+      have hcPure : SPMF.IsCoupling (((a, ·) : β → α × β) <$> evalDist y) (pure a) (evalDist y) :=
+        SPMF.IsCoupling.dirac_left a hnf
+      have hCoupling : SPMF.IsCoupling (((a, ·) : β → α × β) <$> evalDist y)
+          (evalDist (pure a : OracleComp spec₁ α)) (evalDist y) := by
+        simpa [evalDist_pure] using hcPure
+      let c : SPMF.Coupling (evalDist (pure a : OracleComp spec₁ α)) (evalDist y) :=
+        ⟨((a, ·) : β → α × β) <$> evalDist y, hCoupling⟩
+      have heq := hcPure.tsum_pure_left post
+      change ∑' b, Pr[= b | y] * post a b ≤
+        ⨆ c : SPMF.Coupling (evalDist (pure a : OracleComp spec₁ α)) (evalDist y),
+          ∑' z, Pr[= z | c.1] * post z.1 z.2
+      apply le_iSup_of_le c
+      simp only [probOutput_def]
+      exact le_of_eq heq.symm
+  rwp_pure_right {α β} x b post := by
+    change eRelWP x (pure b : OracleComp spec₂ β) post = wp x (fun a => post a b)
+    rw [wp_eq_tsum]
+    apply le_antisymm
+    · refine iSup_le fun c => ?_
+      have hcPure : SPMF.IsCoupling c.1 (evalDist x) (pure b) := by
+        simpa [evalDist_pure] using c.2
+      have heq := hcPure.tsum_pure_right post
+      change ∑' z, c.1 z * post z.1 z.2 ≤ ∑' a, Pr[= a | x] * post a b
+      simp only [probOutput_def]
+      exact le_of_eq heq
+    · have hnf : (evalDist x).toPMF none = 0 := probFailure_eq_zero (mx := x)
+      have hcPure : SPMF.IsCoupling (((·, b) : α → α × β) <$> evalDist x) (evalDist x) (pure b) :=
+        SPMF.IsCoupling.dirac_right b hnf
+      have hCoupling : SPMF.IsCoupling (((·, b) : α → α × β) <$> evalDist x)
+          (evalDist x) (evalDist (pure b : OracleComp spec₂ β)) := by
+        simpa [evalDist_pure] using hcPure
+      let c : SPMF.Coupling (evalDist x) (evalDist (pure b : OracleComp spec₂ β)) :=
+        ⟨((·, b) : α → α × β) <$> evalDist x, hCoupling⟩
+      have heq := hcPure.tsum_pure_right post
+      change ∑' a, Pr[= a | x] * post a b ≤
+        ⨆ c : SPMF.Coupling (evalDist x) (evalDist (pure b : OracleComp spec₂ β)),
+          ∑' z, Pr[= z | c.1] * post z.1 z.2
+      apply le_iSup_of_le c
+      simp only [probOutput_def]
+      exact le_of_eq heq.symm
 
 noncomputable example :
     MAlgRelOrdered (OptionT (OracleComp spec₁)) (OracleComp spec₂) ℝ≥0∞ :=

--- a/VCVio/ProgramLogic/Unary/HoarePropTriple.lean
+++ b/VCVio/ProgramLogic/Unary/HoarePropTriple.lean
@@ -14,10 +14,10 @@ import VCVio.OracleComp.EvalDist
 This file registers the qualitative `Prop`-valued unary monad algebra for
 `OracleComp spec`. The carrier is `Prop` with its standard complete-lattice structure
 (`≤` is implication), and `μ (oa : OracleComp spec Prop)` is the almost-sure assertion
-`∀ x ∈ support oa, x`.
+`allOutputsSatisfy id oa = ∀ x ∈ support oa, x`.
 
 The induced `MAlgOrdered.wp` is the support-based weakest precondition:
-`wp oa post ↔ ∀ x ∈ support oa, post x`.
+`wp oa post ↔ allOutputsSatisfy post oa = ∀ x ∈ support oa, post x`.
 
 This is the qualitative companion of the quantitative `MAlgOrdered (OracleComp spec) ℝ≥0∞`
 in `VCVio/ProgramLogic/Unary/HoareTriple.lean`. Together they let
@@ -32,43 +32,26 @@ namespace OracleComp.ProgramLogic.PropLogic
 variable {ι : Type u} {spec : OracleSpec ι}
 variable {α β : Type}
 
-/-- Qualitative algebra for oracle computations returning `Prop`: the universal
-quantifier over the support. -/
-def μProp (oa : OracleComp spec Prop) : Prop :=
-  ∀ x ∈ support oa, x
-
 /-- The qualitative `Prop`-valued unary monad algebra for `OracleComp`.
 
-`μ` is the almost-sure assertion `∀ x ∈ support oa, x`; `wp` is the support-based
-weakest precondition; `Triple pre oa post` is `pre → ∀ x ∈ support oa, post x`. -/
+`μ` is the almost-sure assertion `allOutputsSatisfy id`; the induced `wp` is the
+support-based weakest precondition; `Triple pre oa post` is
+`pre → allOutputsSatisfy post oa`. -/
 instance instMAlgOrdered : MAlgOrdered (OracleComp spec) Prop where
-  μ := μProp (spec := spec)
-  μ_pure x := by
-    refine propext ⟨fun h => h x ?_, fun hx p hp => ?_⟩
-    · simp [support_pure]
-    · have hpx : p ↔ x := by simpa [support_pure] using hp
-      exact hpx.mpr hx
+  μ := allOutputsSatisfy id
+  μ_pure x := propext (allOutputsSatisfy_pure id x)
   μ_bind_mono {α} f g hfg x := by
-    intro hf y hy
-    rcases (mem_support_bind_iff x g y).1 hy with ⟨a, ha, hy'⟩
-    have hfa : ∀ z ∈ support (f a), z := fun z hz =>
-      hf z ((mem_support_bind_iff x f z).2 ⟨a, ha, hz⟩)
-    exact hfg a hfa y hy'
+    change allOutputsSatisfy id (x >>= f) → allOutputsSatisfy id (x >>= g)
+    rw [allOutputsSatisfy_bind, allOutputsSatisfy_bind]
+    exact allOutputsSatisfy_mono hfg x
 
 /-- Support-based characterization of the `Prop`-valued WP for `OracleComp`. -/
 theorem wp_iff_forall_support (oa : OracleComp spec α) (post : α → Prop) :
     MAlgOrdered.wp (m := OracleComp spec) (l := Prop) oa post ↔
       ∀ x ∈ support oa, post x := by
-  unfold MAlgOrdered.wp
-  change μProp (spec := spec) (oa >>= fun a => pure (post a)) ↔ _
-  unfold μProp
-  constructor
-  · intro h a ha
-    exact h (post a) ((mem_support_bind_iff oa _ (post a)).2
-      ⟨a, ha, by simp [support_pure]⟩)
-  · intro h p hp
-    rcases (mem_support_bind_iff oa _ p).1 hp with ⟨a, ha, hp'⟩
-    rw [show p = post a from by simpa [support_pure] using hp']
-    exact h a ha
+  change allOutputsSatisfy id (oa >>= fun a => pure (post a)) ↔ _
+  rw [allOutputsSatisfy_bind]
+  simp only [allOutputsSatisfy_pure]
+  exact allOutputsSatisfy_iff_forall_support _ oa
 
 end OracleComp.ProgramLogic.PropLogic

--- a/VCVio/ProgramLogic/Unary/HoarePropTriple.lean
+++ b/VCVio/ProgramLogic/Unary/HoarePropTriple.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+import ToMathlib.Control.Monad.Algebra
+import VCVio.EvalDist.Monad.Basic
+import VCVio.OracleComp.EvalDist
+
+/-!
+# Qualitative `Prop`-valued Hoare triples for `OracleComp`
+
+This file registers the qualitative `Prop`-valued unary monad algebra for
+`OracleComp spec`. The carrier is `Prop` with its standard complete-lattice structure
+(`≤` is implication), and `μ (oa : OracleComp spec Prop)` is the almost-sure assertion
+`∀ x ∈ support oa, x`.
+
+The induced `MAlgOrdered.wp` is the support-based weakest precondition:
+`wp oa post ↔ ∀ x ∈ support oa, post x`.
+
+This is the qualitative companion of the quantitative `MAlgOrdered (OracleComp spec) ℝ≥0∞`
+in `VCVio/ProgramLogic/Unary/HoareTriple.lean`. Together they let
+`MAlgRelOrdered.Anchored` (in `ToMathlib/Control/Monad/RelationalAlgebra.lean`) state
+its anchoring axioms uniformly across the qualitative and quantitative settings.
+-/
+
+universe u
+
+namespace OracleComp.ProgramLogic.PropLogic
+
+variable {ι : Type u} {spec : OracleSpec ι}
+variable {α β : Type}
+
+/-- Qualitative algebra for oracle computations returning `Prop`: the universal
+quantifier over the support. -/
+def μProp (oa : OracleComp spec Prop) : Prop :=
+  ∀ x ∈ support oa, x
+
+/-- The qualitative `Prop`-valued unary monad algebra for `OracleComp`.
+
+`μ` is the almost-sure assertion `∀ x ∈ support oa, x`; `wp` is the support-based
+weakest precondition; `Triple pre oa post` is `pre → ∀ x ∈ support oa, post x`. -/
+instance instMAlgOrdered : MAlgOrdered (OracleComp spec) Prop where
+  μ := μProp (spec := spec)
+  μ_pure x := by
+    refine propext ⟨fun h => h x ?_, fun hx p hp => ?_⟩
+    · simp [support_pure]
+    · have hpx : p ↔ x := by simpa [support_pure] using hp
+      exact hpx.mpr hx
+  μ_bind_mono {α} f g hfg x := by
+    intro hf y hy
+    rcases (mem_support_bind_iff x g y).1 hy with ⟨a, ha, hy'⟩
+    have hfa : ∀ z ∈ support (f a), z := fun z hz =>
+      hf z ((mem_support_bind_iff x f z).2 ⟨a, ha, hz⟩)
+    exact hfg a hfa y hy'
+
+/-- Support-based characterization of the `Prop`-valued WP for `OracleComp`. -/
+theorem wp_iff_forall_support (oa : OracleComp spec α) (post : α → Prop) :
+    MAlgOrdered.wp (m := OracleComp spec) (l := Prop) oa post ↔
+      ∀ x ∈ support oa, post x := by
+  unfold MAlgOrdered.wp
+  change μProp (spec := spec) (oa >>= fun a => pure (post a)) ↔ _
+  unfold μProp
+  constructor
+  · intro h a ha
+    exact h (post a) ((mem_support_bind_iff oa _ (post a)).2
+      ⟨a, ha, by simp [support_pure]⟩)
+  · intro h p hp
+    rcases (mem_support_bind_iff oa _ p).1 hp with ⟨a, ha, hp'⟩
+    rw [show p = post a from by simpa [support_pure] using hp']
+    exact h a ha
+
+end OracleComp.ProgramLogic.PropLogic


### PR DESCRIPTION
## Summary

Introduces `MAlgRelOrdered.Anchored`, a coherence layer on top of the relational ordered monad algebra that pins `MAlgRelOrdered m₁ m₂ l` to its unary marginals `MAlgOrdered mᵢ l` whenever one side is `pure`. Building on this, derives "honest" relational weakest-precondition combinators for `ExceptT` and `OptionT` that record case-split outcomes per side, in contrast to the lossy left/right lifts which collapse all failure mass to bottom.

The two `Anchored` axioms (`rwp_pure_left`, `rwp_pure_right`) are sufficient to characterise the relational WP completely whenever one side is `pure`. They are proved for the two main instances:

- `Anchored (OracleComp spec₁) (OracleComp spec₂) ℝ≥0∞` quantitatively, via Dirac coupling collapse of the supremum over couplings.
- `Anchored (OracleComp spec₁) (OracleComp spec₂) Prop` qualitatively, using a new `MAlgOrdered (OracleComp spec) Prop` instance based on a generic `allOutputsSatisfy id`.

## Highlights

### New typeclass

- `MAlgRelOrdered.Anchored m₁ m₂ l` extending `MAlgRelOrdered m₁ m₂ l` with `rwp_pure_left` and `rwp_pure_right` (`ToMathlib/Control/Monad/RelationalAlgebra.lean`).

### Honest unary `ExceptT` / `OptionT` combinators

- `MAlgOrdered.wpExc` and `MAlgOrdered.wpOpt` with full `pure` / `throw` / `fail` / `bind` / `tryCatch` / `mono` laws (`ToMathlib/Control/Monad/Algebra.lean`).

### Honest relational `ExceptT` / `OptionT` combinators

- `rwpExc`, `rwpExcLeft`, `rwpExcRight`, `rwpOpt`, `rwpOptLeft`, `rwpOptRight` with `pure` / `throw` / `fail` / `mono` rules under just `MAlgRelOrdered`, plus pure-side reductions to unary `wpExc` / `wpOpt` and bind laws under `Anchored` (`ToMathlib/Control/Monad/RelationalAlgebraAnchored.lean`).

### Foundational lemmas and instances

- Dirac coupling lemmas (`SPMF.IsCoupling.dirac_left`, `dirac_right`, and friends) in `ToMathlib/ProbabilityTheory/Coupling.lean`.
- Generic `allOutputsSatisfy p mx := ∀ x ∈ support mx, p x` and `someOutputSatisfies p mx := ∃ x ∈ support mx, p x` at the `HasEvalSet` layer (`VCVio/EvalDist/Defs/Support.lean`, with `_pure` / `_bind` simp lemmas in `VCVio/EvalDist/Monad/Basic.lean`).
- `MAlgOrdered (OracleComp spec) Prop` instance using `allOutputsSatisfy id` (`VCVio/ProgramLogic/Unary/HoarePropTriple.lean`), replacing an ad-hoc `μProp` wrapper.
- `Anchored Prop` and `Anchored ℝ≥0∞` instances for `OracleComp` pairs.

### Examples

- `Examples/ProgramLogic/RelationalAnchored.lean` demonstrates pure-pure base cases, anchored pure-side reductions, and asymmetric one-sided combinators.

## Test plan

- [x] `lake build` succeeds with no new warnings.
- [x] `Examples/ProgramLogic/RelationalAnchored.lean` builds and exercises all `rwp{Exc,Opt}{,Left,Right}` reduction paths.
- [x] Existing examples and tests untouched.

## Notes

- The structural variant `OracleComp.allOutputsSatisfyWhen` in `VCVio/OracleComp/Traversal.lean` is intentionally left in place; cutting it over to the new `allOutputsSatisfy` operator can be done in a follow-up if the structural form ends up unused.
- The `Anchored` axioms are designed to be discharged once per concrete `(m₁, m₂, l)` triple, after which all derived `rwpExc` / `rwpOpt` reasoning lifts automatically through transformer stacks.

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.


Made with [Cursor](https://cursor.com)