### PR TITLE
docs: flag unsound-shape security bound theorems as placeholders (FO, MLKEM, MLDSA, FS-with-aborts)

### DIFF
--- a/LatticeCrypto/MLDSA/Security.lean
+++ b/LatticeCrypto/MLDSA/Security.lean
@@ -239,9 +239,21 @@ variable {M : Type}
 open scoped Classical in
 /-- **Main Security Theorem (EUF-CMA, Theorem 4, CRYPTO 2023).**
 
-THIS THEOREM STATEMENT NEEDS TO BE UPDATED ONCE WE FIGURE OUT THE CORRECT BOUND TO STATE
-DIRECTLY FOR ML-DSA. For now it is parameterized by an explicit quantitative HVZK
-simulator hypothesis.
+**WARNING: this is a placeholder statement, not the final theorem.** The current shape is
+unsound as written: `ε`, `p_abort`, and `δ : ℝ` are unconstrained signed reals (only
+`hp : p_abort < 1` is assumed). Inherited from
+`FiatShamirWithAbort.cmaToNmaLoss`, the loss term
+`2qS(qH+1)ε/(1-p) + qS·ε(qS+1)/(2(1-p)²) + qS·ζ_zk + δ` can be made arbitrarily negative
+by taking `ε`, `δ` very negative; `ENNReal.ofReal` then clamps it to `0`, collapsing the
+bound to `adv.advantage ≤ Adv^MLWE + Adv^SelfTargetMSIS` with no statistical slack, which
+is generally false. In the final statement `ε`, `p_abort`, `δ` should be nonnegative
+(e.g. `ℝ≥0` or constrained by `0 ≤ ε`, `0 ≤ p_abort`, `0 ≤ δ` hypotheses) and identified
+with the concrete commitment guessing probability, abort probability, and regularity
+failure probability of the ML-DSA identification scheme.
+
+The proof is intentionally deferred. The statement also needs to be specialized to the
+actual ML-DSA parameters (eliminating the explicit quantitative HVZK simulator hypothesis)
+once that derivation is finalized.
 
 For any classical EUF-CMA adversary `A` making at most `qS` signing queries and `qH` random
 oracle queries, and for the adversaries `B` (against MLWE) and `C` (against SelfTargetMSIS)

--- a/LatticeCrypto/MLKEM/Security.lean
+++ b/LatticeCrypto/MLKEM/Security.lean
@@ -160,7 +160,17 @@ The proof composes three reductions:
 1. **FO transform** (HHK17 Corollary): IND-CCA of the FO-constructed KEM reduces to
    IND-CPA of K-PKE + PRF security of J + correctness + message entropy.
 2. **IND-CPA → MLWE**: Each IND-CPA term reduces to an MLWE advantage.
-3. **Concrete parameters**: `ε_msg = 1/|Message| = 2⁻²⁵⁶` and `δ` from FIPS 203 Table 1. -/
+3. **Concrete parameters**: `ε_msg = 1/|Message| = 2⁻²⁵⁶` and `δ` from FIPS 203 Table 1.
+
+**WARNING: this is a placeholder statement, not the final theorem.** The current shape is
+unsound as written: `correctnessBound : ℝ` is constrained only via
+`h_correct : … .deltaCorrect (ENNReal.ofReal correctnessBound)`, but `ENNReal.ofReal` clamps
+negative reals to `0`, so `correctnessBound = -10⁹` satisfies `h_correct` whenever
+`deltaCorrect 0` does. The right-hand side then has `((2qHK + 3 : ℕ) : ℝ) * correctnessBound`,
+which can be made arbitrarily negative, while the left-hand side is a probability and hence
+nonnegative. In the final statement `correctnessBound` should be a nonnegative real (e.g.
+`ℝ≥0` or `ENNReal`) directly identified with the K-PKE `δ`-correctness error, rather than a
+signed `ℝ` filtered through `ENNReal.ofReal`. The proof is intentionally deferred. -/
 theorem ind_cca_security
     (correctnessBound epsMsg : ℝ) (qHK : ℕ)
     (h_correct :

--- a/VCVio/CryptoFoundations/FiatShamir/WithAbort/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/WithAbort/Security.lean
@@ -83,7 +83,17 @@ and the query bounds `qS`, `qH`; it is captured here by `cmaToNmaLoss`.
 
 The scheme-specific reduction from NMA to computational assumptions (e.g., MLWE +
 SelfTargetMSIS for ML-DSA) is stated separately; see `MLDSA.nma_security` and
-`MLDSA.euf_cma_security`. -/
+`MLDSA.euf_cma_security`.
+
+**WARNING: this is a placeholder statement, not the final theorem.** The current shape is
+unsound as written: `ε` and `δ : ℝ` are unconstrained signed reals (only `0 ≤ ζ_zk` and
+`p_abort < 1` are assumed). Choosing `ε`, `δ` very negative drives `cmaToNmaLoss` into
+`(-∞, 0)`; `ENNReal.ofReal` clamps to `0`; the bound collapses to
+`adv.advantage ≤ Pr[hard relation reduction]` with no statistical slack, which is generally
+false for any non-trivially-secure hard relation. In the final statement `ε` and `δ` should
+be nonnegative (e.g. `ℝ≥0` or constrained by `0 ≤ ε`, `0 ≤ δ` hypotheses), and `p_abort`
+should additionally be `0 ≤ p_abort` so the divisors `1 - p` and `(1 - p)²` carry their
+intended sign. The proof is intentionally deferred. -/
 theorem euf_cma_bound
     (hc : ids.Complete)
     (sim : Stmt → ProbComp (Option (Commit × Chal × Resp)))
@@ -110,7 +120,11 @@ theorem euf_cma_bound
   sorry
 
 /-- Perfect-HVZK special case of `euf_cma_bound`, where the simulator contributes no
-`qS · ζ_zk` loss term. -/
+`qS · ζ_zk` loss term.
+
+**WARNING: this is a placeholder statement, not the final theorem.** It inherits the
+unsoundness of `euf_cma_bound` (unconstrained signed `ε`, `δ : ℝ`); see that theorem's
+docstring. -/
 theorem euf_cma_bound_perfectHVZK
     (hc : ids.Complete)
     (sim : Stmt → ProbComp (Option (Commit × Chal × Resp)))

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/Composed.lean
@@ -110,8 +110,19 @@ noncomputable def singleRORuntime
     (∅ : SingleROQueryCache PKHash M R K)
   toProbCompLift := ProbCompLift.ofMonadLift _
 
-/-- Main composed Fujisaki-Okamoto theorem statement. The proof is intentionally deferred, but the
-reduction artifacts are now existentially quantified rather than passed in as unrelated inputs. -/
+/-- Main composed Fujisaki-Okamoto IND-CCA theorem statement.
+
+**WARNING: this is a placeholder statement, not the final theorem.** The current shape is
+unsound as written: `correctnessBound` and `epsMsg` are unconstrained `ℝ` parameters, so
+the right-hand side can be made arbitrarily negative while the left-hand side is a
+probability and hence nonnegative. In the final composed FO statement these slack terms
+must be constrained (`correctnessBound` is the underlying PKE's `δ`-correctness error, and
+`epsMsg` is the message-distribution collision/min-entropy term, both provably nonnegative
+quantities derived from `pke`).
+
+The proof is intentionally deferred. The reduction artifacts (`cpaAdv₁`, `cpaAdv₂`,
+`prfAdv`) are existentially quantified rather than passed in as unrelated inputs, but the
+bound itself still needs to be tightened before this can be a meaningful security claim. -/
 theorem IND_CCA_bound
     {M PK SK R C KD K KPRF : Type}
     [DecidableEq M] [DecidableEq C] [DecidableEq KD]

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
@@ -314,8 +314,20 @@ def OW_PCVA_Adversary.MakesAtMostQueries
       | .inr (.inl _), (qH', qP', qV') => (qH', qP' - 1, qV')
       | .inr (.inr _), (qH', qP', qV') => (qH', qP', qV' - 1))
 
-/-- The T-transform security statement. The exact reduction is still deferred, but the oracle
-surface and query-budget parameters now match the HHK-style OW-PCVA game. -/
+/-- The T-transform OW-PCVA security statement.
+
+**WARNING: this is a placeholder statement, not the final theorem.** The current shape is
+unsound as written: `correctnessBound`, `gamma`, and `epsMsg` are unconstrained `ℝ`
+parameters, so the right-hand side can be driven arbitrarily negative while the left-hand
+side is a probability and hence nonnegative. In the final HHK-style statement these slack
+terms must be constrained (typically `correctnessBound` is the underlying PKE's
+`δ`-correctness error, `gamma` is the `γ`-spreadness bound on ciphertexts, and `epsMsg` is
+the message-distribution collision/min-entropy term, all of which are provably nonnegative
+quantities derived from `pke`).
+
+The proof is intentionally deferred. The oracle surface and query-budget parameters
+(`qH`, `qP`, `qV`) now match the HHK OW-PCVA game, but the bound itself still needs to be
+tightened before this can be a meaningful security claim. -/
 theorem OW_PCVA_bound
     {M PK SK R C : Type}
     [DecidableEq M] [DecidableEq C] [SampleableType M] [SampleableType R]

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
@@ -515,8 +515,19 @@ noncomputable def runtime
     ((∅, ∅) : QueryCache M R KD K)
   toProbCompLift := ProbCompLift.ofMonadLift _
 
-/-- The generic U-transform CCA bound. The proof is intentionally deferred, but the reduction
-artifacts are now existentially quantified rather than passed in as unrelated inputs. -/
+/-- The generic U-transform CCA bound.
+
+**WARNING: this is a placeholder statement, not the final theorem.** The current shape is
+unsound as written: `correctnessBound₁` and `correctnessBound₂` are unconstrained `ℝ`
+parameters, so the right-hand side can be made arbitrarily negative while the left-hand side
+is a probability and hence nonnegative. In the final statement these slack terms must be
+constrained (for example, derived from a correctness/`δ`-correctness assumption on `pke`,
+quantified as nonnegative reals, or replaced by a concrete expression in `pke`'s correctness
+error and the adversary's query budget).
+
+The proof is intentionally deferred. The reduction artifacts (`prfAdv`, `owAdv`) are
+existentially quantified rather than passed in as unrelated inputs, but the bound itself
+still needs to be tightened before this can be a meaningful security claim. -/
 theorem IND_CCA_bound
     {M PK SK R C KD K KPRF : Type}
     [DecidableEq M] [DecidableEq C] [DecidableEq KD]


### PR DESCRIPTION
## Summary

Several security-bound theorems in the library share the same defect: they take slack parameters of unconstrained signed `\u211d` and add them to a right-hand side that is compared against a probability (`\u2265 0`) on the left. An adversary can instantiate those parameters to large negative values, driving the RHS below zero and falsifying the bound. The proofs are `sorry`, so this hadn't surfaced before. The defect is in the *statement*, not just the proof.

This was originally caught by Yiping's proof agent on the Fujisaki\u2013Okamoto layer; an audit of the rest of the library found the same pattern in MLKEM, MLDSA, and the Fiat\u2013Shamir-with-aborts foundation that the lattice signature schemes depend on.

This PR adds explicit `**WARNING:** placeholder` notes to each affected docstring so users (and proof agents) know not to take these statements at face value, and sketches what the constrained final shape is supposed to look like (e.g. `\u03b4`-correctness, `\u03b3`-spreadness, message-distribution term, all derived from the underlying scheme; or `\u211d\u22650` / `ENNReal` parameters).

## Sites flagged

### Fujisaki\u2013Okamoto (`VCVio/CryptoFoundations/FujisakiOkamoto/`)

- `UTransform.lean` ` UTransform.IND_CCA_bound` (`correctnessBound\u2081`, `correctnessBound\u2082 : \u211d`)
- `TTransform.lean` ` TTransform.OW_PCVA_bound` (`correctnessBound`, `gamma`, `epsMsg : \u211d`)
- `Composed.lean` ` FujisakiOkamoto.IND_CCA_bound` (`correctnessBound`, `epsMsg : \u211d`)

### Lattice schemes (`LatticeCrypto/`)

- `MLKEM/Security.lean` ` MLKEM.ind_cca_security`. `correctnessBound : \u211d` is constrained only via `h_correct : \u2026 .deltaCorrect (ENNReal.ofReal correctnessBound)`, but `ENNReal.ofReal` clamps negatives to `0`, so `correctnessBound = -10\u2079` satisfies `h_correct` whenever `deltaCorrect 0` does, and `((2qHK + 3) : \u211d) * correctnessBound` then drives the RHS arbitrarily negative.
- `MLDSA/Security.lean` ` MLDSA.euf_cma_security`. Inherits the same defect via `cmaToNmaLoss`.

### Fiat\u2013Shamir foundation (`VCVio/CryptoFoundations/FiatShamir/WithAbort/`)

- `Security.lean` ` FiatShamirWithAbort.euf_cma_bound`. `\u03b5` and `\u03b4 : \u211d` are unconstrained; the loss formula `2qS(qH+1)\u03b5/(1-p) + qS\u03b5(qS+1)/(2(1-p)\u00b2) + qS\u03b6_zk + \u03b4` becomes very negative for `\u03b5, \u03b4 \u226a 0`; `ENNReal.ofReal` clamps to `0`; the conclusion collapses to `adv.advantage \u2264 Pr[hard relation reduction]` with no statistical slack, which is generally false.
- `Security.lean` ` FiatShamirWithAbort.euf_cma_bound_perfectHVZK`. Inherits the defect (proved as a corollary of `euf_cma_bound`).

## Not in scope

Every other location with a signed `\u211d` slack parameter that I checked was either (a) carrying an explicit `0 \u2264 \u03b5` hypothesis (e.g. all of `VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean`), (b) a definition rather than a theorem (e.g. `IndistAt`), or (c) fully proved with a hypothesis that becomes vacuous for negative `\u03b5` and is therefore not unsound (e.g. `Examples/ElGamal/Basic.lean` ` elGamal_IND_CPA_le_q_mul_ddh`, `VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean` ` IND_CPA_advantage_toReal_le_q_mul_of_oneTime_signedAdvantageReal_bound`). I'm happy to also add `0 \u2264 \u03b5` hygiene hypotheses to those latter cases in a separate PR if desired.

## Test plan

- [x] Docstring-only changes; no proof obligations and no API surface changes
- [x] No new linter errors

---

Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.