### PR TITLE
feat(relational): trivial-postcondition closers and OTP leakage demo

### DIFF
--- a/Examples/OneTimePad/LeakageFree.lean
+++ b/Examples/OneTimePad/LeakageFree.lean
@@ -54,12 +54,9 @@ theorem tracedEncrypt_eq (sp : ℕ) (msg : BitVec sp) :
 produces identical observation traces. -/
 theorem otp_traceNoninterference (sp : ℕ) (msg₀ msg₁ : BitVec sp) :
     Leakage.TraceNoninterference (tracedEncrypt sp msg₀) (tracedEncrypt sp msg₁) := by
-  simp only [tracedEncrypt_eq]
-  unfold Leakage.TraceNoninterference
-  rw [ProgramLogic.Relational.relTriple'_iff_relTriple]
-  refine ProgramLogic.Relational.relTriple_bind
-    (ProgramLogic.Relational.relTriple_refl ($ᵗ BitVec sp)) fun _ _ _ => ?_
-  exact ProgramLogic.Relational.relTriple_pure_pure rfl
+  simp only [tracedEncrypt_eq, Leakage.TraceNoninterference,
+    ProgramLogic.Relational.relTriple'_iff_relTriple]
+  rvcgen
 
 /-- The traced OTP is probabilistically leak-free: the trace distribution is independent
 of the encrypted message. -/

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -171,6 +171,27 @@ lemma relTriple_post_mono {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ 
   apply (relTriple_iff_relWP (oa := oa) (ob := ob) (R := R')).2
   exact ⟨c, fun z hz => hpost (hc z hz)⟩
 
+/-- The trivial product coupling always exists for `OracleComp`, so any pair of computations
+satisfies the constantly-true postcondition.
+
+The witness is the product coupling `evalDist oa ⊗ evalDist ob`, which is well-defined because
+`OracleComp` computations have no failure mass. This discharges any `RelTriple` goal whose
+postcondition is structurally `fun _ _ => True` and is the foundation of the trivial-leaf
+closer in `tryCloseRelGoalImmediate`. -/
+lemma relTriple_true (oa : OracleComp spec₁ α) (ob : OracleComp spec₂ β) :
+    RelTriple oa ob (fun _ _ => True) := by
+  apply (relTriple_iff_relWP (oa := oa) (ob := ob) (R := fun _ _ => True)).2
+  have hp : (evalDist oa).toPMF none = 0 := probFailure_eq_zero (mx := oa)
+  have hq : (evalDist ob).toPMF none = 0 := probFailure_eq_zero (mx := ob)
+  exact ⟨_root_.SPMF.Coupling.prod hp hq, fun _ _ => trivial⟩
+
+/-- Any postcondition that is unconditionally true gives a valid relational triple,
+via the product coupling. Useful as a closing rule for vacuous postconditions. -/
+lemma relTriple_post_const {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
+    {R : RelPost α β} (h : ∀ a b, R a b) :
+    RelTriple oa ob R :=
+  relTriple_post_mono (relTriple_true oa ob) (fun _ _ _ => h _ _)
+
 /-- Bind composition rule for relational triples. -/
 lemma relTriple_bind
     {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}

--- a/VCVio/ProgramLogic/Relational/Examples.lean
+++ b/VCVio/ProgramLogic/Relational/Examples.lean
@@ -90,4 +90,26 @@ example (oa : OracleComp spec₁ α) :
     RelTriple (spec₁ := spec₁) (spec₂ := spec₁) oa oa (EqRel α) := by
   rvcstep
 
+/-! ### Trivial postcondition discharge (via product coupling)
+
+The product coupling exists for any pair of `OracleComp` computations, so any goal whose
+postcondition is structurally `fun _ _ => True` (or reduces to one through bind/map normalization)
+is closed by the leaf closer without intermediate planning. -/
+
+example (oa : OracleComp spec₁ α) (ob : OracleComp spec₂ β) :
+    RelTriple oa ob (fun _ _ => True) := by
+  rvcgen
+
+example (oa : OracleComp spec₁ α) (ob : OracleComp spec₂ β)
+    (fa : α → OracleComp spec₁ γ) (fb : β → OracleComp spec₂ δ) :
+    RelTriple (oa >>= fa) (ob >>= fb) (fun _ _ => True) := by
+  rvcgen
+
+example (sp : ℕ) (msg₀ msg₁ : BitVec sp) :
+    RelTriple
+      (do let key ← $ᵗ BitVec sp; pure (key ^^^ msg₀, ()))
+      (do let key ← $ᵗ BitVec sp; pure (key ^^^ msg₁, ()))
+      (fun z₁ z₂ => z₁.2 = z₂.2) := by
+  rvcgen
+
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Tactics/Relational.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational.lean
@@ -137,6 +137,9 @@ elab_rules : tactic
           "all_goals try simp only [game_rule]",
           String.intercalate "" [
             "all_goals first | assumption | ",
+            "exact OracleComp.ProgramLogic.Relational.relTriple_true _ _ | ",
+            "(refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_; ",
+            "intros; trivial) | ",
             "exact OracleComp.ProgramLogic.Relational.relTriple_refl _ | ",
             "exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl | ",
             "exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl | ",
@@ -172,6 +175,9 @@ macro "rel_inline" ids:ident* : tactic =>
       (unfold $ids*
        try simp only [game_rule]
        try first
+         | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
+         | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+            intros; trivial)
          | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
          | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
          | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
@@ -180,6 +186,9 @@ macro "rel_inline" ids:ident* : tactic =>
     `(tactic|
       (simp only [game_rule]
        try first
+         | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
+         | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+            intros; trivial)
          | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
          | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
          | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl

--- a/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Relational/Internals.lean
@@ -56,6 +56,9 @@ private def mkRVCGenPlannedStep (label replayText : String) (run : TacticM Bool)
 
 Tries, in order:
 * `assumption` (catches a hypothesis matching the relational triple verbatim);
+* `relTriple_true _ _` (vacuous postcondition `fun _ _ => True`, via the product coupling);
+* `relTriple_post_const` together with `intros; trivial` (postcondition reduces to a
+  trivially provable proposition such as `() = ()`);
 * `relTriple_refl` (identical computations, equality coupling);
 * `relTriple_eqRel_of_eq rfl` (syntactically identical computations);
 * `relTriple_pure_pure rfl` (`pure x ⨯ pure x` with reflexive postcondition);
@@ -66,6 +69,11 @@ Tries, in order:
 * `relTriple_pure_pure ∘ symm` (`pure a ⨯ pure b` with `R b a` in scope). -/
 def tryCloseRelGoalImmediate : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic| assumption)) <||>
+  tryEvalTacticSyntax (← `(tactic|
+    exact OracleComp.ProgramLogic.Relational.relTriple_true _ _)) <||>
+  tryEvalTacticSyntax (← `(tactic|
+    refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+    intros; trivial)) <||>
   tryEvalTacticSyntax (← `(tactic|
     exact OracleComp.ProgramLogic.Relational.relTriple_refl _)) <||>
   tryEvalTacticSyntax (← `(tactic|
@@ -79,11 +87,14 @@ def tryCloseRelGoalImmediate : TacticM Bool := do
   tryEvalTacticSyntax (← `(tactic|
     (try subst_vars
      first
+       | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
        | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
        | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
        | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
        | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
-       | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> assumption)))) <||>
+       | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> assumption)
+       | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+          intros; trivial)))) <||>
   tryEvalTacticSyntax (← `(tactic|
     apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure <;> (symm; assumption)))
 
@@ -441,6 +452,9 @@ private def closeRelTheoremStepGoals : TacticM Unit := do
   discard <| tryEvalTacticSyntax (← `(tactic|
     all_goals first
       | assumption
+      | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
+      | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+         intros; trivial)
       | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
       | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
       | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
@@ -448,11 +462,14 @@ private def closeRelTheoremStepGoals : TacticM Unit := do
       | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
       | (try subst_vars
          first
+           | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
            | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
            | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
            | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
            | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
-           | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption))))
+           | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption)
+           | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+              intros; trivial))))
 
 private def runRVCGenStepWithTheoremDirect
     (thm : TSyntax `term) (requireClosed : Bool := false) : TacticM Bool := do
@@ -857,6 +874,9 @@ def runRVCGenFinish : TacticM Unit := do
     let _ ← tryEvalTacticSyntax
       (← `(tactic| all_goals first
         | assumption
+        | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
+        | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+           intros; trivial)
         | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
         | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
         | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
@@ -864,11 +884,14 @@ def runRVCGenFinish : TacticM Unit := do
         | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
         | (try subst_vars
            first
+             | exact OracleComp.ProgramLogic.Relational.relTriple_true _ _
              | exact OracleComp.ProgramLogic.Relational.relTriple_refl _
              | exact OracleComp.ProgramLogic.Relational.relTriple_eqRel_of_eq rfl
              | exact OracleComp.ProgramLogic.Relational.relTriple_pure_pure rfl
              | exact OracleComp.ProgramLogic.Relational.eRelTriple_pure _ _ _
-             | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption))))
+             | (apply OracleComp.ProgramLogic.Relational.relTriple_pure_pure; assumption)
+             | (refine OracleComp.ProgramLogic.Relational.relTriple_post_const ?_
+                intros; trivial))))
   unless (← getGoals).isEmpty do
     discard <| runBoundedPasses "rvcgen finish" runRVCGenCloseConseqPass
 

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -137,10 +137,18 @@ strips pure-bind layers so that the bind decomposition rule fires on aligned sha
 goals that simplify to pure-pure or refl close immediately.
 
 **Augmented leaf closure**: the relational leaf closer (`tryCloseRelGoalImmediate`, plus its
-`rvcgen` finishing pass) tries the canonical `relTriple_refl` / `relTriple_eqRel_of_eq rfl` /
-`relTriple_pure_pure` / `eRelTriple_pure` family, then a `subst_vars`-driven retry that resolves
-syntactically-distinct pure values unified by local equality hypotheses, and finally a symmetric
-`relTriple_pure_pure ∘ symm` step for postconditions written in the swapped direction.
+`rvcgen` finishing pass) tries, in order:
+1. `assumption`
+2. `relTriple_true _ _` (the postcondition is structurally `fun _ _ => True`, discharged via
+   the universal product coupling, since `OracleComp` has no failure mass);
+3. `relTriple_post_const ?_; intros; trivial` (the postcondition reduces to a trivially provable
+   proposition such as `() = ()` after introduction);
+4. `relTriple_refl` / `relTriple_eqRel_of_eq rfl` / `relTriple_pure_pure` /
+   `eRelTriple_pure` (canonical reflexive and pure-pure leaves);
+5. a `subst_vars`-driven retry of the same closers (resolves syntactically-distinct pure
+   values unified by local equality hypotheses);
+6. a symmetric `relTriple_pure_pure ∘ symm` step for postconditions written in the swapped
+   direction.
 
 **Pass budget**: exhaustive `vcgen` / `rvcgen` runs are bounded by
 `set_option vcvio.vcgen.maxPasses <n>`. The default is conservative so large proofs stay


### PR DESCRIPTION
## Summary

Extends the generic relational tactics framework with a closer for **trivial postconditions**, then demonstrates the payoff on a real proof.

### New library lemmas (`VCVio/ProgramLogic/Relational/Basic.lean`)

- `relTriple_true oa ob : RelTriple oa ob (fun _ _ => True)` — the universal product coupling. Holds for any pair of `OracleComp` computations because they have no failure mass (`evalDist oa ⊗ evalDist ob` is always a valid coupling).
- `relTriple_post_const : (∀ a b, R a b) → RelTriple oa ob R` — a convenience corollary via `relTriple_post_mono` and `relTriple_true`.

### Tactic wiring (`VCVio/ProgramLogic/Tactics/Relational/Internals.lean`, `Tactics/Relational.lean`)

The relational leaf closer (`tryCloseRelGoalImmediate`, plus `closeRelTheoremStepGoals` and `runRVCGenFinish`) now tries, after `assumption`:

1. `relTriple_true _ _` — fires when the postcondition is structurally `fun _ _ => True`.
2. `refine relTriple_post_const ?_; intros; trivial` — fires when the postcondition reduces to a trivially provable proposition such as `() = ()` after introduction.

The `rvcgen?` suggestion text and the `rel_inline` fallback chain are kept in sync.

### Concrete simplification (`Examples/OneTimePad/LeakageFree.lean`)

`otp_traceNoninterference` collapses from a manual unfold + `relTriple_bind` + `relTriple_pure_pure rfl` chain to:

\`\`\`lean
simp only [tracedEncrypt_eq, Leakage.TraceNoninterference,
  ProgramLogic.Relational.relTriple'_iff_relTriple]
rvcgen
\`\`\`

This is the canonical pattern (\"sample-then-pure with constant-time observation traces\") that should now go through automatically without needing manual coupling steps for the trivial trace-equality kont.

### Tests / examples (`VCVio/ProgramLogic/Relational/Examples.lean`)

Added three small examples documenting the new closer's reach:

- `RelTriple oa ob (fun _ _ => True)` directly
- `RelTriple (oa >>= fa) (ob >>= fb) (fun _ _ => True)` (closer fires through bind decomposition)
- the OTP-shaped goal `RelTriple (do let key ← \$ᵗ BitVec sp; pure (key ^^^ msg₀, ())) ... (fun z₁ z₂ => z₁.2 = z₂.2)`

### Docs (`docs/agents/program-logic.md`)

Updated the **Augmented leaf closure** section to enumerate the new closer steps in their actual order.

## Test plan

- [x] `lake build` passes (no new sorries; pre-existing sorry warnings unchanged).
- [x] `Examples/OneTimePad/LeakageFree.lean` compiles with the simplified proof.
- [x] `VCVio/ProgramLogic/Relational/Examples.lean` compiles with the new examples.

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)