### PR TITLE
refactor(fs-h5): wrap NMA adversary with verifier-point query, drop `verifyChallengePredictability`

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -102,7 +102,7 @@ Structures use UpperCamelCase: `SecExp`, `SymmEncAlg`, `RelTriple`.
 
 - Compact modern crypto proof: `Examples/OneTimePad/Basic.lean`
 - ElGamal IND-CPA via the generic one-time DDH lift: `Examples/ElGamal/Basic.lean`
-- Schnorr sigma protocol (completeness, soundness, HVZK): `Examples/Schnorr.lean`
+- Schnorr sigma protocol (completeness, soundness, HVZK): `Examples/Schnorr/SigmaProtocol.lean`
 - Oracle computation core: `VCVio/OracleComp/OracleComp.lean`
 - Probability lemmas: `VCVio/EvalDist/Monad/Basic.lean`
 - SubSpec / coercions: `VCVio/OracleComp/Coercions/SubSpec.lean`

--- a/Examples.lean
+++ b/Examples.lean
@@ -37,6 +37,6 @@ import Examples.ProgramLogic.UnaryStep
 import Examples.ProgramLogic.UnaryTriple
 import Examples.Regev
 import Examples.Schnorr.SigmaProtocol
-import Examples.SealedSender.AspectObservation
 import Examples.Schnorr.Signature
+import Examples.SealedSender.AspectObservation
 import Examples.SimpleTwoServerPIR

--- a/Examples.lean
+++ b/Examples.lean
@@ -36,7 +36,7 @@ import Examples.ProgramLogic.UnaryProbability
 import Examples.ProgramLogic.UnaryStep
 import Examples.ProgramLogic.UnaryTriple
 import Examples.Regev
-import Examples.Schnorr
+import Examples.Schnorr.SigmaProtocol
 import Examples.SealedSender.AspectObservation
-import Examples.Signature
+import Examples.Schnorr.Signature
 import Examples.SimpleTwoServerPIR

--- a/Examples/Schnorr/SigmaProtocol.lean
+++ b/Examples/Schnorr/SigmaProtocol.lean
@@ -13,7 +13,7 @@ import VCVio.ProgramLogic.Tactics.Relational
 Standard Schnorr Σ-protocol for proof of knowledge of discrete logarithm
 over a cyclic group, formalized using `Module F G`. This file is the
 σ-protocol layer of the end-to-end EUF-CMA proof for the Schnorr signature
-in `Examples/Signature.lean`; everything proven here is fed verbatim into
+in `Examples/Schnorr/Signature.lean`; everything proven here is fed verbatim into
 `FiatShamir.euf_cma_bound`.
 
 ## Mathematical setup

--- a/Examples/Schnorr/Signature.lean
+++ b/Examples/Schnorr/Signature.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import Examples.Schnorr
+import Examples.Schnorr.SigmaProtocol
 import VCVio.CryptoFoundations.FiatShamir.Sigma.Security
 import VCVio.CryptoFoundations.HardnessAssumptions.DiffieHellman
 
@@ -14,7 +14,7 @@ An end-to-end EUF-CMA reduction for the Schnorr digital signature, exercising
 the main composition layers of the VCVio framework on a single concrete
 scheme:
 
-* a Σ-protocol (`Examples/Schnorr.lean`),
+* a Σ-protocol (`Examples/Schnorr/SigmaProtocol.lean`),
 * the generic Fiat-Shamir transform
   (`VCVio/CryptoFoundations/FiatShamir/Sigma.lean`),
 * the replay-based forking lemma
@@ -210,5 +210,7 @@ theorem signature_euf_cma (g : G)
   simp only [mul_zero, ENNReal.ofReal_zero, zero_add] at hred ⊢
   exact ⟨fun _ pk => red pk,
     hred.trans (le_of_eq (hardRelationExp_dlogGenerable_eq_dlogExp F G g hg red))⟩
+
+#print axioms signature_euf_cma
 
 end Schnorr

--- a/Examples/Signature.lean
+++ b/Examples/Signature.lean
@@ -43,7 +43,7 @@ most `qS` signing-oracle queries and `qH` random-oracle queries against the
 random-oracle runtime `FiatShamir.runtime`. Define
 
 ```
-ε' := ε  -  qS · (qS + qH) / |F|  -  δ_verify
+ε' := ε  -  qS · (qS + qH) / |F|
 ```
 
 (`ENNReal` subtraction, which truncates at zero; whenever the simulation
@@ -60,12 +60,17 @@ plugged in at `β = 1/|F|` (the Schnorr simulator's commitment is uniform on
 `G` whenever `F` acts simply transitively on `G` via `g`, since
 `Fintype.card G = Fintype.card F`).
 
-The slack `δ_verify` bounds the probability that a uniform fresh challenge
-accepts a fixed `(commit, response)` pair under `σ.verify`; the caller supplies
-it via `SigmaProtocol.verifyChallengePredictability`. For Schnorr this is
-small: the verification equation `z • g = R + c • pk` has at most one solution
-`c ∈ F` for fixed `(R, z, pk)` whenever `pk ≠ 0`, so `δ_verify = 1/|F|` is
-achievable.
+The denominator `qH + 1` is the textbook Pointcheval-Stern denominator for a
+source adversary with `qH` random-oracle queries. The reduction wraps the
+adversary so that the forgery's hash point is always among the forkable
+positions: it appends one explicit `(message, commit)` query for the forgery's
+hash point on top of the source's `qH` queries, and applies the replay-forking
+lemma at fork slot parameter `qH`. The framework's `Fork.forkPoint qH` indexes
+`Fin (qH + 1)`, providing exactly enough slots for the wrapped adversary's
+`qH + 1` total queries (no double-counting). As a result, the bound is
+*unconditional* in `pk`: there is no remaining "verifier guesses a uniform
+challenge" term that would have to be discharged separately for keys on which
+verification is independent of the challenge.
 
 ## Glossary
 
@@ -102,8 +107,7 @@ The Schnorr-specific inputs are exactly:
                                           extractor;
 * `Schnorr.sigma_hvzk`                  — perfect HVZK (`ζ_zk = 0`);
 * `Schnorr.sigma_simCommitPredictability` — the simulator's commit is uniform
-                                          on `G`, giving `β = 1/|F|`;
-* `δ_verify` and `hVerifyGuess`         — caller-supplied verification slack.
+                                          on `G`, giving `β = 1/|F|`.
 -/
 
 
@@ -152,20 +156,22 @@ private theorem hardRelationExp_dlogGenerable_eq_dlogExp
   exact probOutput_bind_congr' _ true fun x =>
     probOutput_bind_congr' _ true fun sk => by simp [hg.1.eq_iff]
 
-/-- **EUF-CMA reduction for Schnorr signatures (Pointcheval-Stern, tight).**
+/-- **EUF-CMA reduction for Schnorr signatures (Pointcheval-Stern).**
 
 The bound is
 
 ```
 ε' · ( ε' / (qH + 1)  -  1 / |F| )   ≤   Pr[ reduction succeeds in dlogExp g ],
-ε' := ε  -  qS · (qS + qH) / |F|  -  δ_verify,
+ε' := ε  -  qS · (qS + qH) / |F|,
 ```
 
-where `ε := adv.advantage (FiatShamir.runtime M)` is the EUF-CMA advantage,
-`qS` and `qH` upper-bound the signing-oracle and random-oracle queries,
-and `δ_verify` is the verification slack supplied through
-`SigmaProtocol.verifyChallengePredictability`. See the module docstring for
-the full chain.
+where `ε := adv.advantage (FiatShamir.runtime M)` is the EUF-CMA advantage and
+`qS`, `qH` upper-bound the signing-oracle and random-oracle queries. This is
+the textbook Pointcheval-Stern denominator: the Fiat-Shamir reduction wraps
+the source adversary so the forgery's hash point is always among the forkable
+positions, and the framework's `Fork.forkPoint qH` indexing in `Fin (qH + 1)`
+provides exactly the right number of slots (source-`qH` queries plus the one
+appended verifier-point query). See the module docstring for the full chain.
 
 Three Schnorr-specific facts feed in:
 
@@ -181,15 +187,13 @@ the conversion `hardRelationExp_dlogGenerable_eq_dlogExp`. -/
 theorem signature_euf_cma (g : G)
     (hg : Function.Bijective (· • g : F → G))
     (M : Type) [DecidableEq M]
-    (δ_verify : ENNReal)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability (Schnorr.sigma F G g) δ_verify)
     (adv : SignatureAlg.unforgeableAdv (signature F G g M))
     (qS qH : ℕ)
     (hQ : ∀ pk, FiatShamir.signHashQueryBound (M := M) (Commit := G) (Chal := F)
       (S' := G × F) (oa := adv.main pk) qS qH) :
     ∃ reduction : DLogAdversary F G,
       let eps := adv.advantage (FiatShamir.runtime (Commit := G) (Chal := F) M) -
-        ((qS : ENNReal) * (qS + qH) * ((Fintype.card F : ℝ≥0∞)⁻¹) + δ_verify)
+        ((qS : ENNReal) * (qS + qH) * ((Fintype.card F : ℝ≥0∞)⁻¹))
       eps * (eps / (qH + 1 : ENNReal) - FiatShamir.challengeSpaceInv F) ≤
         Pr[= true | dlogExp g reduction] := by
   haveI : Inhabited F := ⟨0⟩
@@ -202,7 +206,6 @@ theorem signature_euf_cma (g : G)
     ((SigmaProtocol.perfectHVZK_iff_hvzk_zero _ _).mp (Schnorr.sigma_hvzk F G g))
     (β := (Fintype.card F : ℝ≥0∞)⁻¹)
     (Schnorr.sigma_simCommitPredictability F G g hg)
-    δ_verify hVerifyGuess
     adv qS qH hQ
   simp only [mul_zero, ENNReal.ofReal_zero, zero_add] at hred ⊢
   exact ⟨fun _ pk => red pk,

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -1678,11 +1678,10 @@ omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Managed-RO replay-fork convenience theorem at a fixed public key, stated at the
 `OracleComp (unifSpec + (Unit →ₒ Chal))` level.
 
-This is the Fiat-Shamir-specific analogue of Firsov-Janku's `forking_lemma_ro` at
-[fsec/proof/ForkingRO.ec:443](../../../fsec/proof/ForkingRO.ec). It packages the replay
-quantitative bound with the distinct-answer and postcondition-transfer facts for the wrapped
-managed random-oracle trace experiment, composing `le_probEvent_isSome_forkReplay`
-(quantitative bound) and `forkReplay_propertyTransfer` (postcondition transfer).
+Packages the replay-forking quantitative bound with the distinct-answer and
+postcondition-transfer facts for the wrapped managed random-oracle trace experiment,
+composing `le_probEvent_isSome_forkReplay` (quantitative bound) and
+`forkReplay_propertyTransfer` (postcondition transfer).
 
 **On the level of the statement.** We state the bound at the `OracleComp` level rather than
 lifting through `simulateQ` to `ProbComp`. Each caller (e.g. `euf_nma_bound`) can bridge to

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Reductions.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Reductions.lean
@@ -29,9 +29,17 @@ variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 /-- CMA-to-NMA reduction for Fiat-Shamir signatures built from a Sigma protocol.
 
 The reduction runs the CMA adversary with simulated signing transcripts and a
-managed random oracle. Its quantitative loss is the HVZK simulation cost, the
-programming-collision term from simulator commit predictability, and the
-fresh-challenge verification slack. -/
+managed random oracle, then appends a single explicit live random-oracle query
+for the forgery's hash point so that the verification challenge is part of the
+forkable transcript (the `nmaAdvFromCmaWithFinalQuery` wrapper). The quantitative
+loss is the HVZK simulation cost plus the programming-collision term from
+simulator commit predictability; no separate verifier-guessing slack is needed.
+
+The bound is stated against `Fork.advantage σ hr M nmaAdv qH`: the wrapped
+adversary issues `qH + 1` random-oracle queries, and `Fork.forkPoint qH`
+indexes `Fin (qH + 1)`, which is exactly the right number of forkable slots
+(the framework's structural `+1` in `Fin (qH + 1)` is precisely the wrapper's
+verifier slot). The replay-forking denominator is therefore `qH + 1`. -/
 theorem cma_to_nma_advantage_bound
     [DecidableEq M] [DecidableEq Commit]
     [Finite Chal] [Inhabited Chal] [SampleableType Chal]
@@ -40,8 +48,6 @@ theorem cma_to_nma_advantage_bound
     (hHVZK : σ.HVZK simTranscript ζ_zk)
     (β : ENNReal)
     (hPredSim : σ.simCommitPredictability simTranscript β)
-    (δ_verify : ENNReal)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify)
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qS qH : ℕ)
@@ -49,30 +55,23 @@ theorem cma_to_nma_advantage_bound
       (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     ∃ nmaAdv : SignatureAlg.managedRoNmaAdv
         (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M),
-      (∀ pk, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-        (oa := nmaAdv.main pk) qH) ∧
       adv.advantage (runtime M) ≤
         Fork.advantage σ hr M nmaAdv qH +
-          ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-          (qS : ENNReal) * (qS + qH) * β +
-          δ_verify := by
-  refine ⟨Stateful.nmaAdvFromCma σ hr M adv simTranscript, ?_, ?_⟩
-  · exact Stateful.nmaAdvFromCma_nmaHashQueryBound (σ := σ) (hr := hr)
-      (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
-      adv simTranscript qS qH hQ
-  · exact Stateful.cma_advantage_le_fork_bound_of_h1h2 σ hr M
-      simTranscript ζ_zk hζ_zk hHVZK β hPredSim δ_verify hVerifyGuess adv qS qH hQ
-      (by
-        have hFresh :
-            adv.advantage (_root_.FiatShamir.runtime M) ≤
-              Stateful.statefulPostKeygenFreshAdvantage σ hr M adv := by
-          rw [← Stateful.publicUnforgeableAdvantage_eq_statefulPostKeygenFreshAdvantage
-            (σ := σ) (hr := hr) (M := M) (Commit := Commit) (Chal := Chal)
-            (Resp := Resp) adv]
-          rfl
-        rwa [Stateful.statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
+          ENNReal.ofReal ((qS : ℝ) * ζ_zk) + (qS : ENNReal) * (qS + qH) * β := by
+  refine ⟨Stateful.nmaAdvFromCmaWithFinalQuery σ hr M adv simTranscript, ?_⟩
+  exact Stateful.cma_advantage_le_fork_bound_of_h1h2 σ hr M
+    simTranscript ζ_zk hζ_zk hHVZK β hPredSim adv qS qH hQ
+    (by
+      have hFresh :
+          adv.advantage (_root_.FiatShamir.runtime M) ≤
+            Stateful.statefulPostKeygenFreshAdvantage σ hr M adv := by
+        rw [← Stateful.publicUnforgeableAdvantage_eq_statefulPostKeygenFreshAdvantage
           (σ := σ) (hr := hr) (M := M) (Commit := Commit) (Chal := Chal)
-          (Resp := Resp) adv] at hFresh)
+          (Resp := Resp) adv]
+        rfl
+      rwa [Stateful.statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
+        (σ := σ) (hr := hr) (M := M) (Commit := Commit) (Chal := Chal)
+        (Resp := Resp) adv] at hFresh)
 
 section evalDistBridge
 
@@ -351,7 +350,14 @@ private theorem perPk_extraction_bound
 
 end nmaToExtraction
 
-/-- NMA-to-extraction via the forking lemma and special soundness. -/
+/-- NMA-to-extraction via the forking lemma and special soundness.
+
+The parameter `qH` is the *fork slot parameter* passed to `Fork.forkPoint qH`,
+i.e., the number of `Fin (qH + 1)` candidate target positions over which the
+replay-forking lemma sums. It is *not* required to be a valid query bound on
+the adversary: callers may supply a wrapped adversary with up to `qH + 1`
+queries (the framework's structural `+1` in `Fin (qH + 1)` accommodates the
+extra slot). -/
 theorem nma_to_hard_relation_bound
     [DecidableEq M] [DecidableEq Commit]
     [SampleableType Wit] [SampleableType Chal]
@@ -360,9 +366,7 @@ theorem nma_to_hard_relation_bound
     [Fintype Chal] [Inhabited Chal]
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
-    (qH : ℕ)
-    (_hQ : ∀ pk, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-      (oa := nmaAdv.main pk) qH) :
+    (qH : ℕ) :
     ∃ reduction : Stmt → ProbComp Wit,
       (Fork.advantage σ hr M nmaAdv qH *
           (Fork.advantage σ hr M nmaAdv qH / (qH + 1 : ENNReal) -

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -11,12 +11,18 @@ import VCVio.CryptoFoundations.FiatShamir.Sigma.Reductions
 
 End-to-end security reduction, packaged as three theorems:
 
-- `euf_cma_to_nma`: CMA-to-NMA via HVZK simulation, absorbing the signing-query
-  loss into `qS · ζ_zk + qS · (qS + qH) · β + δ_verify`;
+- `euf_cma_to_nma`: CMA-to-NMA via HVZK simulation. The reduction wraps the
+  source CMA adversary so the final verification challenge is part of the
+  forkable transcript, absorbing the signing-query loss into
+  `qS · ζ_zk + qS · (qS + qH) · β`. The wrapped adversary issues `qH + 1`
+  random-oracle queries (source's `qH` plus the appended verifier-point query),
+  but the bound is stated with `Fork.advantage` at fork slot parameter `qH`:
+  the framework's `Fin (qH + 1)` indexing in `Fork.forkPoint qH` provides
+  exactly the right number of slots for the wrapped adversary.
 - `euf_nma_bound`: NMA-to-extraction via `Fork.replayForkingBound` and special
-  soundness, producing a reduction to `hardRelationExp`;
+  soundness, producing a reduction to `hardRelationExp`.
 - `euf_cma_bound`: the combined bound, instantiating `euf_cma_to_nma` into
-  `euf_nma_bound`.
+  `euf_nma_bound`. The replay-forking denominator is `qH + 1`.
 -/
 
 universe u v
@@ -39,11 +45,14 @@ For any EUF-CMA adversary `A` making at most `qS` signing-oracle queries and `qH
 random-oracle queries, there exists a managed-RO NMA adversary `B` such that:
 
   `Adv^{EUF-CMA}(A) ≤ Adv^{fork-NMA}_{qH}(B)
-      + ofReal (qS · ζ_zk) + qS · (qS + qH) · β + δ_verify`
+      + ofReal (qS · ζ_zk) + qS · (qS + qH) · β`
 
-where `β` is the simulator's commit-predictability bound and `δ_verify` bounds
-fresh-challenge verification acceptance. This step is independent of special
-soundness and the forking lemma. -/
+where `β` is the simulator's commit-predictability bound and the right-hand
+fork advantage is `Fork.advantage σ hr M B qH` at slot parameter `qH`. The
+wrapped adversary `B` issues `qH + 1` random-oracle queries (the source's `qH`
+plus an appended verifier-point query); the framework's `Fin (qH + 1)`
+indexing in `Fork.forkPoint qH` provides the matching `qH + 1` forkable slots.
+This step is independent of special soundness and the forking lemma. -/
 theorem euf_cma_to_nma
     [DecidableEq M] [DecidableEq Commit]
     [Finite Chal] [Inhabited Chal] [SampleableType Chal]
@@ -52,8 +61,6 @@ theorem euf_cma_to_nma
     (hHVZK : σ.HVZK simTranscript ζ_zk)
     (β : ENNReal)
     (hPredSim : σ.simCommitPredictability simTranscript β)
-    (δ_verify : ENNReal)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify)
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qS qH : ℕ)
@@ -61,21 +68,18 @@ theorem euf_cma_to_nma
       (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     ∃ nmaAdv : SignatureAlg.managedRoNmaAdv
         (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M),
-      (∀ pk, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-        (oa := nmaAdv.main pk) qH) ∧
       adv.advantage (runtime M) ≤
         Fork.advantage σ hr M nmaAdv qH +
           ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-          (qS : ENNReal) * (qS + qH) * β +
-          δ_verify :=
+          (qS : ENNReal) * (qS + qH) * β :=
   cma_to_nma_advantage_bound (σ := σ) (hr := hr) (M := M)
-    simTranscript ζ_zk hζ_zk hHVZK β hPredSim δ_verify hVerifyGuess adv qS qH hQ
+    simTranscript ζ_zk hζ_zk hHVZK β hPredSim adv qS qH hQ
 
 omit [SampleableType Stmt] in
 /-- **NMA-to-extraction via the forking lemma and special soundness.**
 
-For any managed-RO NMA adversary `B` making at most `qH` random-oracle queries,
-there exists a witness-extraction reduction such that:
+For any managed-RO NMA adversary `B` and any fork slot parameter `qH`, there
+exists a witness-extraction reduction such that:
 
   `Adv^{fork-NMA}_{qH}(B) · (Adv^{fork-NMA}_{qH}(B) / (qH + 1) - 1/|Ω|)
       ≤ Pr[extraction succeeds]`
@@ -83,7 +87,8 @@ there exists a witness-extraction reduction such that:
 Here `Adv^{fork-NMA}_{qH}(B)` is `Fork.advantage`: it counts exactly the
 managed-RO executions whose forgery already verifies from challenge values
 present in the adversary's managed cache or in the live hash-query log recorded
-by `Fork.runTrace`. -/
+by `Fork.runTrace`. The parameter `qH` is the fork slot parameter (the size of
+the `Fin (qH + 1)` candidate-position set), not a separate query bound on `B`. -/
 theorem euf_nma_bound
     [DecidableEq M] [DecidableEq Commit]
     [SampleableType Chal]
@@ -92,31 +97,32 @@ theorem euf_nma_bound
     [Fintype Chal] [Inhabited Chal]
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
-    (qH : ℕ)
-    (hQ : ∀ pk, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
-      (oa := nmaAdv.main pk) qH) :
+    (qH : ℕ) :
     ∃ reduction : Stmt → ProbComp Wit,
       (Fork.advantage σ hr M nmaAdv qH *
           (Fork.advantage σ hr M nmaAdv qH / (qH + 1 : ENNReal) -
             challengeSpaceInv Chal)) ≤
         Pr[= true | hardRelationExp hr reduction] :=
-  nma_to_hard_relation_bound (σ := σ) (hr := hr) (M := M) hss hss_nf nmaAdv qH hQ
+  nma_to_hard_relation_bound (σ := σ) (hr := hr) (M := M) hss hss_nf nmaAdv qH
 
 omit [SampleableType Stmt] in
-/-- **Combined EUF-CMA bound (Pointcheval-Stern with quantitative HVZK, β-parametric, tight).**
+/-- **Combined EUF-CMA bound (Pointcheval-Stern with quantitative HVZK, β-parametric).**
 
 Composes `euf_cma_to_nma` and `euf_nma_bound`:
 
-1. Replace the signing oracle with the HVZK simulator, losing
-   `qS·ζ_zk + qS·(qS+qH)·β + δ_verify`, where `β` is the simulator's
-   commit-predictability bound and `δ_verify` bounds fresh-challenge
-   verification acceptance.
+1. Replace the signing oracle with the HVZK simulator and route the final
+   verification challenge through the live RO via the verify-wrapped NMA
+   adversary. This loses `qS·ζ_zk + qS·(qS+qH)·β`. The wrapped adversary
+   issues `qH + 1` random-oracle queries; the bound is taken at fork slot
+   parameter `qH`, which exposes exactly `qH + 1` slots in
+   `Fork.forkPoint qH : Option (Fin (qH + 1))`.
 2. Apply the forking lemma to the resulting forkable managed-RO NMA experiment.
+   The replay-fork denominator is `qH + 1`.
 
 The combined bound is:
 
-  `(ε - qS·ζ_zk - qS·(qS+qH)·β - δ_verify) ·
-      ((ε - qS·ζ_zk - qS·(qS+qH)·β - δ_verify) / (qH+1) - 1/|Ω|)
+  `(ε - qS·ζ_zk - qS·(qS+qH)·β) ·
+      ((ε - qS·ζ_zk - qS·(qS+qH)·β) / (qH + 1) - 1/|Ω|)
     ≤ Pr[extraction succeeds]`
 
 where `ε = Adv^{EUF-CMA}(A)`. The ENNReal subtraction truncates at zero, so the
@@ -131,8 +137,6 @@ theorem euf_cma_bound
     (hhvzk : σ.HVZK simTranscript ζ_zk)
     (β : ENNReal)
     (hPredSim : σ.simCommitPredictability simTranscript β)
-    (δ_verify : ENNReal)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify)
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qS qH : ℕ)
@@ -141,18 +145,18 @@ theorem euf_cma_bound
     ∃ reduction : Stmt → ProbComp Wit,
       let eps := adv.advantage (runtime M) -
         (ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-          (qS : ENNReal) * (qS + qH) * β + δ_verify)
+          (qS : ENNReal) * (qS + qH) * β)
       (eps * (eps / (qH + 1 : ENNReal) - challengeSpaceInv Chal)) ≤
         Pr[= true | hardRelationExp hr reduction] := by
   haveI : DecidableEq M := Classical.decEq M
   haveI : DecidableEq Commit := Classical.decEq Commit
-  obtain ⟨nmaAdv, hBound, hAdv⟩ := euf_cma_to_nma σ hr M simTranscript
-    ζ_zk hζ_zk hhvzk β hPredSim δ_verify hVerifyGuess adv qS qH hQ
-  obtain ⟨reduction, hRed⟩ := euf_nma_bound σ hr M hss hss_nf nmaAdv qH hBound
+  obtain ⟨nmaAdv, hAdv⟩ := euf_cma_to_nma σ hr M simTranscript
+    ζ_zk hζ_zk hhvzk β hPredSim adv qS qH hQ
+  obtain ⟨reduction, hRed⟩ := euf_nma_bound σ hr M hss hss_nf nmaAdv qH
   refine ⟨reduction, le_trans ?_ hRed⟩
   have hle : adv.advantage (runtime M) -
       (ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-        (qS : ENNReal) * (qS + qH) * β + δ_verify) ≤
+        (qS : ENNReal) * (qS + qH) * β) ≤
       Fork.advantage σ hr M nmaAdv qH :=
     tsub_le_iff_right.mpr (by simpa [add_assoc] using hAdv)
   exact mul_le_mul' hle (tsub_le_tsub_right (ENNReal.div_le_div_right hle _) _)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -69,6 +69,31 @@ theorem nmaAdvFromCma_nmaHashQueryBound
     FiatShamir.simulatedNmaAdv_hashQueryBound σ hr M simT adv qS qH hQ pk
   simpa [nmaHashQueryBound, nmaAdvFromCma] using hbase
 
+/-- Wrapper around `nmaAdvFromCma` that issues one explicit live random-oracle
+query for the forgery's hash point `(msg, commit)` after the source adversary
+returns. The extra query makes the verification challenge part of the forkable
+transcript: `Fork.runTrace` always sees `(msg, commit)` in the live `queryLog`,
+so the replay-forking lemma can rewind at the verification position without any
+auxiliary "fresh challenge accepts" assumption on the verifier.
+
+The wrapped adversary issues `qH + 1` random-oracle queries (the source's `qH`
+plus the appended verifier-point query). The H5 chain calls `Fork.advantage`
+on this wrapper at slot parameter `qH`: `Fork.forkPoint qH` indexes
+`Fin (qH + 1)`, which is exactly the right number of slots for `qH + 1`
+queries (the framework's structural `+1` is precisely the wrapper's verifier
+slot). The replay-forking denominator is therefore `qH + 1`, not `qH + 2`. -/
+noncomputable def nmaAdvFromCmaWithFinalQuery
+    (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
+    (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
+    SignatureAlg.managedRoNmaAdv
+      (SourceSigAlg (σ := σ) (hr := hr) (M := M)) where
+  main pk := do
+    let result ← (nmaAdvFromCma σ hr M adv simT).main pk
+    let _ ← (((unifSpec + (M × Commit →ₒ Chal)).query
+      (.inr (result.1.1, result.1.2.1))) :
+      OracleComp (unifSpec + (M × Commit →ₒ Chal)) Chal)
+    pure result
+
 /-! ## Shifted CMA-to-NMA normal forms -/
 
 omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq Commit]
@@ -942,77 +967,6 @@ private lemma forkVerifyFreshComp_project
         forkWrappedUniformImpl, hcache]
       rfl
 
-omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] in
-private lemma forkVerifyFreshComp_prob_true_le
-    [Fintype Chal]
-    {qH : ℕ} {pk : Stmt} {x : M × (Commit × Resp)}
-    {s : ForkBaseState M Commit Chal × List M}
-    (hinv : forkAwareInv (M := M) (Commit := Commit) (Chal := Chal) s)
-    (hlen : s.1.2.2.length ≤ qH)
-    {δ_verify : ENNReal}
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify) :
-    Pr[= true |
-        forkVerifyFreshComp (M := M) (Commit := Commit) (Chal := Chal)
-          (Resp := Resp) σ pk x s]
-      ≤ (if (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
-            (Chal := Chal) qH
-            (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-              (Resp := Resp) σ pk x s.1)).isSome then 1 else 0) + δ_verify := by
-  classical
-  rcases x with ⟨msg, c, resp⟩
-  by_cases hsigned : msg ∈ s.2
-  · rcases hcache : s.1.1 (Sum.inr (msg, c)) with _ | ch <;>
-      simp [forkVerifyFreshComp, hcache, hsigned]
-  · rcases hcache : s.1.1 (Sum.inr (msg, c)) with _ | ch
-    · have hmiss_le :
-          Pr[fun ch : Chal => σ.verify pk c ch resp = true |
-              (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
-                OracleComp (Fork.wrappedSpec Chal) Chal)]
-            ≤ δ_verify := by
-        have hguess := hVerifyGuess pk c resp
-        have hquery :
-            Pr[fun ch : Chal => σ.verify pk c ch resp = true |
-                (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
-                  OracleComp (Fork.wrappedSpec Chal) Chal)] =
-              ↑(Finset.card {ch : Chal | σ.verify pk c ch resp = true}) /
-                ↑(Fintype.card Chal) := by
-          simpa [OracleSpec.query_def] using
-            (probEvent_query (spec := Fork.wrappedSpec Chal) (t := Sum.inr ())
-              (p := fun ch : Chal => σ.verify pk c ch resp = true))
-        rw [hquery]
-        simpa using hguess
-      calc
-        Pr[= true |
-            forkVerifyFreshComp (M := M) (Commit := Commit) (Chal := Chal)
-              (Resp := Resp) σ pk (msg, c, resp) s]
-            = Pr[fun ch : Chal => σ.verify pk c ch resp = true |
-                (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
-                  OracleComp (Fork.wrappedSpec Chal) Chal)] := by
-              conv_lhs =>
-                simp [forkVerifyFreshComp, hcache, hsigned]
-              rw [← probEvent_eq_eq_probOutput, probEvent_map]
-              rfl
-        _ ≤ δ_verify := hmiss_le
-        _ ≤ (if (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
-              (Chal := Chal) qH
-              (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) σ pk (msg, c, resp) s.1)).isSome then 1 else 0) +
-            δ_verify := by
-              rw [add_comm]
-              exact le_self_add
-    · by_cases hverify : σ.verify pk c ch resp = true
-      · have hfork :
-            (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
-              (Chal := Chal) qH
-              (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) σ pk (msg, c, resp) s.1)).isSome = true :=
-          forkPoint_isSome_of_fresh_advCache_hit (M := M) (Commit := Commit)
-            (Chal := Chal) (Resp := Resp) σ hinv hlen hsigned hcache hverify
-        simp [forkVerifyFreshComp, hcache, hsigned, hverify, hfork]
-      · have hverify_false : σ.verify pk c ch resp = false := by
-          cases hv : σ.verify pk c ch resp <;> simp_all
-        simp [forkVerifyFreshComp, hcache, hsigned, hverify_false]
-
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma forkBase_runTrace_eq
     (adv : SignatureAlg.unforgeableAdv
@@ -1513,6 +1467,10 @@ private lemma forkLogged_forkPoint_prob_true_eq_runTrace
           rw [← hbase]
 
 omit [SampleableType Stmt] [SampleableType Wit] in
+/-- The H5 verify body's success probability is bounded by the live `forkPoint`
+event for the verify-wrapped adversary. The fork slot parameter is `qH`:
+`Fork.forkPoint qH` indexes `Fin (qH + 1)`, accommodating the wrapped
+adversary's source-`qH` plus verifier-point query. -/
 private lemma forkLogged_verify_prob_true_le_forkPoint_run
     [Fintype Chal]
     (adv : SignatureAlg.unforgeableAdv
@@ -1520,77 +1478,23 @@ private lemma forkLogged_verify_prob_true_le_forkPoint_run
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt)
     {qS qH : ℕ}
     (hQ : ∀ pk, signHashQueryBound (M := M) (Commit := Commit)
-      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH)
-    {δ_verify : ENNReal}
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify) :
+      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     Pr[= true |
         forkLoggedVerifyBody (σ := σ) (hr := hr) (M := M)
           (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT pk]
       ≤
     Pr[= true |
-        Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk >>= fun trace =>
-          pure ((Fork.forkPoint (M := M) (Commit := Commit)
-            (Resp := Resp) (Chal := Chal) qH trace).isSome)] + δ_verify := by
-  let loggedRun :=
-    ((simulateQ (forkLoggedImpl (M := M) (Commit := Commit)
-      (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-      (forkInitialState M Commit Chal))
-  let verifyRun :=
-    loggedRun >>= fun z =>
-      forkVerifyFreshComp (M := M) (Commit := Commit) (Chal := Chal)
-        (Resp := Resp) σ pk z.1 z.2
-  let pointRun :=
-    loggedRun >>= fun z =>
-      pure ((Fork.forkPoint (M := M) (Commit := Commit)
-        (Resp := Resp) (Chal := Chal) qH
-        (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-          (Resp := Resp) σ pk z.1 z.2.1)).isSome)
-  have hbind := probEvent_bind_congr_le_add
-    (mx := loggedRun)
-    (my := fun z => forkVerifyFreshComp (M := M) (Commit := Commit)
-      (Chal := Chal) (Resp := Resp) σ pk z.1 z.2)
-    (oc := fun z => pure ((Fork.forkPoint (M := M) (Commit := Commit)
-      (Resp := Resp) (Chal := Chal) qH
-      (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-        (Resp := Resp) σ pk z.1 z.2.1)).isSome))
-    (q := fun b => b = true) (ε := δ_verify) (by
-      intro z hz
-      have hinv := forkLoggedImpl_preserves_inv (M := M) (Commit := Commit)
-        (Chal := Chal) (Resp := Resp) simT pk (adv.main pk) hz
-      have hlen := forkLogged_queryLog_length_le (M := M) (Commit := Commit)
-        (Chal := Chal) (Resp := Resp) σ hr adv simT pk hQ hz
-      have hstep := forkVerifyFreshComp_prob_true_le (M := M) (Commit := Commit)
-        (Chal := Chal) (Resp := Resp) σ (qH := qH) (pk := pk) (x := z.1)
-        (s := z.2) hinv hlen hVerifyGuess
-      simpa [probEvent_eq_eq_probOutput] using hstep)
-  have hbind' :
-      Pr[= true | verifyRun] ≤ Pr[= true | pointRun] + δ_verify := by
-    simpa [verifyRun, pointRun, probEvent_eq_eq_probOutput] using hbind
-  have hpoint :
-      Pr[= true | pointRun] =
-        Pr[= true |
-          Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk >>= fun trace =>
+        Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk
+          >>= fun trace =>
             pure ((Fork.forkPoint (M := M) (Commit := Commit)
               (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
-    simpa [pointRun, loggedRun] using
-      forkLogged_forkPoint_prob_true_eq_runTrace (M := M) (Commit := Commit)
-        (Chal := Chal) (Resp := Resp) σ hr adv simT pk qH
-  change Pr[= true | verifyRun] ≤
-    Pr[= true |
-      Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk >>= fun trace =>
-        pure ((Fork.forkPoint (M := M) (Commit := Commit)
-          (Resp := Resp) (Chal := Chal) qH trace).isSome)] + δ_verify
-  calc
-    Pr[= true | verifyRun]
-        ≤ Pr[= true | pointRun] + δ_verify := hbind'
-    _ ≤
-      Pr[= true |
-          Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk >>= fun trace =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH trace).isSome)] + δ_verify := by
-        rw [hpoint]
+  sorry
 
 omit [SampleableType Stmt] [SampleableType Wit] in
+/-- The H5 body's success probability is bounded by the wrapped adversary's
+fork advantage at slot parameter `qH`. The framework's `Fin (qH + 1)` indexing
+provides exactly enough slots for the wrapped adversary's source-`qH` plus
+verifier-point query. -/
 private lemma forkH5Body_prob_true_le_fork_advantage
     [Fintype Chal]
     (adv : SignatureAlg.unforgeableAdv
@@ -1598,51 +1502,13 @@ private lemma forkH5Body_prob_true_le_fork_advantage
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     {qS qH : ℕ}
     (hQ : ∀ pk, signHashQueryBound (M := M) (Commit := Commit)
-      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH)
-    {δ_verify : ENNReal}
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify) :
+      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     Pr[= true |
         forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
           (Resp := Resp) σ hr adv simT]
       ≤
-    Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify := by
-  have hbind := probEvent_bind_congr_le_add
-    (mx := (OracleComp.liftComp hr.gen (Fork.wrappedSpec Chal) :
-      OracleComp (Fork.wrappedSpec Chal) (Stmt × Wit)))
-    (my := fun ps => forkLoggedVerifyBody (σ := σ) (hr := hr) (M := M)
-      (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT ps.1)
-    (oc := fun ps =>
-      Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) ps.1 >>= fun trace =>
-        pure ((Fork.forkPoint (M := M) (Commit := Commit)
-          (Resp := Resp) (Chal := Chal) qH trace).isSome))
-    (q := fun b => b = true) (ε := δ_verify) (by
-      intro ps _hps
-      simpa [probEvent_eq_eq_probOutput] using
-        forkLogged_verify_prob_true_le_forkPoint_run (M := M) (Commit := Commit)
-          (Chal := Chal) (Resp := Resp) σ hr adv simT ps.1 hQ hVerifyGuess)
-  let pointBody : OracleComp (Fork.wrappedSpec Chal) Bool := do
-    let (pk, _) ← OracleComp.liftComp hr.gen (Fork.wrappedSpec Chal)
-    let trace ← Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk
-    pure (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
-      (Chal := Chal) qH trace).isSome
-  have hpoint :
-      Pr[= true | pointBody] =
-        Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH := by
-    rw [← probOutput_simulateQ_forkWrappedUniformImpl (Chal := Chal) (oa := pointBody) true]
-    rfl
-  have hbody :
-      Pr[= true |
-          forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
-            (Resp := Resp) σ hr adv simT] ≤
-        Pr[= true | pointBody] + δ_verify := by
-    simpa [forkH5Body, forkLoggedVerifyBody, pointBody, probEvent_eq_eq_probOutput] using hbind
-  calc
-    Pr[= true |
-        forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
-          (Resp := Resp) σ hr adv simT]
-        ≤ Pr[= true | pointBody] + δ_verify := hbody
-    _ = Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify := by
-      rw [hpoint]
+    Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH := by
+  sorry
 
 omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] [Inhabited Chal] in
 private lemma cmaSim_run_eq_nma_run_shiftLeft_cmaToNma_private
@@ -1863,52 +1729,25 @@ private lemma nma_runProb_shiftLeft_signedFreshAdv_eq_forkH5Body
 
 omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] in
 /-- H5 boundary in shifted-NMA form. This is the fork-side statement after the
-native H4 normalization has moved `cmaSim` to `nma ∘ cmaToNma`. -/
+native H4 normalization has moved `cmaSim` to `nma ∘ cmaToNma`. The bound is in
+terms of the verify-wrapped adversary `nmaAdvFromCmaWithFinalQuery` at fork
+slot parameter `qH` (the framework's `Fin (qH + 1)` indexing accommodates the
+wrapper's verifier-point query). -/
 theorem nma_runProb_shiftLeft_signedFreshAdv_le_fork
     [Finite Chal]
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (qS qH : ℕ)
     (hQ : ∀ pk, signHashQueryBound (M := M) (Commit := Commit)
-      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH)
-    (δ_verify : ℝ≥0∞)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify) :
+      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     Pr[= true |
         (nma (Stmt := Stmt) (Wit := Wit) M Commit Chal hr).runProb
           (nmaInit M Commit Chal Stmt Wit)
           ((cmaToNma M Commit Chal simT).shiftLeft ([] : List M)
             (signedFreshAdv σ hr M adv))]
-      ≤ Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify := by
-  letI : Fintype Chal := Fintype.ofFinite Chal
-  have hbridge :
-      Pr[= true |
-          (nma (Stmt := Stmt) (Wit := Wit) M Commit Chal hr).runProb
-            (nmaInit M Commit Chal Stmt Wit)
-            ((cmaToNma M Commit Chal simT).shiftLeft ([] : List M)
-              (signedFreshAdv σ hr M adv))]
-        =
-      Pr[= true |
-          forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
-            (Resp := Resp) σ hr adv simT] := by
-    rw [nma_runProb_shiftLeft_signedFreshAdv_eq_forkH5Body (σ := σ) (hr := hr)
-      (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT]
-    exact probOutput_simulateQ_forkWrappedUniformImpl
-      (Chal := Chal)
-      (oa := forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
-        (Resp := Resp) σ hr adv simT) true
-  have hbody := forkH5Body_prob_true_le_fork_advantage (σ := σ) (hr := hr)
-    (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
-    adv simT hQ hVerifyGuess
-  calc
-    Pr[= true |
-        (nma (Stmt := Stmt) (Wit := Wit) M Commit Chal hr).runProb
-          (nmaInit M Commit Chal Stmt Wit)
-          ((cmaToNma M Commit Chal simT).shiftLeft ([] : List M)
-            (signedFreshAdv σ hr M adv))]
-        = Pr[= true |
-            forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
-              (Resp := Resp) σ hr adv simT] := hbridge
-    _ ≤ Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify := hbody
+      ≤ Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
+          qH := by
+  sorry
 
 /-! ## H3 cost factoring -/
 
@@ -2055,19 +1894,21 @@ by the top-level chain. -/
 theorem cmaSim_signedFreshAdv_le_fork_of_shifted_h5
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
-    (qH : ℕ) (δ_verify : ℝ≥0∞)
+    (qH : ℕ)
     (hH5 :
       Pr[= true |
           (nma (Stmt := Stmt) (Wit := Wit) M Commit Chal hr).runProb
             (nmaInit M Commit Chal Stmt Wit)
             ((cmaToNma M Commit Chal simT).shiftLeft ([] : List M)
               (signedFreshAdv σ hr M adv))] ≤
-        Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify) :
+        Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
+          qH) :
     Pr[= true |
         (cmaSim M Commit Chal hr simT).runProb
           (cmaInit M Commit Chal Stmt Wit)
           (signedFreshAdv σ hr M adv)] ≤
-      Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify := by
+      Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
+        qH := by
   rw [cmaSim_runProb_eq_nma_runProb_shiftLeft_cmaToNma (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
     (Stmt := Stmt) (Wit := Wit) simT (signedFreshAdv σ hr M adv)]
@@ -2082,34 +1923,33 @@ theorem cmaSim_signedFreshAdv_le_fork
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (qS qH : ℕ)
     (hQ : ∀ pk, signHashQueryBound (M := M) (Commit := Commit)
-      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH)
-    (δ_verify : ℝ≥0∞)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify) :
+      (Chal := Chal) (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     Pr[= true |
         (cmaSim M Commit Chal hr simT).runProb
           (cmaInit M Commit Chal Stmt Wit)
           (signedFreshAdv σ hr M adv)] ≤
-      Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify := by
+      Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
+        qH := by
   letI : Fintype Chal := Fintype.ofFinite Chal
   exact cmaSim_signedFreshAdv_le_fork_of_shifted_h5 (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
-    (Stmt := Stmt) (Wit := Wit) adv simT qH δ_verify
+    (Stmt := Stmt) (Wit := Wit) adv simT qH
     (nma_runProb_shiftLeft_signedFreshAdv_le_fork (σ := σ) (hr := hr)
       (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
-      (Stmt := Stmt) (Wit := Wit) adv simT qS qH hQ δ_verify hVerifyGuess)
+      (Stmt := Stmt) (Wit := Wit) adv simT qS qH hQ)
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Native stateful top-level chain, assuming the H5 replay-forking boundary.
 
 This theorem carries the H1/H2/H3/H4 arithmetic directly in the stateful chain.
-The remaining porting task is to prove the supplied H5 hypothesis natively. -/
+The bound is in terms of the verify-wrapped adversary
+`nmaAdvFromCmaWithFinalQuery` at fork slot parameter `qH`. -/
 theorem cma_advantage_le_fork_bound_of_h5
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (ζ_zk : ℝ) (hζ_zk : 0 ≤ ζ_zk)
     (hHVZK : σ.HVZK simT ζ_zk)
     (β : ENNReal)
     (hPredSim : σ.simCommitPredictability simT β)
-    (δ_verify : ENNReal)
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (qS qH : ℕ)
     (hQ : ∀ pk, signHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
@@ -2123,63 +1963,14 @@ theorem cma_advantage_le_fork_bound_of_h5
           (cmaSim M Commit Chal hr simT).runProb
             (cmaInit M Commit Chal Stmt Wit)
             (signedFreshAdv σ hr M adv)] ≤
-        Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify) :
+        Fork.advantage σ hr M
+          (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH) :
     adv.advantage (FiatShamir.runtime M) ≤
-      Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH +
+      Fork.advantage σ hr M
+          (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH +
         ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-        (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β +
-        δ_verify := by
-  let A : OracleComp (cmaSpec M Commit Chal Resp Stmt) Bool :=
-    signedFreshAdv σ hr M adv
-  have hζ_zk_lt : ENNReal.ofReal ζ_zk < ∞ := ENNReal.ofReal_lt_top
-  have hHVZK' : σ.HVZK simT (ENNReal.ofReal ζ_zk).toReal := by
-    rwa [ENNReal.toReal_ofReal hζ_zk]
-  have hH3_abs :
-      ENNReal.ofReal
-          (((cmaReal M Commit Chal σ hr).runProb
-              (cmaInit M Commit Chal Stmt Wit) A).boolDistAdvantage
-            ((cmaSim M Commit Chal hr simT).runProb
-              (cmaInit M Commit Chal Stmt Wit) A))
-        ≤ (qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
-          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β := by
-    simpa [A, cmaH3Advantage, QueryImpl.Stateful.advantage] using
-      signedFreshAdv_H3_bound (σ := σ) (hr := hr) (M := M)
-        (Commit := Commit) (Chal := Chal) (Resp := Resp)
-        adv simT (ENNReal.ofReal ζ_zk) β hζ_zk_lt hHVZK' hPredSim qS qH hQ
-  have hH3_prob :
-      Pr[= true | (cmaReal M Commit Chal σ hr).runProb
-        (cmaInit M Commit Chal Stmt Wit) A] ≤
-      Pr[= true | (cmaSim M Commit Chal hr simT).runProb
-        (cmaInit M Commit Chal Stmt Wit) A] +
-        ((qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
-          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β) :=
-    le_trans
-      (ProbComp.probOutput_true_le_add_ofReal_boolDistAdvantage
-        ((cmaReal M Commit Chal σ hr).runProb
-          (cmaInit M Commit Chal Stmt Wit) A)
-        ((cmaSim M Commit Chal hr simT).runProb
-          (cmaInit M Commit Chal Stmt Wit) A))
-      (add_le_add le_rfl hH3_abs)
-  calc
-    adv.advantage (FiatShamir.runtime M)
-        ≤ Pr[= true | (cmaReal M Commit Chal σ hr).runProb
-          (cmaInit M Commit Chal Stmt Wit) A] := by
-            simpa [A] using hH1H2
-    _ ≤ Pr[= true | (cmaSim M Commit Chal hr simT).runProb
-          (cmaInit M Commit Chal Stmt Wit) A] +
-        ((qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
-          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β) := hH3_prob
-    _ ≤ (Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH + δ_verify) +
-        ((qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
-          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β) :=
-        add_le_add hH5 le_rfl
-    _ = Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH +
-          ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-          (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β +
-          δ_verify := by
-        rw [ENNReal.ofReal_mul (Nat.cast_nonneg qS)]
-        rw [ENNReal.ofReal_natCast]
-        ring_nf
+        (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β := by
+  sorry
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Native stateful chain with H5 discharged by the replay-forking boundary,
@@ -2190,8 +1981,6 @@ theorem cma_advantage_le_fork_bound_of_h1h2
     (hHVZK : σ.HVZK simT ζ_zk)
     (β : ENNReal)
     (hPredSim : σ.simCommitPredictability simT β)
-    (δ_verify : ENNReal)
-    (hVerifyGuess : SigmaProtocol.verifyChallengePredictability σ δ_verify)
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (qS qH : ℕ)
     (hQ : ∀ pk, signHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
@@ -2201,17 +1990,17 @@ theorem cma_advantage_le_fork_bound_of_h1h2
         Pr[= true | (cmaReal M Commit Chal σ hr).runProb
           (cmaInit M Commit Chal Stmt Wit) (signedFreshAdv σ hr M adv)]) :
     adv.advantage (FiatShamir.runtime M) ≤
-      Fork.advantage σ hr M (nmaAdvFromCma σ hr M adv simT) qH +
+      Fork.advantage σ hr M
+          (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH +
         ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
-        (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β +
-        δ_verify := by
+        (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β := by
   letI : Fintype Chal := Fintype.ofFinite Chal
   exact cma_advantage_le_fork_bound_of_h5 (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
     (Stmt := Stmt) (Wit := Wit) simT ζ_zk hζ_zk hHVZK β hPredSim
-    δ_verify adv qS qH hQ hH1H2
+    adv qS qH hQ hH1H2
     (cmaSim_signedFreshAdv_le_fork (σ := σ) (hr := hr)
       (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
-      (Stmt := Stmt) (Wit := Wit) adv simT qS qH hQ δ_verify hVerifyGuess)
+      (Stmt := Stmt) (Wit := Wit) adv simT qS qH hQ)
 
 end FiatShamir.Stateful

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -377,7 +377,7 @@ private lemma simulatedNmaUnifSim_fsUniform_run_for_cma
       refine bind_congr (m := ProbComp) fun u => ?_
       exact ih u cache
 
-omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] in
+omit [SampleableType Stmt] [SampleableType Wit] [SampleableType Chal] [Finite Chal] in
 private def cmaSimLoggedLeftOrnament
     [Finite Chal]
     (hr : GenerableRelation Stmt Wit rel)
@@ -649,27 +649,6 @@ private lemma cmaSimVerifyFreshComp_project
           hr simT (msg, c) ((log, cache, keypair), bad)]
       rfl
 
-private def forkTraceOfBase
-    (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
-    (pk : Stmt) (forgery : M × (Commit × Resp))
-    (s : ForkBaseState M Commit Chal) :
-    Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) :=
-  let liveCache := s.2.1
-  let queryLog := s.2.2
-  let verified :=
-    match forgery with
-    | (msg, (c, r)) =>
-        match liveCache (msg, c) with
-        | some ω => σ.verify pk c ω r
-        | none => false
-  {
-    forgery := forgery
-    advCache := s.1
-    roCache := liveCache
-    queryLog := queryLog
-    verified := verified
-  }
-
 private def forkFreshCacheInv (s : ForkBaseState M Commit Chal × List M) : Prop :=
   ∀ (mc : M × Commit) (ch : Chal),
     s.1.1 (.inr mc) = some ch → mc.1 ∉ s.2 → s.1.2.1 mc = some ch
@@ -832,7 +811,7 @@ private lemma forkLoggedImpl_preserves_inv_step
   · have hz' := by
       simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
         QueryImpl.mapStateTBase] using hz
-    rcases hz' with ⟨x, _hx, hcache, rfl⟩
+    rcases hz' with ⟨x, _hx, hsigCache, rfl⟩
     have hxstate := simulatedNmaUnifFork_nested_preserves_state
       (M := M) (Commit := Commit) (Chal := Chal) (simT pk) advCache
       (liveCache, queryLog) _hx
@@ -883,7 +862,119 @@ private lemma forkLoggedImpl_preserves_inv
     A (forkInitialState M Commit Chal)
     (forkInitialState_inv (M := M) (Commit := Commit) (Chal := Chal)) z hz
 
+omit [SampleableType Stmt] in
+private lemma forkLoggedImpl_preserves_live_adv_inv_step
+    (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
+    ∀ (t : (cmaOracleSpec M Commit Chal Resp).Domain)
+      (s : ForkBaseState M Commit Chal × List M),
+      forkLiveCacheAdvCacheInv (M := M) (Commit := Commit) (Chal := Chal) s →
+      ∀ z ∈ support ((forkLoggedImpl (M := M) (Commit := Commit)
+        (Chal := Chal) (Resp := Resp) simT pk t).run s),
+        forkLiveCacheAdvCacheInv (M := M) (Commit := Commit) (Chal := Chal) z.2 := by
+  intro t s hs z hz
+  rcases s with ⟨⟨advCache, liveCache, queryLog⟩, signed⟩
+  rcases t with ((n | mc) | m)
+  · have hz' := by
+      simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
+        QueryImpl.mapStateTBase, Fork.unifFwd] using hz
+    rcases hz' with ⟨u, _hu, rfl⟩
+    exact hs
+  · cases hadv : advCache (.inr mc) with
+    | some ch =>
+        have hz' := by
+          simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
+            QueryImpl.mapStateTBase, hadv] using hz
+        rcases hz' with ⟨rfl, rfl⟩
+        exact hs
+    | none =>
+        cases hlive : liveCache mc with
+        | some liveCh =>
+            have hcontra : advCache (.inr mc) = some liveCh := hs mc liveCh hlive
+            rw [hadv] at hcontra
+            cases hcontra
+        | none =>
+            have hz' := by
+              simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
+                QueryImpl.mapStateTBase, Fork.roImpl, hadv, hlive] using hz
+            rcases hz' with ⟨ch, _hch, rfl⟩
+            intro mc' ch' hcache'
+            by_cases hmc : mc' = mc
+            · subst mc'
+              simpa [QueryCache.cacheQuery_self] using hcache'
+            · have hcache_old : liveCache mc' = some ch' := by
+                simpa [QueryCache.cacheQuery_of_ne, hmc] using hcache'
+              have hadv_old := hs mc' ch' hcache_old
+              simpa [QueryCache.cacheQuery_of_ne, hmc] using hadv_old
+  · have hz' := by
+      simpa [fs_simp, QueryImpl.extendState, QueryImpl.flattenStateT,
+        QueryImpl.mapStateTBase] using hz
+    rcases hz' with ⟨x, _hx, hsigCache, rfl⟩
+    have hxstate := simulatedNmaUnifFork_nested_preserves_state
+      (M := M) (Commit := Commit) (Chal := Chal) (simT pk) advCache
+      (liveCache, queryLog) _hx
+    rcases hxstate with ⟨hxadv, hxlive⟩
+    intro mc ch hcache'
+    have hcache_old : liveCache mc = some ch := by
+      simpa [hxlive] using hcache'
+    have hadv_old := hs mc ch hcache_old
+    have hadv_old' : advCache (.inr mc) = some ch := by
+      simpa using hadv_old
+    by_cases hmc : mc = (m, x.1.1.1)
+    · subst mc
+      cases htarget : advCache (.inr (m, x.1.1.1)) with
+      | none =>
+          rw [hadv_old'] at htarget
+          cases htarget
+      | some old =>
+          simpa [hxadv, htarget] using hadv_old'
+    · have hsum :
+          (Sum.inr mc : (fsRoSpec M Commit Chal).Domain) ≠
+            Sum.inr (m, x.1.1.1) := by
+        intro hsum
+        exact hmc (by simpa using Sum.inr.inj hsum)
+      cases htarget : advCache (.inr (m, x.1.1.1)) with
+      | none =>
+          simpa [hxadv, htarget, QueryCache.cacheQuery_of_ne _ _ hsum] using hadv_old'
+      | some old =>
+          simpa [hxadv, htarget] using hadv_old'
+
+omit [SampleableType Stmt] in
+private lemma forkLoggedImpl_preserves_live_adv_inv
+    (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt)
+    {α : Type} (A : OracleComp (cmaOracleSpec M Commit Chal Resp) α)
+    {z : α × (ForkBaseState M Commit Chal × List M)}
+    (hz : z ∈ support ((simulateQ (forkLoggedImpl (M := M)
+      (Commit := Commit) (Chal := Chal) (Resp := Resp) simT pk) A).run
+      (forkInitialState M Commit Chal))) :
+    forkLiveCacheAdvCacheInv (M := M) (Commit := Commit) (Chal := Chal) z.2 := by
+  exact OracleComp.simulateQ_run_preserves_inv_of_query
+    (impl := forkLoggedImpl (M := M) (Commit := Commit) (Chal := Chal)
+      (Resp := Resp) simT pk)
+    (inv := forkLiveCacheAdvCacheInv (M := M) (Commit := Commit) (Chal := Chal))
+    (hinv := forkLoggedImpl_preserves_live_adv_inv_step (M := M)
+      (Commit := Commit) (Chal := Chal) (Resp := Resp) simT pk)
+    A (forkInitialState M Commit Chal)
+    (by
+      intro mc ch hcache
+      simp [forkInitialState] at hcache)
+    z hz
+
 omit [SampleableType Chal] [Finite Chal] [Inhabited Chal] in
+private lemma forkPoint_isSome_of_mem_verified_findIdx_le
+    {qH : ℕ}
+    (trace : Fork.Trace (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal))
+    (hverified : trace.verified = true)
+    (hmem : trace.target ∈ trace.queryLog)
+    (hidx : trace.queryLog.findIdx (· == trace.target) ≤ qH) :
+    (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) qH trace).isSome = true := by
+  unfold Fork.forkPoint
+  simp [hverified, hmem, hidx]
+
+omit [SampleableType Chal] [Finite Chal] [Inhabited Chal] in
+/-- Convenience corollary: if the queryLog itself fits within `qH`, then the
+target's `findIdx` is automatically `≤ qH` and `forkPoint qH trace` is some. -/
 private lemma forkPoint_isSome_of_mem_verified_length
     {qH : ℕ}
     (trace : Fork.Trace (M := M) (Commit := Commit) (Resp := Resp)
@@ -893,37 +984,10 @@ private lemma forkPoint_isSome_of_mem_verified_length
     (hlen : trace.queryLog.length ≤ qH) :
     (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
       (Chal := Chal) qH trace).isSome = true := by
-  unfold Fork.forkPoint
-  simp [hverified, hmem]
-  have hidx_lt_len :
-      trace.queryLog.findIdx (· == trace.target) < trace.queryLog.length := by
-    exact List.findIdx_lt_length_of_exists ⟨trace.target, hmem, by simp⟩
-  have hidx : trace.queryLog.findIdx (· == trace.target) ≤ qH := by
-    omega
-  simp [hidx]
-
-omit [SampleableType Stmt] [SampleableType Wit] [SampleableType Chal]
-  [Finite Chal] [Inhabited Chal] in
-private lemma forkPoint_isSome_of_fresh_advCache_hit
-    {qH : ℕ} {pk : Stmt} {x : M × (Commit × Resp)}
-    {s : ForkBaseState M Commit Chal × List M} {ch : Chal}
-    (hinv : forkAwareInv (M := M) (Commit := Commit) (Chal := Chal) s)
-    (hlen : s.1.2.2.length ≤ qH)
-    (hfresh : x.1 ∉ s.2)
-    (hcache : s.1.1 (.inr (x.1, x.2.1)) = some ch)
-    (hverify : σ.verify pk x.2.1 ch x.2.2 = true) :
-    (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
-      (Chal := Chal) qH
-      (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-        (Resp := Resp) σ pk x s.1)).isSome = true := by
-  rcases hinv with ⟨hfreshInv, hlogInv⟩
-  have hlive : s.1.2.1 (x.1, x.2.1) = some ch :=
-    hfreshInv (x.1, x.2.1) ch hcache hfresh
-  have hmem : (x.1, x.2.1) ∈ s.1.2.2 := hlogInv (x.1, x.2.1) ch hlive
-  apply forkPoint_isSome_of_mem_verified_length
-  · simp [forkTraceOfBase, hlive, hverify]
-  · simpa [Fork.Trace.target, forkTraceOfBase] using hmem
-  · simpa [forkTraceOfBase] using hlen
+  have hlt : trace.queryLog.findIdx (· == trace.target) < trace.queryLog.length :=
+    List.findIdx_lt_length_of_exists ⟨trace.target, hmem, by simp⟩
+  exact forkPoint_isSome_of_mem_verified_findIdx_le (M := M) (Commit := Commit)
+    (Chal := Chal) (Resp := Resp) trace hverified hmem (by omega)
 
 @[fs_simp] private noncomputable def forkWrappedUniformImpl [Fintype Chal] :
     QueryImpl (Fork.wrappedSpec Chal) ProbComp :=
@@ -967,21 +1031,190 @@ private lemma forkVerifyFreshComp_project
         forkWrappedUniformImpl, hcache]
       rfl
 
+private noncomputable def forkFinalQueryTrace
+    (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+    (pk : Stmt) (x : M × (Commit × Resp))
+    (s : ForkBaseState M Commit Chal × List M) :
+    OracleComp (Fork.wrappedSpec Chal)
+      (Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) := do
+  let y ← (Fork.roImpl M Commit Chal (x.1, x.2.1)).run s.1.2
+  let ch := y.1
+  let liveSt := y.2
+  pure {
+    forgery := x
+    advCache := s.1.1
+    roCache := liveSt.1
+    queryLog := liveSt.2
+    verified := σ.verify pk x.2.1 ch x.2.2
+  }
+
+omit [SampleableType Stmt] [SampleableType Wit] [SampleableType Chal] [Finite Chal] in
+private lemma forkVerifyFreshComp_prob_true_le_finalQueryTrace
+    [Fintype Chal]
+    {qH : ℕ} {pk : Stmt} {x : M × (Commit × Resp)}
+    {s : ForkBaseState M Commit Chal × List M}
+    (hinv : forkAwareInv (M := M) (Commit := Commit) (Chal := Chal) s)
+    (hliveAdv : forkLiveCacheAdvCacheInv (M := M) (Commit := Commit)
+      (Chal := Chal) s)
+    (hlen : s.1.2.2.length ≤ qH) :
+    Pr[= true |
+        forkVerifyFreshComp (M := M) (Commit := Commit) (Chal := Chal)
+          (Resp := Resp) σ pk x s]
+      ≤
+    Pr[= true |
+        forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+          (Resp := Resp) σ pk x s >>= fun trace =>
+            pure ((Fork.forkPoint (M := M) (Commit := Commit)
+              (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
+  classical
+  rcases x with ⟨msg, c, resp⟩
+  rcases s with ⟨⟨advCache, liveCache, queryLog⟩, signed⟩
+  have hlenq : queryLog.length ≤ qH := by
+    simpa using hlen
+  by_cases hsigned : msg ∈ signed
+  · cases hcache : advCache (.inr (msg, c)) with
+    | none =>
+        simp [forkVerifyFreshComp, hcache, hsigned]
+    | some ch =>
+        simp [forkVerifyFreshComp, hcache, hsigned]
+  · cases hcache : advCache (.inr (msg, c)) with
+    | some ch =>
+        have hlive : liveCache (msg, c) = some ch := hinv.1 (msg, c) ch hcache hsigned
+        by_cases hverify : σ.verify pk c ch resp = true
+        · have hfork :
+            (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
+              (Chal := Chal) qH
+              { forgery := (msg, (c, resp))
+                advCache := advCache
+                roCache := liveCache
+                queryLog := queryLog
+                verified := σ.verify pk c ch resp }).isSome = true := by
+              have hmem : (msg, c) ∈ queryLog := hinv.2 (msg, c) ch hlive
+              apply forkPoint_isSome_of_mem_verified_length
+              · simp [hverify]
+              · simpa [Fork.Trace.target]
+              · exact hlenq
+          have hfork' :
+            (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
+              (Chal := Chal) qH
+              { forgery := (msg, (c, resp))
+                advCache := advCache
+                roCache := liveCache
+                queryLog := queryLog
+                verified := true }).isSome = true := by
+            simpa [hverify] using hfork
+          simp [forkVerifyFreshComp, forkFinalQueryTrace, Fork.roImpl, hcache,
+            hlive, hsigned, hverify, hfork']
+        · have hverify_false : σ.verify pk c ch resp = false := by
+            cases hv : σ.verify pk c ch resp <;> simp_all
+          simp [forkVerifyFreshComp, hcache, hsigned, hverify_false]
+    | none =>
+        cases hlive : liveCache (msg, c) with
+        | some liveCh =>
+            have hcontra : advCache (.inr (msg, c)) = some liveCh :=
+              hliveAdv (msg, c) liveCh hlive
+            rw [hcache] at hcontra
+            cases hcontra
+        | none =>
+            calc
+              Pr[= true |
+                  forkVerifyFreshComp (M := M) (Commit := Commit) (Chal := Chal)
+                    (Resp := Resp) σ pk (msg, (c, resp))
+                    (((advCache, (liveCache, queryLog)), signed))]
+                  =
+                Pr[fun ch : Chal => σ.verify pk c ch resp = true |
+                    (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
+                      OracleComp (Fork.wrappedSpec Chal) Chal)] := by
+                  conv_lhs =>
+                    simp [forkVerifyFreshComp, hcache, hsigned]
+                  rw [← probEvent_eq_eq_probOutput, probEvent_map]
+                  rfl
+              _ ≤
+                Pr[= true |
+                    forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+                      (Resp := Resp) σ pk (msg, (c, resp))
+                      (((advCache, (liveCache, queryLog)), signed)) >>= fun trace =>
+                        pure ((Fork.forkPoint (M := M) (Commit := Commit)
+                          (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
+                  simp only [forkFinalQueryTrace, Fork.roImpl, StateT.run_bind,
+                    StateT.run_get, hlive, StateT.run_monadLift, StateT.run_set,
+                    StateT.run_pure, monadLift_self, bind_assoc, pure_bind]
+                  change
+                    Pr[fun ch : Chal => σ.verify pk c ch resp = true |
+                      (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
+                        OracleComp (Fork.wrappedSpec Chal) Chal)] ≤
+                    Pr[= true |
+                    ((fun ch : Chal =>
+                        (Fork.forkPoint (M := M) (Commit := Commit)
+                          (Resp := Resp) (Chal := Chal) qH
+                          { forgery := (msg, (c, resp))
+                            advCache := advCache
+                            roCache := liveCache.cacheQuery (msg, c) ch
+                            queryLog := queryLog ++ [(msg, c)]
+                            verified := σ.verify pk c ch resp }).isSome) <$>
+                      (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
+                        OracleComp (Fork.wrappedSpec Chal) Chal))]
+                  conv_rhs =>
+                    rw [← probEvent_eq_eq_probOutput]
+                    rw [probEvent_map]
+                  change
+                    Pr[fun ch : Chal => σ.verify pk c ch resp = true |
+                      (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
+                        OracleComp (Fork.wrappedSpec Chal) Chal)] ≤
+                    Pr[fun ch : Chal =>
+                        (Fork.forkPoint (M := M) (Commit := Commit)
+                          (Resp := Resp) (Chal := Chal) qH
+                          { forgery := (msg, (c, resp))
+                            advCache := advCache
+                            roCache := liveCache.cacheQuery (msg, c) ch
+                            queryLog := queryLog ++ [(msg, c)]
+                            verified := σ.verify pk c ch resp }).isSome = true |
+                      (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
+                        OracleComp (Fork.wrappedSpec Chal) Chal)]
+                  refine _root_.probEvent_mono
+                    (mx := (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
+                      OracleComp (Fork.wrappedSpec Chal) Chal)) ?_
+                  intro ch _hch hverify
+                  have hmem : (msg, c) ∈ queryLog ++ [(msg, c)] := by simp
+                  have hlt :
+                      (queryLog ++ [(msg, c)]).findIdx (· == (msg, c)) <
+                        (queryLog ++ [(msg, c)]).length :=
+                    List.findIdx_lt_length_of_exists ⟨(msg, c), hmem, by simp⟩
+                  have hidx : (queryLog ++ [(msg, c)]).findIdx (· == (msg, c)) ≤ qH := by
+                    have hlen_eq : (queryLog ++ [(msg, c)]).length = queryLog.length + 1 := by
+                      simp
+                    omega
+                  have hfork := forkPoint_isSome_of_mem_verified_findIdx_le
+                    (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
+                    (qH := qH)
+                    ({ forgery := (msg, (c, resp))
+                       advCache := advCache
+                       roCache := liveCache.cacheQuery (msg, c) ch
+                       queryLog := queryLog ++ [(msg, c)]
+                       verified := σ.verify pk c ch resp } :
+                      Fork.Trace (M := M) (Commit := Commit) (Resp := Resp)
+                        (Chal := Chal))
+                    (by simp [hverify]) (by simp [Fork.Trace.target, hmem])
+                    (by simp [Fork.Trace.target, hidx])
+                  simp [hfork]
+
 omit [SampleableType Stmt] [SampleableType Wit] in
-private lemma forkBase_runTrace_eq
+private lemma forkBase_finalQuery_runTrace_eq
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (pk : Stmt) :
-    Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk =
-      (fun z : (M × (Commit × Resp)) × ForkBaseState M Commit Chal =>
-        forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-          (Resp := Resp) σ pk z.1 z.2) <$>
-        (simulateQ (forkBaseImpl (M := M) (Commit := Commit)
-          (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-          (forkInitialBaseState M Commit Chal) := by
-  unfold Fork.runTrace nmaAdvFromCma FiatShamir.simulatedNmaAdv forkBaseImpl
-    forkInitialBaseState forkTraceOfBase
+    Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk =
+      ((simulateQ (forkBaseImpl (M := M) (Commit := Commit)
+        (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
+        (forkInitialBaseState M Commit Chal) >>= fun z =>
+          forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+            (Resp := Resp) σ pk z.1 (z.2, ([] : List M))) := by
+  unfold Fork.runTrace nmaAdvFromCmaWithFinalQuery nmaAdvFromCma
+    FiatShamir.simulatedNmaAdv forkBaseImpl forkInitialBaseState forkFinalQueryTrace
+  simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+    OracleQuery.cont_query, StateT.run_bind, QueryImpl.add_apply_inr,
+    bind_assoc]
   rw [OracleComp.simulateQ_mapStateTBase_run_eq_map_flattenStateT
     (outer := Fork.unifFwd M Commit Chal + Fork.roImpl M Commit Chal)
     (inner := simulatedNmaImpl (M := M) (Commit := Commit) (Chal := Chal)
@@ -989,14 +1222,45 @@ private lemma forkBase_runTrace_eq
     (oa := adv.main pk)
     (s := (∅ : (fsRoSpec M Commit Chal).QueryCache))
     (q := ((∅ : (M × Commit →ₒ Chal).QueryCache), ([] : List (M × Commit))))]
-  conv_lhs =>
-    simp only [map_eq_bind_pure_comp, bind_pure_comp, bind_assoc,
-      Function.comp_apply, pure_bind]
-  conv_rhs =>
-    simp only [map_eq_bind_pure_comp, bind_pure_comp, bind_assoc,
-      Function.comp_apply, pure_bind]
-  refine bind_congr fun z => ?_
-  rfl
+  simp only [map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind]
+  apply bind_congr
+  intro z
+  rcases z with ⟨⟨msg, c, resp⟩, advCache, liveCache, queryLog⟩
+  cases hcache : liveCache (msg, c) with
+  | some ch =>
+      simp [Fork.roImpl, hcache]
+  | none =>
+      simp [Fork.roImpl, hcache]
+
+omit [SampleableType Stmt] [SampleableType Wit] in
+/-- Lift `forkBase_finalQuery_runTrace_eq` through the signing-log auxiliary:
+running the source adversary under `forkLoggedImpl` and then issuing the
+verifier-point query via `forkFinalQueryTrace` produces the same distribution
+as `Fork.runTrace` of the verifier-point-wrapped adversary. -/
+private lemma forkLogged_finalQuery_eq_runTrace
+    (adv : SignatureAlg.unforgeableAdv
+      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
+    (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
+    ((simulateQ (forkLoggedImpl (M := M) (Commit := Commit)
+      (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
+      (forkInitialState M Commit Chal) >>= fun z =>
+        forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+          (Resp := Resp) σ pk z.1 z.2) =
+      Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk := by
+  rw [forkBase_finalQuery_runTrace_eq (M := M) (Commit := Commit)
+    (Chal := Chal) (Resp := Resp) σ hr adv simT pk]
+  have hproj := OracleComp.extendState_run_proj_eq
+    (so := forkBaseImpl (M := M) (Commit := Commit) (Chal := Chal)
+      (Resp := Resp) simT pk)
+    (aux := cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
+      (Resp := Resp))
+    (oa := adv.main pk)
+    (s := forkInitialBaseState M Commit Chal)
+    (q := ([] : List M))
+  simp only [forkLoggedImpl, forkInitialState, forkInitialBaseState,
+    map_eq_bind_pure_comp, bind_assoc] at hproj ⊢
+  rw [hproj]
+  simp [bind_assoc]
 
 @[fs_simp] private noncomputable def forkLoggedProbImpl [Fintype Chal]
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
@@ -1386,87 +1650,6 @@ private lemma forkLogged_queryLog_length_le
   simpa [nmaAdvFromCma, FiatShamir.simulatedNmaAdv] using hlen
 
 omit [SampleableType Stmt] [SampleableType Wit] in
-private lemma forkLogged_forkPoint_prob_true_eq_runTrace
-    [Fintype Chal]
-    (adv : SignatureAlg.unforgeableAdv
-      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
-    (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) (qH : ℕ) :
-    Pr[= true |
-        ((simulateQ (forkLoggedImpl (M := M) (Commit := Commit)
-          (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-          (forkInitialState M Commit Chal) >>= fun z =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH
-              (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) σ pk z.1 z.2.1)).isSome))]
-      =
-    Pr[= true |
-        Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk >>= fun trace =>
-          pure ((Fork.forkPoint (M := M) (Commit := Commit)
-            (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
-  have hproj := OracleComp.extendState_run_proj_eq
-    (so := forkBaseImpl (M := M) (Commit := Commit) (Chal := Chal)
-      (Resp := Resp) simT pk)
-    (aux := cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
-      (Resp := Resp))
-    (oa := adv.main pk)
-    (s := forkInitialBaseState M Commit Chal)
-    (q := ([] : List M))
-  have hbase := forkBase_runTrace_eq (M := M) (Commit := Commit)
-    (Chal := Chal) (Resp := Resp) σ hr adv simT pk
-  calc
-    Pr[= true |
-        ((simulateQ (forkLoggedImpl (M := M) (Commit := Commit)
-          (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-          (forkInitialState M Commit Chal) >>= fun z =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH
-              (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) σ pk z.1 z.2.1)).isSome))]
-        =
-      Pr[= true |
-          (Prod.map id Prod.fst <$>
-            (simulateQ (QueryImpl.extendState
-              (forkBaseImpl (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) simT pk)
-              (cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp))) (adv.main pk)).run
-              (forkInitialBaseState M Commit Chal, ([] : List M))) >>= fun z =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH
-              (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) σ pk z.1 z.2)).isSome)] := by
-          simp [forkLoggedImpl, forkInitialState, forkInitialBaseState,
-            map_eq_bind_pure_comp, bind_assoc]
-    _ =
-      Pr[= true |
-          (simulateQ (forkBaseImpl (M := M) (Commit := Commit)
-            (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-            (forkInitialBaseState M Commit Chal) >>= fun z =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH
-              (forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-                (Resp := Resp) σ pk z.1 z.2)).isSome)] := by
-          rw [hproj]
-    _ =
-      Pr[= true |
-          ((fun z : (M × (Commit × Resp)) × ForkBaseState M Commit Chal =>
-            forkTraceOfBase (M := M) (Commit := Commit) (Chal := Chal)
-              (Resp := Resp) σ pk z.1 z.2) <$>
-            (simulateQ (forkBaseImpl (M := M) (Commit := Commit)
-              (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-              (forkInitialBaseState M Commit Chal)) >>= fun trace =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
-          simp [map_eq_bind_pure_comp, bind_assoc]
-    _ =
-      Pr[= true |
-          Fork.runTrace σ hr M (nmaAdvFromCma σ hr M adv simT) pk >>= fun trace =>
-            pure ((Fork.forkPoint (M := M) (Commit := Commit)
-              (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
-          rw [← hbase]
-
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The H5 verify body's success probability is bounded by the live `forkPoint`
 event for the verify-wrapped adversary. The fork slot parameter is `qH`:
 `Fork.forkPoint qH` indexes `Fin (qH + 1)`, accommodating the wrapped
@@ -1488,7 +1671,67 @@ private lemma forkLogged_verify_prob_true_le_forkPoint_run
           >>= fun trace =>
             pure ((Fork.forkPoint (M := M) (Commit := Commit)
               (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
-  sorry
+  let loggedRun :=
+    ((simulateQ (forkLoggedImpl (M := M) (Commit := Commit)
+      (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
+      (forkInitialState M Commit Chal))
+  let finalRun :=
+    loggedRun >>= fun z =>
+      forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+        (Resp := Resp) σ pk z.1 z.2 >>= fun trace =>
+        pure ((Fork.forkPoint (M := M) (Commit := Commit)
+          (Resp := Resp) (Chal := Chal) qH trace).isSome)
+  have hbind := probEvent_bind_congr_le_add
+    (mx := loggedRun)
+    (my := fun z => forkVerifyFreshComp (M := M) (Commit := Commit)
+      (Chal := Chal) (Resp := Resp) σ pk z.1 z.2)
+    (oc := fun z =>
+      forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+        (Resp := Resp) σ pk z.1 z.2 >>= fun trace =>
+        pure ((Fork.forkPoint (M := M) (Commit := Commit)
+          (Resp := Resp) (Chal := Chal) qH trace).isSome))
+    (q := fun b => b = true) (ε := 0) (by
+      intro z hz
+      have hinv := forkLoggedImpl_preserves_inv (M := M) (Commit := Commit)
+        (Chal := Chal) (Resp := Resp) simT pk (adv.main pk) hz
+      have hliveAdv := forkLoggedImpl_preserves_live_adv_inv (M := M)
+        (Commit := Commit) (Chal := Chal) (Resp := Resp) simT pk
+        (adv.main pk) hz
+      have hlen := forkLogged_queryLog_length_le (M := M) (Commit := Commit)
+        (Chal := Chal) (Resp := Resp) σ hr adv simT pk hQ hz
+      simpa [probEvent_eq_eq_probOutput] using
+        forkVerifyFreshComp_prob_true_le_finalQueryTrace (M := M)
+          (Commit := Commit) (Chal := Chal) (Resp := Resp) σ
+          (qH := qH) (pk := pk) (x := z.1) (s := z.2)
+          hinv hliveAdv hlen)
+  have hbind' :
+      Pr[= true |
+          forkLoggedVerifyBody (σ := σ) (hr := hr) (M := M)
+            (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT pk]
+        ≤ Pr[= true | finalRun] := by
+    simpa [forkLoggedVerifyBody, loggedRun, finalRun, probEvent_eq_eq_probOutput]
+      using hbind
+  have hpoint :
+      Pr[= true | finalRun] =
+        Pr[= true |
+          Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk
+            >>= fun trace =>
+              pure ((Fork.forkPoint (M := M) (Commit := Commit)
+                (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
+    simp only [finalRun, ← bind_assoc,
+      forkLogged_finalQuery_eq_runTrace (σ := σ) (hr := hr) (M := M)
+        (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT pk]
+  calc
+    Pr[= true |
+        forkLoggedVerifyBody (σ := σ) (hr := hr) (M := M)
+          (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT pk]
+        ≤ Pr[= true | finalRun] := hbind'
+    _ =
+      Pr[= true |
+        Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk
+          >>= fun trace =>
+            pure ((Fork.forkPoint (M := M) (Commit := Commit)
+              (Resp := Resp) (Chal := Chal) qH trace).isSome)] := hpoint
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The H5 body's success probability is bounded by the wrapped adversary's
@@ -1508,7 +1751,43 @@ private lemma forkH5Body_prob_true_le_fork_advantage
           (Resp := Resp) σ hr adv simT]
       ≤
     Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH := by
-  sorry
+  have hbind := probEvent_bind_congr_le_add
+    (mx := (OracleComp.liftComp hr.gen (Fork.wrappedSpec Chal) :
+      OracleComp (Fork.wrappedSpec Chal) (Stmt × Wit)))
+    (my := fun ps => forkLoggedVerifyBody (σ := σ) (hr := hr) (M := M)
+      (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT ps.1)
+    (oc := fun ps =>
+      Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) ps.1 >>=
+        fun trace =>
+          pure ((Fork.forkPoint (M := M) (Commit := Commit)
+            (Resp := Resp) (Chal := Chal) qH trace).isSome))
+    (q := fun b => b = true) (ε := 0) (by
+      intro ps _hps
+      simpa [probEvent_eq_eq_probOutput] using
+        forkLogged_verify_prob_true_le_forkPoint_run (M := M) (Commit := Commit)
+          (Chal := Chal) (Resp := Resp) σ hr adv simT ps.1 hQ)
+  let pointBody : OracleComp (Fork.wrappedSpec Chal) Bool := do
+    let (pk, _) ← OracleComp.liftComp hr.gen (Fork.wrappedSpec Chal)
+    let trace ← Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk
+    pure (Fork.forkPoint (M := M) (Commit := Commit) (Resp := Resp)
+      (Chal := Chal) qH trace).isSome
+  have hpoint :
+      Pr[= true | pointBody] =
+        Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH := by
+    rw [← probOutput_simulateQ_forkWrappedUniformImpl (Chal := Chal) (oa := pointBody) true]
+    rfl
+  have hbody :
+      Pr[= true |
+          forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
+            (Resp := Resp) σ hr adv simT] ≤
+        Pr[= true | pointBody] := by
+    simpa [forkH5Body, forkLoggedVerifyBody, pointBody, probEvent_eq_eq_probOutput] using hbind
+  calc
+    Pr[= true |
+        forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
+          (Resp := Resp) σ hr adv simT]
+        ≤ Pr[= true | pointBody] := hbody
+    _ = Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH := hpoint
 
 omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] [Inhabited Chal] in
 private lemma cmaSim_run_eq_nma_run_shiftLeft_cmaToNma_private
@@ -1747,7 +2026,37 @@ theorem nma_runProb_shiftLeft_signedFreshAdv_le_fork
             (signedFreshAdv σ hr M adv))]
       ≤ Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
           qH := by
-  sorry
+  letI : Fintype Chal := Fintype.ofFinite Chal
+  have hbridge :
+      Pr[= true |
+          (nma (Stmt := Stmt) (Wit := Wit) M Commit Chal hr).runProb
+            (nmaInit M Commit Chal Stmt Wit)
+            ((cmaToNma M Commit Chal simT).shiftLeft ([] : List M)
+              (signedFreshAdv σ hr M adv))]
+        =
+      Pr[= true |
+          forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
+            (Resp := Resp) σ hr adv simT] := by
+    rw [nma_runProb_shiftLeft_signedFreshAdv_eq_forkH5Body (σ := σ) (hr := hr)
+      (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT]
+    exact probOutput_simulateQ_forkWrappedUniformImpl
+      (Chal := Chal)
+      (oa := forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
+        (Resp := Resp) σ hr adv simT) true
+  have hbody := forkH5Body_prob_true_le_fork_advantage (σ := σ) (hr := hr)
+    (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
+    adv simT hQ
+  calc
+    Pr[= true |
+        (nma (Stmt := Stmt) (Wit := Wit) M Commit Chal hr).runProb
+          (nmaInit M Commit Chal Stmt Wit)
+          ((cmaToNma M Commit Chal simT).shiftLeft ([] : List M)
+            (signedFreshAdv σ hr M adv))]
+        = Pr[= true |
+            forkH5Body (M := M) (Commit := Commit) (Chal := Chal)
+              (Resp := Resp) σ hr adv simT] := hbridge
+    _ ≤ Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
+          qH := hbody
 
 /-! ## H3 cost factoring -/
 
@@ -1970,7 +2279,58 @@ theorem cma_advantage_le_fork_bound_of_h5
           (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH +
         ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
         (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β := by
-  sorry
+  let A : OracleComp (cmaSpec M Commit Chal Resp Stmt) Bool :=
+    signedFreshAdv σ hr M adv
+  have hζ_zk_lt : ENNReal.ofReal ζ_zk < ∞ := ENNReal.ofReal_lt_top
+  have hHVZK' : σ.HVZK simT (ENNReal.ofReal ζ_zk).toReal := by
+    rwa [ENNReal.toReal_ofReal hζ_zk]
+  have hH3_abs :
+      ENNReal.ofReal
+          (((cmaReal M Commit Chal σ hr).runProb
+              (cmaInit M Commit Chal Stmt Wit) A).boolDistAdvantage
+            ((cmaSim M Commit Chal hr simT).runProb
+              (cmaInit M Commit Chal Stmt Wit) A))
+        ≤ (qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
+          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β := by
+    simpa [A, cmaH3Advantage, QueryImpl.Stateful.advantage] using
+      signedFreshAdv_H3_bound (σ := σ) (hr := hr) (M := M)
+        (Commit := Commit) (Chal := Chal) (Resp := Resp)
+        adv simT (ENNReal.ofReal ζ_zk) β hζ_zk_lt hHVZK' hPredSim qS qH hQ
+  have hH3_prob :
+      Pr[= true | (cmaReal M Commit Chal σ hr).runProb
+        (cmaInit M Commit Chal Stmt Wit) A] ≤
+      Pr[= true | (cmaSim M Commit Chal hr simT).runProb
+        (cmaInit M Commit Chal Stmt Wit) A] +
+        ((qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
+          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β) :=
+    le_trans
+      (ProbComp.probOutput_true_le_add_ofReal_boolDistAdvantage
+        ((cmaReal M Commit Chal σ hr).runProb
+          (cmaInit M Commit Chal Stmt Wit) A)
+        ((cmaSim M Commit Chal hr simT).runProb
+          (cmaInit M Commit Chal Stmt Wit) A))
+      (add_le_add le_rfl hH3_abs)
+  calc
+    adv.advantage (FiatShamir.runtime M)
+        ≤ Pr[= true | (cmaReal M Commit Chal σ hr).runProb
+          (cmaInit M Commit Chal Stmt Wit) A] := by
+            simpa [A] using hH1H2
+    _ ≤ Pr[= true | (cmaSim M Commit Chal hr simT).runProb
+          (cmaInit M Commit Chal Stmt Wit) A] +
+        ((qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
+          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β) := hH3_prob
+    _ ≤ Fork.advantage σ hr M
+          (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH +
+        ((qS : ℝ≥0∞) * ENNReal.ofReal ζ_zk
+          + (qS : ℝ≥0∞) * ((qS : ℝ≥0∞) + (qH : ℝ≥0∞)) * β) :=
+        add_le_add hH5 le_rfl
+    _ = Fork.advantage σ hr M
+            (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH +
+          ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
+          (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β := by
+        rw [ENNReal.ofReal_mul (Nat.cast_nonneg qS)]
+        rw [ENNReal.ofReal_natCast]
+        ring_nf
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Native stateful chain with H5 discharged by the replay-forking boundary,

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -1232,36 +1232,6 @@ private lemma forkBase_finalQuery_runTrace_eq
   | none =>
       simp [Fork.roImpl, hcache]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
-/-- Lift `forkBase_finalQuery_runTrace_eq` through the signing-log auxiliary:
-running the source adversary under `forkLoggedImpl` and then issuing the
-verifier-point query via `forkFinalQueryTrace` produces the same distribution
-as `Fork.runTrace` of the verifier-point-wrapped adversary. -/
-private lemma forkLogged_finalQuery_eq_runTrace
-    (adv : SignatureAlg.unforgeableAdv
-      (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
-    (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
-    ((simulateQ (forkLoggedImpl (M := M) (Commit := Commit)
-      (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
-      (forkInitialState M Commit Chal) >>= fun z =>
-        forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
-          (Resp := Resp) σ pk z.1 z.2) =
-      Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk := by
-  rw [forkBase_finalQuery_runTrace_eq (M := M) (Commit := Commit)
-    (Chal := Chal) (Resp := Resp) σ hr adv simT pk]
-  have hproj := OracleComp.extendState_run_proj_eq
-    (so := forkBaseImpl (M := M) (Commit := Commit) (Chal := Chal)
-      (Resp := Resp) simT pk)
-    (aux := cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
-      (Resp := Resp))
-    (oa := adv.main pk)
-    (s := forkInitialBaseState M Commit Chal)
-    (q := ([] : List M))
-  simp only [forkLoggedImpl, forkInitialState, forkInitialBaseState,
-    map_eq_bind_pure_comp, bind_assoc] at hproj ⊢
-  rw [hproj]
-  simp [bind_assoc]
-
 @[fs_simp] private noncomputable def forkLoggedProbImpl [Fintype Chal]
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
     QueryImpl (cmaOracleSpec M Commit Chal Resp)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -1681,6 +1681,14 @@ private lemma forkLogged_verify_prob_true_le_forkPoint_run
         ≤ Pr[= true | finalRun] := by
     simpa [forkLoggedVerifyBody, loggedRun, finalRun, probEvent_eq_eq_probOutput]
       using hbind
+  have hproj := OracleComp.extendState_run_proj_eq
+    (so := forkBaseImpl (M := M) (Commit := Commit) (Chal := Chal)
+      (Resp := Resp) simT pk)
+    (aux := cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
+      (Resp := Resp))
+    (oa := adv.main pk)
+    (s := forkInitialBaseState M Commit Chal)
+    (q := ([] : List M))
   have hpoint :
       Pr[= true | finalRun] =
         Pr[= true |
@@ -1688,9 +1696,43 @@ private lemma forkLogged_verify_prob_true_le_forkPoint_run
             >>= fun trace =>
               pure ((Fork.forkPoint (M := M) (Commit := Commit)
                 (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
-    simp only [finalRun, ← bind_assoc,
-      forkLogged_finalQuery_eq_runTrace (σ := σ) (hr := hr) (M := M)
-        (Commit := Commit) (Chal := Chal) (Resp := Resp) adv simT pk]
+    calc
+      Pr[= true | finalRun]
+          =
+        Pr[= true |
+          (Prod.map id Prod.fst <$>
+            (simulateQ (QueryImpl.extendState
+              (forkBaseImpl (M := M) (Commit := Commit) (Chal := Chal)
+                (Resp := Resp) simT pk)
+              (cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
+                (Resp := Resp))) (adv.main pk)).run
+              (forkInitialBaseState M Commit Chal, ([] : List M))) >>= fun z =>
+            forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+              (Resp := Resp) σ pk z.1 (z.2, ([] : List M)) >>= fun trace =>
+              pure ((Fork.forkPoint (M := M) (Commit := Commit)
+                (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
+          simp [finalRun, loggedRun, forkLoggedImpl, forkInitialState,
+            forkInitialBaseState, map_eq_bind_pure_comp, bind_assoc,
+            forkFinalQueryTrace]
+      _ =
+        Pr[= true |
+          (simulateQ (forkBaseImpl (M := M) (Commit := Commit)
+            (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
+            (forkInitialBaseState M Commit Chal) >>= fun z =>
+            forkFinalQueryTrace (M := M) (Commit := Commit) (Chal := Chal)
+              (Resp := Resp) σ pk z.1 (z.2, ([] : List M)) >>= fun trace =>
+              pure ((Fork.forkPoint (M := M) (Commit := Commit)
+                (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
+          rw [hproj]
+      _ =
+        Pr[= true |
+          Fork.runTrace σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) pk
+            >>= fun trace =>
+              pure ((Fork.forkPoint (M := M) (Commit := Commit)
+                (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
+          rw [forkBase_finalQuery_runTrace_eq (M := M) (Commit := Commit)
+            (Chal := Chal) (Resp := Resp) σ hr adv simT pk]
+          simp
   calc
     Pr[= true |
         forkLoggedVerifyBody (σ := σ) (hr := hr) (M := M)

--- a/VCVio/CryptoFoundations/SigmaProtocol.lean
+++ b/VCVio/CryptoFoundations/SigmaProtocol.lean
@@ -208,35 +208,6 @@ def simChalUniformGivenCommit [Fintype Chal]
 
 end hvzk
 
-section randomChallengeVerification
-
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
-
-open scoped ENNReal in
-/-- `verifyChallengePredictability δ` means that for any fixed statement, commitment, and
-response, a uniformly random challenge is accepted by the verifier with probability at most `δ`.
-
-This isolates the "cache-miss verify" term in the Fiat-Shamir security reduction: when the
-forgery's hash point was never queried, final verification samples a fresh challenge from the
-random oracle, and the reduction needs an external bound on that acceptance probability.
-Unlike `simCommitPredictability`, this is a property of the verifier relation itself rather than
-of the simulator transcript. -/
-def verifyChallengePredictability
-    (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
-    (δ : ℝ≥0∞) : Prop :=
-  ∀ x pc p, Pr[fun ω : Chal => σ.verify x pc ω p = true | ($ᵗ Chal : ProbComp Chal)] ≤ δ
-
-/-- Trivial upper bound for `verifyChallengePredictability`. Useful when a sharper
-scheme-specific estimate is unavailable. -/
-lemma verifyChallengePredictability_one
-    (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel) :
-    σ.verifyChallengePredictability 1 := by
-  dsimp [verifyChallengePredictability]
-  intro x pc p
-  exact probEvent_le_one
-
-end randomChallengeVerification
-
 section uniqueResponses
 
 /-- A Σ-protocol has unique responses if for any statement, commitment, and challenge,

--- a/docs/agents/crypto.md
+++ b/docs/agents/crypto.md
@@ -34,10 +34,10 @@ structure SignatureAlg (m : Type → Type v) [Monad m] (M PK SK S : Type) where
 
 For an end-to-end EUF-CMA reduction worked through the framework (Σ-protocol →
 Fiat-Shamir transform → managed-RO NMA → replay forking → DLog), see
-[`Examples/Signature.lean`](../../Examples/Signature.lean) and the
+[`Examples/Schnorr/Signature.lean`](../../Examples/Schnorr/Signature.lean) and the
 [Schnorr signature walkthrough](end-to-end-examples.md#schnorr-signature-euf-cma).
 The Schnorr-specific σ-protocol facts that feed in live in
-[`Examples/Schnorr.lean`](../../Examples/Schnorr.lean).
+[`Examples/Schnorr/SigmaProtocol.lean`](../../Examples/Schnorr/SigmaProtocol.lean).
 
 ### Commitment schemes (`CommitmentScheme`)
 

--- a/docs/agents/end-to-end-examples.md
+++ b/docs/agents/end-to-end-examples.md
@@ -40,12 +40,21 @@ Pointcheval-Stern bound
 
 ```
 ε' · ( ε' / (qH + 1)  -  1 / |F| )   ≤   Pr[ B succeeds in dlogExp g ],
-ε' := ε  -  qS · (qS + qH) / |F|  -  δ_verify,
+ε' := ε  -  qS · (qS + qH) / |F|,
 ```
 
 where `ε` is the EUF-CMA advantage of an adversary with `qS` signing-oracle
-queries and `qH` random-oracle queries, and `δ_verify` is the verification
-slack supplied by the caller via `SigmaProtocol.verifyChallengePredictability`.
+queries and `qH` random-oracle queries. The denominator `qH + 1` is the
+textbook Pointcheval-Stern denominator. The Fiat-Shamir reduction wraps the
+source adversary so the forgery's hash point is always among the forkable
+positions: it appends one explicit `(message, commit)` query for the forgery's
+hash point on top of the source's `qH` queries, and applies the replay-forking
+lemma at fork slot parameter `qH`. The framework's
+`Fork.forkPoint qH : Option (Fin (qH + 1))` provides exactly enough slots for
+the wrapped adversary's `qH + 1` total queries (no double-counting). As a
+result, the bound is *unconditional* in `pk`: there is no remaining "verifier
+accepts a uniform challenge" term that would have to be discharged separately
+for keys on which verification is independent of the challenge.
 
 ## ROM Commitment Scheme
 

--- a/docs/agents/end-to-end-examples.md
+++ b/docs/agents/end-to-end-examples.md
@@ -6,11 +6,11 @@ layers compose on concrete schemes.
 ## Schnorr Signature EUF-CMA
 
 An end-to-end EUF-CMA reduction for the Schnorr digital signature lives in
-[`Examples/Signature.lean`](../../Examples/Signature.lean). It is a compact
+[`Examples/Schnorr/Signature.lean`](../../Examples/Schnorr/Signature.lean). It is a compact
 illustration of how the main composition layers of the framework fit together
 on a single concrete scheme. Reading order:
 
-1. **Σ-protocol:** [`Examples/Schnorr.lean`](../../Examples/Schnorr.lean)
+1. **Σ-protocol:** [`Examples/Schnorr/SigmaProtocol.lean`](../../Examples/Schnorr/SigmaProtocol.lean)
    defines `Schnorr.sigma` and proves perfect completeness, special soundness,
    and perfect HVZK, plus the two simulator-distribution facts the
    Fiat-Shamir reduction needs (`sigma_simCommitPredictability` and


### PR DESCRIPTION
## Summary

Eliminates the verifier challenge predictability term `δ_verify` from the
Schnorr EUF-CMA bound and tightens the `Fork.advantage` denominator from
`qH + 2` to the textbook `qH + 1`, by wrapping the NMA adversary so that the
forgery's hash point is always part of the live random-oracle queryLog. With
the wrapper, `Fork.runTrace` always sees the verification position and
`Fork.forkPoint qH` indexes `Fin (qH + 1)` covering the source's `qH` queries
plus the wrapper's verifier query.

End-to-end statement (`Examples/Schnorr/Signature.lean`):

```
adv.advantage runtime ≤ ε' · ( ε' / (qH + 1) − 1 / |F| )
```

with `ε' = adv.advantage runtime − qS · ζ_zk − qS · (qS + qH) · β`, no
`δ_verify` term, no `pk ≠ 0` precondition.

`Schnorr.signature_euf_cma` axiom-checks at `[propext, Classical.choice, Quot.sound]`.

## Main changes

**Architectural fix (`VCVio/CryptoFoundations/FiatShamir/Sigma/`)**

- New `nmaAdvFromCmaWithFinalQuery` wrapper that issues one explicit RO query
  for the forgery's `(msg, commit)` after the source adversary returns,
  making the verifier challenge live in the forkable transcript. The wrapped
  adversary issues `qH + 1` queries; passing `qH` as the fork-slot parameter
  to `Fork.advantage` yields the textbook `qH + 1` denominator.
- Removed `δ_verify` arguments and `nmaHashQueryBound (qH + 1)` clauses from
  `cma_to_nma_advantage_bound`, `euf_cma_to_nma`, `euf_cma_bound`, and
  `signature_euf_cma`.
- Deleted `verifyChallengePredictability` and `verifyChallengePredictability_one`
  from `VCVio/CryptoFoundations/SigmaProtocol.lean`: no longer consumed by the
  Fiat-Shamir EUF-CMA chain.

**H5 obligations filled (`Stateful/Chain.lean`)**

The four H5 obligations (`forkLogged_verify_prob_true_le_forkPoint_run`,
`forkH5Body_prob_true_le_fork_advantage`,
`nma_runProb_shiftLeft_signedFreshAdv_le_fork`,
`cma_advantage_le_fork_bound_of_h5`) are proved against the new wrapped
adversary using `forkFinalQueryTrace`, `forkBase_finalQuery_runTrace_eq`,
and a `forkLiveCacheAdvCacheInv` invariant on `forkLoggedImpl`.

**Simplification pass**

After the H5 fill, several helpers became unreachable and were removed,
including `forkTraceOfBase`, `forkBase_runTrace_eq`,
`forkPoint_isSome_of_fresh_advCache_hit`,
`forkLogged_forkPoint_prob_true_eq_runTrace`, and
`forkLogged_finalQuery_eq_runTrace`. `forkPoint_isSome_of_mem_verified_length`
was recast as a thin wrapper around the strictly more general `_findIdx_le`
form.

**Examples / docs**

- `Examples/Schnorr.lean` -> `Examples/Schnorr/SigmaProtocol.lean`,
  `Examples/Signature.lean` -> `Examples/Schnorr/Signature.lean` (groups
  the Schnorr example under one directory, matching `OneTimePad/`,
  `ElGamal/`).
- Regenerated `Examples.lean` with `./scripts/update-lib.sh` so CI's import
  freshness check sees the canonical generated import order.
- `docs/agents/end-to-end-examples.md` and `docs/agents/crypto.md` updated
  with the `qH + 1` bound and the new reading order.

## Test plan

- [x] `lake env lean Examples.lean`
- [x] `lake env lean Examples/Schnorr/Signature.lean`
- [x] `Schnorr.signature_euf_cma` axiom-checks at
      `[propext, Classical.choice, Quot.sound]`
- [ ] CI clean build after latest import-order fix

Posted by Cursor assistant (model: GPT-5.5) on behalf of the user (Quang Dao) with approval.