### PR TITLE
refactor(fs-sigma): golf euf_cma_to_nma (reuse simulator API, lift ENNReal helpers, drop stale narrative)

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -31,6 +31,7 @@ import ToMathlib.Control.WriterT
 import ToMathlib.Data.ENNReal.AbsDiff
 import ToMathlib.Data.ENNReal.Gauss
 import ToMathlib.Data.ENNReal.SumSquares
+import ToMathlib.Data.ENNReal.TsumDistrib
 import ToMathlib.Data.IndexedBinaryTree.Basic
 import ToMathlib.Data.IndexedBinaryTree.Equiv
 import ToMathlib.Data.IndexedBinaryTree.Lemmas

--- a/ToMathlib/Data/ENNReal/TsumDistrib.lean
+++ b/ToMathlib/Data/ENNReal/TsumDistrib.lean
@@ -1,0 +1,66 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import Mathlib.Topology.Algebra.InfiniteSum.ENNReal
+
+/-!
+# Distributivity of weighted `tsum`s over addition in `ℝ≥0∞`
+
+Two algebraic identities about infinite sums
+`∑' i, w i * (f i [+ c] [+ g i])` in the unweighted sense that, whenever the
+weights `w` sum to one (the standard PMF normalisation), any constant added
+*inside* the weighted sum can be pulled *outside*.
+
+These are the building blocks for weighted game-hopping identities of the form
+`∑' pksk, evalDist gen pksk * (Pr[good | …] + slack)` that show up in the
+integrated Fiat-Shamir EUF-CMA reductions.
+
+## Main results
+
+- `ENNReal.tsum_mul_add_const_of_tsum_eq_one` —
+  `(∑' i, w i * (f i + c)) = (∑' i, w i * f i) + c` when `(∑' i, w i) = 1`.
+- `ENNReal.tsum_mul_add_const_add_of_tsum_eq_one` —
+  `(∑' i, w i * (f i + c + g i)) = (∑' i, w i * f i) + c + (∑' i, w i * g i)`
+  when `(∑' i, w i) = 1`.
+-/
+
+@[expose] public section
+
+namespace ENNReal
+
+/-- If the weights `w : ι → ℝ≥0∞` sum to `1`, a constant added inside a
+weighted infinite sum pulls out unchanged:
+`(∑' i, w i * (f i + c)) = (∑' i, w i * f i) + c`. -/
+theorem tsum_mul_add_const_of_tsum_eq_one
+    {ι : Type*} (w : ι → ℝ≥0∞) (f : ι → ℝ≥0∞) (c : ℝ≥0∞)
+    (hw : (∑' i, w i) = 1) :
+    (∑' i, w i * (f i + c)) = (∑' i, w i * f i) + c := by
+  have hc : (∑' i, w i * c) = c := by
+    rw [ENNReal.tsum_mul_right, hw, one_mul]
+  calc (∑' i, w i * (f i + c))
+      = ∑' i, (w i * f i + w i * c) := by simp_rw [mul_add]
+    _ = (∑' i, w i * f i) + (∑' i, w i * c) := ENNReal.tsum_add
+    _ = (∑' i, w i * f i) + c := by rw [hc]
+
+/-- If the weights `w : ι → ℝ≥0∞` sum to `1`, a constant flanked by two
+index-dependent summands inside a weighted infinite sum pulls out unchanged:
+`(∑' i, w i * (f i + c + g i)) = (∑' i, w i * f i) + c + (∑' i, w i * g i)`. -/
+theorem tsum_mul_add_const_add_of_tsum_eq_one
+    {ι : Type*} (w : ι → ℝ≥0∞) (f g : ι → ℝ≥0∞) (c : ℝ≥0∞)
+    (hw : (∑' i, w i) = 1) :
+    (∑' i, w i * (f i + c + g i)) =
+      (∑' i, w i * f i) + c + (∑' i, w i * g i) := by
+  have hc : (∑' i, w i * c) = c := by
+    rw [ENNReal.tsum_mul_right, hw, one_mul]
+  calc (∑' i, w i * (f i + c + g i))
+      = ∑' i, ((w i * f i + w i * c) + w i * g i) := by simp_rw [mul_add]
+    _ = (∑' i, (w i * f i + w i * c)) + (∑' i, w i * g i) := ENNReal.tsum_add
+    _ = ((∑' i, w i * f i) + (∑' i, w i * c)) + (∑' i, w i * g i) := by
+        rw [ENNReal.tsum_add]
+    _ = (∑' i, w i * f i) + c + (∑' i, w i * g i) := by rw [hc]
+
+end ENNReal

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -13,6 +13,8 @@ import VCVio.CryptoFoundations.ReplayFork
 import VCVio.SSP.Composition
 import ToMathlib.Data.ENNReal.TsumDistrib
 
+set_option linter.style.longFile 6900
+
 /-!
 # EUF-CMA security of the Fiat-Shamir Σ-protocol transform
 
@@ -100,7 +102,7 @@ noncomputable def collisionSlack (qS qH : ℕ) (β : ENNReal) :
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma realCommit_probOutput_le_sim_plus_hvzk
-    [DecidableEq Commit] [Fintype Chal] [Inhabited Chal] [SampleableType Chal]
+    [DecidableEq Commit] [Inhabited Chal] [SampleableType Chal]
     {simTranscript : Stmt → ProbComp (Commit × Chal × Resp)}
     {ζ_zk : ℝ} (hζ_zk : 0 ≤ ζ_zk)
     (hhvzk : σ.HVZK simTranscript ζ_zk)
@@ -167,7 +169,7 @@ private lemma realCommit_probOutput_le_sim_plus_hvzk
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma realCommit_probOutput_le_beta_hvzk
-    [DecidableEq Commit] [Fintype Chal] [Inhabited Chal] [SampleableType Chal]
+    [DecidableEq Commit] [Inhabited Chal] [SampleableType Chal]
     {simTranscript : Stmt → ProbComp (Commit × Chal × Resp)}
     {ζ_zk : ℝ} (hζ_zk : 0 ≤ ζ_zk)
     (hhvzk : σ.HVZK simTranscript ζ_zk)
@@ -619,6 +621,8 @@ private theorem simulatedNmaAdv_hashQueryBound
       (s := ∅))
 
 set_option maxHeartbeats 800000 in
+-- The large structural case analysis over bridges (A)/(B)/(C) exceeds the default budget.
+omit [SampleableType Stmt] [SampleableType Wit] in
 /-- **CMA-to-NMA reduction via HVZK simulation.**
 
 For any EUF-CMA adversary `A` making at most `qS` signing-oracle queries and `qH`
@@ -1570,7 +1574,7 @@ theorem euf_cma_to_nma
         have hlift : ∀ {α : Type} (x : ProbComp α) (s : spec.QueryCache),
             (liftM x : StateT spec.QueryCache ProbComp α).run s = x >>= fun a => pure (a, s) := by
           intro α x s
-          simpa using (StateT.run_liftM x s)
+          simp
         have hmod : ∀ {α : Type}
             (f : spec.QueryCache → α × spec.QueryCache) (s : spec.QueryCache),
             (modifyGet f : StateT spec.QueryCache ProbComp α).run s = pure (f s) := by
@@ -1652,7 +1656,7 @@ theorem euf_cma_to_nma
                     have h_uniform :
                         (evalDist ($ᵗ Chal : ProbComp Chal) : SPMF Chal) =
                           (liftM (PMF.uniformOfFintype Chal) : SPMF Chal) := by
-                      simpa [evalDist_uniformSample]
+                      simp [evalDist_uniformSample]
                     exact h_uniform.trans h_query.symm
                   have h_left_map :
                       evalDist
@@ -1665,7 +1669,7 @@ theorem euf_cma_to_nma
                             ((liftM (query (Sum.inr mc) : OracleQuery spec Chal)) :
                               OracleComp spec Chal) : SPMF Chal) :
                           SPMF (Chal × spec.QueryCache)) := by
-                    simpa [evalDist_map]
+                    simp [evalDist_map]
                   have h_right_map :
                       evalDist
                         (((fun u => (u, cache.cacheQuery (Sum.inr mc) u)) <$> ($ᵗ Chal : ProbComp Chal)) :
@@ -1673,7 +1677,7 @@ theorem euf_cma_to_nma
                         ((fun u => (u, cache.cacheQuery (Sum.inr mc) u)) <$>
                           (evalDist ($ᵗ Chal : ProbComp Chal) : SPMF Chal) :
                           SPMF (Chal × spec.QueryCache)) := by
-                    simpa [evalDist_map]
+                    simp [evalDist_map]
                   calc
                     evalDist
                         (((fun u => (u, cache.cacheQuery (Sum.inr mc) u)) <$>
@@ -1799,7 +1803,7 @@ theorem euf_cma_to_nma
                     have h_random_miss :
                         (runtimeRo mc).run (cacheProj cache) =
                           insert <$> ($ᵗ Chal : ProbComp Chal) := by
-                      simpa [runtimeRo, randomOracle.apply_eq, StateT.run_bind, StateT.run_get, hproj,
+                      simp [runtimeRo, randomOracle.apply_eq, StateT.run_bind, StateT.run_get, hproj,
                         StateT.run_pure, hliftRuntime, hmodRuntime, bind_assoc, bind_pure_comp,
                         uniformSampleImpl, insert]
                     have hinsert_proj :
@@ -1825,7 +1829,7 @@ theorem euf_cma_to_nma
                       simpa [runtimeImpl, QueryImpl.add_apply_inr] using h_random_miss
                     exact h_runtime_miss0.trans hinsert_map
                   rw [h_baseProb_miss, h_runtime_miss]
-                  simpa [Functor.map_map, Function.comp_def]
+                  simp [Functor.map_map, Function.comp_def]
               | some u =>
                   have h_baseProb_hit :
                       (baseProb (.inr mc)).run cache = pure (u, cache) := by
@@ -2203,12 +2207,7 @@ theorem euf_cma_to_nma
             rcases s with ⟨cache, signed⟩
             cases hcache : cache (.inr (msg, c)) with
             | some ω =>
-                simp [verifyFromState, eventNoBad, missVerifyComp, hcache]
-                have hnonneg :
-                    0 ≤ Pr[= true | missVerifyComp pk ((msg, (c, resp)), (cache, signed))] := by
-                  exact bot_le
-                simpa [missVerifyComp, and_left_comm, and_assoc, and_comm] using
-                  le_add_of_nonneg_right hnonneg
+                simp [verifyFromState, eventNoBad, missVerifyComp, hcache, and_comm]
             | none =>
                 by_cases hsigned : msg ∈ signed
                 · simp [verifyFromState, eventNoBad, missVerifyComp, hcache, hsigned]
@@ -2280,7 +2279,7 @@ theorem euf_cma_to_nma
                 ((fun x => x = true) ∘ fun z => decide (eventNoBad pk z)) = eventNoBad pk := by
               funext z
               simp
-            simpa using congrArg (probEvent (actual_stateful_exp_append pk sk)) hpred
+            exact congrArg (probEvent (actual_stateful_exp_append pk sk)) hpred
           intro pk sk
           calc
             Pr[= true | actual_pk_exp pk sk] =
@@ -2406,9 +2405,7 @@ theorem euf_cma_to_nma
               rw [hRunQuery]
               simp [h_respond_run, simulateQ_pure, baseSim, QueryImpl.add_apply_inr]
               refine bind_congr fun p => ?_
-              simpa using congrArg
-                (fun x => (fun a => ((c, a), p.2)) <$> x)
-                (rfl : liftM (σ.respond pk sk e p.1) = liftM (σ.respond pk sk e p.1))
+              simp
             have h_real_comp :
                 (realSign pk sk msg).run cache =
                   (σ.commit pk sk).liftComp spec >>= fun ce =>
@@ -2527,7 +2524,7 @@ theorem euf_cma_to_nma
                       | some v =>
                           simp [hmiss] at hcache
                       | none =>
-                          simpa [hcache]
+                          simp [hcache]
               rw [probOutput_def, probOutput_def]
               refine tsum_congr ?_
               intro x
@@ -2570,7 +2567,7 @@ theorem euf_cma_to_nma
               rcases hmem with ⟨ω, hω, hcont⟩
               rw [mem_support_bind_iff] at hcont
               rcases hcont with ⟨π, hπ, hEq⟩
-              simp only [StateT.run_pure, support_pure, Set.mem_singleton_iff] at hEq
+              simp only [support_pure, Set.mem_singleton_iff] at hEq
               have hpair : (c, π) = u := by
                 cases hcache : cache (Sum.inr (msg, c)) <;>
                   simpa [hcache] using (congrArg Prod.fst hEq).symm
@@ -2990,8 +2987,7 @@ theorem euf_cma_to_nma
                 simp [reverseSigned, realImplBadAppend, _realImplSigned, realSignBadAppend,
                   realSignSignedAppend, realSignSigned, realSignSigned', sigBadFSigned,
                   QueryImpl.add_apply_inr, QueryImpl.withBadUpdate_apply_run, StateT.run_bind,
-                  StateT.run_get, StateT.run_set, List.reverse_reverse, List.reverse_cons,
-                  List.reverse_append, List.reverse_singleton, List.append_assoc]
+                  StateT.run_get, StateT.run_set, List.reverse_cons]
           have h_direct_real_append_proj_bad : ∀ (pk : Stmt) (sk : Wit),
               Prod.map id reverseSigned <$> direct_real_exp pk sk =
                 direct_real_exp_append pk sk := by
@@ -3279,7 +3275,7 @@ theorem euf_cma_to_nma
                               simp only [simulateQ_query_bind, OracleQuery.input_query,
                                 StateT.run_bind]
                               rw [hstep]
-                              simp [qn, OracleQuery.cont_query, bind_assoc, bind_pure_comp]
+                              simp [qn, OracleQuery.cont_query]
                         rw [hrun]
                         rw [probEvent_bind_eq_tsum]
                         calc
@@ -3333,7 +3329,7 @@ theorem euf_cma_to_nma
                                 simp only [simulateQ_query_bind, OracleQuery.input_query,
                                   StateT.run_bind]
                                 rw [hstep]
-                                simp [qmc, OracleQuery.cont_query, bind_assoc, bind_pure_comp]
+                                simp [qmc, OracleQuery.cont_query]
                           rw [hrun]
                           rw [probEvent_bind_eq_tsum]
                           calc
@@ -3396,13 +3392,7 @@ theorem euf_cma_to_nma
                                           ((spec + (M →ₒ (Commit × Resp))).Range
                                             (Sum.inl (Sum.inr mc)) × (spec.QueryCache × Bool))) =
                                         pure (u, (cache, false), mc :: keys) := by
-                                      simpa [bind_pure_comp] using
-                                        (pure_bind
-                                          (f := fun a :
-                                            (spec + (M →ₒ (Commit × Resp))).Range
-                                              (Sum.inl (Sum.inr mc)) × (spec.QueryCache × Bool) =>
-                                              pure (a.1, a.2, mc :: keys))
-                                          (x := (u, (cache, false))))
+                                      simp
                                 exact hmap
                           have hrun :
                               (simulateQ (realImplLogged pk sk)
@@ -3465,7 +3455,7 @@ theorem euf_cma_to_nma
                           simp only [simulateQ_query_bind, OracleQuery.input_query,
                             StateT.run_bind]
                           rw [hstep]
-                          simp [qsig, OracleQuery.cont_query, bind_assoc, bind_pure_comp]
+                          simp [qsig, OracleQuery.cont_query]
                     rw [hrun]
                     have hstepBad :
                         Pr[fun cωπ : Commit × Chal × Resp =>
@@ -3481,7 +3471,7 @@ theorem euf_cma_to_nma
                               qsig] := by
                         refine probEvent_congr' (oa := qsig) ?_ rfl
                         intro cωπ _
-                        cases hhit : (cache (.inr (msg, cωπ.1))).isSome <;> simp [hhit]
+                        cases (cache (.inr (msg, cωπ.1))).isSome <;> simp
                       calc
                         Pr[fun cωπ : Commit × Chal × Resp =>
                             ¬ ((cache (.inr (msg, cωπ.1))).isSome = false) |
@@ -3637,8 +3627,7 @@ theorem euf_cma_to_nma
                 simp [reverseSigned, realImplBadAppend, _realImplSigned, realSignBadAppend,
                   realSignSignedAppend, realSignSigned, realSignSigned', sigBadFSigned,
                   QueryImpl.add_apply_inr, QueryImpl.withBadUpdate_apply_run, StateT.run_bind,
-                  StateT.run_get, StateT.run_set, List.reverse_reverse, List.reverse_cons,
-                  List.reverse_append, List.reverse_singleton, List.append_assoc]
+                  StateT.run_get, StateT.run_set, List.reverse_cons]
           have h_direct_real_append_proj : ∀ (pk : Stmt) (sk : Wit),
               Prod.map id reverseSigned <$> direct_real_exp pk sk =
                 direct_real_exp_append pk sk := by
@@ -3725,7 +3714,7 @@ theorem euf_cma_to_nma
                 (qS : ENNReal) * ((qS + qH : ℕ) : ENNReal) * β +
                 ENNReal.ofReal ((qS * (qS + qH) : ℕ) * ζ_zk) +
                 δ_verify := by
-                  simpa [slackReal, add_assoc]
+                  simp [slackReal, add_assoc]
       -- (B) `step_b_per_pksk_signed`: per-(pk, sk), the augmented-state event-level bound.
       --
       -- Derives from `step_b_per_pksk` (proven above on `(cache × Bool)` state) via the data
@@ -4009,7 +3998,7 @@ theorem euf_cma_to_nma
                             simp only [simulateQ_query_bind, OracleQuery.input_query,
                               StateT.run_bind]
                             rw [hstep]
-                            simp [qn, OracleQuery.cont_query, bind_assoc, bind_pure_comp]
+                            simp [qn, OracleQuery.cont_query]
                       rw [hrun]
                       rw [probEvent_bind_eq_tsum]
                       calc
@@ -4065,7 +4054,7 @@ theorem euf_cma_to_nma
                               simp only [simulateQ_query_bind, OracleQuery.input_query,
                                 StateT.run_bind]
                               rw [hstep]
-                              simp [qmc, OracleQuery.cont_query, bind_assoc, bind_pure_comp]
+                              simp [qmc, OracleQuery.cont_query]
                         rw [hrun]
                         rw [probEvent_bind_eq_tsum]
                         calc
@@ -4130,13 +4119,7 @@ theorem euf_cma_to_nma
                                         ((spec + (M →ₒ (Commit × Resp))).Range
                                           (Sum.inl (Sum.inr mc)) × (spec.QueryCache × Bool))) =
                                       pure (u, (cache, false), mc :: keys) := by
-                                    simpa [bind_pure_comp] using
-                                      (pure_bind
-                                        (f := fun a :
-                                          (spec + (M →ₒ (Commit × Resp))).Range
-                                            (Sum.inl (Sum.inr mc)) × (spec.QueryCache × Bool) =>
-                                            pure (a.1, a.2, mc :: keys))
-                                        (x := (u, (cache, false))))
+                                    simp
                               exact hmap
                         have hrun :
                             (simulateQ (_simImplLogged pk)
@@ -4198,7 +4181,7 @@ theorem euf_cma_to_nma
                         simp only [simulateQ_query_bind, OracleQuery.input_query,
                           StateT.run_bind]
                         rw [hstep]
-                        simp [qsig, OracleQuery.cont_query, bind_assoc, bind_pure_comp]
+                        simp [qsig, OracleQuery.cont_query]
                   rw [hrun]
                   have hstepBad :
                       Pr[fun cωπ : Commit × Chal × Resp =>
@@ -4214,7 +4197,7 @@ theorem euf_cma_to_nma
                             qsig] := by
                       refine probEvent_congr' (oa := qsig) ?_ rfl
                       intro cωπ _
-                      cases hhit : (cache (.inr (msg, cωπ.1))).isSome <;> simp [hhit]
+                      cases (cache (.inr (msg, cωπ.1))).isSome <;> simp
                     calc
                       Pr[fun cωπ : Commit × Chal × Resp =>
                           ¬ ((cache (.inr (msg, cωπ.1))).isSome = false) |
@@ -4519,7 +4502,7 @@ theorem euf_cma_to_nma
                 simp [richInit, roInit] at hω
               · constructor
                 · intro msg c ω hω
-                  simp [richInit, advInit, roInit] at hω
+                  simp [richInit, advInit] at hω
                 · intro mc
                   simp [richInit, advInit, roInit]
             have h_simImplSigned_unif_run :
@@ -4756,7 +4739,7 @@ theorem euf_cma_to_nma
                 ((fun v : spec.Range (Sum.inl n) × spec.QueryCache => (v.1, (v.2, signed))) <$>
                   ((fun x : spec.Range (Sum.inl n) => (x, cache)) <$> mx)) =
                   ((fun u : spec.Range (Sum.inl n) => (u, (cache, signed))) <$> mx)
-              simpa [mx, Functor.map_map, Function.comp_def]
+              simp [mx, Functor.map_map]
             have h_baseSimSignedWrapped_hash_hit :
                 ∀ (mc : M × Commit) (cache : spec.QueryCache) (signed : List M) (ω : Chal),
                   cache (.inr mc) = some ω →
@@ -4984,7 +4967,7 @@ theorem euf_cma_to_nma
                               OracleComp spec (spec.Range (Sum.inl n)))) =
                             (liftM (PMF.uniformOfFintype (spec.Range (Sum.inl n))) :
                               SPMF (spec.Range (Sum.inl n))) := by
-                        simpa using (evalDist_query (spec := spec) (t := Sum.inl n))
+                        simp
                       simpa [evalDist_map] using
                         congrArg
                           (fun p : SPMF (spec.Range (Sum.inl n)) =>
@@ -5018,10 +5001,7 @@ theorem euf_cma_to_nma
                                       OracleQuery (Fork.wrappedSpec Chal) Chal) :
                                   OracleComp (Fork.wrappedSpec Chal) Chal)) =
                                 (liftM (PMF.uniformOfFintype Chal) : SPMF Chal) := by
-                            simpa [PMF.map_id] using
-                              (evalDist_liftM
-                                (q := (query (spec := Fork.wrappedSpec Chal) (Sum.inr ()) :
-                                  OracleQuery (Fork.wrappedSpec Chal) Chal)))
+                            simp [PMF.map_id]
                           have hRight :
                               evalDist
                                 ((liftM
@@ -5103,7 +5083,7 @@ theorem euf_cma_to_nma
                 rcases st with ⟨roCache, queryLog⟩
                 rcases forgery with ⟨msg, cs⟩
                 rcases cs with ⟨c, resp⟩
-                cases h : roCache (msg, c) <;> simp [traceOfState, traceMap, Function.comp_def, h]
+                cases h : roCache (msg, c) <;> simp [traceOfState, traceMap, h]
               calc
                 traceOfState <$> (simulateQ traceImpl (adv.main pk)).run traceInit
                     = (traceOfState ∘
@@ -5227,7 +5207,7 @@ theorem euf_cma_to_nma
                                 ((roCache, queryLog) : RoState)) := by
                         simpa using hw
                       rw [hinner] at hw'
-                      simp only [Functor.map_map, Function.comp_def, support_map] at hw'
+                      simp only [support_map] at hw'
                       rcases hw' with ⟨u, hu, hw⟩
                       subst w
                       have huState : u.2 = ((roCache, queryLog) : RoState) := by
@@ -5325,9 +5305,8 @@ theorem euf_cma_to_nma
                               (impl₁' := Fork.unifFwd M Commit Chal)
                               (impl₂' := Fork.roImpl M Commit Chal)]
                             rw [simulateQ_query]
-                            simp [innerPkg, QueryImpl.add_apply_inr, Fork.roImpl, StateT.run_bind,
-                              StateT.run_get, StateT.run_set, hroMiss, bind_pure_comp,
-                              liftComp_eq_liftM]
+                            simp [Fork.roImpl, StateT.run_bind,
+                              StateT.run_get, StateT.run_set, hroMiss, bind_pure_comp]
                           rw [h_simImplSigned_hash_miss mc cache signed bad hcache] at hw
                           have hw' :
                               w ∈ support
@@ -5357,7 +5336,7 @@ theorem euf_cma_to_nma
                           have hst' :
                               ((roCache.cacheQuery mc u, queryLog ++ [mc]) : RoState) = st' := by
                             rcases hp' with ⟨u', hu', huEq⟩
-                            simp [support_query] at hu'
+                            simp at hu'
                             cases huEq
                             rfl
                           cases hst'
@@ -5622,9 +5601,8 @@ theorem euf_cma_to_nma
                               (impl₁' := Fork.unifFwd M Commit Chal)
                               (impl₂' := Fork.roImpl M Commit Chal)]
                             rw [simulateQ_query]
-                            simp [innerPkg, QueryImpl.add_apply_inr, Fork.roImpl, hroMiss,
-                              StateT.run_bind, StateT.run_get, StateT.run_set, bind_pure_comp,
-                              liftComp_eq_liftM]
+                            simp [Fork.roImpl, hroMiss,
+                              StateT.run_bind, StateT.run_get, StateT.run_set, bind_pure_comp]
                           have hlhs :
                               Prod.fst <$>
                                   (simulateQ innerPkg.impl
@@ -5659,7 +5637,7 @@ theorem euf_cma_to_nma
                           rw [simulateQ_map]]
                     rw [StateT.run_map, h_inner_liftComp_run (oa := simTranscript pk)
                       (st := ((roCache, queryLog) : RoState))]
-                    simp [Functor.map_map, Function.comp_def, F]
+                    simp [Functor.map_map, F]
                   have hlhs :
                       Prod.fst <$>
                           (simulateQ innerPkg.impl (F <$> liftComp (simTranscript pk) spec)).run
@@ -6673,8 +6651,9 @@ theorem euf_nma_bound
     (B := fun pkw => Pr[ fun w : Wit => rel pkw.1 w = true |
       eufNmaReduction σ hr M nmaAdv qH pkw.1])
     (q := (qH : ENNReal) + 1) (hinv := challengeSpaceInv Chal)
-    hinv_ne_top (fun _ => probEvent_le_one) (fun pkw => hPerPkFinal pkw.1)
+    hinv_ne_top (fun _ => probEvent_le_one)     (fun pkw => hPerPkFinal pkw.1)
 
+omit [SampleableType Stmt] in
 /-- **Combined EUF-CMA bound (Pointcheval-Stern with quantitative HVZK, β-parametric).**
 
 Composes `euf_cma_to_nma` and `euf_nma_bound`:

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -257,15 +257,18 @@ private lemma map_run_withLogging_inputs_eq_run_signedAppend
     baseS + signAppend
   induction oa using OracleComp.inductionOn generalizing signed₀ with
   | pure x =>
-      simp [implW, implAppend]
+      simp
   | query_bind t oa ih =>
       cases t with
       | inl t' =>
-          simp [implW, implAppend, baseW, baseS, QueryImpl.add_apply_inl, ih]
+          simp [QueryImpl.add_apply_inl, ih]
       | inr msg =>
-          simp [implW, implAppend, signAppend, baseW, baseS, QueryImpl.add_apply_inr,
-            QueryImpl.withLogging_apply, WriterT.run_bind', StateT.run_bind, StateT.run_get,
-            StateT.run_set]
+          simp only [add_apply_inr, simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+            OracleQuery.cont_query, QueryImpl.add_apply_inr, QueryImpl.withLogging_apply,
+            bind_pure_comp, map_bind, Functor.map_map, id_eq, bind_assoc, bind_map_left,
+            WriterT.run_bind', WriterT.run_liftM, List.empty_eq, WriterT.run_tell, pure_bind,
+            List.cons_append, List.nil_append, Prod.map_fst, Prod.map_snd, List.map_cons,
+            StateT.run_bind, StateT.run_get, StateT.run_monadLift, monadLift_self, StateT.run_set]
           refine bind_congr fun sig => ?_
           simpa [List.append_assoc] using ih sig (signed₀ ++ [msg])
 
@@ -1608,9 +1611,11 @@ theorem euf_cma_to_nma
                 rw [hlift]
                 simp [bind_pure_comp]
               rw [h_baseProb_inl]
-              show
-                  evalDist ((fun x => (x, cache)) <$> ((unifSpec.query n : ProbComp (Fin (n + 1))).liftComp spec)) =
-                    evalDist ((fun x => (x, cache)) <$> (unifSpec.query n : ProbComp (Fin (n + 1))))
+              change
+                  evalDist ((fun x => (x, cache)) <$>
+                      ((unifSpec.query n : ProbComp (Fin (n + 1))).liftComp spec)) =
+                    evalDist ((fun x => (x, cache)) <$>
+                      (unifSpec.query n : ProbComp (Fin (n + 1))))
               exact
                 evalDist_map_eq_of_evalDist_eq
                   (mx := ((unifSpec.query n : ProbComp (Fin (n + 1))).liftComp spec))
@@ -4511,7 +4516,7 @@ theorem euf_cma_to_nma
             have h_richInv_init : richInv richInit := by
               constructor
               · intro mc ω hω
-                simp [richInit, advInit, roInit] at hω
+                simp [richInit, roInit] at hω
               · constructor
                 · intro msg c ω hω
                   simp [richInit, advInit, roInit] at hω
@@ -5433,7 +5438,7 @@ theorem euf_cma_to_nma
                           rw [simulateQ_map]]
                     rw [StateT.run_map, h_inner_liftComp_run (oa := simTranscript pk)
                       (st := ((roCache, queryLog) : RoState))]
-                    simp [Functor.map_map, Function.comp_def, F]
+                    simp [Functor.map_map, F]
                   have hw' :
                       w ∈ support
                         ((fun cωπ => (F cωπ, ((roCache, queryLog) : RoState))) <$>

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -11,6 +11,7 @@ import VCVio.CryptoFoundations.HardnessAssumptions.HardRelation
 import VCVio.CryptoFoundations.SeededFork
 import VCVio.CryptoFoundations.ReplayFork
 import VCVio.SSP.Composition
+import ToMathlib.Data.ENNReal.TsumDistrib
 
 /-!
 # EUF-CMA security of the Fiat-Shamir Σ-protocol transform
@@ -702,229 +703,11 @@ theorem euf_cma_to_nma
       | none => ((c, s), cache.cacheQuery (.inr (msg, c)) ω)
   let nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M) :=
-    ⟨fun pk => (simulateQ (baseSim + sigSim pk) (adv.main pk)).run ∅⟩
+    simulatedNmaAdv (σ := σ) (hr := hr) (M := M) (simTranscript := simTranscript)
+      (adv := adv)
   refine ⟨nmaAdv, ?_, ?_⟩
-  · -- Query bound: show the NMA adversary makes at most `qH` hash queries.
-    -- `fwd` forwards each hash query as-is (1 hash query per CMA hash query).
-    -- `sigSim` handles signing queries via `simTranscript` + cache programming,
-    -- generating zero hash queries (only uniform queries from `simTranscript`).
-    -- Requires a general `IsQueryBound` transfer lemma for `simulateQ` + `StateT.run`.
-    intro pk
-    let stepBudget :
-        (spec + (M →ₒ (Commit × Resp))).Domain → ℕ × ℕ → ℕ := fun t _ =>
-      match t with
-      | .inl (.inl _) => 0
-      | .inl (.inr _) => 1
-      | .inr _ => 0
-    have hbind :
-        ∀ {α β : Type} {oa : OracleComp spec α} {ob : α → OracleComp spec β} {Q₁ Q₂ : ℕ},
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal) (oa := oa) Q₁ →
-          (∀ x, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := ob x) Q₂) →
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := oa >>= ob) (Q₁ + Q₂) := by
-      intro α β oa ob Q₁ Q₂ h1 h2
-      exact nmaHashQueryBound_bind (M := M) (Commit := Commit) (Chal := Chal) h1 h2
-    have hfwd :
-        ∀ (t : spec.Domain) (s : spec.QueryCache),
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := (fwd t).run s) (match t with
-              | .inl _ => 0
-              | .inr _ => 1) := by
-      intro t s
-      cases t with
-      | inl n =>
-          simpa [fwd, QueryImpl.liftTarget_apply, HasQuery.toQueryImpl_apply,
-            OracleComp.liftM_run_StateT] using
-            (nmaHashQueryBound_bind (M := M) (Commit := Commit) (Chal := Chal)
-              (show nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                (oa := liftM (spec.query (.inl n))) 0 by
-                  exact
-                    (nmaHashQueryBound_query_iff (M := M) (Commit := Commit) (Chal := Chal)
-                      (.inl n) 0).2 trivial)
-              (fun u =>
-                show nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                  (oa := pure (u, s)) 0 by
-                    trivial))
-      | inr mc =>
-          simpa [fwd, QueryImpl.liftTarget_apply, HasQuery.toQueryImpl_apply,
-            OracleComp.liftM_run_StateT] using
-            (nmaHashQueryBound_bind (M := M) (Commit := Commit) (Chal := Chal)
-              (show nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                (oa := liftM (spec.query (.inr mc))) 1 by
-                  exact
-                    (nmaHashQueryBound_query_iff (M := M) (Commit := Commit) (Chal := Chal)
-                      (.inr mc) 1).2 (Nat.succ_pos 0))
-              (fun u =>
-                show nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                  (oa := pure (u, s)) 0 by
-                    trivial))
-    have hro :
-        ∀ (mc : M × Commit) (s : spec.QueryCache),
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := (roSim mc).run s) 1 := by
-      intro mc s
-      cases hs : s (.inr mc) with
-      | some v =>
-          simp [roSim, hs, nmaHashQueryBound]
-      | none =>
-          simpa [roSim, hs] using
-            ((OracleComp.isQueryBound_map_iff
-                (oa := (fwd (.inr mc)).run s)
-                (f := fun a : Chal × spec.QueryCache =>
-                  (a.1, a.2.cacheQuery (.inr mc) a.1))
-                (b := 1)
-                (canQuery := fun t b => match t with
-                  | .inl _ => True
-                  | .inr _ => 0 < b)
-                (cost := fun t b => match t with
-                  | .inl _ => b
-                  | .inr _ => b - 1)).2
-              (hfwd (.inr mc) s))
-    have hsig :
-        ∀ (msg : M) (s : spec.QueryCache),
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := (sigSim pk msg).run s) 0 := by
-      intro msg s
-      have hsource : OracleComp.IsQueryBound
-          (simTranscript pk) () (fun _ _ => True) (fun _ _ => ()) := by
-        induction simTranscript pk using OracleComp.inductionOn with
-        | pure x =>
-            trivial
-        | query_bind t mx ih =>
-            simp [OracleComp.isQueryBound_query_bind_iff, ih]
-      have htranscript :
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := (simulateQ unifSim (simTranscript pk)).run s) 0 := by
-        simpa [nmaHashQueryBound] using
-          (OracleComp.IsQueryBound.simulateQ_run_of_step
-            (h := hsource) (combine := Nat.add) (mapBudget := fun _ => 0)
-            (stepBudget := fun _ _ => 0) (impl := unifSim)
-            (hbind := by
-              intro γ δ oa' ob b₁ b₂ h1 h2
-              have h1' :
-                  nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                    (oa := oa') b₁ := by
-                simpa [nmaHashQueryBound] using h1
-              have h2' : ∀ x,
-                  nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                    (oa := ob x) b₂ := by
-                intro x
-                simpa [nmaHashQueryBound] using h2 x
-              simpa [nmaHashQueryBound] using
-                (nmaHashQueryBound_bind (M := M) (Commit := Commit) (Chal := Chal)
-                  (oa := oa') (ob := ob) (Q₁ := b₁) (Q₂ := b₂) h1' h2')
-            )
-            (hstep := by
-              intro t b s' ht
-              simpa [unifSim] using hfwd (.inl t) s')
-            (hcombine := by
-              intro t b ht
-              simp)
-            (s := s))
-      simpa [sigSim, nmaHashQueryBound] using
-        ((OracleComp.isQueryBound_map_iff
-            (oa := (simulateQ unifSim (simTranscript pk)).run s)
-            (f := fun a : (Commit × Chal × Resp) × spec.QueryCache =>
-              match a.2 (.inr (msg, a.1.1)) with
-              | some _ => ((a.1.1, a.1.2.2), a.2)
-              | none =>
-              ((a.1.1, a.1.2.2),
-                QueryCache.cacheQuery a.2 (.inr (msg, a.1.1)) a.1.2.1))
-            (b := 0)
-            (canQuery := fun t b => match t with
-              | .inl _ => True
-              | .inr _ => 0 < b)
-            (cost := fun t b => match t with
-              | .inl _ => b
-              | .inr _ => b - 1)).2 htranscript)
-    have hstep :
-        ∀ t b s,
-          (match t, b with
-            | .inl (.inl _), _ => True
-            | .inl (.inr _), (_, qH') => 0 < qH'
-            | .inr _, (qS', _) => 0 < qS') →
-          nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-            (oa := ((baseSim + sigSim pk) t).run s) (stepBudget t b) := by
-      intro t b s ht
-      rcases b with ⟨qS', qH'⟩
-      cases t with
-      | inl t =>
-          cases t with
-          | inl n =>
-              simpa [baseSim, stepBudget] using hfwd (.inl n) s
-          | inr mc =>
-              simpa [baseSim, stepBudget] using hro mc s
-      | inr msg =>
-          simpa [stepBudget] using hsig msg s
-    have hcombine :
-        ∀ t b,
-          (match t, b with
-            | .inl (.inl _), _ => True
-            | .inl (.inr _), (_, qH') => 0 < qH'
-            | .inr _, (qS', _) => 0 < qS') →
-          Nat.add (stepBudget t b)
-            (Prod.snd (match t, b with
-              | .inl (.inl _), b' => b'
-              | .inl (.inr _), (qS', qH') => (qS', qH' - 1)
-              | .inr _, (qS', qH') => (qS' - 1, qH'))) =
-            Prod.snd b := by
-      intro t b ht
-      rcases b with ⟨qS', qH'⟩
-      cases t with
-      | inl t =>
-          cases t with
-          | inl n =>
-              simp [stepBudget]
-          | inr mc =>
-              simp [stepBudget] at ht ⊢
-              omega
-      | inr msg =>
-          simp [stepBudget]
-    simpa [nmaHashQueryBound, signHashQueryBound] using
-      (OracleComp.IsQueryBound.simulateQ_run_of_step
-        (h := _hQ pk) (combine := Nat.add) (mapBudget := Prod.snd)
-        (stepBudget := stepBudget) (impl := baseSim + sigSim pk)
-        (hbind := by
-          intro γ δ oa' ob b₁ b₂ h1 h2
-          have h1' :
-              nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                (oa := oa') b₁ := by
-            simpa [nmaHashQueryBound] using h1
-          have h2' : ∀ x,
-              nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-                (oa := ob x) b₂ := by
-            intro x
-            simpa [nmaHashQueryBound] using h2 x
-          simpa [nmaHashQueryBound] using
-            (hbind (oa := oa') (ob := ob) (Q₁ := b₁) (Q₂ := b₂) h1' h2')
-        )
-        (hstep := by
-          intro t b s ht
-          rcases b with ⟨qS', qH'⟩
-          cases t with
-          | inl t =>
-              cases t with
-              | inl n =>
-                  simpa [nmaHashQueryBound, baseSim, stepBudget] using hfwd (.inl n) s
-              | inr mc =>
-                  simpa [nmaHashQueryBound, baseSim, stepBudget] using hro mc s
-          | inr msg =>
-              simpa [nmaHashQueryBound, stepBudget] using hsig msg s)
-        (hcombine := by
-          intro t b ht
-          rcases b with ⟨qS', qH'⟩
-          cases t with
-          | inl t =>
-              cases t with
-              | inl n =>
-                  simp [stepBudget]
-              | inr mc =>
-                  simp [stepBudget] at ht ⊢
-                  omega
-          | inr msg =>
-              simp [stepBudget])
-        (s := ∅))
+  · exact simulatedNmaAdv_hashQueryBound (σ := σ) (hr := hr) (M := M)
+      (simTranscript := simTranscript) (adv := adv) qS qH _hQ
   · -- Advantage bound: `adv.advantage ≤ Adv^{fork-NMA}_{qH}(nmaAdv)
     --                      + ofReal(qS · (qS+qH+1) · ζ_zk) + collisionSlack qS qH β + δ_verify`.
     --
@@ -968,19 +751,19 @@ theorem euf_cma_to_nma
     -- is identical and deterministic on the sim and real sides, so it does not
     -- contribute to TV beyond the existing `(cache × Bool)`-state bound.
     --
-    -- The (B-finish) collision bound and the (A) / (C') bridges are tracked
-    -- separately as named sub-sorries. Each is mathematically substantive:
+    -- The (B-finish) collision bound and the (A) / (C') bridges are established
+    -- as named intermediate `have`s along this proof. Each is mathematically
+    -- substantive:
     --
-    --   * (A) `bridge_real_freshness`: rewrite `unforgeableExp` as an
-    --     integral over `keygen` of `direct_real_exp pk sk`. Requires
-    --     factoring out `keygen` from the SPMF `runtime.evalDist`, then
-    --     equating the WriterT log of `signingOracle` with the augmented
-    --     `signed` state.
+    --   * (A) `bridge_real_freshness`: rewrites `unforgeableExp` as an integral
+    --     over `keygen` of `direct_real_exp pk sk`, factoring out `keygen` from
+    --     the SPMF `runtime.evalDist` and equating the WriterT log of
+    --     `signingOracle` with the augmented `signed` state.
     --
-    --   * (B-finish) `pr_bad_le_collisionSlack`: union-bound on `qS`
-    --     programming events, each hitting a previously cached point with
-    --     probability ≤ `(qS + qH) / |Chal|`. The per-event uniformity comes
-    --     from the per-query HVZK simulator (challenge marginal is uniform).
+    --   * (B-finish) `pr_bad_le_signed`: a union bound on `qS` programming
+    --     events, each hitting a previously cached point with probability
+    --     ≤ `(qS + qH) · β`. The per-event uniformity comes from the per-query
+    --     HVZK simulator (challenge marginal is `β`-bounded).
     --
     --   * (C') `bridge_sim_fork_freshness`: a forgery `(msg, c, s)` against
     --     `direct_sim_exp` with `¬msg ∈ signed` cannot have used a programmed
@@ -3923,32 +3706,8 @@ theorem euf_cma_to_nma
               (Pr[event pksk.1 | direct_real_exp pksk.1 pksk.2] + slackReal)) =
               (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
                 Pr[event pksk.1 | direct_real_exp pksk.1 pksk.2]) +
-                slackReal := by
-          let termA : Stmt × Wit → ENNReal := fun pksk =>
-            evalDist hr.gen pksk * Pr[event pksk.1 | direct_real_exp pksk.1 pksk.2]
-          let termB : Stmt × Wit → ENNReal := fun pksk =>
-            evalDist hr.gen pksk * slackReal
-          have h_expand :
-              (fun pksk : Stmt × Wit =>
-                evalDist hr.gen pksk *
-                  (Pr[event pksk.1 | direct_real_exp pksk.1 pksk.2] + slackReal)) =
-                (fun pksk : Stmt × Wit => termA pksk + termB pksk) := by
-            funext pksk
-            simp [termA, termB, left_distrib]
-          have h_termB :
-              (∑' (pksk : Stmt × Wit), termB pksk) = slackReal := by
-            simp [termB, ENNReal.tsum_mul_right, h_keygen_sum_one, one_mul]
-          calc
-            (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
-              (Pr[event pksk.1 | direct_real_exp pksk.1 pksk.2] + slackReal)) =
-                ∑' (pksk : Stmt × Wit), (termA pksk + termB pksk) := by
-                  simpa [h_expand]
-            _ = (∑' (pksk : Stmt × Wit), termA pksk) +
-                  (∑' (pksk : Stmt × Wit), termB pksk) := by
-                  rw [ENNReal.tsum_add]
-            _ = (∑' (pksk : Stmt × Wit), termA pksk) +
-                  slackReal := by
-                  rw [h_termB]
+                slackReal :=
+          ENNReal.tsum_mul_add_const_of_tsum_eq_one _ _ _ h_keygen_sum_one
         calc
           (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
             Pr[= true | actual_pk_exp pksk.1 pksk.2])
@@ -4180,13 +3939,12 @@ theorem euf_cma_to_nma
       -- from this step (by `simCommitPredictability`), plus the IH bound with `qS_rem - 1` and
       -- `|c'.dom ∩ .inr| ≤ |c₀.dom ∩ .inr| + 1`.
       --
-      -- **Scope / deferral.** The induction requires:
-      --   * A per-step collision lemma `probEvent_sigSimSigned_bad_step_le` (~40 LOC) bounding
-      --     the per-sign-query bad flip probability using `simCommitPredictability`.
-      --   * A cache-size bookkeeping lemma `cache_inr_size_bound_of_signHashQueryBound` (~30 LOC).
-      --   * The induction itself (~150 LOC), lifting per-step bounds to the total bound
+      -- **Structure.** The induction has three ingredients:
+      --   * A per-step collision bound on the per-sign-query bad flip probability,
+      --     using `simCommitPredictability`.
+      --   * A cache-size bookkeeping bound tied to `signHashQueryBound`.
+      --   * The induction itself, lifting per-step bounds to the total bound
       --     through `probEvent_bind_le_add` at each query step.
-      -- This is a substantial but routine union-bound proof; deferred to a follow-up round.
       have pr_bad_le_signed : ∀ (pk : Stmt),
           Pr[badPred | direct_sim_exp pk] ≤
             (qS : ENNReal) * ((qS + qH : ℕ) : ENNReal) * β := by
@@ -4566,7 +4324,7 @@ theorem euf_cma_to_nma
               simpa [direct_sim_exp_logged]
                 using hlogged
       -- (C') `bridge_sim_fork_freshness`: bridge the (pk-summed) sim-side event probability
-      -- to `Fork.advantage`. No additional slack needed here, the fresh-challenge miss term
+      -- to `Fork.advantage`. No additional slack is needed here, the fresh-challenge miss term
       -- is already isolated in the (A) bridge as `δ_verify`.
       --
       -- Proof structure:
@@ -4574,7 +4332,7 @@ theorem euf_cma_to_nma
       --       LHS (this mirrors `hAdv_eq_tsum` in `euf_nma_bound`).
       --   (2) Apply a per-pk inequality
       --         `Pr[event pk | direct_sim_exp pk] ≤ Pr[forkPoint.isSome | runTrace pk]`
-      --       which is the genuine coupling content (sub-sorry `per_pk_event_le_forkPoint`).
+      --       which is the genuine coupling content (`per_pk_event_le_forkPoint` below).
       --   (3) Chain via `ENNReal.tsum_le_tsum` and `mul_le_mul_left'`.
       --
       -- Key insight driving (2): a forgery `(msg, c, π)` with `¬msg ∈ signed` cannot have
@@ -4584,7 +4342,7 @@ theorem euf_cma_to_nma
       -- `Fork.runTrace`'s `queryLog`), exactly the condition for `forkPoint trace = some _`.
       -- Formally, this requires a coupling between `direct_sim_exp pk` and `runTrace pk`
       -- that preserves the shared `(forgery, advCache)` marginal and tracks the
-      -- `advCache \ roCache` delta. See the sub-sorry's sketch for details.
+      -- `advCache \ roCache` delta, as built below via `richSim`.
       have bridge_sim_fork_freshness :
           (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
             Pr[event pksk.1 | direct_sim_exp pksk.1]) ≤
@@ -4592,23 +4350,23 @@ theorem euf_cma_to_nma
         -- Per-pk inequality: the LHS event at `direct_sim_exp pk` is dominated by the
         -- fork-point success probability at `runTrace pk`. This is the coupling content.
         --
-        -- Proof strategy (deferred): build a "rich" simulator
+        -- Proof structure: build a "rich" simulator
         --   `richSim pk : QueryImpl (spec + sigSpec)
         --       (StateT ((QueryCache × List M × Bool) × (roCache × queryLog)) ProbComp)`
         -- that simultaneously tracks `direct_sim_exp`'s and `runTrace`'s full state.
-        -- Prove two projection lemmas:
+        -- Two projection lemmas then recover each side:
         --   (P1) forgetting `(roCache, queryLog)` recovers `direct_sim_exp pk`;
         --   (P2) forgetting `(signed, bad)` recovers `runTrace pk` (up to the `verified`
         --        reconstruction from `roCache`).
-        -- Then show the pointwise event implication on the joint state: `event pk z ⟹
-        -- (forkPoint qH (trace_of z)).isSome`. This implication uses the key invariant
-        -- that in any rich-sim execution, `roCache ⊆ advCache` (roCache only receives
-        -- roSim-sourced entries, which are also cached in advCache), hence
+        -- The pointwise event implication on the joint state: `event pk z ⟹
+        -- (forkPoint qH (trace_of z)).isSome` uses the key invariant that in any rich-sim
+        -- execution, `roCache ⊆ advCache` (roCache only receives roSim-sourced entries,
+        -- which are also cached in advCache), hence
         -- `advCache (.inr (msg, c)) = some ω ∧ msg ∉ signed ⟹ roCache (msg, c) = some ω`
         -- (since `msg ∉ signed` rules out sign-programmed entries as the only other source
         -- of advCache writes); the lockstep invariant
         -- `(msg, c) ∈ roCache.domain ⟺ (msg, c) ∈ queryLog` then finishes.
-        -- Per-pk inequality, structured as three sub-claims:
+        -- Three sub-claims in full:
         --
         --   (P1) Distributional equality: there is a "rich" simulation `richSim pk` over `spec`
         --        that jointly tracks `direct_sim_exp pk`'s state `(advCache, signed, bad)` and
@@ -4634,11 +4392,6 @@ theorem euf_cma_to_nma
         -- Integration:  LHS = Pr[event | direct_sim_exp]  = Pr[event' | richSim]    (by P1)
         --                                                ≤ Pr[forkPoint' | richSim] (by P3)
         --                                                = Pr[forkPoint | runTrace] (by P2).
-        --
-        -- The construction of `richSim pk` and the three sub-claims (P1)–(P3) are
-        -- deferred to a follow-up proof round. The scaffolding below records the intended
-        -- signature of the per-pk inequality; filling in `richSim` + (P1), (P2), (P3)
-        -- discharges this `sorry` and closes the freshness-preserving `euf_cma_to_nma` chain.
         have per_pk_event_le_forkPoint : ∀ (pk : Stmt),
             Pr[event pk | direct_sim_exp pk] ≤
               Pr[fun trace => (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
@@ -6172,57 +5925,8 @@ theorem euf_cma_to_nma
                 Pr[event pksk.1 | direct_sim_exp pksk.1]) +
               slackHVZK +
               (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
-                Pr[badPred | direct_sim_exp pksk.1]) := by
-          have h_expand :
-              (fun pksk : Stmt × Wit =>
-                evalDist hr.gen pksk *
-                  (Pr[event pksk.1 | direct_sim_exp pksk.1] +
-                    slackHVZK +
-                    Pr[badPred | direct_sim_exp pksk.1])) =
-                (fun pksk : Stmt × Wit =>
-                  (evalDist hr.gen pksk *
-                      Pr[event pksk.1 | direct_sim_exp pksk.1] +
-                    evalDist hr.gen pksk * slackHVZK) +
-                    evalDist hr.gen pksk * Pr[badPred | direct_sim_exp pksk.1]) := by
-            funext pksk
-            rw [mul_add, mul_add]
-          let termA : Stmt × Wit → ENNReal := fun pksk =>
-            evalDist hr.gen pksk * Pr[event pksk.1 | direct_sim_exp pksk.1]
-          let termB : Stmt × Wit → ENNReal := fun pksk =>
-            evalDist hr.gen pksk * slackHVZK
-          let termC : Stmt × Wit → ENNReal := fun pksk =>
-            evalDist hr.gen pksk * Pr[badPred | direct_sim_exp pksk.1]
-          have h_step3 : (∑' (pksk : Stmt × Wit), termB pksk) = slackHVZK := by
-            simp [termB, ENNReal.tsum_mul_right, h_keygen_sum_one, one_mul]
-          calc
-            (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
-              (Pr[event pksk.1 | direct_sim_exp pksk.1] +
-                slackHVZK +
-                Pr[badPred | direct_sim_exp pksk.1])) =
-                tsum (fun pksk : Stmt × Wit => ((termA pksk + termB pksk) + termC pksk)) := by
-                  simpa [termA, termB, termC] using
-                    congrArg (fun f => ∑' (pksk : Stmt × Wit), f pksk) h_expand
-            _ = tsum (fun pksk : Stmt × Wit => termA pksk + termB pksk) +
-                  tsum (fun pksk : Stmt × Wit => termC pksk) := by
-                  rw [ENNReal.tsum_add]
-            _ = (tsum (fun pksk : Stmt × Wit => termA pksk) +
-                  tsum (fun pksk : Stmt × Wit => termB pksk)) +
-                  tsum (fun pksk : Stmt × Wit => termC pksk) := by
-                  rw [ENNReal.tsum_add]
-            _ = (tsum (fun pksk : Stmt × Wit => termA pksk) +
-                  slackHVZK) +
-                  tsum (fun pksk : Stmt × Wit => termC pksk) := by
-                  rw [h_step3]
-            _ = tsum (fun pksk : Stmt × Wit => termA pksk) +
-                  slackHVZK +
-                  tsum (fun pksk : Stmt × Wit => termC pksk) := by
-                  simp [add_assoc]
-            _ = (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
-                    Pr[event pksk.1 | direct_sim_exp pksk.1]) +
-                  slackHVZK +
-                  (∑' (pksk : Stmt × Wit), evalDist hr.gen pksk *
-                    Pr[badPred | direct_sim_exp pksk.1]) := by
-                  simp [termA, termC]
+                Pr[badPred | direct_sim_exp pksk.1]) :=
+          ENNReal.tsum_mul_add_const_add_of_tsum_eq_one _ _ _ _ h_keygen_sum_one
         exact h_step1.trans_eq h_step2
       -- (B-finish) distributed: `S_bad ≤ slackA` (since `hr.gen` is a PMF).
       have h_bad_sum :
@@ -6992,14 +6696,14 @@ exceeds the advantage.
 When HVZK is perfect (`ζ_zk = 0`), the HVZK term vanishes and the bound specializes to
 `(ε - collisionSlack qS qH β - δ_verify) · …`.
 
-The forking-lemma side (the two B1 prefix-faithfulness identities
+The forking-lemma side uses `Fork.replayForkingBound` (via the two B1
+prefix-faithfulness identities
 `evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt` and
-`tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt` in ReplayFork.lean) is
-discharged and feeds the Jensen/Cauchy-Schwarz step inside `Fork.replayForkingBound`
-used by `euf_nma_bound`. The Phase B freshness-drop hop is discharged via
-`SignatureAlg.unforgeableAdv.advantage_le_unforgeableExpNoFresh` instantiated with
-`runtime_evalDist_bind_pure`. Conditional only on the remaining sub-sorries inside
-`euf_cma_to_nma`. -/
+`tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt` in `ReplayFork.lean`)
+to feed the Jensen/Cauchy-Schwarz step inside `euf_nma_bound`. The Phase B
+freshness-drop hop uses
+`SignatureAlg.unforgeableAdv.advantage_le_unforgeableExpNoFresh` instantiated
+with `runtime_evalDist_bind_pure`. -/
 theorem euf_cma_bound
     [SampleableType Chal]
     (hss : σ.SpeciallySound)


### PR DESCRIPTION
## Summary

Three self-contained golfs to the EUF-CMA → NMA reduction in `VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean`, plus one supporting lift into `ToMathlib`. This PR absorbs the previous stack (#339, #340, now closed).

### 1. Deduplicate query-bound block (~218 lines)
The inline `let nmaAdv := ⟨…⟩` in `euf_cma_to_nma` plus its full query-bound proof duplicated the already-defined `private def simulatedNmaAdv` / `private theorem simulatedNmaAdv_hashQueryBound`. Both are now invoked directly.

### 2. Factor repeated weighted-tsum distributivity (~41 lines)
Two `ENNReal.tsum` `calc` chains of the shape
`∑' i, w i * (f i + c [+ g i]) = (∑' i, w i * f i) + c [+ (∑' i, w i * g i)]` (under `(∑' i, w i) = 1`) are replaced by two named helpers.

### 3. Lift helpers to `ToMathlib`
The two helpers are fully generic `ℝ≥0∞` algebra with no Fiat-Shamir content, so they now live in `ToMathlib/Data/ENNReal/TsumDistrib.lean` under the `ENNReal` namespace:
- `ENNReal.tsum_mul_add_const_of_tsum_eq_one`
- `ENNReal.tsum_mul_add_const_add_of_tsum_eq_one`

### 4. Refresh docstrings (~6 lines)
Drop stale 'sub-sorry' / 'deferred to a follow-up proof round' narrative that no longer describes the now-complete proof obligations.

## Impact

- `VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean`: **7038 → 6704 lines (-334)**.
- No change to proof content: `euf_cma_to_nma`, `euf_nma_bound`, `euf_cma_bound` retain the same statements and final bounds.
- New file: `ToMathlib/Data/ENNReal/TsumDistrib.lean` (66 lines, 2 lemmas).

## Test plan

- [x] `lake build VCVio.CryptoFoundations.FiatShamir.Sigma.Security` succeeds (only pre-existing long-line / `show`-tactic style warnings remain).
- [x] `lake build ToMathlib.Data.ENNReal.TsumDistrib` succeeds.
- [ ] Full `lake build` on CI.

---
Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.