### PR TITLE
refactor(examples): tighten OTP and PIR relational proofs

### DIFF
--- a/Examples/OneTimePad/Basic.lean
+++ b/Examples/OneTimePad/Basic.lean
@@ -100,8 +100,7 @@ lemma cipherGivenMsg_equiv (sp : ℕ) (msg₀ msg₁ : BitVec sp) :
   · intro k₁ k₂ hk
     subst hk
     apply Relational.relTriple_pure_pure
-    change k₁ ^^^ msg₀ = k₁ ^^^ c ^^^ msg₁
-    simp only [show c = msg₀ ^^^ msg₁ from rfl,
+    simp only [Relational.EqRel, show c = msg₀ ^^^ msg₁ from rfl,
       BitVec.xor_assoc, BitVec.xor_self, BitVec.xor_zero]
 
 /-- The one-time pad has equal ciphertext rows: all messages yield the same

--- a/Examples/SimpleTwoServerPIR.lean
+++ b/Examples/SimpleTwoServerPIR.lean
@@ -209,11 +209,9 @@ theorem pir_private (i₁ i₂ : Fin N) :
     simp only [ProgramLogic.Relational.EqRel] at hS
     rvcstep using (fun b₁ b₂ => b₁ = b₂)
     · intro b₁ b₂ hb; subst hb
-      cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte,
-        ProgramLogic.Relational.relTriple_iff_relWP, ProgramLogic.Relational.relWP_iff_couplingPost]
-        <;> (split <;> split <;>
-          apply ProgramLogic.Relational.relTriple_pure_pure <;>
-          simp_all [ProgramLogic.Relational.EqRel])
+      cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte] <;> split <;> split <;>
+        exact ProgramLogic.Relational.relTriple_pure_pure
+          (by simp_all [ProgramLogic.Relational.EqRel])
     · exact ProgramLogic.Relational.relTriple_uniformSample_bij
         Function.bijective_id _ (fun _ => rfl)
 


### PR DESCRIPTION
## Summary

Two small, fully-cutover simplifications enabled by the augmented relational tactic framework that landed in #332:

* **`Examples/OneTimePad/Basic.lean`** (`cipherGivenMsg_equiv`): drop the manual `change k₁ ^^^ msg₀ = k₁ ^^^ c ^^^ msg₁` step by folding `Relational.EqRel` unfolding into the closing `simp only`, so the remaining `BitVec.xor` rewrites operate directly on the equality.

* **`Examples/SimpleTwoServerPIR.lean`** (`pir_private`): replace the verbose

  ```lean
  cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte,
    ProgramLogic.Relational.relTriple_iff_relWP, ProgramLogic.Relational.relWP_iff_couplingPost]
    <;> (split <;> split <;>
      apply ProgramLogic.Relational.relTriple_pure_pure <;>
      simp_all [ProgramLogic.Relational.EqRel])
  ```

  with a flatter

  ```lean
  cases b₁ <;> simp only [Bool.false_eq_true, ↓reduceIte] <;> split <;> split <;>
    exact ProgramLogic.Relational.relTriple_pure_pure
      (by simp_all [ProgramLogic.Relational.EqRel])
  ```

  Two of the four simp lemmas were redundant (`relTriple_iff_relWP`, `relWP_iff_couplingPost`); the closing `relTriple_pure_pure` argument now lives directly inside `exact (by ...)`.

Net diff: `+4 / -7` lines, two examples touched. No tactic-framework changes, no `sorry`s introduced. Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

## Test plan

- [x] `lake build` succeeds (no new warnings, no `sorry`s).
- [x] Targeted `lake build Examples.OneTimePad.Basic Examples.SimpleTwoServerPIR` succeeds.

Made with [Cursor](https://cursor.com)