### PR TITLE
refactor(SubSpec, ITree): PFunctor.Lens semantics + mapSpec monad morphism

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -55,6 +55,7 @@ import ToMathlib.PFunctor.Cofree
 import ToMathlib.PFunctor.Equiv.Basic
 import ToMathlib.PFunctor.Free
 import ToMathlib.PFunctor.Lens.Basic
+import ToMathlib.PFunctor.Lens.Cartesian
 import ToMathlib.PFunctor.MFacts
 import ToMathlib.PFunctor.Trace
 import ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence

--- a/ToMathlib/ITree/Sim/Facts.lean
+++ b/ToMathlib/ITree/Sim/Facts.lean
@@ -740,6 +740,27 @@ theorem mapSpec_iter (φ : PFunctor.Lens E F)
         simp only [dest_mapSpec, mapSpecStep, shape']
         rw [hL]
 
+/-! ### Derived `mapSpec` lemmas
+
+These follow directly from `mapSpec_bind` + `mapSpec_pure`. -/
+
+@[simp] theorem mapSpec_map (φ : PFunctor.Lens E F) (f : α → β) (t : ITree E α) :
+    mapSpec φ (ITree.map f t) = ITree.map f (mapSpec φ t) := by
+  simp only [ITree.map, mapSpec_bind, mapSpec_pure]
+
+@[simp] theorem mapSpec_functorMap (φ : PFunctor.Lens E F) (f : α → β)
+    (t : ITree E α) : mapSpec φ (f <$> t) = f <$> mapSpec φ t := by
+  simp only [map_eq_functor_map, mapSpec_map]
+
+@[simp] theorem mapSpec_cat {γ : Type u} (φ : PFunctor.Lens E F)
+    (f : α → ITree E β) (g : β → ITree E γ) (a : α) :
+    mapSpec φ (ITree.cat f g a) =
+      ITree.cat (mapSpec φ ∘ f) (mapSpec φ ∘ g) a := by
+  change mapSpec φ (bind (f a) g) =
+    bind ((mapSpec φ ∘ f) a) (fun b => (mapSpec φ ∘ g) b)
+  rw [mapSpec_bind]
+  rfl
+
 /-! ### Relating `simulate` and `mapSpec` -/
 
 theorem simulate_ofLens (φ : PFunctor.Lens E F) (t : ITree E α) :

--- a/ToMathlib/ITree/Sim/Facts.lean
+++ b/ToMathlib/ITree/Sim/Facts.lean
@@ -21,6 +21,10 @@ The standard equational theory for the simulation operators:
   `mapSpec`.
 * `mapSpec_id`, `mapSpec_comp` — functoriality of `mapSpec` over the lens
   category on `PFunctor`.
+* `mapSpec_bind` — `mapSpec` is a monad morphism (it distributes over `bind`).
+  The proof is by **strong bisimulation** (`PFunctor.M.bisim`), in contrast to
+  `simulate_bind` which only holds up to weak bisim because `simulate` inserts
+  τ-steps. (`mapSpec_iter` is left to a follow-up; see the unification plan.)
 * `simulate_ofLens` — relating `simulate` and `mapSpec` on a renaming.
 
 Each proof is built by coinduction on the shared `ITree` shape and combines
@@ -507,6 +511,59 @@ theorem mapSpec_comp (φ : PFunctor.Lens E F) (ψ : PFunctor.Lens F G) (t : ITre
             fun b => mapSpec φ (c ((ψ ∘ₗ φ).toFunB a b))⟩
         rw [mapSpecStep, shape'_mapSpec, mapSpecStep, hu]
         rfl
+
+/-! ### Monad-morphism laws for `mapSpec`
+
+`mapSpec` is a monad morphism: it distributes over `bind` and `iter`
+strictly (no τ-step insertion), in contrast to `simulate ∘ Handler.ofLens`
+which only matches `mapSpec` up to weak bisim. The proofs are by
+`PFunctor.M.bisim` with a relation that encodes the *defining equation*
+(left-hand side ↔ right-hand side) plus the trivial diagonal closure. -/
+
+theorem mapSpec_bind (φ : PFunctor.Lens E F)
+    (t : ITree E α) (k : α → ITree E β) :
+    mapSpec φ (bind t k) = bind (mapSpec φ t) (fun a => mapSpec φ (k a)) := by
+  refine PFunctor.M.bisim
+    (fun (u v : ITree F β) =>
+      u = v ∨ ∃ t : ITree E α,
+        u = mapSpec φ (bind t k) ∧
+        v = bind (mapSpec φ t) (fun a => mapSpec φ (k a)))
+    ?_ _ _ (Or.inr ⟨t, rfl, rfl⟩)
+  rintro u v (rfl | ⟨t, rfl, rfl⟩)
+  · rcases h : PFunctor.M.dest u with ⟨sh, c⟩
+    exact ⟨sh, c, c, rfl, rfl, fun _ => Or.inl rfl⟩
+  · rcases h : PFunctor.M.dest t with ⟨sh, c⟩
+    cases sh with
+    | pure r =>
+        have ht : t = pure r := by
+          apply PFunctor.M.eq_of_dest_eq; rw [h]
+          change (⟨.pure r, c⟩ : (Poly E α).Obj _) = ⟨.pure r, PEmpty.elim⟩
+          congr 1; funext z; exact z.elim
+        subst ht
+        rw [bind_pure_left, mapSpec_pure, bind_pure_left]
+        rcases hk : PFunctor.M.dest (mapSpec φ (k r)) with ⟨sh', c'⟩
+        exact ⟨sh', c', c', rfl, rfl, fun _ => Or.inl rfl⟩
+    | step =>
+        have ht : t = step (c PUnit.unit) := by
+          apply PFunctor.M.eq_of_dest_eq; rw [h]; rfl
+        subst ht
+        rw [bind_step, mapSpec_step, mapSpec_step, bind_step]
+        refine ⟨.step,
+          fun _ => mapSpec φ (bind (c PUnit.unit) k),
+          fun _ => bind (mapSpec φ (c PUnit.unit)) (fun a => mapSpec φ (k a)),
+          shape'_step _, shape'_step _,
+          fun _ => Or.inr ⟨c PUnit.unit, rfl, rfl⟩⟩
+    | query a =>
+        have ht : t = query a c := by
+          apply PFunctor.M.eq_of_dest_eq; rw [h]; rfl
+        subst ht
+        rw [bind_query, mapSpec_query, mapSpec_query, bind_query]
+        refine ⟨.query (φ.toFunA a),
+          fun b => mapSpec φ (bind (c (φ.toFunB a b)) k),
+          fun b =>
+            bind (mapSpec φ (c (φ.toFunB a b))) (fun a => mapSpec φ (k a)),
+          shape'_query _ _, shape'_query _ _,
+          fun b => Or.inr ⟨c (φ.toFunB a b), rfl, rfl⟩⟩
 
 /-! ### Relating `simulate` and `mapSpec` -/
 

--- a/ToMathlib/ITree/Sim/Facts.lean
+++ b/ToMathlib/ITree/Sim/Facts.lean
@@ -761,6 +761,17 @@ These follow directly from `mapSpec_bind` + `mapSpec_pure`. -/
   rw [mapSpec_bind]
   rfl
 
+/-- `mapSpec` distributes over `Seq.seq`, i.e. it is an Applicative
+morphism. Falls out of `mapSpec_bind` + `mapSpec_functorMap` after unfolding
+the default `seq` of `Monad (ITree F)` to `bind`. -/
+@[simp] theorem mapSpec_seq (φ : PFunctor.Lens E F) (mf : ITree E (α → β))
+    (mx : ITree E α) :
+    mapSpec φ (mf <*> mx) = mapSpec φ mf <*> mapSpec φ mx := by
+  change mapSpec φ (bind mf (fun f => f <$> mx)) =
+    bind (mapSpec φ mf) (fun f => f <$> mapSpec φ mx)
+  rw [mapSpec_bind]
+  simp only [mapSpec_functorMap]
+
 /-! ### Relating `simulate` and `mapSpec` -/
 
 theorem simulate_ofLens (φ : PFunctor.Lens E F) (t : ITree E α) :

--- a/ToMathlib/ITree/Sim/Facts.lean
+++ b/ToMathlib/ITree/Sim/Facts.lean
@@ -21,10 +21,13 @@ The standard equational theory for the simulation operators:
   `mapSpec`.
 * `mapSpec_id`, `mapSpec_comp` — functoriality of `mapSpec` over the lens
   category on `PFunctor`.
-* `mapSpec_bind` — `mapSpec` is a monad morphism (it distributes over `bind`).
-  The proof is by **strong bisimulation** (`PFunctor.M.bisim`), in contrast to
-  `simulate_bind` which only holds up to weak bisim because `simulate` inserts
-  τ-steps. (`mapSpec_iter` is left to a follow-up; see the unification plan.)
+* `mapSpec_bind`, `mapSpec_iter` — `mapSpec` is a monad morphism (it distributes
+  over `bind` and `iter`). Both proofs are by **strong bisimulation**
+  (`PFunctor.M.bisim`), in contrast to `simulate_bind` which only holds up to
+  weak bisim because `simulate` inserts τ-steps. The `iter` case is factored
+  through four small `dest_corec_iterStep_*` helpers that compute one M-dest
+  step of `M.corec (iterStep body)` in each of the four cases for the head of
+  the input ITree.
 * `simulate_ofLens` — relating `simulate` and `mapSpec` on a renaming.
 
 Each proof is built by coinduction on the shared `ITree` shape and combines
@@ -564,6 +567,178 @@ theorem mapSpec_bind (φ : PFunctor.Lens E F)
             bind (mapSpec φ (c (φ.toFunB a b))) (fun a => mapSpec φ (k a)),
           shape'_query _ _, shape'_query _ _,
           fun b => Or.inr ⟨c (φ.toFunB a b), rfl, rfl⟩⟩
+
+/-! ### One-step `M.dest` lemmas for `M.corec (iterStep _)`
+
+Used by `mapSpec_iter` below. They factor the case analysis on `shape' t`
+out of the bisimulation proof. -/
+
+private theorem dest_corec_iterStep_pure_inl
+    (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α)) (j : β)
+    (cIn : (Poly E (β ⊕ α)).B (.pure (.inl j)) → (Poly E (β ⊕ α)).M)
+    (h : PFunctor.M.dest t = ⟨.pure (.inl j), cIn⟩) :
+    PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
+      ⟨.step, fun _ => PFunctor.M.corec (iterStep body) (body j)⟩ := by
+  rw [PFunctor.M.dest_corec_apply, iterStep, h]
+
+private theorem dest_corec_iterStep_pure_inr
+    (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α)) (r : α)
+    (cIn : (Poly E (β ⊕ α)).B (.pure (.inr r)) → (Poly E (β ⊕ α)).M)
+    (h : PFunctor.M.dest t = ⟨.pure (.inr r), cIn⟩) :
+    PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
+      ⟨.pure r, PEmpty.elim⟩ := by
+  rw [PFunctor.M.dest_corec_apply, iterStep, h]
+  congr 1
+  funext z
+  exact z.elim
+
+private theorem dest_corec_iterStep_step
+    (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α))
+    (c : PUnit → ITree E (β ⊕ α))
+    (h : PFunctor.M.dest t = ⟨.step, c⟩) :
+    PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
+      ⟨.step, fun u => PFunctor.M.corec (iterStep body) (c u)⟩ := by
+  rw [PFunctor.M.dest_corec_apply, iterStep, h]
+
+private theorem dest_corec_iterStep_query
+    (body : β → ITree E (β ⊕ α)) (t : ITree E (β ⊕ α)) (a : E.A)
+    (c : E.B a → ITree E (β ⊕ α))
+    (h : PFunctor.M.dest t = ⟨.query a, c⟩) :
+    PFunctor.M.dest (PFunctor.M.corec (iterStep body) t) =
+      ⟨.query a, fun b => PFunctor.M.corec (iterStep body) (c b)⟩ := by
+  rw [PFunctor.M.dest_corec_apply, iterStep, h]
+
+theorem mapSpec_iter (φ : PFunctor.Lens E F)
+    (body : β → ITree E (β ⊕ α)) (init : β) :
+    mapSpec φ (iter body init) = iter (fun j => mapSpec φ (body j)) init := by
+  refine PFunctor.M.bisim
+    (fun (u v : ITree F α) =>
+      u = v ∨ ∃ t : ITree E (β ⊕ α),
+        u = mapSpec φ (PFunctor.M.corec (iterStep body) t) ∧
+        v = PFunctor.M.corec
+              (iterStep (fun j => mapSpec φ (body j))) (mapSpec φ t))
+    ?_ _ _ (Or.inr ⟨body init, rfl, rfl⟩)
+  rintro u v (rfl | ⟨t, rfl, rfl⟩)
+  · rcases h : PFunctor.M.dest u with ⟨sh, c⟩
+    exact ⟨sh, c, c, rfl, rfl, fun _ => Or.inl rfl⟩
+  · rcases h : PFunctor.M.dest t with ⟨sh, c⟩
+    cases sh with
+    | pure rj =>
+        cases rj with
+        | inl j =>
+            have hL : PFunctor.M.dest
+                (PFunctor.M.corec (iterStep body) t) =
+                ⟨.step, fun _ => PFunctor.M.corec (iterStep body) (body j)⟩ :=
+              dest_corec_iterStep_pure_inl body t j c h
+            have hMt : mapSpec φ t = pure (.inl j) := by
+              have ht : t = pure (.inl j) := by
+                apply PFunctor.M.eq_of_dest_eq; rw [h]
+                change (⟨.pure (.inl j), c⟩ : (Poly E (β ⊕ α)).Obj _) =
+                  ⟨.pure (.inl j), PEmpty.elim⟩
+                congr 1; funext z; exact z.elim
+              rw [ht, mapSpec_pure]
+            have hR : PFunctor.M.dest
+                (PFunctor.M.corec
+                  (iterStep (fun j => mapSpec φ (body j))) (mapSpec φ t)) =
+                ⟨.step, fun _ => PFunctor.M.corec
+                  (iterStep (fun j => mapSpec φ (body j)))
+                  (mapSpec φ (body j))⟩ := by
+              rw [hMt]
+              exact dest_corec_iterStep_pure_inl
+                (fun j => mapSpec φ (body j)) (pure (.inl j)) j PEmpty.elim
+                (PFunctor.M.dest_mk _)
+            refine ⟨.step,
+              fun _ => mapSpec φ (PFunctor.M.corec (iterStep body) (body j)),
+              fun _ => PFunctor.M.corec
+                (iterStep (fun j => mapSpec φ (body j))) (mapSpec φ (body j)),
+              ?_, hR, fun _ => Or.inr ⟨body j, rfl, rfl⟩⟩
+            simp only [dest_mapSpec, mapSpecStep, shape']
+            rw [hL]
+        | inr r =>
+            have hL : PFunctor.M.dest
+                (PFunctor.M.corec (iterStep body) t) =
+                ⟨.pure r, PEmpty.elim⟩ :=
+              dest_corec_iterStep_pure_inr body t r c h
+            have hMt : mapSpec φ t = pure (.inr r) := by
+              have ht : t = pure (.inr r) := by
+                apply PFunctor.M.eq_of_dest_eq; rw [h]
+                change (⟨.pure (.inr r), c⟩ : (Poly E (β ⊕ α)).Obj _) =
+                  ⟨.pure (.inr r), PEmpty.elim⟩
+                congr 1; funext z; exact z.elim
+              rw [ht, mapSpec_pure]
+            have hR : PFunctor.M.dest
+                (PFunctor.M.corec
+                  (iterStep (fun j => mapSpec φ (body j))) (mapSpec φ t)) =
+                ⟨.pure r, PEmpty.elim⟩ := by
+              rw [hMt]
+              exact dest_corec_iterStep_pure_inr
+                (fun j => mapSpec φ (body j)) (pure (.inr r)) r PEmpty.elim
+                (PFunctor.M.dest_mk _)
+            refine ⟨.pure r, PEmpty.elim, PEmpty.elim, ?_, hR, fun b => b.elim⟩
+            simp only [dest_mapSpec, mapSpecStep, shape']
+            rw [hL]
+            congr 1
+            funext z
+            exact z.elim
+    | step =>
+        have hL : PFunctor.M.dest
+            (PFunctor.M.corec (iterStep body) t) =
+            ⟨.step, fun u => PFunctor.M.corec (iterStep body) (c u)⟩ :=
+          dest_corec_iterStep_step body t c h
+        have hMt : mapSpec φ t = step (mapSpec φ (c PUnit.unit)) := by
+          have ht : t = step (c PUnit.unit) := by
+            apply PFunctor.M.eq_of_dest_eq; rw [h]; rfl
+          rw [ht, mapSpec_step]
+        have hR : PFunctor.M.dest
+            (PFunctor.M.corec
+              (iterStep (fun j => mapSpec φ (body j))) (mapSpec φ t)) =
+            ⟨.step, fun _ => PFunctor.M.corec
+              (iterStep (fun j => mapSpec φ (body j)))
+              (mapSpec φ (c PUnit.unit))⟩ := by
+          rw [hMt]
+          exact dest_corec_iterStep_step
+            (fun j => mapSpec φ (body j)) (step (mapSpec φ (c PUnit.unit)))
+            (fun _ => mapSpec φ (c PUnit.unit)) (PFunctor.M.dest_mk _)
+        refine ⟨.step,
+          fun _ => mapSpec φ (PFunctor.M.corec (iterStep body) (c PUnit.unit)),
+          fun _ => PFunctor.M.corec
+            (iterStep (fun j => mapSpec φ (body j)))
+            (mapSpec φ (c PUnit.unit)),
+          ?_, hR, fun _ => Or.inr ⟨c PUnit.unit, rfl, rfl⟩⟩
+        simp only [dest_mapSpec, mapSpecStep, shape']
+        rw [hL]
+    | query a =>
+        have hL : PFunctor.M.dest
+            (PFunctor.M.corec (iterStep body) t) =
+            ⟨.query a, fun b => PFunctor.M.corec (iterStep body) (c b)⟩ :=
+          dest_corec_iterStep_query body t a c h
+        have hMt : mapSpec φ t =
+            query (φ.toFunA a) (fun b => mapSpec φ (c (φ.toFunB a b))) := by
+          have ht : t = query a c := by
+            apply PFunctor.M.eq_of_dest_eq; rw [h]; rfl
+          rw [ht, mapSpec_query]
+        have hR : PFunctor.M.dest
+            (PFunctor.M.corec
+              (iterStep (fun j => mapSpec φ (body j))) (mapSpec φ t)) =
+            ⟨.query (φ.toFunA a), fun b => PFunctor.M.corec
+              (iterStep (fun j => mapSpec φ (body j)))
+              (mapSpec φ (c (φ.toFunB a b)))⟩ := by
+          rw [hMt]
+          exact dest_corec_iterStep_query
+            (fun j => mapSpec φ (body j))
+            (query (φ.toFunA a) (fun b => mapSpec φ (c (φ.toFunB a b))))
+            (φ.toFunA a)
+            (fun b => mapSpec φ (c (φ.toFunB a b)))
+            (PFunctor.M.dest_mk _)
+        refine ⟨.query (φ.toFunA a),
+          fun b => mapSpec φ (PFunctor.M.corec (iterStep body)
+            (c (φ.toFunB a b))),
+          fun b => PFunctor.M.corec
+            (iterStep (fun j => mapSpec φ (body j)))
+            (mapSpec φ (c (φ.toFunB a b))),
+          ?_, hR, fun b => Or.inr ⟨c (φ.toFunB a b), rfl, rfl⟩⟩
+        simp only [dest_mapSpec, mapSpecStep, shape']
+        rw [hL]
 
 /-! ### Relating `simulate` and `mapSpec` -/
 

--- a/ToMathlib/PFunctor/Lens/Cartesian.lean
+++ b/ToMathlib/PFunctor/Lens/Cartesian.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import ToMathlib.PFunctor.Lens.Basic
+
+/-!
+# Cartesian Lenses Between Polynomial Functors
+
+A `Lens P Q` between polynomial functors carries a forward map on positions
+(`toFunA : P.A → Q.A`) and, for each position `a : P.A`, a backward map on
+directions (`toFunB a : Q.B (toFunA a) → P.B a`). We say the lens is
+**cartesian** when every backward map `toFunB a` is a bijection.
+
+In the language of the fibration `Poly → Set` that sends a polynomial
+functor to its set of positions, cartesian lenses are exactly the
+cartesian morphisms: the type-square underlying each fiber is a pullback.
+A cartesian lens is a *fiberwise isomorphism* over an arbitrary forward
+map on positions.
+
+The two extremes of the orthogonal factorization system on `Poly` are
+captured separately:
+
+* a **vertical** lens has `toFunA = id` (only the directions move);
+* a **cartesian** lens has each `toFunB a` a bijection (only the positions
+  move freely; each fiber is rigid).
+
+A `PFunctor.Lens.Equiv` (a categorical isomorphism in the lens category)
+is the intersection of the two: `toFunA` is a bijection AND every
+`toFunB a` is a bijection. Thus *every* `Equiv` is cartesian, but a
+cartesian lens whose position map is not a bijection (e.g.
+`Lens.inl : Lens P (P + Q)`) is not an `Equiv`.
+
+The downstream consumer of this file is `LawfulSubSpec` in
+`VCVio/OracleComp/Coercions/SubSpec.lean`: a `LawfulSubSpec` is by
+definition the predicate "the underlying
+`Lens spec.toPFunctor superSpec.toPFunctor` is cartesian", which is the
+exact condition needed to pull the uniform distribution on
+`superSpec.Range` back through a sub-spec embedding without distortion.
+-/
+
+@[expose] public section
+
+universe u v uA uB uA₁ uB₁ uA₂ uB₂ uA₃ uB₃ uA₄ uB₄
+
+namespace PFunctor
+
+namespace Lens
+
+variable {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+
+/-- A lens `l : Lens P Q` is **cartesian** when every backward fiber
+`l.toFunB a : Q.B (l.toFunA a) → P.B a` is a bijection. Equivalently,
+`l` is a cartesian morphism in the fibration `Poly → Set` of polynomial
+functors over their position sets. -/
+def IsCartesian (l : Lens P Q) : Prop :=
+  ∀ a, Function.Bijective (l.toFunB a)
+
+namespace IsCartesian
+
+@[simp]
+theorem id_lens (P : PFunctor.{uA, uB}) : (Lens.id P).IsCartesian := fun _ =>
+  Function.bijective_id
+
+theorem comp {l₁ : Lens Q R} {l₂ : Lens P Q}
+    (h₁ : l₁.IsCartesian) (h₂ : l₂.IsCartesian) :
+    (l₁ ∘ₗ l₂).IsCartesian := fun a =>
+  (h₂ a).comp (h₁ (l₂.toFunA a))
+
+end IsCartesian
+
+/-! ## Cartesianness of canonical lens constructors
+
+Most "embedding-shaped" lenses produced by the lens algebra are cartesian.
+We collect the witnesses here so that downstream classes (notably
+`LawfulSubSpec`) can be discharged uniformly. -/
+
+namespace IsCartesian
+
+theorem inl {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
+    (Lens.inl : Lens.{uA₁, uB, max uA₁ uA₂, uB} P (P + Q)).IsCartesian := fun _ =>
+  Function.bijective_id
+
+theorem inr {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}} :
+    (Lens.inr : Lens.{uA₂, uB, max uA₁ uA₂, uB} Q (P + Q)).IsCartesian := fun _ =>
+  Function.bijective_id
+
+theorem sumMap {P : PFunctor.{uA₁, uB₁}} {Q : PFunctor.{uA₂, uB₁}}
+    {R : PFunctor.{uA₃, uB₃}} {W : PFunctor.{uA₄, uB₃}}
+    {l₁ : Lens P R} {l₂ : Lens Q W}
+    (h₁ : l₁.IsCartesian) (h₂ : l₂.IsCartesian) :
+    (l₁ ⊎ₗ l₂).IsCartesian
+  | Sum.inl a => h₁ a
+  | Sum.inr a => h₂ a
+
+theorem sumPair {P : PFunctor.{uA₁, uB}} {Q : PFunctor.{uA₂, uB}}
+    {R : PFunctor.{uA₃, uB₃}} {l₁ : Lens P R} {l₂ : Lens Q R}
+    (h₁ : l₁.IsCartesian) (h₂ : l₂.IsCartesian) :
+    (Lens.sumPair l₁ l₂).IsCartesian
+  | Sum.inl a => h₁ a
+  | Sum.inr a => h₂ a
+
+theorem sigmaMap {I : Type v}
+    {F : I → PFunctor.{uA₁, uB₁}} {G : I → PFunctor.{uA₂, uB₂}}
+    {l : ∀ i, Lens (F i) (G i)} (hl : ∀ i, (l i).IsCartesian) :
+    (Lens.sigmaMap l).IsCartesian
+  | ⟨i, fa⟩ => hl i fa
+
+theorem sigmaExists {I : Type v}
+    {F : I → PFunctor.{uA₁, uB₁}} {R : PFunctor.{uA₂, uB₂}}
+    {l : ∀ i, Lens (F i) R} (hl : ∀ i, (l i).IsCartesian) :
+    (Lens.sigmaExists l).IsCartesian
+  | ⟨i, fa⟩ => hl i fa
+
+end IsCartesian
+
+/-! ## Sigma injection
+
+The natural inclusion of the `j`-th summand into a `sigma`: the unique
+lens whose forward action picks the `j`-th tag and whose backward action
+is the identity on directions. This is the `Lens` whose corresponding
+`MonadLift` underlies `OracleSpec.subSpec_sigma`. -/
+
+/-- Lens injection `Lens (F j) (sigma F)` for a fixed index `j : I`. -/
+def sigmaInj {I : Type v} {F : I → PFunctor.{uA, uB}} (j : I) :
+    Lens (F j) (sigma F) :=
+  (fun fa => ⟨j, fa⟩) ⇆ (fun _ d => d)
+
+namespace IsCartesian
+
+theorem sigmaInj {I : Type v} {F : I → PFunctor.{uA, uB}} (j : I) :
+    (Lens.sigmaInj (F := F) j).IsCartesian := fun _ =>
+  Function.bijective_id
+
+end IsCartesian
+
+end Lens
+
+end PFunctor

--- a/ToMathlib/PFunctor/Lens/Cartesian.lean
+++ b/ToMathlib/PFunctor/Lens/Cartesian.lean
@@ -62,7 +62,7 @@ def IsCartesian (l : Lens P Q) : Prop :=
 namespace IsCartesian
 
 @[simp]
-theorem id_lens (P : PFunctor.{uA, uB}) : (Lens.id P).IsCartesian := fun _ =>
+theorem id (P : PFunctor.{uA, uB}) : (Lens.id P).IsCartesian := fun _ =>
   Function.bijective_id
 
 theorem comp {l₁ : Lens Q R} {l₂ : Lens P Q}

--- a/VCVio/OracleComp/Coercions/Add.lean
+++ b/VCVio/OracleComp/Coercions/Add.lean
@@ -10,9 +10,12 @@ import VCVio.OracleComp.ProbComp
 # Coercing Computations to Larger Oracle Sets
 
 This file defines `SubSpec` instances for oracle specs constructed with
-either `OracleSpec.add` or `OracleSpec.sigma`.
-
-TODO: document the "canonical forms" that work well with this
+either `OracleSpec.add` or `OracleSpec.sigma`. Each instance spells out the
+`monadLift` action explicitly (rather than letting it default from
+`onQuery` / `onResponse`) so that the lifted query reduces fully under
+`isDefEq`. This is load-bearing for `rw` / `simp` lemmas like
+`probEvent_liftComp` to find their pattern through the synthesized
+`MonadLiftT` instance chain.
 -/
 
 open OracleSpec
@@ -30,19 +33,22 @@ section instances
 /-- We need `Inhabited` to prevent infinite type-class searching. -/
 instance (priority := low) {τ : Type u} [Inhabited τ] {spec : OracleSpec.{u, v} τ} :
     OracleSpec.emptySpec.{u,v} ⊂ₒ spec where
-  monadLift | q => PEmpty.elim q.input
-  liftM_map q := PEmpty.elim q.input
+  monadLift q := PEmpty.elim q.input
+  onQuery t := t.elim
+  onResponse t := t.elim
+  liftM_eq_lift q := PEmpty.elim q.input
 
 instance (priority := low) {τ : Type u} [Inhabited τ] {spec : OracleSpec.{u, v} τ} :
     OracleSpec.LawfulSubSpec OracleSpec.emptySpec spec where
-  cont_bijective t := PEmpty.elim t
+  onResponse_bijective t := PEmpty.elim t
 
 section add_left
 
 /-- Add additional oracles to the right side of the existing ones. -/
 instance subSpec_add_left : spec₁ ⊂ₒ (spec₁ + spec₂) where
-  monadLift | q => .mk (.inl q.input) q.cont
-  liftM_map | _ => fun _ => rfl
+  monadLift q := ⟨.inl q.input, q.cont⟩
+  onQuery := Sum.inl
+  onResponse _ := id
 
 @[simp] lemma liftM_add_left_def (q : OracleQuery spec₁ α) :
     (liftM q : OracleQuery (spec₁ + spec₂) α) = .mk (.inl q.input) q.cont := rfl
@@ -51,7 +57,7 @@ instance subSpec_add_left : spec₁ ⊂ₒ (spec₁ + spec₂) where
     (liftM (query t) : OracleQuery (spec₁ + spec₂) (spec₁.Range t)) = query (Sum.inl t) := rfl
 
 instance lawfulSubSpec_add_left : OracleSpec.LawfulSubSpec spec₁ (spec₁ + spec₂) where
-  cont_bijective _ := Function.bijective_id
+  onResponse_bijective _ := Function.bijective_id
 
 end add_left
 
@@ -59,8 +65,9 @@ section add_right
 
 /-- Add additional oracles to the left side of the exiting ones. -/
 instance subSpec_add_right : spec₂ ⊂ₒ (spec₁ + spec₂) where
-  monadLift | q => .mk (.inr q.input) q.cont
-  liftM_map | _ => fun _ => rfl
+  monadLift q := ⟨.inr q.input, q.cont⟩
+  onQuery := Sum.inr
+  onResponse _ := id
 
 @[simp] lemma liftM_add_right_def (q : OracleQuery spec₂ α) :
     (liftM q : OracleQuery (spec₁ + spec₂) α) = .mk (.inr q.input) q.cont := rfl
@@ -69,7 +76,7 @@ instance subSpec_add_right : spec₂ ⊂ₒ (spec₁ + spec₂) where
     (liftM (query t) : OracleQuery (spec₁ + spec₂) (spec₂.Range t)) = query (Sum.inr t) := rfl
 
 instance lawfulSubSpec_add_right : OracleSpec.LawfulSubSpec spec₂ (spec₁ + spec₂) where
-  cont_bijective _ := Function.bijective_id
+  onResponse_bijective _ := Function.bijective_id
 
 end add_right
 
@@ -78,32 +85,30 @@ section left_add_left_add
 instance subSpec_left_add_left_add_of_subSpec [h : spec₁ ⊂ₒ spec₃] :
     spec₁ + spec₂ ⊂ₒ spec₃ + spec₂ where
   monadLift
-    | .mk (.inl q) f => liftM (OracleQuery.mk q f)
-    | .mk (.inr q) f => .mk (.inr q) f
-  liftM_map
-    | .mk (.inl q) f => by
-      intro g
-      calc
-        (liftM (liftM (OracleQuery.mk q (g ∘ f)) : OracleQuery spec₃ _) :
-            OracleQuery (spec₃ + spec₂) _) =
-            (liftM (g <$> (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _)) :
-              OracleQuery (spec₃ + spec₂) _) := by
-              simpa [liftM, monadLift] using
-                congrArg (fun z => (liftM z : OracleQuery (spec₃ + spec₂) _))
-                  (OracleSpec.SubSpec.liftM_map (spec := spec₁) (superSpec := spec₃)
-                    (q := OracleQuery.mk q f) (f := g))
-        _ = g <$> (liftM (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _) :
-            OracleQuery (spec₃ + spec₂) _) := by
-              simpa [liftM, monadLift] using
-                (OracleSpec.SubSpec.liftM_map (spec := spec₃) (superSpec := spec₃ + spec₂)
-                  (q := (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _)) (f := g))
-    | .mk (.inr q) f => fun _ => rfl
+    | ⟨.inl t, f⟩ => ⟨.inl (h.onQuery t), f ∘ h.onResponse t⟩
+    | ⟨.inr t, f⟩ => ⟨.inr t, f⟩
+  onQuery
+    | .inl t => .inl (h.onQuery t)
+    | .inr t => .inr t
+  onResponse
+    | .inl t => h.onResponse t
+    | .inr _ => id
+  liftM_eq_lift q := by rcases q with ⟨_ | _, _⟩ <;> rfl
 
 @[simp] lemma liftM_left_add_left_add_def
     [h : spec₁ ⊂ₒ spec₃] (q : OracleQuery (spec₁ + spec₂) α) :
     (liftM q : OracleQuery (spec₃ + spec₂) α) = match q with
       | .mk (.inl q) f => liftM ((liftM (OracleQuery.mk q f) : OracleQuery spec₃ _))
-      | .mk (.inr q) f => .mk (.inr q) f := rfl
+      | .mk (.inr q) f => .mk (.inr q) f := by
+  rcases q with ⟨t | t, f⟩
+  · let qOuter : OracleQuery (spec₁ + spec₂) α := ⟨Sum.inl t, f⟩
+    let qInner : OracleQuery spec₁ α := ⟨t, f⟩
+    change (liftM qOuter : OracleQuery (spec₃ + spec₂) α) =
+        liftM (liftM qInner : OracleQuery spec₃ α)
+    rw [show (liftM qInner : OracleQuery spec₃ α) =
+        ⟨h.onQuery t, f ∘ h.onResponse t⟩ from h.liftM_eq_lift qInner]
+    rfl
+  · rfl
 
 @[simp high] lemma liftM_left_add_left_add_query
     [h : spec₁ ⊂ₒ spec₃] (t : (spec₁ + spec₂).Domain) :
@@ -115,9 +120,10 @@ instance subSpec_left_add_left_add_of_subSpec [h : spec₁ ⊂ₒ spec₃] :
 instance lawfulSubSpec_left_add_left_add [spec₁ ⊂ₒ spec₃]
     [OracleSpec.LawfulSubSpec spec₁ spec₃] :
     OracleSpec.LawfulSubSpec (spec₁ + spec₂) (spec₃ + spec₂) where
-  cont_bijective t := by
+  onResponse_bijective t := by
     match t with
-    | .inl t => exact OracleSpec.LawfulSubSpec.cont_bijective (spec := spec₁) (superSpec := spec₃) t
+    | .inl t =>
+      exact OracleSpec.LawfulSubSpec.onResponse_bijective (spec := spec₁) (superSpec := spec₃) t
     | .inr _ => exact Function.bijective_id
 
 end left_add_left_add
@@ -127,32 +133,30 @@ section right_add_right_add
 instance subSpec_right_add_right_add_of_subSpec [h : spec₂ ⊂ₒ spec₃] :
     spec₁ + spec₂ ⊂ₒ spec₁ + spec₃ where
   monadLift
-    | .mk (.inl q) f => .mk (.inl q) f
-    | .mk (.inr q) f => liftM (OracleQuery.mk q f)
-  liftM_map
-    | .mk (.inl q) f => fun _ => rfl
-    | .mk (.inr q) f => by
-      intro g
-      calc
-        (liftM (liftM (OracleQuery.mk q (g ∘ f)) : OracleQuery spec₃ _) :
-            OracleQuery (spec₁ + spec₃) _) =
-            (liftM (g <$> (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _)) :
-              OracleQuery (spec₁ + spec₃) _) := by
-              simpa [liftM, monadLift] using
-                congrArg (fun z => (liftM z : OracleQuery (spec₁ + spec₃) _))
-                  (OracleSpec.SubSpec.liftM_map (spec := spec₂) (superSpec := spec₃)
-                    (q := OracleQuery.mk q f) (f := g))
-        _ = g <$> (liftM (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _) :
-            OracleQuery (spec₁ + spec₃) _) := by
-              simpa [liftM, monadLift] using
-                (OracleSpec.SubSpec.liftM_map (spec := spec₃) (superSpec := spec₁ + spec₃)
-                  (q := (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _)) (f := g))
+    | ⟨.inl t, f⟩ => ⟨.inl t, f⟩
+    | ⟨.inr t, f⟩ => ⟨.inr (h.onQuery t), f ∘ h.onResponse t⟩
+  onQuery
+    | .inl t => .inl t
+    | .inr t => .inr (h.onQuery t)
+  onResponse
+    | .inl _ => id
+    | .inr t => h.onResponse t
+  liftM_eq_lift q := by rcases q with ⟨_ | _, _⟩ <;> rfl
 
 @[simp] lemma liftM_right_add_right_add_def
     [h : spec₂ ⊂ₒ spec₃] (q : OracleQuery (spec₁ + spec₂) α) :
     (liftM q : OracleQuery (spec₁ + spec₃) α) = match q with
       | .mk (.inl q) f => .mk (.inl q) f
-      | .mk (.inr q) f => (liftM (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _)) := rfl
+      | .mk (.inr q) f => (liftM (liftM (OracleQuery.mk q f) : OracleQuery spec₃ _)) := by
+  rcases q with ⟨t | t, f⟩
+  · rfl
+  · let qOuter : OracleQuery (spec₁ + spec₂) α := ⟨Sum.inr t, f⟩
+    let qInner : OracleQuery spec₂ α := ⟨t, f⟩
+    change (liftM qOuter : OracleQuery (spec₁ + spec₃) α) =
+        liftM (liftM qInner : OracleQuery spec₃ α)
+    rw [show (liftM qInner : OracleQuery spec₃ α) =
+        ⟨h.onQuery t, f ∘ h.onResponse t⟩ from h.liftM_eq_lift qInner]
+    rfl
 
 @[simp high] lemma liftM_right_add_right_add_query
     [h : spec₂ ⊂ₒ spec₃] (t : (spec₁ + spec₂).Domain) :
@@ -164,10 +168,11 @@ instance subSpec_right_add_right_add_of_subSpec [h : spec₂ ⊂ₒ spec₃] :
 instance lawfulSubSpec_right_add_right_add [spec₂ ⊂ₒ spec₃]
     [OracleSpec.LawfulSubSpec spec₂ spec₃] :
     OracleSpec.LawfulSubSpec (spec₁ + spec₂) (spec₁ + spec₃) where
-  cont_bijective t := by
+  onResponse_bijective t := by
     match t with
     | .inl _ => exact Function.bijective_id
-    | .inr t => exact OracleSpec.LawfulSubSpec.cont_bijective (spec := spec₂) (superSpec := spec₃) t
+    | .inr t =>
+      exact OracleSpec.LawfulSubSpec.onResponse_bijective (spec := spec₂) (superSpec := spec₃) t
 
 end right_add_right_add
 
@@ -178,17 +183,23 @@ instance subSpec_add_assoc : spec₁ + (spec₂ + spec₃) ⊂ₒ spec₁ + spec
     | ⟨.inl t, f⟩ => ⟨.inl (.inl t), f⟩
     | ⟨.inr (.inl t), f⟩ => ⟨.inl (.inr t), f⟩
     | ⟨.inr (.inr t), f⟩ => ⟨.inr t, f⟩
-  liftM_map
-    | ⟨.inl _, _⟩ => fun _ => rfl
-    | ⟨.inr (.inl _), _⟩ => fun _ => rfl
-    | ⟨.inr (.inr _), _⟩ => fun _ => rfl
+  onQuery
+    | .inl t => .inl (.inl t)
+    | .inr (.inl t) => .inl (.inr t)
+    | .inr (.inr t) => .inr t
+  onResponse
+    | .inl _ => id
+    | .inr (.inl _) => id
+    | .inr (.inr _) => id
+  liftM_eq_lift q := by rcases q with ⟨_ | _ | _, _⟩ <;> rfl
 
 @[simp] lemma liftM_add_assoc_def (q : OracleQuery (spec₁ + (spec₂ + spec₃)) α) :
     (liftM q : OracleQuery (spec₁ + spec₂ + spec₃) α) =
     match q with
     | ⟨.inl t, f⟩ => ⟨.inl (.inl t), f⟩
     | ⟨.inr (.inl t), f⟩ => ⟨.inl (.inr t), f⟩
-    | ⟨.inr (.inr t), f⟩ => ⟨.inr t, f⟩ := rfl
+    | ⟨.inr (.inr t), f⟩ => ⟨.inr t, f⟩ := by
+  rcases q with ⟨t | t | t, f⟩ <;> rfl
 
 @[simp] lemma liftM_add_assoc_query (t : (spec₁ + (spec₂ + spec₃)).Domain) :
     (liftM (query t) : OracleQuery (spec₁ + spec₂ + spec₃) ((spec₁ + (spec₂ + spec₃)).Range t)) =
@@ -200,7 +211,7 @@ instance subSpec_add_assoc : spec₁ + (spec₂ + spec₃) ⊂ₒ spec₁ + spec
 
 instance lawfulSubSpec_add_assoc :
     OracleSpec.LawfulSubSpec (spec₁ + (spec₂ + spec₃)) (spec₁ + spec₂ + spec₃) where
-  cont_bijective t := by
+  onResponse_bijective t := by
     rcases t with t | t | t <;> exact Function.bijective_id
 
 end add_assoc
@@ -213,8 +224,9 @@ variable {σ ι} (specs : σ → OracleSpec ι)
 
 instance subSpec_sigma {σ ι} (specs : σ → OracleSpec ι) (j : σ) :
     specs j ⊂ₒ OracleSpec.sigma specs where
-  monadLift | .mk t f => .mk ⟨j, t⟩ f
-  liftM_map | _ => fun _ => rfl
+  monadLift q := ⟨⟨j, q.input⟩, q.cont⟩
+  onQuery t := ⟨j, t⟩
+  onResponse _ := id
 
 @[simp low] lemma liftM_sigma_def (j : σ) (q : OracleQuery (specs j) α) :
     (liftM q : OracleQuery (OracleSpec.sigma specs) _) = .mk ⟨j, q.input⟩ q.cont := rfl
@@ -225,7 +237,7 @@ instance subSpec_sigma {σ ι} (specs : σ → OracleSpec ι) (j : σ) :
 
 instance lawfulSubSpec_sigma (j : σ) :
     OracleSpec.LawfulSubSpec (specs j) (OracleSpec.sigma specs) where
-  cont_bijective _ := Function.bijective_id
+  onResponse_bijective _ := Function.bijective_id
 
 end sigma
 

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -10,13 +10,30 @@ import ToMathlib.General
 /-!
 # Coercions Between Computations With Additional Oracles
 
-This file defines a `isSubSpec` relation for pairs of `oracleSpec` where one can be
-thought of as an extension of the other with additional oracles.
-The definition consists is a thin wrapper around a `MonadLift` instance on `OracleQuery`,
-which extends to a lifting operation on `OracleComp`.
+This file defines the `SubSpec` relation between pairs of `OracleSpec`s. An
+instance `spec ⊂ₒ superSpec` packages the data of a polynomial-functor lens
+between the underlying `PFunctor`s, given by
 
-We use the notation `spec ⊂ₒ spec'` to represent that one set of oracles is a subset of another,
-where the non-inclusive subset symbol reflects that we avoid defining this instance reflexively.
+* `onQuery : spec.Domain → superSpec.Domain` --- forward translation on query
+  inputs (oracle indices), and
+* `onResponse : (t : spec.Domain) → superSpec.Range (onQuery t) → spec.Range t`
+  --- fiberwise backward translation on query responses.
+
+By the Yoneda lemma this lens data is in bijection with natural transformations
+`OracleQuery spec → OracleQuery superSpec`. The class therefore `extends
+MonadLift (OracleQuery spec) (OracleQuery superSpec)`. Concrete instances
+spell `monadLift` out alongside the lens data and discharge the
+propositional coherence `liftM_eq_lift` (typically `rfl`); see the class
+docstring for why the `monadLift` field is not defaulted.
+
+We use the notation `spec ⊂ₒ spec'` to represent this inclusion. The
+non-inclusive subset symbol reflects that we avoid defining `SubSpec`
+reflexively, since `MonadLiftT.refl` already handles the identity case.
+
+`LawfulSubSpec` refines `SubSpec` with the requirement that `onResponse` is
+bijective on every fiber. This is exactly the data of a `PFunctor.Equiv`-style
+embedding and is what is needed to preserve the uniform distribution under
+lifting.
 -/
 
 open OracleSpec OracleComp BigOperators ENNReal
@@ -28,60 +45,94 @@ variable {ι : Type u} {τ : Type v}
 
 namespace OracleSpec
 
-/-- Relation defining an inclusion of one set of oracles into another, where the mapping
-doesn't affect the underlying probability distribution of the computation.
-Informally, `spec ⊂ₒ superSpec` means that for any query to an oracle of `sub_spec`,
-it can be perfectly simulated by a computation using the oracles of `superSpec`.
+/-- Inclusion of one set of oracles into another, packaged as a polynomial-functor
+lens between the underlying `OracleSpec`s. Carries the forward translation
+`onQuery` on query inputs and the fiberwise backward translation `onResponse`
+on query responses, plus the resulting `MonadLift` action.
 
-We avoid implementing this via the built-in subset notation as we care about the actual data
-of the mapping rather than just its existence, which is needed when defining type coercions. -/
+We `extends MonadLift (OracleQuery spec) (OracleQuery superSpec)` so that
+typeclass synthesis can derive `MonadLift` (and therefore `MonadLiftT`)
+through the structure projection `SubSpec.toMonadLift`. The `monadLift`
+field is **not** defaulted: each concrete `SubSpec` instance must spell it
+out, alongside `onQuery` / `onResponse`, and discharge the propositional
+coherence `liftM_eq_lift` (typically by `rfl`).
+
+Spelling `monadLift` out explicitly (rather than defaulting it from the
+lens data) is what makes the lifted query fully reduce during `rw` / `simp`
+pattern matching against lemmas like `probEvent_liftComp`. A defaulted
+`monadLift` field becomes opaque to `isDefEq` once it travels through the
+`MonadLiftT` instance chain, which silently breaks rewriting.
+
+Informally, `spec ⊂ₒ superSpec` says that any query to an oracle of `spec`
+can be perfectly simulated by a query to an oracle of `superSpec`. We avoid
+the built-in `Subset` notation because we care about the actual data of the
+mapping (it is needed when defining type coercions), not just its existence. -/
 class SubSpec (spec : OracleSpec.{u, w} ι) (superSpec : OracleSpec.{v, w} τ)
     extends MonadLift (OracleQuery spec) (OracleQuery superSpec) where
-  liftM_map {α β : Type _} (q : OracleQuery spec α) (f : α → β) :
-      liftM (n := OracleQuery superSpec) (f <$> q) = f <$> liftM q
+  /-- Forward translation on query inputs (oracle indices). -/
+  onQuery : spec.Domain → superSpec.Domain
+  /-- Fiberwise backward translation on query responses. -/
+  onResponse : (t : spec.Domain) → superSpec.Range (onQuery t) → spec.Range t
+  /-- Coherence between the `MonadLift` action and the lens data: lifting a
+  query is the lens applied to that query. Concrete instances supply
+  `monadLift` directly in the lens form, making this `rfl`. -/
+  liftM_eq_lift : ∀ {β : Type w} (q : OracleQuery spec β),
+      monadLift q = ⟨onQuery q.input, q.cont ∘ onResponse q.input⟩ := by
+    intros; rfl
 
-infix : 50 " ⊂ₒ " => SubSpec
+@[inherit_doc] infix : 50 " ⊂ₒ " => SubSpec
 
 namespace SubSpec
 
 variable {κ : Type w'} {spec₃ : OracleSpec κ}
 
-/-- Transitivity for `SubSpec`: if `spec₁ ⊂ₒ spec₂` and `spec₂ ⊂ₒ spec₃`,
-then `spec₁ ⊂ₒ spec₃`. -/
-@[reducible] def trans (h₁ : spec ⊂ₒ superSpec) (h₂ : superSpec ⊂ₒ spec₃) : spec ⊂ₒ spec₃ where
-  monadLift q := h₂.monadLift (h₁.monadLift q)
-  liftM_map q f := by
-    have h₁map := h₁.liftM_map (q := q) (f := f)
-    have h₁map' := congrArg h₂.monadLift h₁map
-    calc
-      h₂.monadLift (h₁.monadLift (f <$> q))
-          = h₂.monadLift (f <$> h₁.monadLift q) := h₁map'
-      _ = f <$> h₂.monadLift (h₁.monadLift q) := by
-          simpa using (h₂.liftM_map (q := h₁.monadLift q) (f := f))
+/-- The lens action on a single query: forward on the input, post-compose the
+backward fiber on the continuation. Used as the canonical reduced form of
+`liftM q` for proofs that need to inspect the resulting query. -/
+@[reducible] def liftQuery [h : SubSpec spec superSpec] (q : OracleQuery spec α) :
+    OracleQuery superSpec α :=
+  ⟨h.onQuery q.input, q.cont ∘ h.onResponse q.input⟩
+
+/-- Transitivity of `SubSpec`: lens composition. -/
+@[reducible] def trans (h₁ : spec ⊂ₒ superSpec) (h₂ : superSpec ⊂ₒ spec₃) :
+    spec ⊂ₒ spec₃ where
+  monadLift q :=
+    ⟨h₂.onQuery (h₁.onQuery q.input),
+      q.cont ∘ h₁.onResponse q.input ∘ h₂.onResponse (h₁.onQuery q.input)⟩
+  onQuery t := h₂.onQuery (h₁.onQuery t)
+  onResponse t r := h₁.onResponse t (h₂.onResponse (h₁.onQuery t) r)
 
 end SubSpec
 
-/-- `LawfulSubSpec` extends `SubSpec` with the requirement that lifting preserves
-distributions. The axiom requires that the continuation of each lifted query is a
-bijection from the super-range to the sub-range, which guarantees that the uniform
-distribution is preserved under the mapping. -/
+/-- `LawfulSubSpec` extends `SubSpec` with the requirement that the backward
+translation `onResponse` is bijective on every fiber. Equivalently: the
+continuation of each lifted base query `liftM (spec.query t)` is a bijection
+from the super-range to the sub-range. This is what is needed to preserve the
+uniform distribution under the lift. -/
 class LawfulSubSpec (spec : OracleSpec.{u, w} ι) (superSpec : OracleSpec.{v, w} τ)
     [h : SubSpec spec superSpec] : Prop where
-  cont_bijective (t : spec.Domain) :
-    Function.Bijective (h.toMonadLift.monadLift (spec.query t)).snd
+  /-- The backward translation is bijective on every fiber. -/
+  onResponse_bijective (t : spec.Domain) :
+    Function.Bijective (h.onResponse t)
 
 namespace LawfulSubSpec
 
 variable {ι : Type u} {τ : Type v} {spec : OracleSpec ι} {superSpec : OracleSpec τ}
     [h : spec ⊂ₒ superSpec] [LawfulSubSpec spec superSpec]
 
+/-- Pushing the uniform distribution on `superSpec.Range` through the lens's
+backward fiber recovers the uniform distribution on `spec.Range`. Load-bearing
+for `evalDist_liftComp` below. -/
 lemma evalDist_liftM_query [superSpec.Fintype] [superSpec.Inhabited]
     [spec.Fintype] [spec.Inhabited] (t : spec.Domain) :
     (PMF.uniformOfFintype (superSpec.Range
-      (h.toMonadLift.monadLift (spec.query t)).fst)).map
-      (h.toMonadLift.monadLift (spec.query t)).snd =
-      PMF.uniformOfFintype (spec.Range t) :=
-  PMF.uniformOfFintype_map_of_bijective _ (cont_bijective t)
+      ((liftM (n := OracleQuery superSpec) (spec.query t)).fst))).map
+      ((liftM (n := OracleQuery superSpec) (spec.query t)).snd) =
+      PMF.uniformOfFintype (spec.Range t) := by
+  have lift_eq : (liftM (spec.query t) : OracleQuery superSpec (spec.Range t)) =
+      ⟨h.onQuery t, h.onResponse t⟩ := h.liftM_eq_lift _
+  rw [lift_eq]
+  exact PMF.uniformOfFintype_map_of_bijective _ (onResponse_bijective t)
 
 end LawfulSubSpec
 

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -169,8 +169,8 @@ for `evalDist_liftComp` below. -/
 lemma evalDist_liftM_query [superSpec.Fintype] [superSpec.Inhabited]
     [spec.Fintype] [spec.Inhabited] (t : spec.Domain) :
     (PMF.uniformOfFintype (superSpec.Range
-      ((liftM (n := OracleQuery superSpec) (spec.query t)).fst))).map
-      ((liftM (n := OracleQuery superSpec) (spec.query t)).snd) =
+      ((liftM (n := OracleQuery superSpec) (spec.query t)).input))).map
+      ((liftM (n := OracleQuery superSpec) (spec.query t)).cont) =
       PMF.uniformOfFintype (spec.Range t) := by
   have lift_eq : (liftM (spec.query t) : OracleQuery superSpec (spec.Range t)) =
       ⟨h.onQuery t, h.onResponse t⟩ := h.liftM_eq_lift _

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -6,13 +6,15 @@ Authors: Devon Tuma, Quang Dao
 import VCVio.OracleComp.SimSemantics.SimulateQ
 import VCVio.OracleComp.EvalDist
 import ToMathlib.General
+import ToMathlib.PFunctor.Lens.Cartesian
 
 /-!
 # Coercions Between Computations With Additional Oracles
 
 This file defines the `SubSpec` relation between pairs of `OracleSpec`s. An
 instance `spec ⊂ₒ superSpec` packages the data of a polynomial-functor lens
-between the underlying `PFunctor`s, given by
+`PFunctor.Lens spec.toPFunctor superSpec.toPFunctor` between the underlying
+`PFunctor`s, given by
 
 * `onQuery : spec.Domain → superSpec.Domain` --- forward translation on query
   inputs (oracle indices), and
@@ -31,9 +33,14 @@ non-inclusive subset symbol reflects that we avoid defining `SubSpec`
 reflexively, since `MonadLiftT.refl` already handles the identity case.
 
 `LawfulSubSpec` refines `SubSpec` with the requirement that `onResponse` is
-bijective on every fiber. This is exactly the data of a `PFunctor.Equiv`-style
-embedding and is what is needed to preserve the uniform distribution under
-lifting.
+bijective on every fiber, i.e. that the underlying lens is **cartesian** in
+the sense of `PFunctor.Lens.IsCartesian`. This is *strictly weaker* than
+`PFunctor.Lens.Equiv` (which would also require `onQuery` to be a bijection,
+ruling out the basic case `spec ⊂ₒ (spec + spec')` where `onQuery = Sum.inl`).
+Cartesianness is exactly the condition needed to preserve the uniform
+distribution under lifting (`evalDist_liftComp`); see
+`LawfulSubSpec.toLens_isCartesian` for the bridge to the lens-level
+predicate.
 -/
 
 open OracleSpec OracleComp BigOperators ENNReal
@@ -93,6 +100,23 @@ backward fiber on the continuation. Used as the canonical reduced form of
     OracleQuery superSpec α :=
   ⟨h.onQuery q.input, q.cont ∘ h.onResponse q.input⟩
 
+/-- The polynomial-functor lens between the underlying `PFunctor`s carried by
+a `SubSpec` instance. This is the lens-level view of the data; concrete
+properties (like cartesianness via `LawfulSubSpec`) are stated on this lens.
+
+The other half of the data, `monadLift`, is fixed by `liftM_eq_lift` to be
+the standard action of this lens on `OracleQuery`. -/
+def toLens (h : SubSpec spec superSpec) :
+    PFunctor.Lens spec.toPFunctor superSpec.toPFunctor where
+  toFunA := h.onQuery
+  toFunB := h.onResponse
+
+@[simp] lemma toLens_toFunA (h : SubSpec spec superSpec) :
+    h.toLens.toFunA = h.onQuery := rfl
+
+@[simp] lemma toLens_toFunB (h : SubSpec spec superSpec) :
+    h.toLens.toFunB = h.onResponse := rfl
+
 /-- Transitivity of `SubSpec`: lens composition. -/
 @[reducible] def trans (h₁ : spec ⊂ₒ superSpec) (h₂ : superSpec ⊂ₒ spec₃) :
     spec ⊂ₒ spec₃ where
@@ -102,13 +126,26 @@ backward fiber on the continuation. Used as the canonical reduced form of
   onQuery t := h₂.onQuery (h₁.onQuery t)
   onResponse t r := h₁.onResponse t (h₂.onResponse (h₁.onQuery t) r)
 
+@[simp] lemma trans_toLens (h₁ : spec ⊂ₒ superSpec) (h₂ : superSpec ⊂ₒ spec₃) :
+    (SubSpec.trans h₁ h₂).toLens = h₂.toLens ∘ₗ h₁.toLens := rfl
+
 end SubSpec
 
 /-- `LawfulSubSpec` extends `SubSpec` with the requirement that the backward
 translation `onResponse` is bijective on every fiber. Equivalently: the
-continuation of each lifted base query `liftM (spec.query t)` is a bijection
-from the super-range to the sub-range. This is what is needed to preserve the
-uniform distribution under the lift. -/
+underlying lens `SubSpec.toLens` is *cartesian* in the sense of
+`PFunctor.Lens.IsCartesian`, i.e. it is a fiberwise isomorphism over an
+arbitrary forward map on positions.
+
+This is *strictly weaker* than `PFunctor.Lens.Equiv`, which would also force
+`onQuery` to be a bijection. We intentionally only require fiberwise
+bijectivity because the canonical `SubSpec` instances embed a small spec
+into a larger one (e.g. `spec₁ ⊂ₒ (spec₁ + spec₂)` with `onQuery = Sum.inl`),
+and these embeddings are essential to the API.
+
+Cartesianness is exactly what is needed to preserve the uniform distribution
+under the lift: see `evalDist_liftM_query` and the bridge
+`LawfulSubSpec.toLens_isCartesian`. -/
 class LawfulSubSpec (spec : OracleSpec.{u, w} ι) (superSpec : OracleSpec.{v, w} τ)
     [h : SubSpec spec superSpec] : Prop where
   /-- The backward translation is bijective on every fiber. -/
@@ -119,6 +156,12 @@ namespace LawfulSubSpec
 
 variable {ι : Type u} {τ : Type v} {spec : OracleSpec ι} {superSpec : OracleSpec τ}
     [h : spec ⊂ₒ superSpec] [LawfulSubSpec spec superSpec]
+
+/-- The lens-level statement of `LawfulSubSpec`: the underlying
+`PFunctor.Lens` is cartesian. This makes the dictionary between the
+oracle-spec layer and the polynomial-functor lens layer explicit. -/
+lemma toLens_isCartesian : h.toLens.IsCartesian := fun t =>
+  onResponse_bijective (h := h) t
 
 /-- Pushing the uniform distribution on `superSpec.Range` through the lens's
 backward fiber recovers the uniform distribution on `spec.Range`. Load-bearing

--- a/docs/agents/gotchas.md
+++ b/docs/agents/gotchas.md
@@ -41,7 +41,7 @@ Files like `Fork.lean`, `Sigma.lean`, and `RF_RP_Switching_alt.lean` contain lar
 
 ### 8. Universe polymorphism
 
-`OracleComp` has 3 universe parameters, `SubSpec` has 6. Universe unification errors are common when composing specs or building reductions.
+`OracleComp` has 3 universe parameters, `SubSpec` has 3 (`u, v, w`: indices `ι : Type u`, `τ : Type v`, shared response universe `w`). Universe unification errors are still common when composing specs or building reductions because the lens-style `MonadLift` parent can drag extra metavariables in.
 
 **Fix**: Use `{ι : Type*}` instead of `{ι : Type u}` to let universes resolve independently. Keep `α β : Type` (not `Type u`).
 

--- a/docs/agents/oracle-comp.md
+++ b/docs/agents/oracle-comp.md
@@ -69,9 +69,48 @@ induction oa using OracleComp.inductionOn with
 `spec ⊂ₒ superSpec` means every query in `spec` can be simulated in `superSpec` without changing the distribution.
 
 ```lean
-class SubSpec (spec : OracleSpec ι) (superSpec : OracleSpec τ)
-    extends MonadLift (OracleQuery spec) (OracleQuery superSpec)
+class SubSpec (spec : OracleSpec.{u, w} ι) (superSpec : OracleSpec.{v, w} τ)
+    extends MonadLift (OracleQuery spec) (OracleQuery superSpec) where
+  onQuery    : spec.Domain → superSpec.Domain
+  onResponse : (t : spec.Domain) → superSpec.Range (onQuery t) → spec.Range t
+  liftM_eq_lift :
+    ∀ {β} (q : OracleQuery spec β),
+      monadLift q = ⟨onQuery q.input, q.cont ∘ onResponse q.input⟩ := by intros; rfl
 ```
+
+### Lens semantics
+
+`onQuery` and `onResponse` together package a `PFunctor.Lens spec.toPFunctor superSpec.toPFunctor` (call it `h.toLens`):
+
+| Class field | Lens field |
+|-------------|------------|
+| `onQuery : spec.Domain → superSpec.Domain` | `toFunA : P.A → Q.A` |
+| `onResponse t : superSpec.Range (onQuery t) → spec.Range t` | `toFunB t : Q.B (toFunA t) → P.B t` |
+
+By the Yoneda lemma for polynomial functors this lens data is in bijection with natural transformations `OracleQuery spec ⟹ OracleQuery superSpec`. The `MonadLift` parent records that natural transformation; the `liftM_eq_lift` field is the propositional coherence axiom forcing it to agree with the lens. Concrete `SubSpec` instances spell `monadLift` out *by hand* (rather than letting it default from the lens data), so that the lifted query reduces fully under `isDefEq` — this is what makes pattern-matching simp lemmas like `probEvent_liftComp` actually fire.
+
+`SubSpec.toLens` exposes the underlying lens; `SubSpec.trans` is composition of these lenses; `MonadLiftT.refl` covers the identity.
+
+#### Why `SubSpec` extends `MonadLift` rather than `PFunctor.Lens`
+
+The fields *are* a lens. We extend `MonadLift` for two pragmatic reasons:
+
+1. **Typeclass synthesis.** Lifting `OracleComp spec α → OracleComp superSpec α` is plumbed through the `MonadLift` / `MonadLiftT` mechanism; bridging through `PFunctor.Lens` separately would require an instance of the form `PFunctor.Lens A B → MonadLift (Obj A) (Obj B)`, which Lean cannot synthesize from `OracleQuery spec` because `OracleQuery` is a `def` (and `def`-headed instance heads cannot be matched).
+2. **Reducibility under `rw` / `simp`.** A defaulted `monadLift` field becomes opaque to `isDefEq` during pattern matching. Hand-written `monadLift` per instance keeps the lifted query fully reducible.
+
+### LawfulSubSpec ↔ cartesian lens
+
+`LawfulSubSpec spec superSpec` extends `SubSpec spec superSpec` with the propositional requirement that **every backward fiber `onResponse t` is a bijection**. This is *exactly* the `PFunctor.Lens.IsCartesian` predicate from `ToMathlib/PFunctor/Lens/Cartesian.lean`:
+
+```lean
+def Lens.IsCartesian (l : Lens P Q) : Prop := ∀ a, Function.Bijective (l.toFunB a)
+```
+
+The bridge lemma `LawfulSubSpec.toLens_isCartesian` is the one-line statement that the underlying lens of a `LawfulSubSpec` is cartesian.
+
+A *cartesian* lens is a fiberwise isomorphism over an arbitrary forward map on positions. This is **strictly weaker** than `PFunctor.Lens.Equiv` (an isomorphism in the lens category), which would *also* require `onQuery` to be a bijection. We intentionally only require fiberwise bijectivity because the basic `SubSpec` instances embed a small spec into a larger one (e.g. `spec₁ ⊂ₒ (spec₁ + spec₂)` with `onQuery = Sum.inl`); these embeddings are essential and would be ruled out by `Equiv`.
+
+Cartesianness is the precise condition needed to push uniform distributions through the lift: `LawfulSubSpec.evalDist_liftM_query` shows that pulling the uniform distribution on `superSpec.Range (onQuery t)` back through `onResponse t` recovers the uniform distribution on `spec.Range t`.
 
 ### When you need SubSpec
 


### PR DESCRIPTION
Lands **Step 1** + the **core of Step 2** of the ITree / OracleSpec / Lens unification plan ([note](../../../Documents/Notes/vcvio-itree-oraclespec-lens-unification-plan.md)).

## Why

Two halves of the codebase, OracleComp's `SubSpec` and ITree's `Handler.ofLens`, were silently expressing the same concept (a polynomial-functor lens) in two different vocabularies. The opaque `liftM_map` axiom hid the lens nature of `SubSpec`, and the lawful version (`cont_bijective`) duplicated what is, structurally, the cartesian-morphism property of a `PFunctor.Lens`. This PR makes the lens vocabulary primary and removes the duplication.

## What

### Step 1 — `SubSpec` cutover (commits `63875dc`, `7f892cd`, `17aef90`)

- `SubSpec` now carries the lens data as native fields:
  - `onQuery : spec.Domain → superSpec.Domain`
  - `onResponse : (t : spec.Domain) → superSpec.Range (onQuery t) → spec.Range t`
  - `monadLift` is **explicitly hand-written** at every instance site (uniform `monadLift q := ⟨onQuery q.input, q.cont ∘ onResponse q.input⟩`), preserving `rfl`-defeq for downstream `simp`/`rw`.
  - `liftM_eq_lift` propositional coherence (typically `rfl`).
- `LawfulSubSpec` carries a single field `onResponse_bijective : ∀ t, Function.Bijective (h.onResponse t)`. The old `liftM_map` axiom is gone (now `rfl`).
- New `ToMathlib/PFunctor/Lens/Cartesian.lean`: `IsCartesian l := ∀ a, Function.Bijective (l.toFunB a)` plus closure under `id`, `comp`, `inl`, `inr`, `sumMap`, `sumPair`, `sigmaMap`, `sigmaExists`, `sigmaInj`. Bridge `LawfulSubSpec.toLens_isCartesian` realizes the cartesian-lens correspondence as a first-class lemma.
- All `SubSpec`/`LawfulSubSpec` instance bodies in `VCVio/`, `LatticeCrypto/`, `Examples/` updated to the two-field `onQuery := …; onResponse := …` shape.
- Downstream `evalDist_liftComp` rewrite re-routed through `PMF.uniformOfFintype_map_of_bijective` after the lens rewrite changed the shape of `evalDist_liftM_query`.
- Docs: `docs/agents/oracle-comp.md` (new SubSpec subsections — *Lens semantics*, *Why `SubSpec` extends `MonadLift` rather than `PFunctor.Lens` directly*, *LawfulSubSpec ↔ cartesian lens*), `docs/agents/gotchas.md` (corrected universe count).

### Step 2 — `mapSpec` equational theory (commits `79b99f3`, `abed323`, `0ba2f02`, `efd8553`)

`mapSpec` is `Handler.ofLens`'s τ-free cousin: a pure renaming of queries that does **not** insert silent steps. It's the moral analogue of Coq's `translate` and the ITree-side counterpart of `liftComp` on the OracleComp side. This PR rounds out its monad-morphism equational theory:

- `mapSpec_bind : mapSpec φ (bind t k) = bind (mapSpec φ t) (mapSpec φ ∘ k)` — strong bisim via `PFunctor.M.bisim`.
- `mapSpec_iter : mapSpec φ (iter body init) = iter (mapSpec φ ∘ body) init` — strong bisim, factored through four `private dest_corec_iterStep_*` helpers (one per shape of the input ITree's head) so the bisim case analysis becomes mechanical (`simp only [dest_mapSpec, mapSpecStep, shape']; rw [hL]`).
- Derived `@[simp]` lemmas: `mapSpec_map`, `mapSpec_functorMap`, `mapSpec_cat`, `mapSpec_seq`. Together with `mapSpec_pure` / `mapSpec_query` / `mapSpec_step` / `mapSpec_id` / `mapSpec_comp` (already in tree), `mapSpec` is now fully an Applicative+Monad+Iter morphism.

### Review pass (commit `17aef90`)

- Renamed `IsCartesian.id_lens` → `IsCartesian.id` (parallel to `IsCartesian.comp`).
- Switched `evalDist_liftM_query` to `OracleQuery.input` / `OracleQuery.cont` projections instead of generic `.fst` / `.snd` (matches the rest of the file).

## Test plan

- `lake build` is fully green across `VCVio`, `LatticeCrypto`, `LatticeCryptoTest`, `Examples`, `ToMathlib`. Only pre-existing `sorry` warnings remain (all in `KEMDEM`, `RenyiDivergence`, `UC.Standard`, `FujisakiOkamoto`, `FiatShamir.Sigma.Security`).
- All `SubSpec` instance bodies are at most a handful of lines; `liftM_map` is no longer mentioned anywhere; `cont_bijective` replaced by `onResponse_bijective`.

## Out of scope (intentional)

- The `(liftM … : OracleComp …)` and `query (spec := …)` ascription pain points are **structural** `MonadLift` / `HasQuery` issues, not fixable inside `SubSpec`. Documented in §4.5.6 of the plan note; will be revisited in a separate "`HasQuery`-first" pass.
- ITree-side `mapSpec_mapM` and cartesian-preservation theorems are deferred (would benefit from a future ITree-side `evalDist`).
- Event-family facts (`runState`, etc.) deferred until a downstream consumer needs them.