### PR TITLE
refactor(tactics): index @[wpStep] via Sym.DiscrTree + Sym.Pattern

### DIFF
--- a/VCVio/ProgramLogic/Tactics/Common/WpStepRegistry.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/WpStepRegistry.lean
@@ -5,6 +5,8 @@ Authors: Quang Dao
 -/
 
 import Lean
+import Lean.Meta.Sym.Pattern
+import Lean.Meta.Sym.Simp.DiscrTree
 import VCVio.ProgramLogic.Tactics.Common.Core
 
 /-!
@@ -14,30 +16,38 @@ Discrimination-tree backed registry for the equational `wp _ _ = …` rewrites u
 the inner driver of `vcstep` / `vcgen` for raw `wp`-shaped goals.
 
 A `@[wpStep]` lemma has shape `wp comp post = …`; the registry indexes it by the
-discrimination-tree path of its `comp` argument. The dispatch tactic
-`runWpStepRules`, together with the canonical registrations for every shipped
-`wp_*` lemma, lives in `VCVio.ProgramLogic.Tactics.Common.WpStepDispatch`.
+discrimination-tree path of its `comp` argument. Pattern construction goes through
+`Lean.Meta.Sym.mkPatternFromDeclWithKey`, so leading universal binders are
+internalized as de Bruijn variables and reducibles are unfolded once during
+preprocessing. Insertion uses `Sym.insertPattern`, which automatically wildcards
+proof / instance argument positions in the discrimination-tree key. Lookup is the
+pure `Sym.DiscrTree.getMatch`, run in `MetaM` only to read the persistent
+environment and to run a `withReducible whnf` on the goal's `comp` so the head
+agrees with the preprocessed pattern.
+
+The dispatch tactic `runWpStepRules`, together with the canonical registrations
+for every shipped `wp_*` lemma, lives in
+`VCVio.ProgramLogic.Tactics.Common.WpStepDispatch`.
 -/
 
 open Lean Elab Meta Lean.Meta
 
 namespace OracleComp.ProgramLogic
 
-/-- Pre-computed discrimination-tree keys for the `comp` sub-expression of a
-`@[wpStep]` theorem (the LHS computation in `wp comp post = …`). -/
-abbrev WpStepPatternKeys := Array DiscrTree.Key
-
-/-- A registered `@[wpStep]` lemma: its declaration name plus the discrimination-tree
-keys for fast structural lookup against the `oa` of a `wp oa post` goal. -/
+/-- A registered `@[wpStep]` lemma: its declaration name plus the preprocessed
+`Sym.Pattern` keyed on the LHS computation of the rule. -/
 structure WpStepEntry where
   decl : Name
-  patternKeys : WpStepPatternKeys
-  deriving Inhabited, BEq, Repr
+  pattern : Lean.Meta.Sym.Pattern
+  deriving Inhabited
+
+instance : BEq WpStepEntry where
+  beq a b := a.decl == b.decl
 
 /-- Persistent state for the `@[wpStep]` registry.
 
 * `all` retains insertion order, exposed for diagnostics / tooling.
-* `tree` is the discrimination tree used by `getRegisteredWpStepEntries`. -/
+* `tree` is the discrimination tree consulted by `getRegisteredWpStepEntries`. -/
 structure WpStepRegistry where
   all : Array WpStepEntry := #[]
   tree : DiscrTree WpStepEntry := .empty
@@ -45,8 +55,7 @@ structure WpStepRegistry where
 
 private def WpStepRegistry.addToTree (tree : DiscrTree WpStepEntry) (entry : WpStepEntry) :
     DiscrTree WpStepEntry :=
-  if entry.patternKeys.isEmpty then tree
-  else tree.insertKeyValue entry.patternKeys entry
+  Lean.Meta.Sym.insertPattern tree entry.pattern entry
 
 initialize wpStepRegistry :
     SimpleScopedEnvExtension WpStepEntry WpStepRegistry ←
@@ -58,38 +67,54 @@ initialize wpStepRegistry :
     initial := {}
   }
 
-/-- Extract the LHS computation `comp` from a `@[wpStep]` theorem whose target,
-after instantiating universally quantified variables, has shape `wp comp post = …`.
-Returns `none` if the target is not an `Eq` whose LHS is a `wp` application. -/
-private def extractWpStepLhsComp (declTy : Expr) : MetaM (Option Expr) := do
-  let (_, _, targetTy) ← withReducible <| forallMetaTelescopeReducing declTy
-  let target := targetTy.consumeMData
-  unless target.isAppOfArity ``Eq 3 do return none
-  let lhs := target.getArg! 1
-  match wpGoalParts? lhs with
-  | some (oa, _) => return some oa
-  | none => return none
+/-- Selector for `Sym.mkPatternFromDeclWithKey`: extract the `comp` argument from
+the LHS of a `wp comp post = …` equation.
 
-private def buildWpStepEntry (decl : Name) (declTy : Expr) : MetaM WpStepEntry := do
-  let some lhsComp ← extractWpStepLhsComp declTy
-    | throwError m!
-        "@[wpStep] expects a theorem of shape `wp comp post = …`; got:{indentExpr declTy}"
-  let keys ← DiscrTree.mkPath lhsComp
-  return { decl, patternKeys := keys }
+After `Sym.preprocessType`, the abbrev `OracleComp.ProgramLogic.wp` has been
+unfolded to `MAlgOrdered.wp`. Both forms are accepted defensively in case a rule
+has been written for the more general algebra interface. The `comp` is the
+second-to-last explicit argument of the wp head application. -/
+private def selectWpStepLhsComp (body : Expr) : MetaM (Expr × Unit) := do
+  let body := body.consumeMData
+  unless body.isAppOfArity ``Eq 3 do
+    throwError m!"@[wpStep] expects an equational target; got:{indentExpr body}"
+  let lhs := (body.getArg! 1).consumeMData
+  let fn := lhs.getAppFn
+  unless fn.isConstOf ``MAlgOrdered.wp || fn.isConstOf ``OracleComp.ProgramLogic.wp do
+    throwError m!"@[wpStep] expects an `wp _ _` LHS; got:{indentExpr lhs}"
+  let n := lhs.getAppNumArgs
+  unless n ≥ 2 do
+    throwError m!"@[wpStep] LHS has too few arguments:{indentExpr lhs}"
+  let oa := lhs.getArg! (n - 2)
+  return (oa, ())
+
+private def buildWpStepEntry (decl : Name) : MetaM WpStepEntry := do
+  let (pattern, _) ← Lean.Meta.Sym.mkPatternFromDeclWithKey decl selectWpStepLhsComp
+  return { decl, pattern }
 
 initialize registerBuiltinAttribute {
   name := `wpStep
   descr := "Register an equational `wp comp post = …` rule for the runWpStepRules planner."
   add := fun decl _ kind => MetaM.run' do
-    let declTy := (← getConstInfo decl).type
-    let entry ← buildWpStepEntry decl declTy
+    let entry ← buildWpStepEntry decl
     wpStepRegistry.add entry kind
 }
 
-/-- Retrieve the `@[wpStep]` entries whose LHS pattern matches `oa` structurally. -/
+/-- Retrieve the `@[wpStep]` entries whose LHS pattern matches `oa` in the
+discrimination tree.
+
+The goal's `oa` is first instantiated and `withReducible whnf`-normalized so its
+head agrees with the registered patterns (which were unfolded once via
+`Sym.preprocessType` at registration time). The actual tree traversal is the
+pure `Sym.DiscrTree.getMatch`, which already wildcards proof / instance
+positions and de Bruijn pattern variables.
+
+Returned candidates are still validated by the dispatch tactic when it tries
+each rewrite, so over-approximation here is harmless. -/
 def getRegisteredWpStepEntries (oa : Expr) : MetaM (Array WpStepEntry) := do
   let oa ← instantiateMVars oa
+  let oa ← withReducible <| whnf oa
   let registry := wpStepRegistry.getState (← getEnv)
-  registry.tree.getMatch oa
+  return Lean.Meta.Sym.getMatch registry.tree oa
 
 end OracleComp.ProgramLogic

--- a/docs/agents/program-logic.md
+++ b/docs/agents/program-logic.md
@@ -138,12 +138,20 @@ so user-defined rules slot into the same lookup pipeline without further wiring.
 
 **Opt-in `wp`-rewrite lookup**: mark an equational rewrite of shape
 `wp comp post = …` with `@[wpStep]` to extend the inner `wp`-stepping driver
-(`runWpStepRules`). The driver indexes registered rules by the discrimination-tree
-path of `comp` and tries `rw`, then `simp only`, on each match. The default registry
-already covers `wp_pure`, `wp_bind`, `wp_ite`, `wp_dite`, `wp_map`, the `replicate` /
-`mapM` / `foldlM` families, `wp_query`, `wp_uniformSample`, and the
-`simulateQ` / `liftComp` transport rules, so user-authored `wp` lemmas slot into the
-same dispatch without further wiring.
+(`runWpStepRules`). The driver indexes registered rules by the path of `comp`
+in a `Lean.Meta.Sym`-backed discrimination tree: pattern construction goes
+through `Lean.Meta.Sym.mkPatternFromDeclWithKey`, which preprocesses the rule's
+LHS (unfolding reducibles, beta/zeta/eta normalizing) and turns universally
+quantified arguments into de Bruijn pattern variables, while
+`Lean.Meta.Sym.insertPattern` automatically wildcards proof / instance
+positions in the discrimination-tree key. Lookup at dispatch time is the pure
+`Lean.Meta.Sym.DiscrTree.getMatch` after a `withReducible whnf` on the goal's
+`comp` to align with the preprocessed patterns. Each match is then tried via
+`rw`, falling back to `simp only`. The default registry already covers
+`wp_pure`, `wp_bind`, `wp_ite`, `wp_dite`, `wp_map`, the `replicate` / `mapM`
+/ `foldlM` families, `wp_query`, `wp_uniformSample`, and the `simulateQ` /
+`liftComp` transport rules, so user-authored `wp` lemmas slot into the same
+dispatch without further wiring.
 
 **Bind normalization**: `rvcstep` (and therefore `rvcgen`) runs a best-effort
 `simp only [bind_assoc, pure_bind, bind_pure_comp, Functor.map_map, map_pure]` pre-pass on the


### PR DESCRIPTION
Stacked on #342 (`quang/vcspec-phase2-runtime`). Please merge that one first; this PR's diff against `main` will then collapse to just the changes shown below.

## Summary

- Migrate the `@[wpStep]` registry from `Lean.Meta.DiscrTree` to the `Lean.Meta.Sym`-backed discrimination-tree API. Patterns are now built via `Sym.mkPatternFromDeclWithKey` and inserted with `Sym.insertPattern`, which preprocesses reducibles, internalizes universal binders as de Bruijn variables, and automatically wildcards proof / instance positions in the discrimination key.
- Lookup uses the pure `Sym.DiscrTree.getMatch`. Because `Sym.getMatch` does no internal normalization (unlike `Lean.Meta.DiscrTree.getMatch`, which folds in `withReducible`), `getRegisteredWpStepEntries` now applies `withReducible <| whnf oa` to the goal's `comp` first so reducible heads (`monadLift`, `query`, `liftComp`, etc.) line up with the preprocessed patterns.
- Dispatch in `runWpStepRules` is unchanged: candidates are still tried via `rw` and `simp only` in `MetaM`. This is purely a registry-internals change.
- Update `docs/agents/program-logic.md` to describe the new `Sym.Pattern` / `Sym.DiscrTree` pipeline and the `whnf` step on lookup.

This is the first concrete step toward integrating the upstream `SymM` ecosystem into the VCVio tactic framework: rule storage / lookup is now unified with how core Lean's new `mvcgen'` indexes its `wp`-style rules, while the public attribute surface (`@[wpStep]`) and the dispatch tactic stay the same.

## Notes on the regression we hit (and fixed)

The first version of this migration did not call `whnf` on the goal's `comp`. That broke `Examples/ProgramLogic/UnaryStep.lean`, where goals of the form `wp⟦(query t : OracleComp spec _)⟧ post` failed to match `wp_liftComp` because the preprocessed pattern had the literal `monadLift` head while the goal still showed the `liftM` / coercion-style abbreviation. Adding `withReducible <| whnf` on the goal `comp` before `Sym.getMatch` resolves it without weakening the pattern.

## Test plan

- [x] `lake build VCVio.ProgramLogic.Tactics.Common.WpStepRegistry VCVio.ProgramLogic.Tactics.Common.WpStepDispatch`
- [x] `lake build VCVio` (full library) ✅
- [x] `lake build Examples` ✅
- [x] Smoke test on `Examples/ProgramLogic/UnaryStep.lean` (the file that exposed the `monadLift` regression) ✅ after the `whnf` fix
- [x] Sanity check: `LatticeCryptoTest.Falcon.Main` failure is pre-existing and reproduces unchanged on `quang/vcspec-phase2-runtime`

---
Posted by Cursor assistant (model: Claude Opus 4.7) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)