### PR TITLE
Refactor FreeM paths and telescopes

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -57,7 +57,8 @@ import ToMathlib.PFunctor.Category
 import ToMathlib.PFunctor.Chart.Basic
 import ToMathlib.PFunctor.Cofree
 import ToMathlib.PFunctor.Equiv.Basic
-import ToMathlib.PFunctor.Free
+import ToMathlib.PFunctor.Free.Basic
+import ToMathlib.PFunctor.Free.Path
 import ToMathlib.PFunctor.Lens.Basic
 import ToMathlib.PFunctor.Lens.Cartesian
 import ToMathlib.PFunctor.Lens.State

--- a/ToMathlib/Control/Monad/FreeCont.lean
+++ b/ToMathlib/Control/Monad/FreeCont.lean
@@ -6,7 +6,7 @@ Authors: Quang Dao
 module
 
 public import ToMathlib.Control.Monad.Free
-public import ToMathlib.PFunctor.Free
+public import ToMathlib.PFunctor.Free.Basic
 public import Mathlib.Control.Monad.Cont
 public import Mathlib
 

--- a/ToMathlib/PFunctor/Bound.lean
+++ b/ToMathlib/PFunctor/Bound.lean
@@ -5,7 +5,7 @@ Authors: Devon Tuma
 -/
 module
 
-public import ToMathlib.PFunctor.Free
+public import ToMathlib.PFunctor.Free.Basic
 
 /-!
 # Roll Bounds for the Free Monad of a Polynomial Functor

--- a/ToMathlib/PFunctor/Free.lean
+++ b/ToMathlib/PFunctor/Free.lean
@@ -17,7 +17,7 @@ We define the free monad on a **polynomial functor** (`PFunctor`), and prove som
 
 @[expose] public section
 
-universe u v uA uB
+universe u v w z t uA uB
 
 namespace PFunctor
 
@@ -109,7 +109,98 @@ lemma pure_inj (x y : α) : FreeM.pure (P := P) x = FreeM.pure y ↔ x = y := by
     simp
   · simp [hx]
 
--- @[simp] lemma bind
+/-! ## Branch transcripts and dependent append -/
+
+/-- A complete branch through a `FreeM` tree. For a terminal `pure` leaf the
+branch is trivial; for a `roll a rest` node it consists of a child choice
+`b : P.B a` and a branch through the selected subtree `rest b`.
+
+For ordinary interaction specs this is the usual transcript. More generally,
+the observed branch data is determined entirely by the polynomial fiber `P.B`;
+positions with singleton fibers contribute no nontrivial branch choice. -/
+def Transcript {α : Type v} : FreeM P α → Type uB
+  | .pure _ => PUnit
+  | .roll a rest => (b : P.B a) × Transcript (rest b)
+
+/-- The leaf payload selected by a branch transcript. Although the transcript
+itself records only branch choices, the tree and transcript together determine
+the terminal `pure` payload. -/
+def output : (s : FreeM P α) → Transcript s → α
+  | .pure x, _ => x
+  | .roll _ rest, ⟨b, tr⟩ => output (rest b) tr
+
+@[simp]
+theorem output_pure (x : α) (tr : Transcript (FreeM.pure (P := P) x)) :
+    output (FreeM.pure x) tr = x := rfl
+
+@[simp]
+theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
+    (b : P.B a) (tr : Transcript (rest b)) :
+    output (FreeM.roll a rest) ⟨b, tr⟩ = output (rest b) tr := rfl
+
+/-- Dependent sequential composition for `FreeM` trees. Run `s₁`, then
+continue with a suffix selected by the branch transcript of `s₁`; the suffix
+may change the leaf payload from `α` to `β`.
+
+The payload produced by `s₁` is still available to the suffix as
+`FreeM.output s₁ tr`, since it is determined by the tree and branch transcript. -/
+def append {β : Type w} :
+    (s₁ : FreeM P α) →
+    (Transcript s₁ → FreeM P β) →
+    FreeM P β
+  | .pure _, s₂ => s₂ ⟨⟩
+  | .roll a rest, s₂ =>
+      .roll a fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)
+
+@[simp]
+theorem append_pure {β : Type w} (x : α)
+    (s₂ : Transcript (FreeM.pure (P := P) x) → FreeM P β) :
+    append (FreeM.pure x) s₂ = s₂ ⟨⟩ := rfl
+
+@[simp]
+theorem append_roll {β : Type w} (a : P.A) (rest : P.B a → FreeM P α)
+    (s₂ : Transcript (FreeM.roll a rest) → FreeM P β) :
+    append (FreeM.roll a rest) s₂ =
+      FreeM.roll a (fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)) := rfl
+
+/-! ## Telescopes -/
+
+/-- Initial-algebra presentation of a state-machine telescope of `FreeM`
+rounds. At each state `s`, an inhabitant either terminates or extends by
+running `round s` and recursing into the next state selected by the branch
+transcript of that round. -/
+inductive Telescope {St : Type z} {Out : St → Type v}
+    (round : (s : St) → FreeM P (Out s))
+    (step : (s : St) → Transcript (round s) → St) : St → Type (max uB z)
+  | done (s : St) : Telescope round step s
+  | extend (s : St)
+      (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+      Telescope round step s
+
+namespace Telescope
+
+variable {St : Type z} {Out : St → Type v} {round : (s : St) → FreeM P (Out s)}
+    {step : (s : St) → Transcript (round s) → St}
+
+/-- Flatten a telescope into a single `FreeM` tree by iterated dependent
+append, using `finish` at terminal states. -/
+def toFreeM {β : Type t} (finish : St → FreeM P β) :
+    {s : St} → Telescope round step s → FreeM P β
+  | _, .done s => finish s
+  | _, .extend s cont => append (round s) fun tr => (cont tr).toFreeM finish
+
+@[simp]
+theorem toFreeM_done {β : Type t} (finish : St → FreeM P β) (s : St) :
+    (Telescope.done (round := round) (step := step) s).toFreeM finish =
+      finish s := rfl
+
+@[simp]
+theorem toFreeM_extend {β : Type t} (finish : St → FreeM P β) (s : St)
+    (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+    (Telescope.extend s cont).toFreeM finish =
+      append (round s) (fun tr => (cont tr).toFreeM finish) := rfl
+
+end Telescope
 
 /-- Proving a predicate `C` of `FreeM P α` requires two cases:
 * `pure x` for some `x : α`

--- a/ToMathlib/PFunctor/Free/Basic.lean
+++ b/ToMathlib/PFunctor/Free/Basic.lean
@@ -17,7 +17,7 @@ We define the free monad on a **polynomial functor** (`PFunctor`), and prove som
 
 @[expose] public section
 
-universe u v w z t uA uB
+universe u v uA uB
 
 namespace PFunctor
 
@@ -108,99 +108,6 @@ lemma pure_inj (x y : α) : FreeM.pure (P := P) x = FreeM.pure y ↔ x = y := by
   · cases hx
     simp
   · simp [hx]
-
-/-! ## Branch transcripts and dependent append -/
-
-/-- A complete branch through a `FreeM` tree. For a terminal `pure` leaf the
-branch is trivial; for a `roll a rest` node it consists of a child choice
-`b : P.B a` and a branch through the selected subtree `rest b`.
-
-For ordinary interaction specs this is the usual transcript. More generally,
-the observed branch data is determined entirely by the polynomial fiber `P.B`;
-positions with singleton fibers contribute no nontrivial branch choice. -/
-def Transcript {α : Type v} : FreeM P α → Type uB
-  | .pure _ => PUnit
-  | .roll a rest => (b : P.B a) × Transcript (rest b)
-
-/-- The leaf payload selected by a branch transcript. Although the transcript
-itself records only branch choices, the tree and transcript together determine
-the terminal `pure` payload. -/
-def output : (s : FreeM P α) → Transcript s → α
-  | .pure x, _ => x
-  | .roll _ rest, ⟨b, tr⟩ => output (rest b) tr
-
-@[simp]
-theorem output_pure (x : α) (tr : Transcript (FreeM.pure (P := P) x)) :
-    output (FreeM.pure x) tr = x := rfl
-
-@[simp]
-theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
-    (b : P.B a) (tr : Transcript (rest b)) :
-    output (FreeM.roll a rest) ⟨b, tr⟩ = output (rest b) tr := rfl
-
-/-- Dependent sequential composition for `FreeM` trees. Run `s₁`, then
-continue with a suffix selected by the branch transcript of `s₁`; the suffix
-may change the leaf payload from `α` to `β`.
-
-The payload produced by `s₁` is still available to the suffix as
-`FreeM.output s₁ tr`, since it is determined by the tree and branch transcript. -/
-def append {β : Type w} :
-    (s₁ : FreeM P α) →
-    (Transcript s₁ → FreeM P β) →
-    FreeM P β
-  | .pure _, s₂ => s₂ ⟨⟩
-  | .roll a rest, s₂ =>
-      .roll a fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)
-
-@[simp]
-theorem append_pure {β : Type w} (x : α)
-    (s₂ : Transcript (FreeM.pure (P := P) x) → FreeM P β) :
-    append (FreeM.pure x) s₂ = s₂ ⟨⟩ := rfl
-
-@[simp]
-theorem append_roll {β : Type w} (a : P.A) (rest : P.B a → FreeM P α)
-    (s₂ : Transcript (FreeM.roll a rest) → FreeM P β) :
-    append (FreeM.roll a rest) s₂ =
-      FreeM.roll a (fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)) := rfl
-
-/-! ## Telescopes -/
-
-/-- Initial-algebra presentation of a state-machine telescope of `FreeM`
-rounds. At each state `s`, an inhabitant either terminates or extends by
-running `round s` and recursing into the next state selected by the branch
-transcript of that round. -/
-inductive Telescope {St : Type z} {Out : St → Type v}
-    (round : (s : St) → FreeM P (Out s))
-    (step : (s : St) → Transcript (round s) → St) : St → Type (max uB z)
-  | done (s : St) : Telescope round step s
-  | extend (s : St)
-      (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
-      Telescope round step s
-
-namespace Telescope
-
-variable {St : Type z} {Out : St → Type v} {round : (s : St) → FreeM P (Out s)}
-    {step : (s : St) → Transcript (round s) → St}
-
-/-- Flatten a telescope into a single `FreeM` tree by iterated dependent
-append, using `finish` at terminal states. -/
-def toFreeM {β : Type t} (finish : St → FreeM P β) :
-    {s : St} → Telescope round step s → FreeM P β
-  | _, .done s => finish s
-  | _, .extend s cont => append (round s) fun tr => (cont tr).toFreeM finish
-
-@[simp]
-theorem toFreeM_done {β : Type t} (finish : St → FreeM P β) (s : St) :
-    (Telescope.done (round := round) (step := step) s).toFreeM finish =
-      finish s := rfl
-
-@[simp]
-theorem toFreeM_extend {β : Type t} (finish : St → FreeM P β) (s : St)
-    (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
-    (Telescope.extend s cont).toFreeM finish =
-      append (round s) (fun tr => (cont tr).toFreeM finish) := rfl
-
-end Telescope
 
 /-- Proving a predicate `C` of `FreeM P α` requires two cases:
 * `pure x` for some `x : α`

--- a/ToMathlib/PFunctor/Free/Path.lean
+++ b/ToMathlib/PFunctor/Free/Path.lean
@@ -15,22 +15,30 @@ basic free monad on a polynomial functor.
 
 For a polynomial/container `P`, `PFunctor.FreeM P α` is the inductive type of
 well-founded `P`-branching trees with leaves labelled by `α`. The definitions
-below isolate the canonical branch object of such a tree:
+below isolate the branch-object pattern of such a tree:
 
-* `FreeM.Transcript s` records a complete root-to-leaf branch through `s`.
-* `FreeM.output s tr` recovers the leaf payload selected by that branch.
-* `FreeM.append s k` grafts a suffix tree selected by the branch path of `s`.
-* `FreeM.Telescope` is the state-indexed initial algebra obtained by iterating
-  such rounds, where the next state is selected by a branch path.
+* `FreeM.PathView` describes how to present one observed node step.
+* `FreeM.PathWith view s` records a complete root-to-leaf branch through `s`
+  using that presentation.
+* `FreeM.Path s` is the canonical path view, recording an explicit polynomial
+  direction at every node.
+* `FreeM.output s path` recovers the leaf payload selected by that path.
+* `FreeM.append s k` grafts a suffix tree selected by the canonical path of `s`.
+* `FreeM.TelescopeWith` is the state-indexed initial algebra obtained by
+  iterating such rounds, where the next state is selected by an abstract
+  observation of the round.
+* `FreeM.Telescope` is the specialization where observations are canonical
+  branch paths.
 
 ## Terminology and references
 
 The same object appears under several names in the literature. In polynomial
 functor language, the free monad on a polynomial is a type of terminating
 decision trees. In container and W-type language, these are well-founded trees
-and `Transcript` is the type of paths through such a tree. In dependent-type
-presentations of games, these are dependent type trees and paths. In programming
-language semantics, the coinductive analogue is an interaction tree.
+and `Path` is the type of paths through such a tree. In dependent-type
+presentations of games, these are dependent type trees and paths. In
+programming language semantics, the coinductive analogue is an interaction
+tree.
 
 Relevant references include:
 
@@ -55,83 +63,177 @@ namespace FreeM
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
-/-- A complete branch through a `FreeM` tree. For a terminal `pure` leaf the
-branch is trivial; for a `roll a rest` node it consists of a child choice
-`b : P.B a` and a branch through the selected subtree `rest b`.
+/-- Presentation of one observed path step at a `FreeM` node.
 
-For ordinary interaction specs this is the usual transcript. More generally,
-the observed branch data is determined entirely by the polynomial fiber `P.B`;
-positions with singleton fibers contribute no nontrivial branch choice. -/
-def Transcript {α : Type v} : FreeM P α → Type uB
+For a node `roll a rest`, a recursive path algebra first supplies a family
+`K : P.B a → Type w` of path tails for each child. A `PathView` chooses a
+presentation of the one-step path data over that family. The `pack` and
+`unpack` maps connect that presentation to the canonical sigma view. -/
+structure PathView (P : PFunctor.{uA, uB}) where
+  Step : (a : P.A) → (P.B a → Type w) → Type w
+  pack : {a : P.A} → {K : P.B a → Type w} → ((b : P.B a) × K b) → Step a K
+  unpack : {a : P.A} → {K : P.B a → Type w} → Step a K → (b : P.B a) × K b
+
+namespace PathView
+
+/-- The canonical path view records the chosen polynomial direction together
+with the recursive path tail. -/
+def canonical (P : PFunctor.{uA, uB}) : PathView.{uB} P where
+  Step _ K := (b : _) × K b
+  pack x := x
+  unpack x := x
+
+end PathView
+
+/-- A complete branch through a `FreeM` tree, presented through a chosen
+`PathView`. For a terminal `pure` leaf the path is trivial; for a `roll` node,
+the path is one observed step whose tails are recursive paths through the
+children. -/
+def PathWith (view : PathView.{w} P) {α : Type v} : FreeM P α → Type w
   | .pure _ => PUnit
-  | .roll a rest => (b : P.B a) × Transcript (rest b)
+  | .roll a rest => view.Step a (fun b => PathWith view (rest b))
 
-/-- The leaf payload selected by a branch transcript. Although the transcript
-itself records only branch choices, the tree and transcript together determine
-the terminal `pure` payload. -/
-def output : (s : FreeM P α) → Transcript s → α
+/-- The canonical root-to-leaf path through a `FreeM` tree. This records an
+explicit polynomial direction at every `roll` node. -/
+abbrev Path {α : Type v} (s : FreeM P α) : Type uB :=
+  PathWith (PathView.canonical P) s
+
+/-- The leaf payload selected by a path. Although the path itself records only
+branch choices, the tree and path together determine the terminal `pure`
+payload. -/
+def outputWith (view : PathView.{w} P) : (s : FreeM P α) → PathWith view s → α
   | .pure x, _ => x
-  | .roll _ rest, ⟨b, tr⟩ => output (rest b) tr
+  | .roll _ rest, path =>
+      let ⟨b, tail⟩ := view.unpack path
+      outputWith view (rest b) tail
+
+/-- The leaf payload selected by a canonical path. -/
+def output : (s : FreeM P α) → Path s → α :=
+  outputWith (PathView.canonical P)
 
 @[simp]
-theorem output_pure (x : α) (tr : Transcript (FreeM.pure (P := P) x)) :
-    output (FreeM.pure x) tr = x := rfl
+theorem output_pure (x : α) (path : Path (FreeM.pure (P := P) x)) :
+    output (FreeM.pure x) path = x := rfl
 
 @[simp]
 theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
-    (b : P.B a) (tr : Transcript (rest b)) :
-    output (FreeM.roll a rest) ⟨b, tr⟩ = output (rest b) tr := rfl
+    (b : P.B a) (path : Path (rest b)) :
+    output (FreeM.roll a rest) ⟨b, path⟩ = output (rest b) path := rfl
 
-/-- Dependent sequential composition for `FreeM` trees. Run `s₁`, then
-continue with a suffix selected by the branch transcript of `s₁`; the suffix
-may change the leaf payload from `α` to `β`.
+/-- Dependent sequential composition for `FreeM` trees using an arbitrary path
+view. Run `s₁`, then continue with a suffix selected by the observed path of
+`s₁`; the suffix may change the leaf payload from `α` to `β`.
 
 The payload produced by `s₁` is still available to the suffix as
-`FreeM.output s₁ tr`, since it is determined by the tree and branch transcript. -/
-def append {β : Type w} :
+`FreeM.outputWith view s₁ path`, since it is determined by the tree and path. -/
+def appendWith (view : PathView.{w} P) {β : Type t} :
     (s₁ : FreeM P α) →
-    (Transcript s₁ → FreeM P β) →
+    (PathWith view s₁ → FreeM P β) →
     FreeM P β
   | .pure _, s₂ => s₂ ⟨⟩
   | .roll a rest, s₂ =>
-      .roll a fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)
+      .roll a fun b => appendWith view (rest b) (fun path => s₂ (view.pack ⟨b, path⟩))
+
+/-- Dependent sequential composition for `FreeM` trees using canonical paths. -/
+def append {β : Type t} :
+    (s₁ : FreeM P α) →
+    (Path s₁ → FreeM P β) →
+    FreeM P β
+  | .pure _, s₂ => s₂ ⟨⟩
+  | .roll a rest, s₂ =>
+      .roll a fun b => append (rest b) (fun path => s₂ ⟨b, path⟩)
 
 @[simp]
-theorem append_pure {β : Type w} (x : α)
-    (s₂ : Transcript (FreeM.pure (P := P) x) → FreeM P β) :
+theorem append_pure {β : Type t} (x : α)
+    (s₂ : Path (FreeM.pure (P := P) x) → FreeM P β) :
     append (FreeM.pure x) s₂ = s₂ ⟨⟩ := rfl
 
 @[simp]
-theorem append_roll {β : Type w} (a : P.A) (rest : P.B a → FreeM P α)
-    (s₂ : Transcript (FreeM.roll a rest) → FreeM P β) :
+theorem append_roll {β : Type t} (a : P.A) (rest : P.B a → FreeM P α)
+    (s₂ : Path (FreeM.roll a rest) → FreeM P β) :
     append (FreeM.roll a rest) s₂ =
-      FreeM.roll a (fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)) := rfl
+      FreeM.roll a (fun b => append (rest b) (fun path => s₂ ⟨b, path⟩)) := rfl
 
 /-! ## Telescopes -/
 
 /-- Initial-algebra presentation of a state-machine telescope of `FreeM`
-rounds. At each state `s`, an inhabitant either terminates or extends by
-running `round s` and recursing into the next state selected by the branch
-transcript of that round. -/
-inductive Telescope {St : Type z} {Out : St → Type v}
+rounds observed through an arbitrary observation family `Obs`.
+
+At each state `s`, an inhabitant either terminates or extends by running
+`round s` and recursing into the next state selected by an observation
+`obs : Obs s`. The observation family is intentionally abstract: canonical
+`FreeM` branch paths use `Obs s = Path (round s)`, while quotiented or compact
+views can erase uninformative singleton choices. -/
+inductive TelescopeWith {St : Type z} {Out : St → Type v}
     (round : (s : St) → FreeM P (Out s))
-    (step : (s : St) → Transcript (round s) → St) : St → Type (max uB z)
-  | done (s : St) : Telescope round step s
+    (Obs : St → Type w)
+    (step : (s : St) → Obs s → St) : St → Type (max w z)
+  | done (s : St) : TelescopeWith round Obs step s
   | extend (s : St)
-      (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
-      Telescope round step s
+      (cont : (obs : Obs s) → TelescopeWith round Obs step (step s obs)) :
+      TelescopeWith round Obs step s
+
+namespace TelescopeWith
+
+variable {St : Type z} {Out : St → Type v} {round : (s : St) → FreeM P (Out s)}
+    {Obs : St → Type w} {step : (s : St) → Obs s → St}
+
+/-- Flatten a telescope into a single `FreeM` tree by iterated dependent
+append, using `appendRound` to graft each observed round and `finish` at
+terminal states. -/
+def toFreeM {β : Type t}
+    (appendRound : (s : St) → (Obs s → FreeM P β) → FreeM P β)
+    (finish : St → FreeM P β) :
+    {s : St} → TelescopeWith round Obs step s → FreeM P β
+  | _, .done s => finish s
+  | _, .extend s cont => appendRound s fun obs => (cont obs).toFreeM appendRound finish
+
+@[simp]
+theorem toFreeM_done {β : Type t}
+    (appendRound : (s : St) → (Obs s → FreeM P β) → FreeM P β)
+    (finish : St → FreeM P β) (s : St) :
+    (TelescopeWith.done (round := round) (Obs := Obs) (step := step) s).toFreeM
+      appendRound finish =
+      finish s := rfl
+
+@[simp]
+theorem toFreeM_extend {β : Type t}
+    (appendRound : (s : St) → (Obs s → FreeM P β) → FreeM P β)
+    (finish : St → FreeM P β) (s : St)
+    (cont : (obs : Obs s) → TelescopeWith round Obs step (step s obs)) :
+    (TelescopeWith.extend s cont).toFreeM appendRound finish =
+      appendRound s (fun obs => (cont obs).toFreeM appendRound finish) := rfl
+
+end TelescopeWith
+
+/-- State-machine telescopes whose observations are canonical `FreeM` branch
+paths. This is the default specialization of `TelescopeWith`; users with a
+more compact observation type should use `TelescopeWith` directly. -/
+abbrev Telescope {St : Type z} {Out : St → Type v}
+    (round : (s : St) → FreeM P (Out s))
+    (step : (s : St) → Path (round s) → St) : St → Type (max uB z) :=
+  TelescopeWith round (fun s => Path (round s)) step
 
 namespace Telescope
 
 variable {St : Type z} {Out : St → Type v} {round : (s : St) → FreeM P (Out s)}
-    {step : (s : St) → Transcript (round s) → St}
+    {step : (s : St) → Path (round s) → St}
 
-/-- Flatten a telescope into a single `FreeM` tree by iterated dependent
-append, using `finish` at terminal states. -/
+/-- Constructor wrapper for terminating a canonical-path telescope. -/
+abbrev done (s : St) : Telescope round step s :=
+  TelescopeWith.done s
+
+/-- Constructor wrapper for extending a canonical-path telescope. -/
+abbrev extend (s : St)
+    (cont : (path : Path (round s)) → Telescope round step (step s path)) :
+    Telescope round step s :=
+  TelescopeWith.extend s cont
+
+/-- Flatten a canonical-path telescope into a single `FreeM` tree by iterated
+dependent append, using `finish` at terminal states. -/
 def toFreeM {β : Type t} (finish : St → FreeM P β) :
-    {s : St} → Telescope round step s → FreeM P β
-  | _, .done s => finish s
-  | _, .extend s cont => append (round s) fun tr => (cont tr).toFreeM finish
+    {s : St} → Telescope round step s → FreeM P β :=
+  TelescopeWith.toFreeM (fun s => append (round s)) finish
 
 @[simp]
 theorem toFreeM_done {β : Type t} (finish : St → FreeM P β) (s : St) :
@@ -140,9 +242,9 @@ theorem toFreeM_done {β : Type t} (finish : St → FreeM P β) (s : St) :
 
 @[simp]
 theorem toFreeM_extend {β : Type t} (finish : St → FreeM P β) (s : St)
-    (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+    (cont : (path : Path (round s)) → Telescope round step (step s path)) :
     (Telescope.extend s cont).toFreeM finish =
-      append (round s) (fun tr => (cont tr).toFreeM finish) := rfl
+      append (round s) (fun path => (cont path).toFreeM finish) := rfl
 
 end Telescope
 

--- a/ToMathlib/PFunctor/Free/Path.lean
+++ b/ToMathlib/PFunctor/Free/Path.lean
@@ -1,0 +1,151 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+public import ToMathlib.PFunctor.Free.Basic
+
+/-!
+# Branch paths and telescopes for `PFunctor.FreeM`
+
+This file contains the path-dependent structure that lives on top of the
+basic free monad on a polynomial functor.
+
+For a polynomial/container `P`, `PFunctor.FreeM P α` is the inductive type of
+well-founded `P`-branching trees with leaves labelled by `α`. The definitions
+below isolate the canonical branch object of such a tree:
+
+* `FreeM.Transcript s` records a complete root-to-leaf branch through `s`.
+* `FreeM.output s tr` recovers the leaf payload selected by that branch.
+* `FreeM.append s k` grafts a suffix tree selected by the branch path of `s`.
+* `FreeM.Telescope` is the state-indexed initial algebra obtained by iterating
+  such rounds, where the next state is selected by a branch path.
+
+## Terminology and references
+
+The same object appears under several names in the literature. In polynomial
+functor language, the free monad on a polynomial is a type of terminating
+decision trees. In container and W-type language, these are well-founded trees
+and `Transcript` is the type of paths through such a tree. In dependent-type
+presentations of games, these are dependent type trees and paths. In programming
+language semantics, the coinductive analogue is an interaction tree.
+
+Relevant references include:
+
+* Hancock and Setzer, *Interactive Programs in Dependent Type Theory*, for
+  dependent I/O-trees over command-response worlds.
+* Altenkirch, Ghani, Hancock, McBride, and Morris, *Indexed Containers*, for
+  containers, indexed containers, and interaction structures.
+* Libkind and Spivak, *Pattern runs on matter*, for free polynomial monads as
+  terminating decision trees.
+* Escardo and Oliva, *Higher-order games with dependent types*, for dependent
+  type trees and paths in history-dependent games.
+* Xia, Zakowski, He, Hur, Malecha, Pierce, and Zdancewic, *Interaction Trees*,
+  for the coinductive programming-language analogue.
+-/
+
+@[expose] public section
+
+universe v w z t uA uB
+
+namespace PFunctor
+namespace FreeM
+
+variable {P : PFunctor.{uA, uB}} {α : Type v}
+
+/-- A complete branch through a `FreeM` tree. For a terminal `pure` leaf the
+branch is trivial; for a `roll a rest` node it consists of a child choice
+`b : P.B a` and a branch through the selected subtree `rest b`.
+
+For ordinary interaction specs this is the usual transcript. More generally,
+the observed branch data is determined entirely by the polynomial fiber `P.B`;
+positions with singleton fibers contribute no nontrivial branch choice. -/
+def Transcript {α : Type v} : FreeM P α → Type uB
+  | .pure _ => PUnit
+  | .roll a rest => (b : P.B a) × Transcript (rest b)
+
+/-- The leaf payload selected by a branch transcript. Although the transcript
+itself records only branch choices, the tree and transcript together determine
+the terminal `pure` payload. -/
+def output : (s : FreeM P α) → Transcript s → α
+  | .pure x, _ => x
+  | .roll _ rest, ⟨b, tr⟩ => output (rest b) tr
+
+@[simp]
+theorem output_pure (x : α) (tr : Transcript (FreeM.pure (P := P) x)) :
+    output (FreeM.pure x) tr = x := rfl
+
+@[simp]
+theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
+    (b : P.B a) (tr : Transcript (rest b)) :
+    output (FreeM.roll a rest) ⟨b, tr⟩ = output (rest b) tr := rfl
+
+/-- Dependent sequential composition for `FreeM` trees. Run `s₁`, then
+continue with a suffix selected by the branch transcript of `s₁`; the suffix
+may change the leaf payload from `α` to `β`.
+
+The payload produced by `s₁` is still available to the suffix as
+`FreeM.output s₁ tr`, since it is determined by the tree and branch transcript. -/
+def append {β : Type w} :
+    (s₁ : FreeM P α) →
+    (Transcript s₁ → FreeM P β) →
+    FreeM P β
+  | .pure _, s₂ => s₂ ⟨⟩
+  | .roll a rest, s₂ =>
+      .roll a fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)
+
+@[simp]
+theorem append_pure {β : Type w} (x : α)
+    (s₂ : Transcript (FreeM.pure (P := P) x) → FreeM P β) :
+    append (FreeM.pure x) s₂ = s₂ ⟨⟩ := rfl
+
+@[simp]
+theorem append_roll {β : Type w} (a : P.A) (rest : P.B a → FreeM P α)
+    (s₂ : Transcript (FreeM.roll a rest) → FreeM P β) :
+    append (FreeM.roll a rest) s₂ =
+      FreeM.roll a (fun b => append (rest b) (fun p => s₂ ⟨b, p⟩)) := rfl
+
+/-! ## Telescopes -/
+
+/-- Initial-algebra presentation of a state-machine telescope of `FreeM`
+rounds. At each state `s`, an inhabitant either terminates or extends by
+running `round s` and recursing into the next state selected by the branch
+transcript of that round. -/
+inductive Telescope {St : Type z} {Out : St → Type v}
+    (round : (s : St) → FreeM P (Out s))
+    (step : (s : St) → Transcript (round s) → St) : St → Type (max uB z)
+  | done (s : St) : Telescope round step s
+  | extend (s : St)
+      (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+      Telescope round step s
+
+namespace Telescope
+
+variable {St : Type z} {Out : St → Type v} {round : (s : St) → FreeM P (Out s)}
+    {step : (s : St) → Transcript (round s) → St}
+
+/-- Flatten a telescope into a single `FreeM` tree by iterated dependent
+append, using `finish` at terminal states. -/
+def toFreeM {β : Type t} (finish : St → FreeM P β) :
+    {s : St} → Telescope round step s → FreeM P β
+  | _, .done s => finish s
+  | _, .extend s cont => append (round s) fun tr => (cont tr).toFreeM finish
+
+@[simp]
+theorem toFreeM_done {β : Type t} (finish : St → FreeM P β) (s : St) :
+    (Telescope.done (round := round) (step := step) s).toFreeM finish =
+      finish s := rfl
+
+@[simp]
+theorem toFreeM_extend {β : Type t} (finish : St → FreeM P β) (s : St)
+    (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+    (Telescope.extend s cont).toFreeM finish =
+      append (round s) (fun tr => (cont tr).toFreeM finish) := rfl
+
+end Telescope
+
+
+end FreeM
+end PFunctor

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -93,6 +93,7 @@ import VCVio.Interaction.Basic.SpecFintype
 import VCVio.Interaction.Basic.StateChain
 import VCVio.Interaction.Basic.Strategy
 import VCVio.Interaction.Basic.Syntax
+import VCVio.Interaction.Basic.Telescope
 import VCVio.Interaction.Concurrent.Bisimulation
 import VCVio.Interaction.Concurrent.Control
 import VCVio.Interaction.Concurrent.Current

--- a/VCVio/Interaction/Basic/Append.lean
+++ b/VCVio/Interaction/Basic/Append.lean
@@ -30,9 +30,9 @@ namespace Spec
 
 /-- Sequential composition of interactions: run `s₁` first, then continue with
 `s₂ tr₁` where `tr₁` records what happened in `s₁`. -/
-@[reducible]
-def append : (s₁ : Spec) → (Transcript s₁ → Spec) → Spec :=
-  PFunctor.FreeM.append
+def append : (s₁ : Spec) → (Transcript s₁ → Spec) → Spec
+  | .done, s₂ => s₂ ⟨⟩
+  | .node X rest, s₂ => .node X (fun x => (rest x).append (fun p => s₂ ⟨x, p⟩))
 
 /-- Lift a two-argument type family `F tr₁ tr₂` (indexed by per-phase transcripts)
 to a single-argument family on the combined transcript of `s₁.append s₂`.
@@ -535,8 +535,7 @@ theorem Decoration.Over.map_append {L : Type u → Type v} {F G : ∀ X, L X →
         (fun tr₁ => Over.map η (s₂ tr₁) (d₂ tr₁) (r₂ tr₁))
   | .done, _, _, _, r₁, r₂ => rfl
   | .node X rest, s₂, ⟨l, dRest⟩, d₂, ⟨fData, rRest⟩, r₂ => by
-      simp only [Spec.append, PFunctor.FreeM.append, Decoration.append, Decoration.Over.append,
-        Decoration.Over.map]
+      simp only [Spec.append, Decoration.append, Decoration.Over.append, Decoration.Over.map]
       congr 1; funext x
       exact map_append η (rest x) (fun p => s₂ ⟨x, p⟩) (dRest x) (fun p => d₂ ⟨x, p⟩)
         (rRest x) (fun p => r₂ ⟨x, p⟩)
@@ -551,7 +550,7 @@ theorem Decoration.map_append {S : Type u → Type v} {T : Type u → Type w}
       (Decoration.map f s₁ d₁).append (fun tr₁ => Decoration.map f (s₂ tr₁) (d₂ tr₁))
   | .done, _, _, _ => rfl
   | .node X rest, s₂, ⟨s, dRest⟩, d₂ => by
-      simp only [Spec.append, PFunctor.FreeM.append, Decoration.append, Decoration.map]
+      simp only [Spec.append, Decoration.append, Decoration.map]
       congr 1; funext x
       exact map_append f (rest x) (fun p => s₂ ⟨x, p⟩) (dRest x) (fun p => d₂ ⟨x, p⟩)
 

--- a/VCVio/Interaction/Basic/Append.lean
+++ b/VCVio/Interaction/Basic/Append.lean
@@ -30,9 +30,9 @@ namespace Spec
 
 /-- Sequential composition of interactions: run `s₁` first, then continue with
 `s₂ tr₁` where `tr₁` records what happened in `s₁`. -/
-def append : (s₁ : Spec) → (Transcript s₁ → Spec) → Spec
-  | .done, s₂ => s₂ ⟨⟩
-  | .node X rest, s₂ => .node X (fun x => (rest x).append (fun p => s₂ ⟨x, p⟩))
+@[reducible]
+def append : (s₁ : Spec) → (Transcript s₁ → Spec) → Spec :=
+  PFunctor.FreeM.append
 
 /-- Lift a two-argument type family `F tr₁ tr₂` (indexed by per-phase transcripts)
 to a single-argument family on the combined transcript of `s₁.append s₂`.
@@ -535,7 +535,8 @@ theorem Decoration.Over.map_append {L : Type u → Type v} {F G : ∀ X, L X →
         (fun tr₁ => Over.map η (s₂ tr₁) (d₂ tr₁) (r₂ tr₁))
   | .done, _, _, _, r₁, r₂ => rfl
   | .node X rest, s₂, ⟨l, dRest⟩, d₂, ⟨fData, rRest⟩, r₂ => by
-      simp only [Spec.append, Decoration.append, Decoration.Over.append, Decoration.Over.map]
+      simp only [Spec.append, PFunctor.FreeM.append, Decoration.append, Decoration.Over.append,
+        Decoration.Over.map]
       congr 1; funext x
       exact map_append η (rest x) (fun p => s₂ ⟨x, p⟩) (dRest x) (fun p => d₂ ⟨x, p⟩)
         (rRest x) (fun p => r₂ ⟨x, p⟩)
@@ -550,7 +551,7 @@ theorem Decoration.map_append {S : Type u → Type v} {T : Type u → Type w}
       (Decoration.map f s₁ d₁).append (fun tr₁ => Decoration.map f (s₂ tr₁) (d₂ tr₁))
   | .done, _, _, _ => rfl
   | .node X rest, s₂, ⟨s, dRest⟩, d₂ => by
-      simp only [Spec.append, Decoration.append, Decoration.map]
+      simp only [Spec.append, PFunctor.FreeM.append, Decoration.append, Decoration.map]
       congr 1; funext x
       exact map_append f (rest x) (fun p => s₂ ⟨x, p⟩) (dRest x) (fun p => d₂ ⟨x, p⟩)
 

--- a/VCVio/Interaction/Basic/Chain.lean
+++ b/VCVio/Interaction/Basic/Chain.lean
@@ -211,13 +211,13 @@ private def branchingRound : Spec :=
 
 /-- The second round depends on the full first-round transcript. -/
 private def secondRound : Transcript branchingRound → Spec
-  | ⟨true, ⟨n, ⟨⟩⟩⟩ => .node (Fin (n + 1)) fun _ => .done
+  | ⟨true, ⟨(n : Nat), ⟨⟩⟩⟩ => .node (Fin (n + 1)) fun _ => .done
   | ⟨false, ⟨i, ⟨⟩⟩⟩ => .node (Fin (i.val + 2)) fun _ => .done
 
 /-- The third round depends on the full two-round transcript prefix. -/
 private def thirdRound :
     (tr₁ : Transcript branchingRound) → Transcript (secondRound tr₁) → Spec
-  | ⟨true, ⟨n, ⟨⟩⟩⟩, ⟨k, ⟨⟩⟩ => .node (Fin (n + k.val + 1)) fun _ => .done
+  | ⟨true, ⟨(n : Nat), ⟨⟩⟩⟩, ⟨k, ⟨⟩⟩ => .node (Fin (n + k.val + 1)) fun _ => .done
   | ⟨false, ⟨i, ⟨⟩⟩⟩, ⟨k, ⟨⟩⟩ => .node (Fin (i.val + k.val + 2)) fun _ => .done
 
 /-- A three-round chain whose final move type genuinely depends on the prefix transcript. -/

--- a/VCVio/Interaction/Basic/Node.lean
+++ b/VCVio/Interaction/Basic/Node.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import ToMathlib.PFunctor.Free
+import ToMathlib.PFunctor.Free.Basic
 
 /-!
 # Node-local contexts and schemas

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -3,7 +3,7 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import ToMathlib.PFunctor.Free
+import ToMathlib.PFunctor.Free.Path
 
 /-!
 # Interaction specifications and transcripts

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -191,9 +191,8 @@ def recOn {motive : Spec → Sort*}
 recorded, producing a root-to-leaf path through the interaction tree.
 For `.done`, the transcript is trivial (`PUnit`); for `.node X rest`,
 it is a chosen move `x : X` paired with a transcript for `rest x`. -/
-def Transcript : Spec → Type u
-  | .done => PUnit
-  | .node X rest => (x : X) × Transcript (rest x)
+abbrev Transcript (s : Spec.{u}) : Type u :=
+  PFunctor.FreeM.Transcript s
 
 /-- A straight-line `Spec` with no branching: each move type in the list
 becomes one round, and later rounds do not depend on earlier moves. -/

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -192,7 +192,7 @@ recorded, producing a root-to-leaf path through the interaction tree.
 For `.done`, the transcript is trivial (`PUnit`); for `.node X rest`,
 it is a chosen move `x : X` paired with a transcript for `rest x`. -/
 abbrev Transcript (s : Spec.{u}) : Type u :=
-  PFunctor.FreeM.Transcript s
+  PFunctor.FreeM.Path s
 
 /-- A straight-line `Spec` with no branching: each move type in the list
 becomes one round, and later rounds do not depend on earlier moves. -/

--- a/VCVio/Interaction/Basic/Telescope.lean
+++ b/VCVio/Interaction/Basic/Telescope.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.Basic.Append
+
+/-!
+# Platonic chain primitive (`Spec.Telescope`)
+
+`Telescope round step` is the *initial algebra* of the segment functor that
+extends a protocol by one round whose spec depends on the current state and
+then transitions to a new state determined by the round's transcript.
+
+Given
+* a state space `St : Type v`,
+* a round assignment `round : St → Spec.{u}`,
+* a state transition `step : (s : St) → Transcript (round s) → St`,
+
+an inhabitant of `Telescope round step s₀` is a finite tree of `extend` steps
+ending in `done`. The construction is well-founded by virtue of being an
+inductive: there is no way to construct an infinite-depth instance, so
+inhabitation is itself a constructive termination proof for the underlying
+state machine.
+
+## Universal property
+
+`Telescope round step` is the carrier of the initial `(round, step)`-algebra
+in the slice category over `St`: for any other `(round, step)`-algebra
+`(P : St → Type _, alg)`, there is a unique structure-preserving map
+`Telescope round step → P` given by structural recursion on the inductive.
+`toSpec` is one such recursion, with target algebra
+`(fun _ => Spec, .done, fun s cont => (round s).append cont)`.
+
+## References
+
+* Hancock–Setzer (2000), recursion over interaction interfaces.
+* Spivak–Niu (2024), polynomial functors as the algebra of interaction.
+-/
+
+universe u v
+
+namespace Interaction
+namespace Spec
+
+/-- Initial-algebra presentation of a state-machine telescope of `Spec`s.
+
+At each state `s : St`, an inhabitant either terminates (`.done s`) or extends
+by running the round `round s : Spec` and recursing into
+`Telescope round step (step s tr)` for every transcript `tr`. As an inductive
+type, every inhabitant is finite, so the existence of a `Telescope` term is a
+proof that the underlying state machine terminates. -/
+inductive Telescope {St : Type v}
+    (round : St → Spec.{u})
+    (step : (s : St) → Transcript (round s) → St) : St → Type (max u v)
+  | done (s : St) : Telescope round step s
+  | extend (s : St)
+      (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+      Telescope round step s
+
+namespace Telescope
+
+variable {St : Type v} {round : St → Spec.{u}}
+    {step : (s : St) → Transcript (round s) → St}
+
+/-- Flatten a `Telescope` into a concrete `Spec` by iterated `Spec.append`.
+Each `extend` step contributes its round spec to the head, with the tail
+expanding through the recursive continuation. -/
+def toSpec : {s : St} → Telescope round step s → Spec
+  | _, .done _ => .done
+  | _, .extend s cont => (round s).append fun tr => (cont tr).toSpec
+
+@[simp, grind =]
+theorem toSpec_done (s : St) :
+    (Telescope.done (round := round) (step := step) s).toSpec = .done := rfl
+
+@[simp, grind =]
+theorem toSpec_extend (s : St)
+    (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+    (Telescope.extend s cont).toSpec =
+      (round s).append (fun tr => (cont tr).toSpec) := rfl
+
+end Telescope
+end Spec
+end Interaction

--- a/VCVio/Interaction/Basic/Telescope.lean
+++ b/VCVio/Interaction/Basic/Telescope.lean
@@ -50,25 +50,31 @@ by running the round `round s : Spec` and recursing into
 `Telescope round step (step s tr)` for every transcript `tr`. As an inductive
 type, every inhabitant is finite, so the existence of a `Telescope` term is a
 proof that the underlying state machine terminates. -/
-inductive Telescope {St : Type v}
+abbrev Telescope {St : Type v}
     (round : St → Spec.{u})
-    (step : (s : St) → Transcript (round s) → St) : St → Type (max u v)
-  | done (s : St) : Telescope round step s
-  | extend (s : St)
-      (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
-      Telescope round step s
+    (step : (s : St) → Transcript (round s) → St) : St → Type (max u v) :=
+  PFunctor.FreeM.Telescope round step
 
 namespace Telescope
 
 variable {St : Type v} {round : St → Spec.{u}}
     {step : (s : St) → Transcript (round s) → St}
 
+/-- Constructor wrapper for terminating a `Spec.Telescope`. -/
+abbrev done (s : St) : Telescope round step s :=
+  PFunctor.FreeM.Telescope.done s
+
+/-- Constructor wrapper for extending a `Spec.Telescope` by one round. -/
+abbrev extend (s : St)
+    (cont : (tr : Transcript (round s)) → Telescope round step (step s tr)) :
+    Telescope round step s :=
+  PFunctor.FreeM.Telescope.extend s cont
+
 /-- Flatten a `Telescope` into a concrete `Spec` by iterated `Spec.append`.
 Each `extend` step contributes its round spec to the head, with the tail
 expanding through the recursive continuation. -/
-def toSpec : {s : St} → Telescope round step s → Spec
-  | _, .done _ => .done
-  | _, .extend s cont => (round s).append fun tr => (cont tr).toSpec
+def toSpec : {s : St} → Telescope round step s → Spec :=
+  PFunctor.FreeM.Telescope.toFreeM (fun _ => Spec.done)
 
 @[simp, grind =]
 theorem toSpec_done (s : St) :

--- a/VCVio/Interaction/Basic/Telescope.lean
+++ b/VCVio/Interaction/Basic/Telescope.lean
@@ -73,8 +73,9 @@ abbrev extend (s : St)
 /-- Flatten a `Telescope` into a concrete `Spec` by iterated `Spec.append`.
 Each `extend` step contributes its round spec to the head, with the tail
 expanding through the recursive continuation. -/
-def toSpec : {s : St} → Telescope round step s → Spec :=
-  PFunctor.FreeM.Telescope.toFreeM (fun _ => Spec.done)
+def toSpec : {s : St} → Telescope round step s → Spec
+  | _, .done _ => .done
+  | _, .extend s cont => (round s).append fun tr => (cont tr).toSpec
 
 @[simp, grind =]
 theorem toSpec_done (s : St) :

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -447,7 +447,8 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
           Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_2, Counterpart.appendFlat.eq_2]
-        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
+        simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
+          Strategy.runWithRoles_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         have hpure := @Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure m _ _
@@ -483,7 +484,8 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
         exact ih
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_3, Counterpart.appendFlat.eq_3]
-        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
+        simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
+          Strategy.runWithRoles_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -569,7 +571,8 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_2, Counterpart.appendFlat.eq_2]
-        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
+        simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
+          Strategy.runWithRoles_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         rw [LawfulCommMonad.bind_comm]
@@ -594,7 +597,8 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         simp only [Strategy.compWithRolesFlat.eq_3, Counterpart.appendFlat.eq_3]
-        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
+        simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
+          Strategy.runWithRoles_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -684,7 +688,8 @@ theorem Strategy.runWithRoles_compWithRoles_append
           Spec.Transcript.append, Spec.Transcript.liftAppend, Spec.Transcript.packAppend]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.compWithRoles, Counterpart.append]
-        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_sender]
+        simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
+          Strategy.runWithRoles_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         rw [LawfulCommMonad.bind_comm]
@@ -707,7 +712,8 @@ theorem Strategy.runWithRoles_compWithRoles_append
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         simp only [Strategy.compWithRoles, Counterpart.append]
-        simp only [monad_norm, Spec.append, Spec.Decoration.append, Strategy.runWithRoles_receiver]
+        simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
+          Strategy.runWithRoles_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -476,7 +476,11 @@ theorem Counterpart.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunc
             id := by
         funext c'
         exact @Counterpart.mapOutput_id m _ _ (rest x) (rRest x) (fun p => A ⟨x, p⟩) c'
-      simp [Counterpart.mapOutput, Counterpart.mapSender, hid]
+      change
+        (Counterpart.mapOutput
+          (fun (p : Transcript (rest x)) (y : A ⟨x, p⟩) => y)) <$> c x = c x
+      rw [hid]
+      exact LawfulFunctor.id_map (c x)
   | .node X rest, ⟨.receiver, rRest⟩ =>
       let F : ((x : X) × Counterpart m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) →
           ((x : X) × Counterpart m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) :=

--- a/VCVio/OracleComp/OracleComp.lean
+++ b/VCVio/OracleComp/OracleComp.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.OracleComp.HasQuery.Basic
-import ToMathlib.PFunctor.Free
+import ToMathlib.PFunctor.Free.Basic
 
 /-!
 # Computations with Oracle Access


### PR DESCRIPTION
## Summary
- Split the `PFunctor.FreeM` layer into `Free.Basic` and `Free.Path`.
- Add generic `FreeM.PathView`, canonical `FreeM.Path`, payload-polymorphic `append`, and `TelescopeWith`/`Telescope`.
- Re-express `Interaction.Spec` transcript, append, and telescope APIs through the generic FreeM layer, with focused downstream proof fixes.

## Test plan
- `lake build VCVio`

Posted by Cursor assistant (model: GPT-5.5) on behalf of the user (Quang Dao) with approval.

Made with [Cursor](https://cursor.com)