### PR TITLE
chore: Use `monad_norm` simp set across library where appropriate

### DIFF
--- a/Examples/CommitmentScheme/Common.lean
+++ b/Examples/CommitmentScheme/Common.lean
@@ -108,9 +108,9 @@ lemma probEvent_from_fresh_query_le_inv
           let u ← (CMOracle M S C).query t
           pure (u, cache₀.cacheQuery t u)) := by
       simp only [cachingOracle.apply_eq, liftM, MonadLiftT.monadLift, MonadLift.monadLift,
-        StateT.run_bind, StateT.run_get, pure_bind, hfresh]
+        StateT.run_bind, StateT.run_get, monad_norm, hfresh]
       change (StateT.lift (PFunctor.FreeM.lift ((CMOracle M S C).query t)) cache₀ >>= _) = _
-      simp only [StateT.lift, bind_assoc, pure_bind,
+      simp only [StateT.lift, monad_norm,
         modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
         StateT.modifyGet, StateT.run]
       rfl

--- a/Examples/CommitmentScheme/Extractability.lean
+++ b/Examples/CommitmentScheme/Extractability.lean
@@ -158,8 +158,7 @@ omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited 
 private lemma extractabilityInner_eq_fst_tagged {t : ℕ}
     (A : ExtractAdversary M S C AUX t) :
     extractabilityInner A = Prod.fst <$> extractabilityInner_tagged A := by
-  simp only [extractabilityInner, extractabilityInner_tagged, map_eq_bind_pure_comp,
-    bind_assoc, Function.comp, pure_bind]
+  simp only [extractabilityInner, extractabilityInner_tagged, monad_norm, Function.comp]
   congr 1; ext ⟨⟨cm, aux⟩, tr⟩
   congr 1; ext ⟨m, s⟩
   congr 1; ext c

--- a/Examples/CommitmentScheme/Hiding/CountBounds.lean
+++ b/Examples/CommitmentScheme/Hiding/CountBounds.lean
@@ -71,7 +71,7 @@ lemma sum_counts_step_le_succ_hidingImplCountAll (ms : M × S)
     (hx : x ∈ support ((hidingImplCountAll (M := M) (S := S) (C := C) ms).run st)) :
     (∑ s' : S, x.2.2 s') ≤ (∑ s' : S, st.2 s') + 1 := by
   obtain ⟨cache, counts⟩ := st
-  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind] at hx
+  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, monad_norm] at hx
   cases hcache : cache ms with
   | some u =>
       simp only [hcache, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx
@@ -81,7 +81,7 @@ lemma sum_counts_step_le_succ_hidingImplCountAll (ms : M × S)
       simp only [hcache, StateT.run_bind] at hx
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
-      simp only [StateT.run_set, StateT.run_pure, pure_bind, support_pure,
+      simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
       rw [hx]
       simp [sum_update_succ_count]
@@ -134,7 +134,7 @@ lemma count_mono_step_hidingImplCountAll (s : S) (ms : M × S)
     (hx : x ∈ support ((hidingImplCountAll (M := M) (S := S) (C := C) ms).run st)) :
     st.2 s ≤ x.2.2 s := by
   obtain ⟨cache, counts⟩ := st
-  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind] at hx
+  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, monad_norm] at hx
   cases hcache : cache ms with
   | some u =>
       simp only [hcache, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx
@@ -143,7 +143,7 @@ lemma count_mono_step_hidingImplCountAll (s : S) (ms : M × S)
       simp only [hcache, StateT.run_bind] at hx
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
-      simp only [StateT.run_set, StateT.run_pure, pure_bind, support_pure,
+      simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
       rw [hx]
       by_cases hs : ms.2 = s
@@ -167,7 +167,7 @@ lemma count_coord_le_succ_of_mem_support_step_hidingImplCountAll
   have hmono :
       counts s ≤ x.2.2 s :=
     count_mono_step_hidingImplCountAll (M := M) (S := S) (C := C) s ms (cache, counts) x hx
-  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind] at hx
+  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, monad_norm] at hx
   cases hcache : cache ms with
   | some u =>
       simp only [hcache, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx
@@ -177,7 +177,7 @@ lemma count_coord_le_succ_of_mem_support_step_hidingImplCountAll
       simp only [hcache, StateT.run_bind] at hx
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
-      simp only [StateT.run_set, StateT.run_pure, pure_bind, support_pure,
+      simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
       subst hx
       constructor
@@ -200,7 +200,7 @@ lemma count_coord_le_add_hit_of_mem_support_step_hidingImplCountAll
     (hx : x ∈ support ((hidingImplCountAll (M := M) (S := S) (C := C) ms).run st)) :
     x.2.2 s ≤ st.2 s + if ms.2 = s then 1 else 0 := by
   obtain ⟨cache, counts⟩ := st
-  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind] at hx
+  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, monad_norm] at hx
   cases hcache : cache ms with
   | some u =>
       simp only [hcache, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx
@@ -216,7 +216,7 @@ lemma count_coord_le_add_hit_of_mem_support_step_hidingImplCountAll
       simp only [hcache, StateT.run_bind] at hx
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
-      simp only [StateT.run_set, StateT.run_pure, pure_bind, support_pure,
+      simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
       subst hx
       by_cases hs : ms.2 = s
@@ -255,7 +255,7 @@ lemma self_mem_cache_of_mem_support_step_hidingImplCountAll (ms : M × S)
     (hx : x ∈ support ((hidingImplCountAll (M := M) (S := S) (C := C) ms).run st)) :
     x.2.1 ms = some x.1 := by
   obtain ⟨cache, counts⟩ := st
-  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind] at hx
+  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, monad_norm] at hx
   cases hcache : cache ms with
   | some u =>
       simp only [hcache, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx
@@ -265,7 +265,7 @@ lemma self_mem_cache_of_mem_support_step_hidingImplCountAll (ms : M × S)
       simp only [hcache, StateT.run_bind] at hx
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
-      simp only [StateT.run_set, StateT.run_pure, pure_bind, support_pure,
+      simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
       subst hx
       simp
@@ -283,7 +283,7 @@ lemma hidingCountInv_step_hidingImplCountAll (ms₀ : M × S)
     (hx : x ∈ support ((hidingImplCountAll (M := M) (S := S) (C := C) ms₀).run st)) :
     HidingCountInv x.2 := by
   obtain ⟨cache, counts⟩ := st
-  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind] at hx
+  simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, monad_norm] at hx
   cases hcache : cache ms₀ with
   | some u₀ =>
       simp only [hcache, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hx
@@ -293,7 +293,7 @@ lemma hidingCountInv_step_hidingImplCountAll (ms₀ : M × S)
       simp only [hcache, StateT.run_bind] at hx
       rw [mem_support_bind_iff] at hx
       obtain ⟨u₀, _, hx⟩ := hx
-      simp only [StateT.run_set, StateT.run_pure, pure_bind, support_pure,
+      simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
       subst hx
       intro ms u hms

--- a/Examples/CommitmentScheme/Hiding/Defs.lean
+++ b/Examples/CommitmentScheme/Hiding/Defs.lean
@@ -155,13 +155,13 @@ lemma hidingImpl₁_step_totalBound (s : S) (ms : M × S)
   obtain ⟨cache, cnt⟩ := st
   cases hcache : cache ms with
   | some u =>
-      simpa [hidingImpl₁, hcache, StateT.run_bind, StateT.run_get, pure_bind] using
+      simpa [hidingImpl₁, hcache, StateT.run_bind, StateT.run_get, monad_norm] using
         (show IsTotalQueryBound
             (pure (u, (cache, cnt)) :
               OracleComp (CMOracle M S C) (C × (QueryCache (CMOracle M S C) × ℕ))) 1 from
           trivial)
   | none =>
-      simpa [hidingImpl₁, hcache, StateT.run_bind, StateT.run_get, pure_bind,
+      simpa [hidingImpl₁, hcache, StateT.run_bind, StateT.run_get, monad_norm,
         StateT.run_set, StateT.run_pure, OracleComp.liftM_run_StateT, MonadLift.monadLift]
         using
           (show IsTotalQueryBound
@@ -181,14 +181,14 @@ lemma hidingImplCountAll_step_totalBound (ms : M × S)
   obtain ⟨cache, counts⟩ := st
   cases hcache : cache ms with
   | some u =>
-      simpa [hidingImplCountAll, hcache, StateT.run_bind, StateT.run_get, pure_bind] using
+      simpa [hidingImplCountAll, hcache, StateT.run_bind, StateT.run_get, monad_norm] using
         (show IsTotalQueryBound
             (pure (u, (cache, counts)) :
               OracleComp (CMOracle M S C)
                 (C × (QueryCache (CMOracle M S C) × (S → ℕ)))) 1 from
           trivial)
   | none =>
-      simpa [hidingImplCountAll, hcache, StateT.run_bind, StateT.run_get, pure_bind,
+      simpa [hidingImplCountAll, hcache, StateT.run_bind, StateT.run_get, monad_norm,
         StateT.run_set, StateT.run_pure, OracleComp.liftM_run_StateT, MonadLift.monadLift]
         using
           (show IsTotalQueryBound

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/Average.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/Average.lean
@@ -324,7 +324,7 @@ theorem hidingReal_eq_impl₁ {AUX : Type} {t : ℕ}
         simp [StateT.run_pure, Prod.map]
       | none =>
         simp only [StateT.run_bind, OracleComp.liftM_run_StateT]
-        simp only [bind_assoc, pure_bind]
+        simp only [monad_norm]
         simp [StateT.run_set, StateT.run_pure, Prod.map, StateT.run_modifyGet]
     ) (hidingOa A s) (∅, 0)).symm
 

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
@@ -398,7 +398,7 @@ theorem run_cached_logging_proj_eq_cachingOracle
       rw [simulateQ_query_bind, StateT.run_bind, simulateQ_query_bind, StateT.run_bind]
       cases ht : cache₀ t with
       | some u =>
-          simp [ht, StateT.run_bind, StateT.run_get, pure_bind]
+          simp [ht, StateT.run_bind, StateT.run_get, monad_norm]
           simpa [simulateQ_map, StateT.map, StateT.run, Function.comp_def] using ih u cache₀
       | none =>
           simp only [OracleQuery.input_query, QueryImpl.withCaching_apply,

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
@@ -789,9 +789,8 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
               change (StateT.lift
                   (PFunctor.FreeM.lift ((CMOracle M S C).query t))
                   (cache₀.cacheQuery (m, s) cm) >>= _) = _
-              simp only [StateT.lift, bind_assoc, pure_bind,
-                modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
-                StateT.modifyGet, StateT.run]
+              simp only [StateT.lift, modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
+                StateT.modifyGet, StateT.run, monad_norm]
               rfl
             have hmiss_common :
                 (liftM ((CMOracle M S C).cachingOracle t) :
@@ -805,7 +804,7 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
               change (StateT.lift
                 (PFunctor.FreeM.lift ((CMOracle M S C).query t))
                 cache₀ >>= _) = _
-              simp only [StateT.lift, bind_assoc, pure_bind,
+              simp only [StateT.lift, monad_norm,
                 modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
                 StateT.modifyGet, StateT.run]
               rfl

--- a/Examples/ElGamal/Basic.lean
+++ b/Examples/ElGamal/Basic.lean
@@ -186,7 +186,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
       pure (decide (bit = bit'))]
     · refine probOutput_bind_congr' ($ᵗ G) true ?_
       intro head
-      simpa [inner, bind_assoc, map_eq_bind_pure_comp] using
+      simpa [inner, monad_norm] using
         (probOutput_bind_bind_swap
           ($ᵗ G)
           (do
@@ -197,7 +197,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
             let bit' ← adv.distinguish x.2.2 (head, mask + if bit then x.1 else x.2.1)
             pure (decide (bit = bit')))
           true)
-    · simpa [f, bind_assoc, map_eq_bind_pure_comp] using
+    · simpa [f, monad_norm] using
         (probOutput_bind_bind_swap
           (do
             let head ← ($ᵗ G)
@@ -227,8 +227,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
         let bit ← ($ᵗ Bool)
         let bit' ← adv.distinguish st (b • gen, c • gen + if bit then m₁ else m₂)
         pure (decide (bit = bit'))]
-      · simpa [DiffieHellman.ddhExpRand, IND_CPA_OneTime_DDHReduction, bind_assoc,
-          map_eq_bind_pure_comp,
+      · simpa [DiffieHellman.ddhExpRand, IND_CPA_OneTime_DDHReduction, monad_norm,
           show ∀ a b : Bool, (a == b) = decide (a = b) from by decide] using
           (probOutput_bind_bijective_uniform_cross
             (α := F) (β := G) (f := (· • gen)) hg
@@ -249,7 +248,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
           let bit ← ($ᵗ Bool)
           let bit' ← adv.distinguish st (head, c • gen + if bit then m₁ else m₂)
           pure (decide (bit = bit'))]
-        · simpa [bind_assoc, map_eq_bind_pure_comp] using
+        · simpa [monad_norm] using
             (probOutput_bind_bijective_uniform_cross
               (α := F) (β := G) (f := (· • gen)) hg
               (g := fun head => do
@@ -261,7 +260,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
               true)
         · refine probOutput_bind_congr' ($ᵗ G) true ?_
           intro head
-          simpa [inner, bind_assoc, map_eq_bind_pure_comp] using
+          simpa [inner, monad_norm] using
             (probOutput_bind_bijective_uniform_cross
               (α := F) (β := G) (f := (· • gen)) hg
               (g := fun mask => do

--- a/Examples/ElGamal/Common.lean
+++ b/Examples/ElGamal/Common.lean
@@ -35,7 +35,7 @@ lemma uniformMaskedCipher_bind_dist_indep {β : Type}
       evalDist_map_eq_of_evalDist_eq
         (h := evalDist_add_left_uniform_eq (α := M) m₁ m₂)
         (f := fun z : M => (head, z))
-  simpa [map_eq_bind_pure_comp, Function.comp, evalDist_bind, bind_assoc] using
+  simpa [monad_norm, Function.comp, evalDist_bind] using
     congrArg (fun p => p >>= fun c => 𝒟[cont c]) hmask
 
 end ElGamalExamples

--- a/Examples/ElGamal/Hash.lean
+++ b/Examples/ElGamal/Hash.lean
@@ -164,7 +164,7 @@ theorem cpaGame_eq_ddhReal
   have hswap :
       Pr[= true | cpaCanonical] =
       Pr[= true | ddhCanonical] := by
-    simpa [cpaCanonical, ddhCanonical, bind_assoc, map_eq_bind_pure_comp] using
+    simpa [cpaCanonical, ddhCanonical, monad_norm] using
       (probOutput_bind_bind_swap
         ($ᵗ Bool)
         (do
@@ -190,10 +190,10 @@ theorem cpaGame_eq_ddhReal
       let b' ← adv.distinguish x.2.2
         (y • g, hash hk (y • (a • g)) + if b then x.1 else x.2.1)
       pure (b == b')]
-    · simpa [ddhExpReal, ddhReduction, bind_assoc, map_eq_bind_pure_comp,
+    · simpa [ddhExpReal, ddhReduction, monad_norm,
         smul_smul, mul_comm] using
         (probOutput_bind_congr' ($ᵗ F) true (fun a => by
-          simpa [bind_assoc, map_eq_bind_pure_comp, smul_smul, mul_comm] using
+          simpa [monad_norm, smul_smul, mul_comm] using
             (probOutput_bind_bind_swap
               ($ᵗ F)
               (do
@@ -206,7 +206,7 @@ theorem cpaGame_eq_ddhReal
                   (y • g, hash hk (y • (a • g)) + if b then x.1 else x.2.1)
                 pure (b == b'))
               true)))
-    · simpa [ddhCanonical, bind_assoc, map_eq_bind_pure_comp] using
+    · simpa [ddhCanonical, monad_norm] using
         (probOutput_bind_bind_swap
           ($ᵗ F)
           ($ᵗ HK)
@@ -249,9 +249,9 @@ theorem ddhRand_eq_esReal
       let b' ← adv.distinguish x.2.2
         (y • g, hash hk (z • g) + if b then x.1 else x.2.1)
       pure (b == b')]
-    · simpa [ddhExpRand, ddhReduction, bind_assoc, map_eq_bind_pure_comp] using
+    · simpa [ddhExpRand, ddhReduction, monad_norm] using
         (probOutput_bind_congr' ($ᵗ F) true (fun a => by
-          simpa [bind_assoc, map_eq_bind_pure_comp] using
+          simpa [monad_norm] using
             (probOutput_bind_bind_swap
               ($ᵗ F)
               (do
@@ -275,9 +275,9 @@ theorem ddhRand_eq_esReal
           let b' ← adv.distinguish x.2.2
             (y • g, hash hk (z • g) + if b then x.1 else x.2.1)
           pure (b == b')]
-      · simpa [bind_assoc, map_eq_bind_pure_comp] using
+      · simpa [monad_norm] using
           (probOutput_bind_congr' ($ᵗ F) true (fun a => by
-            simpa [bind_assoc, map_eq_bind_pure_comp] using
+            simpa [monad_norm] using
               (probOutput_bind_bind_swap
                 ($ᵗ F)
                 (do
@@ -291,7 +291,7 @@ theorem ddhRand_eq_esReal
                     (y • g, hash hk (z • g) + if b then x.1 else x.2.1)
                   pure (b == b'))
                 true)))
-      · simpa [canonical, bind_assoc, map_eq_bind_pure_comp] using
+      · simpa [canonical, monad_norm] using
           (probOutput_bind_bind_swap
             ($ᵗ F)
             ($ᵗ HK)
@@ -309,8 +309,7 @@ theorem ddhRand_eq_esReal
       Pr[= true | canonical] := by
     refine probOutput_bind_congr' ($ᵗ HK) true ?_
     intro hk
-    simpa [EntropySmoothing.realExp, esReduction, canonical, bind_assoc,
-      map_eq_bind_pure_comp] using
+    simpa [EntropySmoothing.realExp, esReduction, canonical, monad_norm] using
       (probOutput_bind_bind_swap
         ($ᵗ F)
         (do
@@ -377,7 +376,7 @@ theorem esIdeal_eq_half
       let h ← ($ᵗ M)
       let b' ← adv.distinguish x.2.2 (y • g, h + if b then x.1 else x.2.1)
       pure (decide (b = b'))]
-    · simpa [inner, bind_assoc, map_eq_bind_pure_comp] using
+    · simpa [inner, monad_norm] using
         (probOutput_bind_bind_swap
           ($ᵗ M)
           (do
@@ -394,7 +393,7 @@ theorem esIdeal_eq_half
           let b ← ($ᵗ Bool)
           let b' ← f hk b
           pure (decide (b = b'))]
-      · simpa [f, bind_assoc, map_eq_bind_pure_comp] using
+      · simpa [f, monad_norm] using
           (probOutput_bind_bind_swap
             (do
               let sk ← ($ᵗ F)

--- a/Examples/ElGamal/SSP.lean
+++ b/Examples/ElGamal/SSP.lean
@@ -390,7 +390,7 @@ private theorem composed_rand_swap_handler_evalDist (gen : G)
     -- unfolds to a concrete ProbComp. Case-split on `s` and apply the uniform-masking lemma.
     cases s with
     | none =>
-        simp only [dhTripleRand, StateT.run, bind_assoc, pure_bind]
+        simp only [dhTripleRand, StateT.run, monad_norm]
         change 𝒟[do
               let a ← ($ᵗ F)
               let b ← ($ᵗ F)
@@ -411,7 +411,7 @@ private theorem composed_rand_swap_handler_evalDist (gen : G)
           (α := F) (β := G) (fun x : F => x • gen) hg m₀ m₁
           (fun y => pure ((b • gen, y), some a))
     | some a =>
-        simp only [dhTripleRand, StateT.run, bind_assoc, pure_bind]
+        simp only [dhTripleRand, StateT.run, monad_norm]
         change 𝒟[do
               let b ← ($ᵗ F)
               let c ← ($ᵗ F)

--- a/Examples/OneTimePad/Basic.lean
+++ b/Examples/OneTimePad/Basic.lean
@@ -43,7 +43,7 @@ lemma complete (sp : ℕ) : (oneTimePad sp).Complete := by
   have hsimp : (oneTimePad sp).CompleteExp msg =
       (fun _ : BitVec sp => (some msg : Option (BitVec sp))) <$>
         ($ᵗ BitVec sp : ProbComp (BitVec sp)) := by
-    simp [SymmEncAlg.CompleteExp, oneTimePad, monad_norm, Function.comp]
+    simp [SymmEncAlg.CompleteExp, oneTimePad, monad_norm]
   rw [hsimp, probOutput_eq_one_iff]
   exact ⟨HasEvalPMF.probFailure_eq_zero _,
     support_map_const (mx := ($ᵗ BitVec sp : ProbComp (BitVec sp))) (y := some msg)
@@ -54,7 +54,7 @@ lemma probOutput_cipher_uniform (sp : ℕ)
     Pr[= σ | (oneTimePad sp).PerfectSecrecyCipherExp mgen] =
       (Fintype.card (BitVec sp) : ℝ≥0∞)⁻¹ := by
   simpa [SymmEncAlg.PerfectSecrecyCipherExp, SymmEncAlg.PerfectSecrecyExp, oneTimePad,
-    map_eq_bind_pure_comp, bind_assoc, pure_bind] using
+    monad_norm] using
     probOutput_cipher_from_pair_uniform sp (mx := mgen) σ
 
 /-- The one-time pad is perfectly secret in the canonical independence form. -/
@@ -65,7 +65,7 @@ lemma perfectSecrecyAt (sp : ℕ) : (oneTimePad sp).perfectSecrecyAt := by
         Pr[= msg | mgen] *
           (Fintype.card (BitVec sp) : ℝ≥0∞)⁻¹ := by
     simpa [SymmEncAlg.PerfectSecrecyExp, oneTimePad,
-      bind_assoc, pure_bind] using
+      monad_norm] using
       probOutput_pair_xor_uniform sp (mx := mgen) msg σ
   rw [hpair, ← probOutput_cipher_uniform]
 

--- a/Examples/OneTimePad/Basic.lean
+++ b/Examples/OneTimePad/Basic.lean
@@ -43,7 +43,7 @@ lemma complete (sp : ℕ) : (oneTimePad sp).Complete := by
   have hsimp : (oneTimePad sp).CompleteExp msg =
       (fun _ : BitVec sp => (some msg : Option (BitVec sp))) <$>
         ($ᵗ BitVec sp : ProbComp (BitVec sp)) := by
-    simp [SymmEncAlg.CompleteExp, oneTimePad, map_eq_bind_pure_comp, pure_bind, Function.comp]
+    simp [SymmEncAlg.CompleteExp, oneTimePad, monad_norm, Function.comp]
   rw [hsimp, probOutput_eq_one_iff]
   exact ⟨HasEvalPMF.probFailure_eq_zero _,
     support_map_const (mx := ($ᵗ BitVec sp : ProbComp (BitVec sp))) (y := some msg)

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -184,7 +184,7 @@ theorem prgRealExp_eq_prfRealExp
   simp_rw [simulateQ_prfReal_reduction]
   change 𝒟[(·, ·) <$> ($ᵗ K) <*> ($ᵗ S) >>=
     fun ks => adv (streamOutputs (prf.eval ks.1) n ks.2)] = _
-  simp only [seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc, pure_bind, Function.comp_def]
+  simp only [monad_norm, Function.comp_def]
   rw [evalDist_bind, evalDist_bind, hkey]
 
 omit [DecidableEq O] in

--- a/Examples/ProgramLogic/RelationalStep.lean
+++ b/Examples/ProgramLogic/RelationalStep.lean
@@ -358,11 +358,11 @@ the bind rule entirely when both sides reduce to a leaf). -/
 
 example {a : α} {f : α → OracleComp spec β} :
     ⟪(do let x ← pure a; f x) ~ f a | EqRel β⟫ := by
-  simpa only [pure_bind] using (relTriple_refl (oa := f a))
+  simpa only [monad_norm] using (relTriple_refl (oa := f a))
 
 example {oa : OracleComp spec α} {f : α → OracleComp spec β} {g : β → OracleComp spec γ} :
     ⟪((oa >>= f) >>= g) ~ (do let x ← oa; let y ← f x; g y) | EqRel γ⟫ := by
-  simpa only [bind_assoc] using
+  simpa only [monad_norm] using
     (relTriple_refl (oa := oa >>= fun x => f x >>= g))
 
 /-! ## Regression: multi-goal isolation

--- a/Examples/Schnorr/SigmaProtocol.lean
+++ b/Examples/Schnorr/SigmaProtocol.lean
@@ -99,7 +99,7 @@ theorem sigma_complete (g : G) :
     PerfectlyComplete (sigma F G g) := by
   intro pk sk h
   have h_eq : sk • g = pk := of_decide_eq_true h
-  simp only [sigma, pure_bind]
+  simp only [sigma, monad_norm]
   have hverify : ∀ (r c : F), (r + c * sk) • g = r • g + c • pk := by
     intro r c; rw [add_smul, mul_smul, h_eq]
   simp [hverify]
@@ -175,7 +175,7 @@ private lemma realTranscript_eq_indep (g : G) (pk : G) (sk : F) :
         let r ← $ᵗ F
         let c ← $ᵗ F
         pure ((r • g, c, r + c * sk) : G × F × F)) := by
-  simp only [SigmaProtocol.realTranscript, sigma, bind_assoc, pure_bind]
+  simp only [SigmaProtocol.realTranscript, sigma, monad_norm]
 
 omit [DecidableEq F] in
 /-- **Simulator commit-predictability for Schnorr.** With the standard bijection
@@ -217,7 +217,7 @@ theorem sigma_simCommitPredictability (g : G)
       intro c
       have h_map : (do let z ← ($ᵗ F); pure (z • g - c • pk) : ProbComp G) =
           (fun z : F => z • g - c • pk) <$> ($ᵗ F) := by
-        simp [map_eq_bind_pure_comp]
+        simp [monad_norm]
       rw [h_map,
         probOutput_map_bijective_uniform_cross F (f := fun z : F => z • g - c • pk) (hbij_c c),
         probOutput_uniformSample (α := G)]

--- a/Examples/SimpleTwoServerPIR.lean
+++ b/Examples/SimpleTwoServerPIR.lean
@@ -76,9 +76,9 @@ to convert the `for`/`let mut` desugaring (which uses `forIn` + `MProd` state +
 `ForInStep.yield`) into the direct `foldlM` formulation. The only proof obligation
 is showing that each branch of the loop body wraps its result in `ForInStep.yield`. -/
 theorem pirQuery'_eq_pirQuery (i₀ : Fin N) : pirQuery' i₀ = pirQuery i₀ := by
-  simp only [pirQuery', pirQuery, pure_bind]
+  simp only [pirQuery', pirQuery, monad_norm]
   exact List.forIn_mprod_yield_eq_foldlM _ _ _ _ _ (fun j b c => by
-    simp only [bind_assoc]
+    simp only [monad_norm]
     congr 1; ext b₁
     split <;> split <;> simp)
 

--- a/ToMathlib/Control/Lawful/Basic.lean
+++ b/ToMathlib/Control/Lawful/Basic.lean
@@ -25,35 +25,29 @@ universe u v
 
 variable {m : Type u → Type v} [Monad m] [LawfulMonad m]
 
-@[simp]
-theorem do_pure_bind {α β : Type u} (a : α) (f : α → m β) :
-    (do let x ← (pure a : m α); f x) = f a :=
-  pure_bind a f
+-- @[simp]
+-- theorem do_pure_bind {α β : Type u} (a : α) (f : α → m β) :
+--     (do let x ← (pure a : m α); f x) = f a := by simp
 
-@[simp]
-theorem do_bind_pure {α : Type u} (x : m α) :
-    (do let a ← x; pure a) = x :=
-  bind_pure x
+-- @[simp]
+-- theorem do_bind_pure {α : Type u} (x : m α) :
+--     (do let a ← x; pure a) = x := by simp
 
-@[simp]
-theorem do_bind_assoc {α β γ : Type u} (x : m α) (f : α → m β) (g : β → m γ) :
-    (do let b ← (do let a ← x; f a); g b) = (do let a ← x; let b ← f a; g b) :=
-  bind_assoc x f g
+-- @[simp]
+-- theorem do_bind_assoc {α β γ : Type u} (x : m α) (f : α → m β) (g : β → m γ) :
+--     (do let b ← (do let a ← x; f a); g b) = (do let a ← x; let b ← f a; g b) := by simp
 
-@[simp]
-theorem do_bind_pure_comp {α β : Type u} (f : α → β) (x : m α) :
-    (do let a ← x; pure (f a)) = f <$> x :=
-  bind_pure_comp f x
+-- @[simp]
+-- theorem do_bind_pure_comp {α β : Type u} (f : α → β) (x : m α) :
+--     (do let a ← x; pure (f a)) = f <$> x := by simp
 
-@[simp]
-theorem do_map_bind {α β γ : Type u} (f : β → γ) (x : m α) (g : α → m β) :
-    f <$> (do let a ← x; g a) = (do let a ← x; f <$> g a) :=
-  map_bind f x g
+-- @[simp]
+-- theorem do_map_bind {α β γ : Type u} (f : β → γ) (x : m α) (g : α → m β) :
+--     f <$> (do let a ← x; g a) = (do let a ← x; f <$> g a) := by simp
 
-@[simp]
-theorem do_bind_map_left {α β γ : Type u} (f : α → β) (x : m α) (g : β → m γ) :
-    (do let b ← f <$> x; g b) = (do let a ← x; g (f a)) :=
-  bind_map_left f x g
+-- @[simp]
+-- theorem do_bind_map_left {α β γ : Type u} (f : α → β) (x : m α) (g : β → m γ) :
+--     (do let b ← f <$> x; g b) = (do let a ← x; g (f a)) := by simp
 
 end LawfulMonad
 

--- a/ToMathlib/Control/Lawful/Basic.lean
+++ b/ToMathlib/Control/Lawful/Basic.lean
@@ -25,29 +25,29 @@ universe u v
 
 variable {m : Type u → Type v} [Monad m] [LawfulMonad m]
 
--- @[simp]
--- theorem do_pure_bind {α β : Type u} (a : α) (f : α → m β) :
---     (do let x ← (pure a : m α); f x) = f a := by simp
+@[simp]
+theorem do_pure_bind {α β : Type u} (a : α) (f : α → m β) :
+    (do let x ← (pure a : m α); f x) = f a := by simp
 
--- @[simp]
--- theorem do_bind_pure {α : Type u} (x : m α) :
---     (do let a ← x; pure a) = x := by simp
+@[simp]
+theorem do_bind_pure {α : Type u} (x : m α) :
+    (do let a ← x; pure a) = x := by simp
 
--- @[simp]
--- theorem do_bind_assoc {α β γ : Type u} (x : m α) (f : α → m β) (g : β → m γ) :
---     (do let b ← (do let a ← x; f a); g b) = (do let a ← x; let b ← f a; g b) := by simp
+@[simp]
+theorem do_bind_assoc {α β γ : Type u} (x : m α) (f : α → m β) (g : β → m γ) :
+    (do let b ← (do let a ← x; f a); g b) = (do let a ← x; let b ← f a; g b) := by simp
 
--- @[simp]
--- theorem do_bind_pure_comp {α β : Type u} (f : α → β) (x : m α) :
---     (do let a ← x; pure (f a)) = f <$> x := by simp
+@[simp]
+theorem do_bind_pure_comp {α β : Type u} (f : α → β) (x : m α) :
+    (do let a ← x; pure (f a)) = f <$> x := by simp
 
--- @[simp]
--- theorem do_map_bind {α β γ : Type u} (f : β → γ) (x : m α) (g : α → m β) :
---     f <$> (do let a ← x; g a) = (do let a ← x; f <$> g a) := by simp
+@[simp]
+theorem do_map_bind {α β γ : Type u} (f : β → γ) (x : m α) (g : α → m β) :
+    f <$> (do let a ← x; g a) = (do let a ← x; f <$> g a) := by simp
 
--- @[simp]
--- theorem do_bind_map_left {α β γ : Type u} (f : α → β) (x : m α) (g : β → m γ) :
---     (do let b ← f <$> x; g b) = (do let a ← x; g (f a)) := by simp
+@[simp]
+theorem do_bind_map_left {α β γ : Type u} (f : α → β) (x : m α) (g : β → m γ) :
+    (do let b ← f <$> x; g b) = (do let a ← x; g (f a)) := by simp
 
 end LawfulMonad
 

--- a/ToMathlib/Control/Monad/Commutative.lean
+++ b/ToMathlib/Control/Monad/Commutative.lean
@@ -50,10 +50,10 @@ instance {m} [Monad m] [Commutative m] {α β} (ma : m α) (mb : m β) :
   -- Use associativity to factor out the pair construction
   have h1 : (ma >>= fun a => mb >>= fun b => f (a, b)) =
            ((ma >>= fun a => mb >>= fun b => pure (a, b)) >>= fun ⟨a, b⟩ => f (a, b)) := by
-    simp only [bind_assoc, pure_bind]
+    simp only [monad_norm]
   have h2 : (mb >>= fun b => ma >>= fun a => f (a, b)) =
            ((mb >>= fun b => ma >>= fun a => pure (b, a)) >>= fun ⟨b, a⟩ => f (a, b)) := by
-    simp only [bind_assoc, pure_bind]
+    simp only [monad_norm]
   rw [h1, h2]
   -- Apply commutativity
   rw [bind_comm]
@@ -74,10 +74,10 @@ alias bind_swap := bind_comm_comp
   -- Use associativity to factor out the pair construction
   have h1 : (ma >>= fun a => mb >>= fun b => f (a, b)) =
            ((ma >>= fun a => mb >>= fun b => pure (a, b)) >>= fun ⟨a, b⟩ => f (a, b)) := by
-    simp only [bind_assoc, pure_bind]
+    simp only [monad_norm]
   have h2 : (mb >>= fun b => ma >>= fun a => f (a, b)) =
            ((mb >>= fun b => ma >>= fun a => pure (b, a)) >>= fun ⟨b, a⟩ => f (a, b)) := by
-    simp only [bind_assoc, pure_bind]
+    simp only [monad_norm]
   rw [h1, h2]
   -- Apply commutativity
   rw [h]

--- a/ToMathlib/Control/Monad/Hom.lean
+++ b/ToMathlib/Control/Monad/Hom.lean
@@ -142,12 +142,10 @@ variable {m : Type u → Type v} [Monad m]
     F (mx >>= my) = F mx >>= fun x => F (my x) := by grind
 
 @[simp, grind =] lemma mmap_map [LawfulMonad m] [LawfulMonad n] (F : m →ᵐ n)
-    (x : m α) (g : α → β) : F (g <$> x) = g <$> F x := by
-  simp [map_eq_bind_pure_comp]
+    (x : m α) (g : α → β) : F (g <$> x) = g <$> F x := by simp [monad_norm]
 
 @[simp] lemma mmap_seq [LawfulMonad m] [LawfulMonad n] (F : m →ᵐ n)
-    (x : m (α → β)) (y : m α) : F (x <*> y) = F x <*> F y := by
-  simp [seq_eq_bind_map]
+    (x : m (α → β)) (y : m α) : F (x <*> y) = F x <*> F y := by simp [monad_norm]
 
 @[simp] lemma mmap_seqLeft [LawfulMonad m] [LawfulMonad n] (F : m →ᵐ n)
     (x : m α) (y : m β) : F (x <* y) = F x <* F y := by

--- a/ToMathlib/Control/OptionT.lean
+++ b/ToMathlib/Control/OptionT.lean
@@ -65,7 +65,7 @@ protected def mapM' {m : Type u → Type v} {n : Type u → Type w}
   toFun_pure' x := by
     simp
   toFun_bind' x y := by
-    simp only [run_bind, Option.elimM, MonadHom.toFun_bind', bind_assoc]
+    simp only [run_bind, Option.elimM, MonadHom.toFun_bind', monad_norm]
     congr 1
     ext x; cases x; all_goals simp
 

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -661,7 +661,7 @@ theorem List.forIn_mprod_yield_eq_foldlM
   | nil => simp [List.forIn_nil, List.foldlM_nil]
   | cons x xs ih =>
     rw [List.forIn_cons, List.foldlM_cons, hfg]
-    simp only [bind_assoc, pure_bind]
+    simp only [monad_norm]
     congr 1; funext ⟨b', c'⟩
     exact ih b' c'
 
@@ -676,8 +676,6 @@ theorem bind_eq_of_map_eq {m : Type → Type*} [Monad m] [LawfulMonad m]
     (h_first : proj <$> m₁ = m₂)
     (h_cont : ∀ a₁, f₁ a₁ = f₂ (proj a₁)) :
     m₁ >>= f₁ = m₂ >>= f₂ := by
-  rw [← h_first, map_eq_bind_pure_comp, bind_assoc]
-  simp only [Function.comp, pure_bind]
-  exact bind_congr fun a₁ => h_cont a₁
+  simp only [← h_first, monad_norm, funext h_cont, Function.comp_apply]
 
 end CrossTypeBind

--- a/ToMathlib/PFunctor/Bound.lean
+++ b/ToMathlib/PFunctor/Bound.lean
@@ -75,7 +75,7 @@ private lemma isRollBound_map_aux (oa : FreeM P α) (f : α → β)
   | pure x => intro b; exact ⟨fun _ => trivial, fun _ => trivial⟩
   | roll a r ih =>
     intro b
-    simp only [map_eq_bind_pure_comp, Function.comp_def, monad_bind_def, bind_roll]
+    simp only [monad_norm, Function.comp_def, monad_bind_def, bind_roll]
     rw [isRollBound_roll_iff, isRollBound_roll_iff]
     exact and_congr_right fun _ => forall_congr' fun y => ih y
 

--- a/ToMathlib/PFunctor/Free.lean
+++ b/ToMathlib/PFunctor/Free.lean
@@ -190,7 +190,7 @@ lemma mapM_map {α β} (x : FreeM P α) (f : α → β) :
 lemma mapM_seq {α β}
     (s : (a : P.A) → m (P.B a)) (x : FreeM P (α → β)) (y : FreeM P α) :
     FreeM.mapM s (x <*> y) = (FreeM.mapM s x) <*> (FreeM.mapM s y) := by
-  simp [seq_eq_bind_map]
+  simp [monad_norm]
 
 @[simp]
 lemma mapM_lift (s : (a : P.A) → m (P.B a)) (x : P.Obj α) :

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
@@ -577,32 +577,32 @@ private lemma IND_CPA_stepAdversary_game_eq_hybridBranch [Inhabited M]
     dsimp at hresume
     apply evalDist_ext; intro y
     refine Eq.trans ?_ (probOutput_map_eq_of_evalDist_eq hresume (false == ·) y)
-    simp only [map_eq_bind_pure_comp, bind_assoc]
+    simp only [monad_norm]
     refine probOutput_bind_congr'
       ((IND_CPA_stepPrefix (encAlg' := encAlg') pk_sk.1 k (adversary pk_sk.1)).run (∅, 0)) y
       fun ⟨res, _st⟩ => ?_
     cases res with
     | done guess =>
-        dsimp; simp only [pure_bind]
+        dsimp; simp only [monad_norm]
         simp
     | paused _ _ =>
-        dsimp; simp only [map_eq_bind_pure_comp, Function.comp, pure_bind, bind_assoc]
+        dsimp; simp only [monad_norm, Function.comp]
   · rename_i pk_sk
     have hresume := IND_CPA_stepPrefix_resume_eq_hybridLR (encAlg' := encAlg')
       pk_sk.1 k true (adversary pk_sk.1) (∅, 0) (Nat.zero_le k)
     dsimp at hresume
     apply evalDist_ext; intro y
     refine Eq.trans ?_ (probOutput_map_eq_of_evalDist_eq hresume (true == ·) y)
-    simp only [map_eq_bind_pure_comp, bind_assoc]
+    simp only [monad_norm]
     refine probOutput_bind_congr'
       ((IND_CPA_stepPrefix (encAlg' := encAlg') pk_sk.1 k (adversary pk_sk.1)).run (∅, 0)) y
       fun ⟨res, _st⟩ => ?_
     cases res with
     | done guess =>
-        dsimp; simp only [pure_bind]
+        dsimp; simp only [monad_norm]
         simp
     | paused _ _ =>
-        dsimp; simp only [map_eq_bind_pure_comp, Function.comp, pure_bind, bind_assoc]
+        dsimp; simp only [monad_norm, Function.comp]
 
 end MultiQueryToOneTime
 

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
@@ -565,10 +565,10 @@ private lemma IND_CPA_stepAdversary_game_eq_hybridBranch [Inhabited M]
                else encAlg'.IND_CPA_LR_hybridGame adversary k
       pure (bit == z)]
   cases bit <;> dsimp <;>
-    simp only [IND_CPA_LR_hybridGame, bind_assoc] <;>
+    simp only [IND_CPA_LR_hybridGame, monad_norm] <;>
     (refine probOutput_bind_congr' encAlg'.keygen x ?_) <;>
     intro pk_sk <;>
-    simp only [IND_CPA_stepAdversary, bind_assoc] <;>
+    simp only [IND_CPA_stepAdversary, monad_norm] <;>
     (change (𝒟[_]) x = (𝒟[_]) x) <;>
     congr 1
   · rename_i pk_sk

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma.lean
@@ -507,7 +507,7 @@ theorem perfectlyCorrect [SampleableType Chal]
         StateT.run_get, pure_bind, uniformSampleImpl, bind_assoc, map_bind,
         liftM, MonadLiftT.monadLift,
         MonadLift.monadLift, StateT.run_lift, hmod]
-    simp only [bind_assoc, pure_bind]
+    simp only [monad_norm]
     simp_rw [hpeel, hro_miss, hpeel]
     have hro_hit : ∀ {β : Type} (q : M × Commit) (r : Chal)
         (rest : Chal → StateT ((M × Commit →ₒ Chal).QueryCache) ProbComp β),

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -458,7 +458,7 @@ private theorem preservesInv_layered
           (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run s₀) >>= fun us =>
             (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
         simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
-          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+          monad_norm, OracleQuery.cont_query, OracleQuery.input_query]
       rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at hz
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at hz
       obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := hz
@@ -569,7 +569,7 @@ private theorem queryLog_cache_outer_lockstep
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
               (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
         simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
-          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+          monad_norm, OracleQuery.cont_query, OracleQuery.input_query]
       rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at hz
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at hz
       obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := hz
@@ -743,7 +743,7 @@ private theorem queryLog_extends_l₀
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
               (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
         simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
-          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+          monad_norm, OracleQuery.cont_query, OracleQuery.input_query]
       rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at h
       obtain ⟨us_w, hus_w, pw, hpw, hz_eq⟩ := h
@@ -876,7 +876,7 @@ private theorem inner_prefix_det
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
               (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
         simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
-          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+          monad_norm, OracleQuery.cont_query, OracleQuery.input_query]
       rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h₁ h₂
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at h₁ h₂
       obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁
@@ -1109,7 +1109,7 @@ private theorem inner_prefix_det_one_more_inr
             (((unifFwd M Commit Chal + roImpl M Commit Chal) t).run (c₀, l₀)) >>= fun us =>
               (simulateQ (unifFwd M Commit Chal + roImpl M Commit Chal) (oa us.1)).run us.2 := by
         simp [simulateQ_bind, simulateQ_query, StateT.run_bind,
-          map_eq_bind_pure_comp, OracleQuery.cont_query, OracleQuery.input_query]
+          monad_norm, OracleQuery.cont_query, OracleQuery.input_query]
       rw [hY, simulateQ_bind, WriterT.run_bind', support_bind] at h₁ h₂
       simp only [Set.mem_iUnion, support_map, Set.mem_image] at h₁ h₂
       obtain ⟨us_w₁, hus_w₁, pw₁, hpw₁, hz_eq₁⟩ := h₁

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Bridge.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Bridge.lean
@@ -262,7 +262,7 @@ lemma cmaRealRun_eq_keygen_bind
             ((([] : List M), (∅ : RoCache M Commit Chal),
               (some (ps.1, ps.2) : Option (Stmt × Wit))), false))) by
     simp [cmaReal, cmaInit, StateT.run, StateT.mk]]
-  simp only [bind_assoc, pure_bind]
+  simp only [monad_norm]
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-! ## Joint signing/hash query bounds -/

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -113,7 +113,7 @@ theorem cmaToNma_shiftLeft_signedFreshAdv_eq_bind
               (Commit := Commit) (Chal := Chal) (Resp := Resp) p)).run log' := by
   unfold QueryImpl.Stateful.shiftLeft QueryImpl.Stateful.run signedFreshAdv
   rw [StateT.run'_eq, simulateQ_bind, StateT.run_bind]
-  simp [map_eq_bind_pure_comp, bind_assoc]
+  simp [monad_norm]
 
 /-! ## H5 fork-side infrastructure -/
 
@@ -338,8 +338,7 @@ private lemma nma_lift_unif_run
     | query_bind n k ih =>
         simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
           OracleQuery.cont_query, id_map, StateT.run_bind]
-        simp only [map_eq_bind_pure_comp, StateT.run_mk, bind_assoc,
-          Function.comp_apply, pure_bind, impl₁]
+        simp only [monad_norm, StateT.run_mk, impl₁]
         refine bind_congr (m := ProbComp) fun u => ?_
         exact ih u s
   have hsim := QueryImpl.simulateQ_liftM_eq_of_query
@@ -523,14 +522,14 @@ private def cmaSimLoggedLeftOrnament
         exact simulatedNmaUnifSim_fsUniform_run_for_cma (M := M)
           (Commit := Commit) (Chal := Chal) (oa := simT pk) (cache := advCache)
       rw [hleft]
-      simp only [map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind]
+      simp only [monad_norm]
       conv_rhs =>
         lhs
         change simulateQ (fsUniformImpl (M := M) (Commit := Commit) (Chal := Chal))
           ((simulateQ (simulatedNmaUnifSim (M := M) (Commit := Commit)
             (Chal := Chal)) (simT pk)).run advCache)
         rw [hright]
-      simp only [map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind]
+      simp only [monad_norm]
       refine bind_congr (m := ProbComp) fun x => ?_
       cases htarget : cache (m, x.1) with
       | some old =>
@@ -569,10 +568,8 @@ private lemma cmaToNma_lift_ro_query_run
       (fun ch => (ch, log)) <$>
         (((nmaSpec M Commit Chal Stmt).query (.ro mc)) :
           OracleComp (nmaSpec M Commit Chal Stmt) Chal)
-  simp only [simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query, cmaToNma,
-    StateT.run_mk, StateT.run_bind, map_eq_bind_pure_comp,
-    Function.comp_apply]
-  simp [map_eq_bind_pure_comp]
+  simp [simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query, cmaToNma,
+    StateT.run_mk, map_eq_bind_pure_comp]
 
 omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] [Inhabited Chal] in
 private lemma cmaSim_lift_ro_query_run
@@ -608,13 +605,13 @@ private lemma cmaSim_lift_ro_query_run
     (Chal := Chal) (Resp := Resp) (Stmt := Stmt) simT mc log]
   cases hcache : cache mc with
   | none =>
-      simp [simulateQ_map, StateT.run_map, nma, nmaPublic, cmaFrame,
+      simp [nma, nmaPublic, cmaFrame,
         cmaOuterLens, cmaNmaLens, QueryImpl.Stateful.Frame.linkReshape,
-        hcache, QueryCache.cacheQuery, Functor.map_map]
+        hcache, QueryCache.cacheQuery, monad_norm]
   | some ch =>
-      simp [simulateQ_map, StateT.run_map, nma, nmaPublic, cmaFrame,
+      simp [nma, nmaPublic, cmaFrame,
         cmaOuterLens, cmaNmaLens, QueryImpl.Stateful.Frame.linkReshape,
-        hcache]
+        hcache, monad_norm]
 
 omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] [Inhabited Chal] in
 private lemma cmaSimVerifyFreshComp_project
@@ -1222,7 +1219,7 @@ private lemma forkBase_finalQuery_runTrace_eq
     (oa := adv.main pk)
     (s := (∅ : (fsRoSpec M Commit Chal).QueryCache))
     (q := ((∅ : (M × Commit →ₒ Chal).QueryCache), ([] : List (M × Commit))))]
-  simp only [map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind]
+  simp only [monad_norm]
   apply bind_congr
   intro z
   rcases z with ⟨⟨msg, c, resp⟩, advCache, liveCache, queryLog⟩
@@ -2000,7 +1997,7 @@ private lemma nma_runProb_shiftLeft_signedFreshAdv_eq_forkH5Body
             hr simT) (adv.main ps.1)).run st0) >>= common := by
         simp only [bind_map_left]
         refine bind_congr fun x => ?_
-        simpa [cmaSim, _root_.FiatShamir, map_eq_bind_pure_comp] using
+        simpa [cmaSim, _root_.FiatShamir, monad_norm] using
           cmaSimVerifyFreshComp_project (σ := σ) (hr := hr) (M := M)
           (Commit := Commit) (Chal := Chal) (Resp := Resp)
           (Stmt := Stmt) (Wit := Wit) simT ps.1 x.1 x.2

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -1135,7 +1135,7 @@ private lemma forkVerifyFreshComp_prob_true_le_finalQueryTrace
                           (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
                   simp only [forkFinalQueryTrace, Fork.roImpl, StateT.run_bind,
                     StateT.run_get, hlive, StateT.run_monadLift, StateT.run_set,
-                    StateT.run_pure, monadLift_self, bind_assoc, pure_bind]
+                    StateT.run_pure, monadLift_self, monad_norm]
                   change
                     Pr[fun ch : Chal => σ.verify pk c ch resp = true |
                       (((Fork.wrappedSpec Chal).query (Sum.inr ())) :
@@ -1709,8 +1709,7 @@ private lemma forkLogged_verify_prob_true_le_forkPoint_run
               pure ((Fork.forkPoint (M := M) (Commit := Commit)
                 (Resp := Resp) (Chal := Chal) qH trace).isSome)] := by
           simp [finalRun, loggedRun, forkLoggedImpl, forkInitialState,
-            forkInitialBaseState, map_eq_bind_pure_comp, bind_assoc,
-            forkFinalQueryTrace]
+            forkInitialBaseState, monad_norm, forkFinalQueryTrace]
       _ =
         Pr[= true |
           (simulateQ (forkBaseImpl (M := M) (Commit := Commit)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -490,7 +490,7 @@ private theorem postKeygenFreshAppendProb_eq_statefulPostKeygenFreshProb
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
     (oa := adv.main pk)
     pk sk ([] : List M) (∅ : RoCache M Commit Chal)]
-  simp only [map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind]
+  simp only [monad_norm]
   refine bind_congr (m := ProbComp) fun z => ?_
   rcases z with ⟨out, st⟩
   rcases out with ⟨msg, sig⟩

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -271,9 +271,9 @@ private lemma cmaRealSourceFullSum_sign_run_some
   rcases cp with ⟨c, prv⟩
   cases hcache : cache (m, c) with
   | some ch =>
-      simp [map_eq_bind_pure_comp]
+      simp [monad_norm]
   | none =>
-      simp [map_eq_bind_pure_comp]
+      simp [monad_norm]
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private def cmaRealSourceFullSum_postKeygenOrnament
@@ -460,7 +460,7 @@ private lemma postKeygenAppendImpl_run_eq_cmaRealSourceFullSum_run
         (fun z : α × (List M × RoCache M Commit Chal) => ((z.1, z.2.1), z.2.2)) <$>
           (simulateQ impl.flattenStateT oa).run (signed, cache) := by
         rw [hflat]
-        simp [map_eq_bind_pure_comp, bind_assoc]
+        simp [monad_norm]
     _ =
         (fun z : α × CmaState M Commit Chal Stmt Wit =>
           ((z.1, z.2.1.1), z.2.1.2.1)) <$>
@@ -643,7 +643,7 @@ private def cmaRealAppendOrnament :
           | some ch =>
               simp [fs_simp, map_eq_bind_pure_comp]
           | none =>
-              simp [fs_simp, map_eq_bind_pure_comp, bind_assoc]
+              simp [fs_simp, monad_norm]
       | some ps =>
           rcases ps with ⟨pk, sk⟩
           simp only [add_apply_inr, fs_simp,
@@ -653,9 +653,9 @@ private def cmaRealAppendOrnament :
           rcases cp with ⟨c, prv⟩
           cases hcache : cache (m, c) with
           | some ch =>
-              simp [fs_simp, map_eq_bind_pure_comp, bind_assoc]
+              simp [fs_simp, monad_norm]
           | none =>
-              simp [fs_simp, map_eq_bind_pure_comp, bind_assoc]
+              simp [fs_simp, monad_norm]
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaReal_cmaSignLog_liftM_run_eq_cmaRealSourceFullSum_run
@@ -757,7 +757,7 @@ theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
     (hr := hr) (M := M) (Commit := Commit) (Chal := Chal)
     (Resp := Resp) (oa := adv.main ps.1) ps.1 ps.2
     ([] : List M) (∅ : RoCache M Commit Chal)]
-  simp only [Prod.mk.eta, map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind]
+  simp only [Prod.mk.eta, monad_norm, Function.comp_apply]
   refine bind_congr (m := ProbComp) fun z => ?_
   rcases z with ⟨out, st⟩
   rcases out with ⟨msg, sig⟩
@@ -805,7 +805,7 @@ theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
           simp [cmaRealSourceFullSum, cmaRealSourceFull, hcache]
         rw [hrun]
         simp
-      simpa [map_eq_bind_pure_comp] using hleft.trans hright.symm
+      simpa [monad_norm] using hleft.trans hright.symm
   | none =>
       have hleft :
           (((_root_.FiatShamir
@@ -814,8 +814,7 @@ theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
             fun a => pure (!decide (msg ∈ signed) && a.1)) =
             (($ᵗ Chal) >>= fun ch =>
               pure (!decide (msg ∈ signed) && σ.verify ps.1 c ch resp)) := by
-        simp [FiatShamir, hcache, uniformSampleImpl, map_eq_bind_pure_comp,
-          bind_assoc]
+        simp [FiatShamir, hcache, uniformSampleImpl, monad_norm]
       have hright :
           ((simulateQ (cmaRealSourceFullSum M Commit Chal σ hr)
               ((SourceSigAlg (σ := σ) (hr := hr) (M := M)).verify
@@ -826,15 +825,13 @@ theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
             (($ᵗ Chal) >>= fun ch =>
               pure (!decide (msg ∈ signed) && σ.verify ps.1 c ch resp)) := by
         simp only [SourceSigAlg, FiatShamir, HasQuery.instOfMonadLift_query,
-          bind_pure_comp, map_eq_bind_pure_comp, liftM_bind, Function.comp_apply, liftM_pure,
-          simulateQ_bind, simulateQ_pure, StateT.run_bind, StateT.run_pure, bind_assoc,
-          pure_bind]
+          monad_norm, liftM_bind, liftM_pure,
+          simulateQ_bind, simulateQ_pure, StateT.run_bind, StateT.run_pure]
         rw [cmaRealSourceFullSum_lift_ro_query_run (σ := σ) (hr := hr)
           (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
           (Stmt := Stmt) (Wit := Wit) (mc := (msg, c))]
-        simp [cmaRealSourceFullSum, cmaRealSourceFull, hcache,
-          map_eq_bind_pure_comp, bind_assoc]
-      simpa [map_eq_bind_pure_comp] using hleft.trans hright.symm
+        simp [cmaRealSourceFullSum, cmaRealSourceFull, hcache, monad_norm]
+      simpa [monad_norm] using hleft.trans hright.symm
 
 /-- Fixed-key public post-keygen experiment in the WriterT signing-log form. -/
 @[reducible] private noncomputable def postKeygenFreshWriterComp

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -170,7 +170,7 @@ theorem statefulCmaFreshAdvantage_eq_statefulPostKeygenFreshAdvantage
     statefulPostKeygenFreshAdvantage
   rw [cmaRealRun_eq_keygen_bind (σ := σ) (hr := hr) (M := M)
     (Commit := Commit) (Chal := Chal) (Resp := Resp) adv]
-  simp only [bind_assoc]
+  simp only [monad_norm]
   apply congrArg (fun p => Pr[= true | p])
   apply bind_congr
   intro ps
@@ -179,7 +179,6 @@ theorem statefulCmaFreshAdvantage_eq_statefulPostKeygenFreshAdvantage
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
     adv ps.1 ((([] : List M), (∅ : RoCache M Commit Chal),
       (some (ps.1, ps.2) : Option (Stmt × Wit))), false)]
-  simp
 
 /-! ## Public WriterT compatibility -/
 
@@ -346,18 +345,17 @@ private def cmaRealSourceFullSum_postKeygenOrnament
       | none =>
           simp [fs_simp, hcache, uniformSampleImpl]
     · simp only [add_apply_inr, fs_simp, bind_pure_comp,
-        map_eq_bind_pure_comp, Prod.mk.eta, StateT.run_mk, bind_assoc,
+        map_eq_bind_pure_comp, Prod.mk.eta, StateT.run_mk, monad_norm,
         FiatShamir, QueryImpl.toHasQuery_query,
         randomOracle, QueryImpl.withCaching_apply, StateT.run_bind, StateT.run_monadLift,
-        monadLift_self, StateT.run_get, Function.comp_apply, StateT.run_pure, pure_bind]
+        monadLift_self, StateT.run_get, Function.comp_apply]
       refine bind_congr (m := ProbComp) fun cp => ?_
       rcases cp with ⟨c, prv⟩
       cases hcache : cache (m, c) with
       | some ch =>
           simp [fs_simp, map_eq_bind_pure_comp]
       | none =>
-          simp [fs_simp, uniformSampleImpl, StateT.run_modifyGet,
-            map_eq_bind_pure_comp, bind_assoc]
+          simp [fs_simp, uniformSampleImpl, StateT.run_modifyGet, monad_norm]
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma postKeygenAppendProdImpl_eq_flattenStateT
@@ -394,10 +392,9 @@ private lemma postKeygenAppendProdImpl_eq_flattenStateT
     simp [fsBaseImpl, unifFwdImpl, randomOracle, map_eq_bind_pure_comp]
   · ext st
     rcases st with ⟨signed, cache⟩
-    simp [postKeygenAppendProdImpl, postKeygenAppendImpl,
+    simp [postKeygenAppendProdImpl, postKeygenAppendImpl, monad_norm,
       QueryImpl.flattenStateT, QueryImpl.add_apply_inr, QueryImpl.appendInputLog_apply,
-      StateT.run_bind, StateT.run_get, StateT.run_set, StateT.run_monadLift,
-      map_eq_bind_pure_comp, bind_assoc]
+      StateT.run_bind, StateT.run_get, StateT.run_set, StateT.run_monadLift]
 
 /-- Fixed-key public post-keygen experiment after WriterT logging has been
 converted to an input log. This is split at the candidate/log boundary. -/
@@ -582,8 +579,7 @@ private lemma cmaRealLoggedProdImpl_lift_query_eq_cmaRealAppendProdImpl
     ext st
     rcases st with ⟨signed, st⟩
     simp [fs_simp, QueryImpl.extendStateLeft, QueryImpl.mapStateTBase,
-      QueryImpl.flattenStateT, StateT.run_bind, map_eq_bind_pure_comp,
-      bind_assoc]
+      QueryImpl.flattenStateT, StateT.run_bind, monad_norm]
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaRealLoggedProdImpl_liftAdv_run {α : Type}
@@ -633,9 +629,8 @@ private def cmaRealAppendOrnament :
           simp [fs_simp, QueryImpl.extendStateLeft, hcache, map_eq_bind_pure_comp]
     · cases hkp : keypair with
       | none =>
-          simp only [add_apply_inr, fs_simp,
-            QueryImpl.extendStateLeft, bind_pure_comp, map_eq_bind_pure_comp,
-            Prod.mk.eta, StateT.run_mk, bind_assoc]
+          simp only [add_apply_inr, fs_simp, monad_norm, QueryImpl.extendStateLeft,
+            Prod.mk.eta, StateT.run_mk]
           refine bind_congr (m := ProbComp) fun ps => ?_
           refine bind_congr (m := ProbComp) fun cp => ?_
           rcases cp with ⟨c, prv⟩
@@ -646,9 +641,8 @@ private def cmaRealAppendOrnament :
               simp [fs_simp, monad_norm]
       | some ps =>
           rcases ps with ⟨pk, sk⟩
-          simp only [add_apply_inr, fs_simp,
-            QueryImpl.extendStateLeft, bind_pure_comp, map_eq_bind_pure_comp,
-            Prod.mk.eta, StateT.run_mk, bind_assoc]
+          simp only [add_apply_inr, fs_simp, monad_norm, QueryImpl.extendStateLeft,
+            Prod.mk.eta, StateT.run_mk]
           refine bind_congr (m := ProbComp) fun cp => ?_
           rcases cp with ⟨c, prv⟩
           cases hcache : cache (m, c) with
@@ -743,8 +737,7 @@ theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
   simp only [StateT.run'_eq, simulateQ_bind, simulateQ_query,
     OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind,
     bind_assoc]
-  simp only [postKeygenAppendImpl, StateT.run_pure,
-    bind_pure_comp, map_eq_bind_pure_comp, bind_assoc, Function.comp_apply, pure_bind,
+  simp only [postKeygenAppendImpl, StateT.run_pure, monad_norm,
     cmaSignLogImpl, bind_pure, CompTriple.comp_eq, StateT.run_monadLift, monadLift_self,
     simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
     cmaReal, Prod.mk.eta, simulateQ_pure, cmaInit, StateT.run_bind, StateT.run_mk]

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -353,7 +353,7 @@ private def cmaRealSourceFullSum_postKeygenOrnament
       rcases cp with ⟨c, prv⟩
       cases hcache : cache (m, c) with
       | some ch =>
-          simp [fs_simp, map_eq_bind_pure_comp]
+          simp [fs_simp, monad_norm]
       | none =>
           simp [fs_simp, uniformSampleImpl, StateT.run_modifyGet, monad_norm]
 
@@ -377,7 +377,7 @@ private lemma postKeygenAppendProdImpl_eq_flattenStateT
           (StateT (List M) (StateT (RoCache M Commit Chal) ProbComp))).flattenStateT
         (.inl n)).run (signed, cache)
     rw [QueryImpl.flattenStateT_liftTarget_apply_run]
-    simp [fsBaseImpl, unifFwdImpl, map_eq_bind_pure_comp]
+    simp [fsBaseImpl, unifFwdImpl, monad_norm]
   · ext st
     rcases st with ⟨signed, cache⟩
     conv_lhs =>
@@ -389,7 +389,7 @@ private lemma postKeygenAppendProdImpl_eq_flattenStateT
           (StateT (List M) (StateT (RoCache M Commit Chal) ProbComp))).flattenStateT
         (.inr mc)).run (signed, cache)
     rw [QueryImpl.flattenStateT_liftTarget_apply_run]
-    simp [fsBaseImpl, unifFwdImpl, randomOracle, map_eq_bind_pure_comp]
+    simp [fsBaseImpl, unifFwdImpl, randomOracle, monad_norm]
   · ext st
     rcases st with ⟨signed, cache⟩
     simp [postKeygenAppendProdImpl, postKeygenAppendImpl, monad_norm,
@@ -621,12 +621,12 @@ private def cmaRealAppendOrnament :
   project_step := fun t st _ => by
     rcases st with ⟨⟨signed, cache, keypair⟩, bad⟩
     rcases t with (n | mc) | m
-    · simp [fs_simp, QueryImpl.extendStateLeft, map_eq_bind_pure_comp]
+    · simp [fs_simp, QueryImpl.extendStateLeft, monad_norm]
     · cases hcache : cache mc with
       | some ch =>
-          simp [fs_simp, QueryImpl.extendStateLeft, hcache, map_eq_bind_pure_comp]
+          simp [fs_simp, QueryImpl.extendStateLeft, hcache, monad_norm]
       | none =>
-          simp [fs_simp, QueryImpl.extendStateLeft, hcache, map_eq_bind_pure_comp]
+          simp [fs_simp, QueryImpl.extendStateLeft, hcache, monad_norm]
     · cases hkp : keypair with
       | none =>
           simp only [add_apply_inr, fs_simp, monad_norm, QueryImpl.extendStateLeft,
@@ -636,7 +636,7 @@ private def cmaRealAppendOrnament :
           rcases cp with ⟨c, prv⟩
           cases hcache : cache (m, c) with
           | some ch =>
-              simp [fs_simp, map_eq_bind_pure_comp]
+              simp [fs_simp, monad_norm]
           | none =>
               simp [fs_simp, monad_norm]
       | some ps =>

--- a/VCVio/CryptoFoundations/FiatShamir/WithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/WithAbort.lean
@@ -250,8 +250,8 @@ lemma verify_eq_true_of_cached
       fun c => pure (ids.verify pk w c z)).run cache) = _
   rw [StateT.run_bind]
   simp only [randomOracle, QueryImpl.withCaching_apply,
-    StateT.run_bind, StateT.run_get, pure_bind, hcached,
-    StateT.run_pure, map_pure, hverify]
+    StateT.run_bind, StateT.run_get, monad_norm, hcached,
+    StateT.run_pure, hverify, Function.comp_apply]
 
 /-- Correctness of the Fiat-Shamir with aborts signature scheme: the canonical
 keygen-sign-verify execution succeeds with probability at least `1 - δ`, where `δ` bounds

--- a/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
@@ -321,7 +321,7 @@ theorem dlogSuccess_sq_le_cdhSuccess_dlogToCDHReduction
         (Pr[= b' | adversary g (b • g)] *
           (if (a' * b') • g = (a * b) • g then 1 else 0)))) := by
     unfold cdhExp dlogToCDHReduction
-    simp only [bind_assoc, pure_bind, probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_left]
+    simp only [monad_norm, probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_left]
     refine tsum_congr fun a => ?_
     refine tsum_congr fun b => ?_
     refine tsum_congr fun a' => ?_

--- a/VCVio/CryptoFoundations/HashCommitment.lean
+++ b/VCVio/CryptoFoundations/HashCommitment.lean
@@ -76,7 +76,7 @@ theorem bindingAdvantage_toCommitment_le_keyedCRAdvantage
       keyedCRAdvantage H (bindingAdv_toCRAdv A) := by
   unfold bindingAdvantage CommitmentScheme.bindingExp
     keyedCRAdvantage keyedCRExp bindingAdv_toCRAdv KeyedHashFamily.toCommitment
-  simp only [bind_assoc, pure_bind]
+  simp only [monad_norm]
   refine probOutput_bind_mono fun k _ => ?_
   refine probOutput_bind_mono fun ⟨c, m₁, s₁, m₂, s₂⟩ _ => ?_
   grind

--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -73,7 +73,7 @@ theorem perfectlyCorrect_composeWithDEM
   simp only [AsymmEncAlg.CorrectExp, composeWithDEM]
   rw [← hkem]
   unfold KEMScheme.CorrectExp
-  simp only [bind_assoc, pure_bind]
+  simp only [monad_norm]
   apply probOutput_bind_congr
   intro ⟨pk, sk⟩ hks
   apply probOutput_bind_congr
@@ -93,7 +93,7 @@ theorem perfectlyCorrect_composeWithDEM
   have hkEq := kem_decaps_mem_support hkem hks hck hkOpt
   subst hkEq
   simp only [probOutput_pure]
-  simpa [DEMScheme.CorrectExp, bind_assoc]
+  simpa [DEMScheme.CorrectExp, monad_norm]
     using (hdem k msg)
 
 end Correct

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -2331,7 +2331,7 @@ private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
               rw [replayOracle_run_nextEntry_none t t
                 ({stR with replacement := u} : ReplayForkState spec t)
                 h_Rcon h_Rmis hR_next]
-              simp only [bind_assoc, pure_bind, map_bind]
+              simp only [monad_norm]
               refine bind_congr fun u' => ?_
               exact fst_map_simulateQ_replayOracle_of_live t (oa u')
                 ((({stR with replacement := u}).markMismatch).noteObserved t u')
@@ -2359,7 +2359,7 @@ private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
               rw [replayOracle_run_mismatch_ne t₀ t t₀ u'₀
                 ({stL with replacement := u} : ReplayForkState spec t₀)
                 h_Lcon h_Lmis hL_next h_tt₀]
-              simp only [bind_assoc, pure_bind, map_bind]
+              simp only [monad_norm]
               refine bind_congr fun u' => ?_
               exact fst_map_simulateQ_replayOracle_of_live t₀ (oa u')
                 ((({stL with replacement := u}).markMismatch).noteObserved t u')
@@ -2374,7 +2374,7 @@ private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
               rw [replayOracle_run_nextEntry_none t₀ t
                 ({stR with replacement := u} : ReplayForkState spec t₀)
                 h_Rcon h_Rmis hR_next]
-              simp only [bind_assoc, pure_bind, map_bind]
+              simp only [monad_norm]
               refine bind_congr fun u' => ?_
               exact fst_map_simulateQ_replayOracle_of_live t₀ (oa u')
                 ((({stR with replacement := u}).markMismatch).noteObserved t u')
@@ -2487,7 +2487,7 @@ private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
               rw [replayOracle_run_mismatch_ne t₀ t t₀ u'₀
                 ({stL with replacement := u} : ReplayForkState spec t₀)
                 h_Lcon h_Lmis hL_next h_tt₀]
-              simp only [bind_assoc, pure_bind, map_bind]
+              simp only [monad_norm]
               refine bind_congr fun u' => ?_
               exact fst_map_simulateQ_replayOracle_of_live t₀ (oa u')
                 ((({stL with replacement := u}).markMismatch).noteObserved t u')
@@ -2502,7 +2502,7 @@ private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
               rw [replayOracle_run_mismatch_ne t₀ t t₀ u'₀
                 ({stR with replacement := u} : ReplayForkState spec t₀)
                 h_Rcon h_Rmis hR_next h_tt₀]
-              simp only [bind_assoc, pure_bind, map_bind]
+              simp only [monad_norm]
               refine bind_congr fun u' => ?_
               exact fst_map_simulateQ_replayOracle_of_live t₀ (oa u')
                 ((({stR with replacement := u}).markMismatch).noteObserved t u')
@@ -3434,7 +3434,7 @@ private lemma sq_probOutput_main_le_noGuardReplayComp
         some <$> ((cf p.1, ·) <$> (cf <$> Prod.fst <$> (do
           let u ← liftComp ($ᵗ spec.Range i) spec
           replayRunWithTraceValue main i p.2 ↑s u))) := by
-      simp [map_eq_bind_pure_comp, Function.comp]
+        simp [monad_norm]
     rw [hinner, probOutput_some_map_some, probOutput_prod_mk_snd_map]
     change (if (some s, some s).1 = cf p.1 then
         Pr[= (some s, some s).2 | (cf <$> Prod.fst <$> (do

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -148,7 +148,7 @@ lemma ProbComp.boolBiasAdvantage_bind_uniformBool_eq_boolDistAdvantage
             let a ← pref
             let z ← if b then real a else rand a
             pure (b == z)] := by
-              simpa [game, bind_assoc] using
+              simpa [game, monad_norm] using
                 (probOutput_bind_bind_swap pref ($ᵗ Bool)
                   (fun a b => do
                     let z ← if b then real a else rand a

--- a/VCVio/CryptoFoundations/SeededFork.lean
+++ b/VCVio/CryptoFoundations/SeededFork.lean
@@ -619,7 +619,7 @@ private lemma sq_probOutput_main_le_noGuardComp (s : Fin (qb i + 1)) :
                        (simulateQ seededOracle main).run'
                          ((σ.takeAtIndex i ↑s).addValue i u))
                      pure (cf x₁, cf x₂)) := by
-      simp only [map_eq_bind_pure_comp, bind_assoc, Function.comp, pure_bind]
+      simp only [monad_norm, Function.comp]
     rw [hcomp, probOutput_some_map_some, probOutput_bind_bind_prod_mk_eq_mul']
     congr 1
     have h := seededOracle.evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue
@@ -925,7 +925,7 @@ theorem le_probOutput_seededFork (s : Fin (qb i + 1)) :
                        else
                          pure none)] := by
               rw [hif]
-              simpa [map_eq_bind_pure_comp] using hmono
+              simpa [monad_norm] using hmono
             have hadd :
                 Pr[= z |
                   (fun r ↦ Option.map (Prod.map cf cf) r) <$>

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -252,7 +252,7 @@ lemma unforgeableAdv.advantage_le_unforgeableExpNoFresh
         runtime.evalDist joint := by
     rw [← h_pull]
     congr 1
-    simp only [hjoint_def, bind_assoc, pure_bind]
+    simp only [hjoint_def, monad_norm]
   have hNoFresh : (runtime.evalDist do
         let (pk, sk) ← sigAlg.keygen
         let impl : QueryImpl (spec + (M →ₒ S))
@@ -267,7 +267,7 @@ lemma unforgeableAdv.advantage_le_unforgeableExpNoFresh
       (fun t : M × QueryLog (M →ₒ S) × Bool => t.2.2) <$> runtime.evalDist joint := by
     rw [← h_pull]
     congr 1
-    simp only [hjoint_def, bind_assoc, pure_bind, bind_pure]
+    simp only [hjoint_def, monad_norm]
   rw [hExp, hNoFresh, ← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput,
     probEvent_map, probEvent_map]
   refine probEvent_mono fun _ _ hv => ?_

--- a/VCVio/CryptoFoundations/SymmEncAlg.lean
+++ b/VCVio/CryptoFoundations/SymmEncAlg.lean
@@ -73,8 +73,7 @@ lemma PerfectSecrecyExp_eq_bind [LawfulMonad m] (encAlg : SymmEncAlg m M K C)
     encAlg.PerfectSecrecyExp mgen =
       mgen >>= fun msg =>
         (msg, ·) <$> encAlg.PerfectSecrecyCipherGivenMsgExp msg := by
-  simp [PerfectSecrecyExp, PerfectSecrecyCipherGivenMsgExp,
-    map_eq_bind_pure_comp, bind_assoc]
+  simp [PerfectSecrecyExp, PerfectSecrecyCipherGivenMsgExp, monad_norm]
 
 lemma PerfectSecrecyCipherExp_eq_bind [LawfulMonad m] (encAlg : SymmEncAlg m M K C)
     (mgen : m M) :

--- a/VCVio/CryptoFoundations/SymmEncAlg.lean
+++ b/VCVio/CryptoFoundations/SymmEncAlg.lean
@@ -81,7 +81,7 @@ lemma PerfectSecrecyCipherExp_eq_bind [LawfulMonad m] (encAlg : SymmEncAlg m M K
     encAlg.PerfectSecrecyCipherExp mgen =
       mgen >>= fun msg =>
         encAlg.PerfectSecrecyCipherGivenMsgExp msg := by
-  simp [PerfectSecrecyCipherExp, PerfectSecrecyExp_eq_bind, map_eq_bind_pure_comp, bind_assoc]
+  simp [PerfectSecrecyCipherExp, PerfectSecrecyExp_eq_bind, monad_norm]
 
 variable [HasEvalPMF m]
 

--- a/VCVio/EvalDist/Defs/NeverFails.lean
+++ b/VCVio/EvalDist/Defs/NeverFails.lean
@@ -158,7 +158,7 @@ Mapping a value through a total function preserves `NeverFail`.
 @[simp, grind .]
 instance instMap [LawfulMonad m] {mx : m α} [h : NeverFail mx] (f : α → β) :
     NeverFail (f <$> mx) := by
-  simp only [map_eq_bind_pure_comp, bind_of_forall, Function.comp_def]
+  simp only [monad_norm, bind_of_forall, Function.comp_def]
 
 
 

--- a/VCVio/EvalDist/Instances/ErrorT.lean
+++ b/VCVio/EvalDist/Instances/ErrorT.lean
@@ -147,7 +147,7 @@ noncomputable def toSPMF' [HasEvalPMF m] : ExceptT ε m →ᵐ SPMF where
   toFun_pure' x := by simp
   toFun_bind' mx f := by
     change HasEvalSPMF.toSPMF (mx.run >>= ExceptT.bindCont f) >>= _ = _
-    simp only [MonadHom.toFun_bind', bind_assoc]
+    simp only [MonadHom.toFun_bind', monad_norm]
     congr 1; funext r
     cases r with
     | ok a =>

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -77,7 +77,7 @@ lemma probOutput_map_eq_tsum_subtype (y : β) :
 
 lemma probOutput_map_eq_tsum (y : β) :
     Pr[= y | f <$> mx] = ∑' x, Pr[= x | mx] * Pr[= y | (pure (f x) : m β)] := by
-  simp only [map_eq_bind_pure_comp, probOutput_bind_eq_tsum, Function.comp_apply]
+  simp [monad_norm, probOutput_bind_eq_tsum]
 
 lemma probOutput_map_eq_tsum_subtype_ite [DecidableEq β] (y : β) :
     Pr[= y | f <$> mx] = ∑' x : support mx, if y = f x then Pr[= x | mx] else 0 := by
@@ -154,13 +154,13 @@ lemma finSupport_map_const [DecidableEq α] [DecidableEq β] [HasEvalFinset m]
 lemma probOutput_map_const (y' : β) :
     Pr[= y' | (fun _ => y) <$> mx] =
       (1 - Pr[⊥ | mx]) * Pr[= y' | (pure y : m β)] := by
-  rw [map_eq_bind_pure_comp, Function.comp_def, probOutput_bind_const]
+  simp only [monad_norm, Function.comp_def, probOutput_bind_const]
 
 @[simp, aesop safe norm, grind =_]
 lemma probEvent_map_const (p : β → Prop) :
     Pr[ p | (fun _ => y) <$> mx] =
       (1 - Pr[⊥ | mx]) * Pr[ p | (pure y : m β)] := by
-  rw [map_eq_bind_pure_comp, Function.comp_def, probEvent_bind_const]
+  simp only [monad_norm, Function.comp_def, probEvent_bind_const]
 
 @[simp, aesop safe norm]
 lemma probEvent_map_const' (p : β → Prop) [DecidablePred p] :

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -27,7 +27,7 @@ open ENNReal
 @[simp, grind =]
 lemma support_map [HasEvalSet m] [LawfulMonad m] (f : α → β) (mx : m α) :
     support (f <$> mx) = f '' support mx := by
-  simp [map_eq_bind_pure_comp]
+  simp [monad_norm]
   aesop
 
 @[simp, grind =]
@@ -38,7 +38,7 @@ lemma finSupport_map [HasEvalSet m] [HasEvalFinset m] [LawfulMonad m]
 
 @[simp, grind =]
 lemma evalDist_map [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (f : α → β) :
-    𝒟[f <$> mx] = f <$> (𝒟[mx]) := by simp [map_eq_bind_pure_comp]
+    𝒟[f <$> mx] = f <$> (𝒟[mx]) := by simp [monad_norm]
 
 lemma evalDist_map_eq_of_evalDist_eq [HasEvalSPMF m] [LawfulMonad m]
     {mx my : m α} (h : 𝒟[mx] = 𝒟[my]) (f : α → β) :
@@ -111,7 +111,7 @@ lemma probOutput_map_eq_sum_filter_finSupport [HasEvalFinset m] [DecidableEq α]
 
 @[simp, grind =]
 lemma probFailure_map : Pr[⊥ | f <$> mx] = Pr[⊥ | mx] := by
-  simp [map_eq_bind_pure_comp, probFailure_bind_eq_add_tsum]
+  simp [monad_norm, probFailure_bind_eq_add_tsum]
 
 @[simp, grind =]
 lemma probEvent_map (q : β → Prop) : Pr[ q | f <$> mx] = Pr[ q ∘ f | mx] := by

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -36,7 +36,7 @@ lemma mem_support_seq_iff [HasEvalSet m] [LawfulMonad m] (mf : m (α → β)) (m
   simp [seq_eq_bind_map]
 
 @[simp] lemma evalDist_seq [HasEvalSPMF m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
-    𝒟[mf <*> mx] = 𝒟[mf] <*> 𝒟[mx] := by simp [seq_eq_bind_map]
+    𝒟[mf <*> mx] = 𝒟[mf] <*> 𝒟[mx] := by simp [monad_norm]
 
 lemma probOutput_seq_eq_tsum [HasEvalSPMF m] [LawfulMonad m]
     (mf : m (α → β)) (mx : m α) (y : β) :
@@ -164,7 +164,7 @@ lemma evalDist_seq_map [HasEvalSPMF m] :
 lemma probOutput_seq_map_eq_tsum [HasEvalSPMF m]
     (z : γ) : Pr[= z | f <$> mx <*> my] = ∑' (x : α) (y : β),
       Pr[= x | mx] * Pr[= y | my] * Pr[= z | (pure (f x y) : m γ)] := by
-  simp only [map_eq_bind_pure_comp, Function.comp, seq_eq_bind_map, bind_assoc, pure_bind,
+  simp only [monad_norm, Function.comp,
     probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_left, mul_assoc]
 
 lemma probOutput_seq_map_eq_tsum_ite [HasEvalSPMF m] [DecidableEq γ]

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -111,14 +111,14 @@ lemma probOutput_seq_map_prod_mk_map_eq_mul' (z : γ × δ) :
 @[simp]
 lemma probOutput_bind_map_prod_mk_eq_mul (z : γ × δ) :
     Pr[= z | do let x ← mx; (f x, g ·) <$> my] = Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
-  simpa [seq_eq_bind_map, map_eq_bind_pure_comp] using
+  simpa [monad_norm] using
     probOutput_seq_map_prod_mk_map_eq_mul mx my f g z
 
 @[simp]
 lemma probOutput_bind_map_prod_mk_eq_mul'
     (mx : m α) (my : m β) (f : α → γ) (g : β → δ) (z : γ × δ) :
     Pr[= z | do let y ← my; (f ·, g y) <$> mx] = Pr[= z.1 | f <$> mx] * Pr[= z.2 | g <$> my] := by
-  simpa [seq_eq_bind_map, map_eq_bind_pure_comp] using
+  simpa [monad_norm] using
     probOutput_seq_map_prod_mk_map_eq_mul' mx my f g z
 
 @[simp high]

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -447,9 +447,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
           Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_2, Counterpart.appendFlat.eq_2]
-        simp only [do_pure_bind]
-        simp only [Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
-        simp only [do_pure_bind, bind_assoc]
+        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         have hpure := @Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure m _ _
@@ -461,7 +459,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
               (fun tr₂ => OutputP ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) tr₁ tr₂⟩)
             from f ⟨xc.fst, tr₁⟩ mid)
-        erw [hpure, do_pure_bind]
+        erw [hpure, pure_bind]
         refine congrArg (fun k => cpt₁ xc.1 >>= k) ?_
         funext cRest
         have ih := @go (rest xc.fst) (rRest xc.fst)
@@ -481,13 +479,11 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
-        simp only [Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure, do_pure_bind] at ih
+        simp only [Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure, pure_bind] at ih
         exact ih
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_3, Counterpart.appendFlat.eq_3]
-        simp only [do_pure_bind]
-        simp only [Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
-        simp only [do_pure_bind, bind_assoc]
+        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -509,9 +505,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
-  have h := go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
-  simp only [do_bind_pure, Prod.eta] at h
-  exact h
+  simpa [monad_norm] using go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
 
 /-- Executing a flat composed strategy/counterpart factors into first executing
 the prefix interaction and then executing the suffix continuation. -/
@@ -575,9 +569,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_2, Counterpart.appendFlat.eq_2]
-        simp only [do_pure_bind]
-        simp only [Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
-        simp only [do_pure_bind, bind_assoc]
+        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         rw [LawfulCommMonad.bind_comm]
@@ -602,9 +594,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_3, Counterpart.appendFlat.eq_3]
-        simp only [do_pure_bind]
-        simp only [Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
-        simp only [do_pure_bind, bind_assoc]
+        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -626,9 +616,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
-  have h := go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
-  simp only [do_bind_pure, Prod.eta] at h
-  exact h
+  simpa [monad_norm] using go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
 
 /-- Executing a factored composed strategy/counterpart (using `compWithRoles` and
 `Counterpart.append`) factors into first executing the prefix interaction and then
@@ -696,9 +684,7 @@ theorem Strategy.runWithRoles_compWithRoles_append
           Spec.Transcript.append, Spec.Transcript.liftAppend, Spec.Transcript.packAppend]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.compWithRoles, Counterpart.append]
-        simp only [do_pure_bind]
-        simp only [Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
-        simp only [do_pure_bind, bind_assoc]
+        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         rw [LawfulCommMonad.bind_comm]
@@ -721,9 +707,7 @@ theorem Strategy.runWithRoles_compWithRoles_append
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         simp only [Strategy.compWithRoles, Counterpart.append]
-        simp only [do_pure_bind]
-        simp only [Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
-        simp only [do_pure_bind, bind_assoc]
+        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -743,9 +727,7 @@ theorem Strategy.runWithRoles_compWithRoles_append
               (FC ⟨xc.fst, p⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
-  have h := go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
-  simp only [do_bind_pure] at h
-  exact h
+  simpa [monad_norm] using go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
 
 /-- Role swapping commutes with replication. -/
 theorem RoleDecoration.swap_replicate {spec : Spec}

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -279,7 +279,7 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
             go (rest x) (rRest x)
               (s₂ := fun p => s₂ ⟨x, p⟩)
               (r₂ := fun p => r₂ ⟨x, p⟩) next
-        simpa [map_eq_bind_pure_comp, bind_assoc] using hcont
+        simpa [monad_norm] using hcont
   exact go s₁ r₁ strat
 
 /-- Compose counterparts along `Spec.append` with a two-argument output family
@@ -353,7 +353,7 @@ theorem Counterpart.append_eq_appendFlat_mapOutput
       funext x
       refine congrArg (fun k => c₁ x >>= k) ?_
       funext cRest
-      simpa [bind_assoc] using
+      simpa [monad_norm] using
         congrArg pure
           (append_eq_appendFlat_mapOutput cRest (fun p o => c₂ ⟨x, p⟩ o))
   | .node _ rest, _, ⟨.receiver, rRest⟩, _, _, _, c₁, c₂ => by

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -635,7 +635,7 @@ theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
               (fun tr => OutputC' ⟨xc.1, tr⟩) tr) →
             ((tr : Transcript (Spec.node _ rest)) × OutputP' tr × OutputC' tr) :=
           fun a => ⟨⟨xc.1, a.1⟩, a.2.1, a.2.2⟩
-        simpa [bind_assoc, addPrefix] using
+        simpa [monad_norm, addPrefix] using
           congrArg (fun z => addPrefix <$> z)
             (go (rest xc.1) (rRest xc.1) (fun tr => fP ⟨xc.1, tr⟩) (fun tr => fC ⟨xc.1, tr⟩)
               xc.2 cNext)
@@ -653,7 +653,7 @@ theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
               (fun tr => OutputC' ⟨xc.1, tr⟩) tr) →
             ((tr : Transcript (Spec.node _ rest)) × OutputP' tr × OutputC' tr) :=
           fun a => ⟨⟨xc.1, a.1⟩, a.2.1, a.2.2⟩
-        simpa [bind_assoc, addPrefix] using
+        simpa [monad_norm, addPrefix] using
           congrArg (fun z => addPrefix <$> z)
             (go (rest xc.1) (rRest xc.1) (fun tr => fP ⟨xc.1, tr⟩) (fun tr => fC ⟨xc.1, tr⟩)
               next xc.2)

--- a/VCVio/Interaction/UC/AsyncRuntime.lean
+++ b/VCVio/Interaction/UC/AsyncRuntime.lean
@@ -272,8 +272,7 @@ theorem runStepsAsync_empty_trivial_eq
       simp [runStepsAsync, ProcessOver.runSteps]
   | succ n ih =>
       rw [runStepsAsync, ProcessOver.runSteps]
-      simp only [Interaction.UC.trivialEnvScheduler_apply, pure_bind,
-        bind_assoc, ih]
+      simp only [Interaction.UC.trivialEnvScheduler_apply, monad_norm, ih]
       rfl
 
 end Concurrent
@@ -398,7 +397,7 @@ theorem processSemantics_eq_processSemanticsAsync_trivial
         fuel ⟨init process, ()⟩
       observe process final.proc)
   rw [Concurrent.runStepsAsync_empty_trivial_eq]
-  simp only [bind_assoc, pure_bind]
+  simp only [monad_norm]
 
 /--
 The `ProbComp` specialization of `processSemantics_eq_processSemanticsAsync_trivial`:

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -257,7 +257,7 @@ lemma liftComp_map (mx : OracleComp spec α) (f : α → β) :
 @[simp]
 lemma liftComp_seq (og : OracleComp spec (α → β)) (mx : OracleComp spec α) :
     liftComp (og <*> mx) superSpec = liftComp og superSpec <*> liftComp mx superSpec := by
-  simp [liftComp, seq_eq_bind_map]
+  simp [liftComp, monad_norm]
 
 -- NOTE: `liftComp_failure` cannot be stated for `OracleComp spec` because `failure` only exists
 -- in `OptionT (OracleComp spec)`, not in `OracleComp spec` itself. `OracleComp` is

--- a/VCVio/OracleComp/Constructions/Replicate.lean
+++ b/VCVio/OracleComp/Constructions/Replicate.lean
@@ -68,7 +68,7 @@ lemma replicateTR_eq_replicate : replicateTR n oa = replicate n oa := by
   | succ n ih => simp [List.replicate, List.mapM_cons, ih]
 
 lemma replicate_succ : replicate (n + 1) oa = List.cons <$> oa <*> replicate n oa := by
-  simp [replicate_succ_bind, seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc, Function.comp]
+  simp [replicate_succ_bind, monad_norm, Function.comp]
 
 @[simp]
 lemma replicate_pure (x : α) :

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -90,7 +90,7 @@ lemma probOutput_bind_bijective_uniform_cross
   haveI := Fintype.ofBijective f hf
   have h : (($ᵗ α) >>= fun x => g (f x)) =
       ((f <$> ($ᵗ α)) >>= g) := by
-    simp [map_eq_bind_pure_comp, bind_assoc, pure_bind]
+    simp [monad_norm]
   rw [h, probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
   congr 1
   funext y
@@ -125,7 +125,7 @@ lemma probOutput_bind_add_left_uniform [AddGroup α] {β : Type}
   have hleft :
       (do let y ← $ᵗ α; f (m + y)) =
         (((fun y : α => m + y) <$> ($ᵗ α)) >>= fun y => f y) := by
-    simp [map_eq_bind_pure_comp, bind_assoc]
+    simp [monad_norm]
   rw [hleft, probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
   refine tsum_congr fun y => ?_
   rw [probOutput_add_left_uniform (α := α) m y]
@@ -144,7 +144,7 @@ lemma probOutput_bind_add_right_uniform [AddGroup α] {β : Type}
   have hright :
       (do let y ← $ᵗ α; f (y + m)) =
         (((fun y : α => y + m) <$> ($ᵗ α)) >>= fun y => f y) := by
-    simp [map_eq_bind_pure_comp, bind_assoc]
+    simp [monad_norm]
   rw [hright, probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
   refine tsum_congr fun y => ?_
   rw [probOutput_add_right_uniform (α := α) m y]
@@ -208,13 +208,13 @@ lemma evalDist_bind_bijective_add_right_uniform {β γ : Type}
   have hbind :
       (do let x ← ($ᵗ α); cont (f x + m)) =
         (f <$> ($ᵗ α)) >>= fun y => cont (y + m) := by
-    simp [map_eq_bind_pure_comp, bind_assoc]
+    simp [monad_norm]
   rw [hbind, evalDist_bind,
       evalDist_map_bijective_uniform_cross (α := α) (β := β) f hf, ← evalDist_bind]
   have hshift :
       (do let y ← ($ᵗ β); cont (y + m)) =
         (((· + m) : β → β) <$> ($ᵗ β)) >>= cont := by
-    simp [map_eq_bind_pure_comp, bind_assoc]
+    simp [monad_norm]
   rw [hshift, evalDist_bind, evalDist_add_right_uniform (α := β) m, ← evalDist_bind]
 
 /-- Constant-irrelevance form of `evalDist_bind_bijective_add_right_uniform`: sampling through a

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -103,7 +103,7 @@ theorem bind_congr_of_forall_mem_support (mx : OracleComp spec α) {f g : α →
     (h : ∀ x ∈ support mx, f x = g x) : mx >>= f = mx >>= g := by
   induction mx using OracleComp.inductionOn with
   | pure a =>
-    simp only [pure_bind]
+    simp only [monad_norm]
     exact h a (by simp [support_pure])
   | query_bind q k ih =>
     change liftM (query q) >>= (fun u => k u >>= f) =

--- a/VCVio/OracleComp/QueryTracking/Birthday.lean
+++ b/VCVio/OracleComp/QueryTracking/Birthday.lean
@@ -660,10 +660,10 @@ theorem probEvent_cacheCollision_le_birthday_total_tight {α : Type}
             StateT.run_bind, StateT.run_get, pure_bind, ht_none]
           -- Goal involves StateT.lift ... cache₀
           change (StateT.lift (PFunctor.FreeM.lift (query t)) cache₀ >>= _) = _
-          simp only [StateT.lift, bind_assoc, pure_bind,
+          simp only [StateT.lift, monad_norm,
             modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
             StateT.modifyGet, StateT.run]; rfl
-        rw [hstep, bind_assoc]; simp [pure_bind]
+        rw [hstep]; simp [monad_norm]
       rw [hrun]
       -- Apply probEvent_bind_le_add to decompose:
       -- ε₁ = Pr[CacheHasCollision (cache₀.cacheQuery t u) | u ← query t] ≤ k * C⁻¹

--- a/VCVio/OracleComp/QueryTracking/CachingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingOracle.lean
@@ -485,9 +485,9 @@ private lemma fst_map_cachingOracle_run_some (cache : spec.QueryCache) (t : spec
   unfold cachingOracle QueryImpl.withCaching QueryImpl.ofLift
   simp only [StateT.run_bind,
     show (get : StateT spec.QueryCache (OracleComp spec) _).run cache =
-      (pure (cache, cache) : OracleComp spec _) from rfl, pure_bind, hv,
+      (pure (cache, cache) : OracleComp spec _) from rfl, monad_norm, hv,
     show (pure v : StateT spec.QueryCache (OracleComp spec) _).run cache =
-      (pure (v, cache) : OracleComp spec _) from rfl, map_pure]
+      (pure (v, cache) : OracleComp spec _) from rfl, Function.comp_apply]
 
 private lemma fst_map_cachingOracle_run_none (cache : spec.QueryCache) (t : spec.Domain)
     (hv : cache t = none) :
@@ -496,15 +496,14 @@ private lemma fst_map_cachingOracle_run_none (cache : spec.QueryCache) (t : spec
   unfold cachingOracle QueryImpl.withCaching QueryImpl.ofLift
   simp only [StateT.run_bind,
     show (get : StateT spec.QueryCache (OracleComp spec) _).run cache =
-      (pure (cache, cache) : OracleComp spec _) from rfl, pure_bind, hv,
+      (pure (cache, cache) : OracleComp spec _) from rfl, monad_norm, hv,
     show (liftM (query t : OracleComp spec _) :
         StateT _ (OracleComp spec) _).run cache =
       ((query t : OracleComp spec _) >>= fun u => pure (u, cache)) from rfl,
-    bind_assoc, pure_bind,
     show ∀ u, (modifyGet (fun c : QueryCache spec => (u, c.cacheQuery t u)) :
         StateT _ (OracleComp spec) _).run cache =
       (pure (u, cache.cacheQuery t u) : OracleComp spec _) from fun _ => rfl,
-    map_bind, map_pure, bind_pure]
+    map_bind, Function.comp_apply]
 
 lemma withCacheOverlay_query_hit (cache : spec.QueryCache) (t : spec.Domain)
     (v : spec.Range t) (hv : cache t = some v) :

--- a/VCVio/OracleComp/QueryTracking/CachingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingOracle.lean
@@ -220,7 +220,7 @@ lemma withCaching_cache_le [LawfulMonad m] [HasEvalSet m]
     have hlift : (liftM (so t) : StateT spec.QueryCache m (spec.Range t)).run cache₀ =
         so t >>= fun v => pure (v, cache₀) := rfl
     rw [hlift, bind_assoc] at hz
-    simp only [pure_bind] at hz
+    simp only [monad_norm] at hz
     rcases (mem_support_bind_iff _ _ _).1 hz with ⟨v, _, hmod⟩
     have : (modifyGet fun c => (v, QueryCache.cacheQuery c t v) :
         StateT spec.QueryCache m (spec.Range t)).run cache₀ =

--- a/VCVio/OracleComp/QueryTracking/CachingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingOracle.lean
@@ -219,8 +219,7 @@ lemma withCaching_cache_le [LawfulMonad m] [HasEvalSet m]
     simp only [ht, StateT.run_bind] at hz
     have hlift : (liftM (so t) : StateT spec.QueryCache m (spec.Range t)).run cache₀ =
         so t >>= fun v => pure (v, cache₀) := rfl
-    rw [hlift, bind_assoc] at hz
-    simp only [monad_norm] at hz
+    simp only [hlift, monad_norm] at hz
     rcases (mem_support_bind_iff _ _ _).1 hz with ⟨v, _, hmod⟩
     have : (modifyGet fun c => (v, QueryCache.cacheQuery c t v) :
         StateT spec.QueryCache m (spec.Range t)).run cache₀ =
@@ -570,7 +569,7 @@ theorem cachingOracle_query_caches (t : spec.Domain)
         StateT (QueryCache spec) (OracleComp spec) _).run cache₀ =
         ((liftM (query t) : OracleComp _ _) >>= fun u =>
           pure (u, cache₀)) from rfl] at hmem
-    rw [bind_assoc] at hmem; simp only [pure_bind] at hmem
+    simp only [monad_norm] at hmem
     rw [support_bind] at hmem; simp only [Set.mem_iUnion] at hmem
     obtain ⟨u, _, hmem⟩ := hmem
     simp only [modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,

--- a/VCVio/OracleComp/QueryTracking/Collision.lean
+++ b/VCVio/OracleComp/QueryTracking/Collision.lean
@@ -160,7 +160,7 @@ theorem log_entry_in_cache_and_mono {α : Type}
       (fun zz : (α × QueryLog spec) × QueryCache spec =>
         ((zz.1.1, (⟨t, u⟩ : (i : spec.Domain) × spec.Range i) :: zz.1.2), zz.2)) <$>
       ((simulateQ cachingOracle ((simulateQ loggingOracle (mx u)).run)).run cache_mid)
-      from by simp only [StateT.map, StateT.run, map_eq_bind_pure_comp,
+      from by simp only [StateT.map, StateT.run, monad_norm,
         Function.comp_def]] at hmem
     rw [support_map] at hmem
     obtain ⟨⟨⟨x', log'⟩, cache_final⟩, hmem_cont, heq⟩ := hmem

--- a/VCVio/OracleComp/QueryTracking/Enforcement.lean
+++ b/VCVio/OracleComp/QueryTracking/Enforcement.lean
@@ -69,7 +69,7 @@ theorem fst_map_run_simulateQ
     change Prod.fst <$> ((spec.enforceOracle t).run qb >>=
       fun p => (simulateQ enforceOracle (mx p.1)).run p.2) = liftM (query t) >>= mx
     rw [run_apply, if_pos hpos]
-    simp only [map_eq_bind_pure_comp, Function.comp, bind_assoc, pure_bind]
+    simp only [monad_norm, Function.comp]
     congr 1
     ext u
     exact ih u (hcont u)

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -207,8 +207,8 @@ theorem map_run_withLogging_inputs_eq_run_appendInputLog
       | inr t' =>
           simp only [OracleSpec.add_apply_inr, simulateQ_bind, simulateQ_query,
             OracleQuery.input_query, OracleQuery.cont_query, add_apply_inr, withLogging_apply,
-            bind_pure_comp, map_bind, Functor.map_map, id_eq, bind_assoc, bind_map_left,
-            WriterT.run_bind', WriterT.run_liftM, List.empty_eq, WriterT.run_tell, pure_bind,
+            bind_pure_comp, map_bind, Functor.map_map, id_eq, monad_norm, bind_map_left,
+            WriterT.run_bind', WriterT.run_liftM, List.empty_eq, WriterT.run_tell,
             List.cons_append, List.nil_append, Prod.map_fst, Prod.map_snd, List.map_cons,
             appendInputLog_apply, StateT.run_bind, StateT.run_get, StateT.run_monadLift,
             monadLift_self, StateT.run_set]

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -207,9 +207,9 @@ theorem map_run_withLogging_inputs_eq_run_appendInputLog
       | inr t' =>
           simp only [OracleSpec.add_apply_inr, simulateQ_bind, simulateQ_query,
             OracleQuery.input_query, OracleQuery.cont_query, add_apply_inr, withLogging_apply,
-            bind_pure_comp, map_bind, Functor.map_map, id_eq, monad_norm, bind_map_left,
+            bind_pure_comp, map_bind, monad_norm,
             WriterT.run_bind', WriterT.run_liftM, List.empty_eq, WriterT.run_tell,
-            List.cons_append, List.nil_append, Prod.map_fst, Prod.map_snd, List.map_cons,
+            List.cons_append, List.nil_append,
             appendInputLog_apply, StateT.run_bind, StateT.run_get, StateT.run_monadLift,
             monadLift_self, StateT.run_set]
           refine bind_congr fun u => ?_

--- a/VCVio/OracleComp/QueryTracking/QueryBound.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryBound.lean
@@ -325,7 +325,7 @@ lemma isQueryBoundP_bind {oa : OracleComp spec α} {ob : α → OracleComp spec 
     IsQueryBoundP (oa >>= ob) p (n + m) := by
   induction oa using OracleComp.inductionOn generalizing n with
   | pure x =>
-      simp only [pure_bind]
+      simp only [monad_norm]
       exact (h' x (by simp)).mono (Nat.le_add_left _ _)
   | query_bind t mx ih =>
       rw [isQueryBoundP_query_bind_iff] at h
@@ -516,7 +516,7 @@ private lemma isPerIndexQueryBound_bind_aux (oa : OracleComp spec α)
   induction oa using OracleComp.inductionOn with
   | pure x =>
     intro qb₁ _
-    simp only [pure_bind]
+    simp only [monad_norm]
     exact (h2 x).mono le_add_self
   | query_bind t mx ih =>
     intro qb₁ h1
@@ -908,7 +908,7 @@ theorem IsTotalQueryBound.residual_of_mem_support_counting
   | pure x =>
       rw [countingOracle.mem_support_simulate_pure_iff] at hz
       subst z
-      simpa [pure_bind] using h
+      simpa [monad_norm] using h
   | query_bind t mx ih =>
       rw [bind_assoc, isTotalQueryBound_query_bind_iff] at h
       rw [countingOracle.mem_support_simulate_queryBind_iff] at hz
@@ -1165,7 +1165,7 @@ theorem IsQueryBoundP.residual_of_mem_support_counting [DecidableEq ι] [Fintype
   | pure x =>
       rw [countingOracle.mem_support_simulate_pure_iff] at hz
       subst z
-      simpa [pure_bind] using h
+      simpa [monad_norm] using h
   | query_bind t mx ih =>
       rw [bind_assoc, isQueryBoundP_query_bind_iff] at h
       rw [countingOracle.mem_support_simulate_queryBind_iff] at hz

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -395,7 +395,7 @@ lemma probOutput_generateSeed_bind_map_simulateQ
       f <$> Prod.fst <$> (simulateQ seededOracle oa).run seed : OracleComp spec₀ β)] =
       Pr[= y | f <$> oa] := by
   -- Reduce `map` to `bind` + `pure`, then apply the `bind` lemma.
-  simpa [map_eq_bind_pure_comp, Function.comp] using
+  simpa [monad_norm, Function.comp] using
     (probOutput_generateSeed_bind_simulateQ_bind (qc := qc) (js := js)
       (oa := oa) (ob := fun x => pure (f x)) (y := y))
 
@@ -531,8 +531,7 @@ lemma evalDist_liftComp_replicate_uniformSample_bind_simulateQ_run'_addValues
   | zero => intro σ; simp [replicate_zero, QuerySeed.addValues_nil]
   | succ n ih =>
     intro σ
-    simp only [replicate_succ, seq_eq_bind_map, map_eq_bind_pure_comp,
-      liftComp_bind, liftComp_pure, bind_assoc, Function.comp, pure_bind]
+    simp only [replicate_succ, monad_norm, liftComp_bind, liftComp_pure, Function.comp]
     have hrew : (do
         let u ← liftComp ($ᵗ spec₀.Range i) spec₀
         let us ← liftComp (replicate n ($ᵗ spec₀.Range i)) spec₀

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -376,7 +376,7 @@ lemma probOutput_generateSeed_bind_simulateQ_bind
     let x ← Prod.fst <$> (simulateQ seededOracle oa).run seed
     ob x) = ((do
     let seed ← liftComp (generateSeed spec₀ qc js) spec₀
-    (simulateQ seededOracle oa).run' seed) >>= ob) from by simp [bind_assoc]]
+    (simulateQ seededOracle oa).run' seed) >>= ob) from by simp [monad_norm]]
   rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
   congr 1; ext x
   congr 1

--- a/VCVio/OracleComp/QueryTracking/Unpredictability.lean
+++ b/VCVio/OracleComp/QueryTracking/Unpredictability.lean
@@ -54,8 +54,7 @@ theorem probOutput_fresh_cachingOracle_query
     Pr[= (u, cache₀.cacheQuery t u) | (cachingOracle t).run cache₀] =
       (Fintype.card (spec'.Range t) : ℝ≥0∞)⁻¹ := by
   simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind, hfresh]
-  simp only [liftM, MonadLiftT.monadLift, MonadLift.monadLift, StateT.run_lift, bind_assoc,
-    pure_bind]
+  simp only [liftM, MonadLiftT.monadLift, MonadLift.monadLift, StateT.run_lift, monad_norm]
   simp only [modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
     StateT.modifyGet, StateT.run]
   erw [probOutput_map_injective _ (fun a b hab => by exact Prod.ext_iff.mp hab |>.1)]
@@ -157,11 +156,11 @@ theorem probEvent_cache_has_value_le_of_unique_preimage {α : Type}
           simp only [cachingOracle.apply_eq, liftM, MonadLiftT.monadLift, MonadLift.monadLift,
             StateT.run_bind, StateT.run_get, pure_bind, ht_none]
           change (StateT.lift (PFunctor.FreeM.lift (query t)) cache₀ >>= _) = _
-          simp only [StateT.lift, bind_assoc, pure_bind,
+          simp only [StateT.lift, monad_norm,
             modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
             StateT.modifyGet, StateT.run]
           rfl
-        rw [hstep, bind_assoc]; simp [pure_bind]
+        rw [hstep]; simp [monad_norm]
       rw [hrun]
       -- Decompose: ∑ u, Pr[=u|query t] * Pr[event | cont(u)]
       rw [probEvent_bind_eq_tsum]

--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -74,12 +74,12 @@ lemma simulateQ_query_bind [LawfulMonad r] (q : OracleQuery spec α)
 @[simp, grind =]
 lemma simulateQ_map [LawfulMonad r] (mx : OracleComp spec α) (f : α → β) :
     simulateQ impl (f <$> mx) = f <$> simulateQ impl mx := by
-  simp [map_eq_bind_pure_comp]
+  simp [monad_norm]
 
 @[simp]
 lemma simulateQ_seq [LawfulMonad r] (og : OracleComp spec (α → β)) (mx : OracleComp spec α) :
     simulateQ impl (og <*> mx) = simulateQ impl og <*> simulateQ impl mx := by
-  simp [seq_eq_bind_map]
+  simp [monad_norm]
 
 @[simp]
 lemma simulateQ_seqLeft [LawfulMonad r] (mx : OracleComp spec α) (my : OracleComp spec β) :

--- a/VCVio/OracleComp/SimSemantics/StateSeparating.lean
+++ b/VCVio/OracleComp/SimSemantics/StateSeparating.lean
@@ -160,7 +160,7 @@ lemma runState_ofStateless {α : Type v} (h : QueryImpl E (OracleComp I))
           (fun p => (simulateQ (ofStateless h) (k p.1)).run p.2) =
         (fun x => (x, PUnit.unit)) <$> (h t >>= fun u => simulateQ h (k u))
     rw [StateT.run_monadLift]
-    simp only [bind_assoc, pure_bind, map_bind]
+    simp only [monad_norm]
     refine bind_congr fun u => ?_
     exact ih u
 

--- a/VCVio/OracleComp/SimSemantics/StateT.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT.lean
@@ -199,10 +199,10 @@ theorem simulateQ_flattenStateT_run
             (fun y : (α × σ) × τ => (y.1.1, (y.1.2, y.2))) <$>
               ((simulateQ impl (k x.1.1)).run x.1.2).run x.2 by
         simpa [simulateQ_bind, simulateQ_query, QueryImpl.flattenStateT,
-          StateT.run_bind, map_eq_bind_pure_comp, bind_assoc] using this
+          StateT.run_bind, monad_norm] using this
       refine bind_congr (m := m) fun x => ?_
       rcases x with ⟨⟨u, s'⟩, q'⟩
-      simpa [map_eq_bind_pure_comp] using ih u s' q'
+      simpa [monad_norm] using ih u s' q'
 
 /-- Output-only corollary of `simulateQ_flattenStateT_run`. -/
 theorem simulateQ_flattenStateT_run'

--- a/VCVio/OracleComp/SimSemantics/StateT.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT.lean
@@ -93,7 +93,7 @@ def flattenStateT {ι : Type _} {spec : OracleSpec ι}
     ((impl.liftTarget (StateT σ (StateT τ m))).flattenStateT t).run (s, q) =
       (fun y : spec.Range t × τ => (y.1, (s, y.2))) <$> (impl t).run q := by
   simp [flattenStateT, QueryImpl.liftTarget_apply, StateT.run_bind,
-    StateT.run_monadLift, map_eq_bind_pure_comp]
+    StateT.run_monadLift, monad_norm]
 
 /-- Indexed version of `QueryImpl.parallelStateT`. Note that `m` cannot vary with `t`.
 dtumad: The `Function.update` thing is nice but forces `DecidableEq`. -/

--- a/VCVio/OracleComp/Traversal.lean
+++ b/VCVio/OracleComp/Traversal.lean
@@ -142,7 +142,7 @@ lemma allPathsSatisfy_bind_iff
   | pure x =>
       simp
   | query_bind q oa ih =>
-      simp only [bind_assoc, OracleComp.allPathsSatisfy_query_bind, ih]
+      simp only [monad_norm, OracleComp.allPathsSatisfy_query_bind, ih]
 
 /-- A bind satisfies an existential path property exactly when either the first computation
 already satisfies it on some path, or one reachable continuation does. -/
@@ -159,7 +159,7 @@ lemma somePathSatisfies_bind_iff
   | pure x =>
       simp
   | query_bind q oa ih =>
-      simp only [bind_assoc, OracleComp.somePathSatisfies_query_bind, ih]
+      simp only [monad_norm, OracleComp.somePathSatisfies_query_bind, ih]
 
 /-- Output-only specialization of [`OracleComp.allPathsSatisfy_bind_iff`]. -/
 @[simp]

--- a/VCVio/ProgramLogic/Relational/Leakage.lean
+++ b/VCVio/ProgramLogic/Relational/Leakage.lean
@@ -233,7 +233,7 @@ private lemma snd_map_bind_snd {m : Type → Type _} [Monad m] [LawfulMonad m]
     {α' ω₁ γ' ω₂ : Type} (mx : m (α' × ω₁)) (f : ω₁ → m (γ' × ω₂)) :
     Prod.snd <$> (mx >>= fun z => f z.2) =
     (Prod.snd <$> mx) >>= fun w => Prod.snd <$> f w := by
-  simp only [← bind_pure_comp, bind_assoc, pure_bind]
+  simp only [monad_norm, Function.comp_apply]
 
 /-- Trace noninterference is preserved by sequential composition (bind).
 The continuations may depend on both the result and the trace, but whenever the

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -1508,7 +1508,7 @@ lemma expectedQuerySlack_bind_eq_of_right_zero
   | pure x =>
       simp [hzero x qS p]
   | query_bind t cont ih =>
-      simp only [bind_assoc]
+      simp only [monad_norm]
       rw [expectedQuerySlack_query_bind, expectedQuerySlack_query_bind]
       congr
       funext u qS' p'

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -1179,12 +1179,12 @@ inductive ProbEqAction where
 
 private def normalizeProbEqGoal : TacticM Unit := do
   discard <| tryEvalTacticSyntax (← `(tactic|
-    simp only [monad_norm]))
+    simp only [map_eq_bind_pure_comp, bind_assoc]))
 
 def runProbEqSwap : TacticM Bool := do
   normalizeProbEqGoal
   tryEvalTacticSyntax (← `(tactic| (
-    try simp only [monad_norm]
+    try simp only [bind_assoc]
     first
       | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
          exact probEvent_bind_bind_swap _ _ _ _)

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -1179,12 +1179,12 @@ inductive ProbEqAction where
 
 private def normalizeProbEqGoal : TacticM Unit := do
   discard <| tryEvalTacticSyntax (← `(tactic|
-    simp only [map_eq_bind_pure_comp, bind_assoc]))
+    simp only [monad_norm]))
 
 def runProbEqSwap : TacticM Bool := do
   normalizeProbEqGoal
   tryEvalTacticSyntax (← `(tactic| (
-    try simp only [bind_assoc]
+    try simp only [monad_norm]
     first
       | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
          exact probEvent_bind_bind_swap _ _ _ _)
@@ -1198,7 +1198,7 @@ def runProbEqSwap : TacticM Bool := do
       | (rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
          refine tsum_congr fun _ => ?_
          congr 1
-         try simp only [bind_assoc]
+         try simp only [monad_norm]
          first
            | exact probEvent_bind_bind_swap _ _ _ _
            | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]
@@ -1209,7 +1209,7 @@ def runProbEqSwap : TacticM Bool := do
          rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
          refine tsum_congr fun _ => ?_
          congr 1
-         try simp only [bind_assoc]
+         try simp only [monad_norm]
          first
            | exact probEvent_bind_bind_swap _ _ _ _
            | (rw [← probEvent_eq_eq_probOutput, ← probEvent_eq_eq_probOutput]

--- a/VCVio/ProgramLogic/Unary/HandlerSpecs.lean
+++ b/VCVio/ProgramLogic/Unary/HandlerSpecs.lean
@@ -526,8 +526,7 @@ theorem countingOracle_triple (t : spec.Domain) (qc₀ : QueryCount ι) :
         (fun x => (x, QueryCount.single t * (1 : QueryCount ι))) <$>
           (HasQuery.query t : OracleComp spec _) := by
     change (_ >>= _ : OracleComp _ _) = _
-    simp [WriterT.run_tell, HasQuery.instOfMonadLift_query,
-      bind_assoc, map_eq_bind_pure_comp]
+    simp [WriterT.run_tell, HasQuery.instOfMonadLift_query, monad_norm]
   rw [hrun] at hmem
   simp only [support_map] at hmem
   obtain ⟨_, _, hw⟩ := hmem
@@ -595,8 +594,7 @@ theorem costOracle_triple (costFn : spec.Domain → ω)
       (fun x => (x, costFn t * (1 : ω))) <$>
         (HasQuery.query t : OracleComp spec _) := by
     change (_ >>= _ : OracleComp _ _) = _
-    simp [WriterT.run_tell, HasQuery.instOfMonadLift_query,
-      bind_assoc, map_eq_bind_pure_comp]
+    simp [WriterT.run_tell, HasQuery.instOfMonadLift_query, monad_norm]
   rw [hrun] at hmem
   simp only [support_map] at hmem
   obtain ⟨_, _, hw⟩ := hmem

--- a/VCVio/StateSeparating/Advantage.lean
+++ b/VCVio/StateSeparating/Advantage.lean
@@ -150,7 +150,7 @@ lemma simulateQ_StateT_evalDist_congr_of_bij {α : Type} {σ₁ σ₂ : Type}
   | query_bind t k ih =>
     simp only [simulateQ_bind, simulateQ_query, OracleQuery.cont_query, OracleQuery.input_query,
       id_map, StateT.run_bind, map_bind, evalDist_bind, evalDist_map, hh t s]
-    simp only [map_eq_bind_pure_comp, bind_assoc]
+    simp only [monad_norm]
     refine bind_congr fun p => ?_
     rcases p with ⟨x, s'⟩
     have hih := ih x (φ.symm s')

--- a/docs/agents/gotchas.md
+++ b/docs/agents/gotchas.md
@@ -75,7 +75,7 @@ Use `return (b == b')` or `return decide (r x w)` instead. `guard` requires `Opt
 
 Lean 4.29 changed `do`-block elaboration so the desugared bind may use a `Bind` instance
 that differs syntactically from `Monad.toBind`. This means `pure_bind`, `bind_assoc`, and
-`bind_pure` won't fire via `simp` or `rw` on goals produced by `do` notation.
+`bind_pure` won't fire via `simp` or `rw` on goals produced by `do` notation in special cases of using more non-standard instances.
 
 **Symptom**: `simp [pure_bind]` or `rw [bind_assoc]` does nothing on a `do`-block goal.
 

--- a/docs/agents/proof-workflows.md
+++ b/docs/agents/proof-workflows.md
@@ -28,6 +28,43 @@
    → Use `vcstep` if the swap should close the goal
    → Use `vcstep rw` (or `vcstep rw under n`) if you need to continue after rewriting
 
+## Monadic Normalization with `monad_norm`
+
+The canonical way to normalize monadic expressions in this codebase is Mathlib's
+`monad_norm` simp set (declared in `Mathlib.Tactic.Attr.Register`). It bundles
+`pure_bind`, `bind_assoc`, `bind_pure`, `map_pure`, `pure_seq`, `seq_assoc`,
+`seq_eq_bind_map`, and `map_eq_bind_pure_comp`, which between them push goals
+toward an associated bind-canonical form.
+
+Prefer `simp [monad_norm]` (or `simp […, monad_norm]`) over hand-rolled lemma
+lists like `simp [bind_assoc, pure_bind, …]`. It documents intent, keeps proofs
+robust if Mathlib adds further rules, and reads more clearly. In `simp only`
+calls it is fine too — `simp only [monad_norm]` is just the closed set.
+
+When it isn't feasible:
+
+- **Direction-flipping conflicts.** `monad_norm` rewrites `f <$> x` toward
+  `x >>= pure ∘ f`. Proofs that deliberately use `bind_pure_comp` /
+  `map_pure` to keep the goal in `<$>` form (common in StateT-heavy proofs in
+  `Examples/CommitmentScheme/Hiding/*` and large stretches of
+  `VCVio/CryptoFoundations/ReplayFork.lean`) will break, because a downstream
+  `rw [some_lemma_about_<$>]` no longer matches. Keep the explicit lemma list
+  at those sites.
+- **Tightly tuned `simp only` chains.** When a proof relies on a *specific*
+  partial-rewrite state between two `simp only` calls (e.g. peeling structure
+  before a `simp_rw [hpeel, …]`), folding `monad_norm` into the earlier call
+  can over-rewrite. Leave the two-pass structure alone.
+- **`rw` and `simp_rw` lemma lists.** These take individual lemmas, not simp
+  sets — `monad_norm` doesn't apply.
+- **Files that don't import `Mathlib.Tactic.Attr.Register`.** A few low-level
+  files in `ToMathlib/Control/Monad/` (e.g. `Indexed.lean`, `Graded.lean`)
+  import only `Mathlib.Algebra.…` and don't see `monad_norm`. Don't widen
+  imports just to use it; spelling out `bind_assoc` is fine there.
+
+Treat `monad_norm` as the default and the manual lemma list as the exception.
+When you do choose the manual list, the choice is usually load-bearing — leave
+a one-line comment explaining what shape downstream needs.
+
 ## Game-Hopping Recipe
 
 ### Step 1: State the security theorem


### PR DESCRIPTION
This PR updates proofs across the library to use the `monad_norm` simp set as a canonical normalization pathway, and makes replacements across the code. In a few cases this closes proofs earlier or in simpler ways and also just shortens many proofs, but it also encourages a uniform normalization across the library for monadic computations so that agents tend to write lemmas in similar styles that they can more easily re-use (e.g. writing the `bind` reduced version of a `map` lemma).