### PR TITLE
Generalize interaction paths through lenses

### DIFF
--- a/ToMathlib/PFunctor/Free/Basic.lean
+++ b/ToMathlib/PFunctor/Free/Basic.lean
@@ -7,6 +7,7 @@ module
 
 public import ToMathlib.Control.Monad.Hom
 public import ToMathlib.PFunctor.Basic
+public import ToMathlib.PFunctor.Lens.Basic
 
 /-!
 # Free Monad of a Polynomial Functor
@@ -17,7 +18,7 @@ We define the free monad on a **polynomial functor** (`PFunctor`), and prove som
 
 @[expose] public section
 
-universe u v uA uB
+universe u v uA uB uA₂ uB₂ uA₃ uB₃
 
 namespace PFunctor
 
@@ -108,6 +109,66 @@ lemma pure_inj (x y : α) : FreeM.pure (P := P) x = FreeM.pure y ↔ x = y := by
   · cases hx
     simp
   · simp [hx]
+
+section mapLens
+
+variable {Q : PFunctor.{uA₂, uB₂}} {R : PFunctor.{uA₃, uB₃}}
+
+/-- Transport a free polynomial tree along a polynomial lens.
+
+The source polynomial `P` is the abstract/control interface. The target
+polynomial `Q` is the concrete/runtime interface. At each `P`-node, the lens
+chooses a `Q`-position by `toFunA`; when runtime supplies a `Q`-direction,
+`toFunB` maps it back to the corresponding `P`-direction selecting the
+control continuation. -/
+protected def mapLens (l : Lens P Q) : FreeM P α → FreeM Q α
+  | .pure x => .pure x
+  | .roll a rest => .roll (l.toFunA a) fun d =>
+      (rest (l.toFunB a d)).mapLens l
+
+@[simp]
+theorem mapLens_pure (l : Lens P Q) (x : α) :
+    (FreeM.pure x : FreeM P α).mapLens l = FreeM.pure x :=
+  rfl
+
+@[simp]
+theorem mapLens_roll (l : Lens P Q) (a : P.A) (rest : P.B a → FreeM P α) :
+    (FreeM.roll a rest).mapLens l =
+      FreeM.roll (l.toFunA a) (fun d => (rest (l.toFunB a d)).mapLens l) :=
+  rfl
+
+@[simp]
+theorem mapLens_id (x : FreeM P α) :
+    x.mapLens (Lens.id P) = x := by
+  induction x with
+  | pure _ => rfl
+  | roll a rest ih =>
+      exact congrArg (FreeM.roll a) (funext ih)
+
+@[simp]
+theorem mapLens_comp (l₂ : Lens Q R) (l₁ : Lens P Q) (x : FreeM P α) :
+    (x.mapLens l₁).mapLens l₂ = x.mapLens (l₂ ∘ₗ l₁) := by
+  induction x with
+  | pure _ => rfl
+  | roll a rest ih =>
+      exact congrArg (FreeM.roll (l₂.toFunA (l₁.toFunA a))) (funext fun d => ih _)
+
+@[simp]
+theorem mapLens_bind (l : Lens P Q) (x : FreeM P α) (f : α → FreeM P β) :
+    (FreeM.bind x f).mapLens l =
+      FreeM.bind (x.mapLens l) (fun a => (f a).mapLens l) := by
+  induction x with
+  | pure _ => rfl
+  | roll a rest ih =>
+      exact congrArg (FreeM.roll (l.toFunA a)) (funext fun d => ih _)
+
+@[simp]
+theorem mapLens_bind' (l : Lens P Q) (x : FreeM P α) (f : α → FreeM P β) :
+    (x >>= f).mapLens l =
+      x.mapLens l >>= fun a => (f a).mapLens l :=
+  mapLens_bind l x f
+
+end mapLens
 
 /-- Proving a predicate `C` of `FreeM P α` requires two cases:
 * `pure x` for some `x : α`

--- a/ToMathlib/PFunctor/Free/Path.lean
+++ b/ToMathlib/PFunctor/Free/Path.lean
@@ -17,11 +17,9 @@ For a polynomial/container `P`, `PFunctor.FreeM P α` is the inductive type of
 well-founded `P`-branching trees with leaves labelled by `α`. The definitions
 below isolate the branch-object pattern of such a tree:
 
-* `FreeM.PathView` describes how to present one observed node step.
-* `FreeM.PathWith view s` records a complete root-to-leaf branch through `s`
-  using that presentation.
-* `FreeM.Path s` is the canonical path view, recording an explicit polynomial
-  direction at every node.
+* `FreeM.Path s` records an explicit polynomial direction at every node.
+* `FreeM.PathAlong l s` records a runtime branch through a control tree
+  executed along a polynomial lens.
 * `FreeM.output s path` recovers the leaf payload selected by that path.
 * `FreeM.append s k` grafts a suffix tree selected by the canonical path of `s`.
 * `FreeM.TelescopeWith` is the state-indexed initial algebra obtained by
@@ -63,63 +61,6 @@ namespace FreeM
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
-/-- Presentation of one observed path step at a `FreeM` node.
-
-For a node `roll a rest`, a recursive path algebra first supplies a family
-`K : P.B a → Type w` of path tails for each child. A `PathView` chooses a
-presentation of the one-step path data over that family. The `pack` and
-`unpack` maps connect that presentation to the canonical sigma view. -/
-structure PathView (P : PFunctor.{uA, uB}) where
-  Step : (a : P.A) → (P.B a → Type w) → Type w
-  pack : {a : P.A} → {K : P.B a → Type w} → ((b : P.B a) × K b) → Step a K
-  unpack : {a : P.A} → {K : P.B a → Type w} → Step a K → (b : P.B a) × K b
-
-namespace PathView
-
-/-- The canonical path view records the chosen polynomial direction together
-with the recursive path tail. -/
-def canonical (P : PFunctor.{uA, uB}) : PathView.{uB} P where
-  Step _ K := (b : _) × K b
-  pack x := x
-  unpack x := x
-
-end PathView
-
-/-- A complete branch through a `FreeM` tree, presented through a chosen
-`PathView`. For a terminal `pure` leaf the path is trivial; for a `roll` node,
-the path is one observed step whose tails are recursive paths through the
-children. -/
-def PathWith (view : PathView.{w} P) {α : Type v} : FreeM P α → Type w
-  | .pure _ => PUnit
-  | .roll a rest => view.Step a (fun b => PathWith view (rest b))
-
-/-- The canonical root-to-leaf path through a `FreeM` tree. This records an
-explicit polynomial direction at every `roll` node. -/
-abbrev Path {α : Type v} (s : FreeM P α) : Type uB :=
-  PathWith (PathView.canonical P) s
-
-/-- The leaf payload selected by a path. Although the path itself records only
-branch choices, the tree and path together determine the terminal `pure`
-payload. -/
-def outputWith (view : PathView.{w} P) : (s : FreeM P α) → PathWith view s → α
-  | .pure x, _ => x
-  | .roll _ rest, path =>
-      let ⟨b, tail⟩ := view.unpack path
-      outputWith view (rest b) tail
-
-/-- The leaf payload selected by a canonical path. -/
-def output : (s : FreeM P α) → Path s → α :=
-  outputWith (PathView.canonical P)
-
-@[simp]
-theorem output_pure (x : α) (path : Path (FreeM.pure (P := P) x)) :
-    output (FreeM.pure x) path = x := rfl
-
-@[simp]
-theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
-    (b : P.B a) (path : Path (rest b)) :
-    output (FreeM.roll a rest) ⟨b, path⟩ = output (rest b) path := rfl
-
 /-! ## Runtime paths along a lens -/
 
 variable {Q : PFunctor.{uA₂, uB₂}}
@@ -128,7 +69,7 @@ variable {Q : PFunctor.{uA₂, uB₂}}
 
 The tree's control flow is still governed by `P`, but each node is exposed
 through the concrete/runtime polynomial `Q`: at control position `a`, runtime
-chooses a direction of `Q.B (l.toFunA a)`, which the lens maps back to the
+chooses a direction `d : Q.B (l.toFunA a)`, which the lens maps back to the
 abstract control branch `P.B a`.
 
 This is defined directly by recursion on the control tree, rather than as
@@ -156,6 +97,28 @@ theorem outputAlong_roll (l : Lens P Q) (a : P.A)
     outputAlong l (FreeM.roll a rest) ⟨d, path⟩ =
       outputAlong l (rest (l.toFunB a d)) path :=
   rfl
+
+/-- The canonical root-to-leaf path through a `FreeM` tree.
+
+This is the identity-lens specialization of `PathAlong`, so the plain path API
+and the generic runtime-path API share one definitional core. -/
+abbrev Path {α : Type v} (s : FreeM P α) : Type uB :=
+  PathAlong (Lens.id P) s
+
+/-- The leaf payload selected by a path. Although the path itself records only
+branch choices, the tree and path together determine the terminal `pure`
+payload. -/
+def output : (s : FreeM P α) → Path s → α :=
+  outputAlong (Lens.id P)
+
+@[simp]
+theorem output_pure (x : α) (path : Path (FreeM.pure (P := P) x)) :
+    output (FreeM.pure x) path = x := rfl
+
+@[simp]
+theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
+    (b : P.B a) (path : Path (rest b)) :
+    output (FreeM.roll a rest) ⟨b, path⟩ = output (rest b) path := rfl
 
 /-- Project a concrete runtime path along a lens back to the abstract
 canonical branch path of the control tree. -/
@@ -187,56 +150,6 @@ theorem output_projectPathAlong (l : Lens P Q) :
   | .pure _, _ => rfl
   | .roll a rest, ⟨d, path⟩ =>
       output_projectPathAlong l (rest (l.toFunB a d)) path
-
-/-! ## Identity-lens paths -/
-
-/--
-View a canonical path as a runtime path along the identity lens.
-
-Together with `projectPathAlong (Lens.id P)`, this gives the structural
-identification between the existing canonical path API and the generic
-runtime-path API at the identity lens.
--/
-def pathToPathAlongId :
-    (s : FreeM P α) → Path s → PathAlong (Lens.id P) s
-  | .pure _, _ => ⟨⟩
-  | .roll _ rest, ⟨b, path⟩ =>
-      ⟨b, pathToPathAlongId (rest b) path⟩
-
-@[simp]
-theorem pathToPathAlongId_pure (x : α)
-    (path : Path (FreeM.pure x : FreeM P α)) :
-    pathToPathAlongId (FreeM.pure x) path = ⟨⟩ :=
-  rfl
-
-@[simp]
-theorem pathToPathAlongId_roll (a : P.A) (rest : P.B a → FreeM P α)
-    (b : P.B a) (path : Path (rest b)) :
-    pathToPathAlongId (FreeM.roll a rest) ⟨b, path⟩ =
-      ⟨b, pathToPathAlongId (rest b) path⟩ :=
-  rfl
-
-@[simp]
-theorem projectPathAlong_id_pathToPathAlongId :
-    (s : FreeM P α) → (path : Path s) →
-      projectPathAlong (Lens.id P) s (pathToPathAlongId s path) = path
-  | .pure _, ⟨⟩ => rfl
-  | .roll a rest, ⟨b, path⟩ => by
-      change
-        ⟨b, projectPathAlong (Lens.id P) (rest b) (pathToPathAlongId (rest b) path)⟩ =
-          (⟨b, path⟩ : Path (FreeM.roll a rest))
-      rw [projectPathAlong_id_pathToPathAlongId]
-
-@[simp]
-theorem pathToPathAlongId_projectPathAlong_id :
-    (s : FreeM P α) → (path : PathAlong (Lens.id P) s) →
-      pathToPathAlongId s (projectPathAlong (Lens.id P) s path) = path
-  | .pure _, ⟨⟩ => rfl
-  | .roll a rest, ⟨b, path⟩ => by
-      change
-        ⟨b, pathToPathAlongId (rest b) (projectPathAlong (Lens.id P) (rest b) path)⟩ =
-          (⟨b, path⟩ : PathAlong (Lens.id P) (FreeM.roll a rest))
-      rw [pathToPathAlongId_projectPathAlong_id]
 
 /-! ## Runtime paths and lens-mapped trees -/
 
@@ -330,20 +243,6 @@ theorem outputAlong_mapLensPathToPathAlong (l : Lens P Q) :
   | .pure _, ⟨⟩ => rfl
   | .roll a rest, ⟨d, path⟩ =>
       outputAlong_mapLensPathToPathAlong l (rest (l.toFunB a d)) path
-
-/-- Dependent sequential composition for `FreeM` trees using an arbitrary path
-view. Run `s₁`, then continue with a suffix selected by the observed path of
-`s₁`; the suffix may change the leaf payload from `α` to `β`.
-
-The payload produced by `s₁` is still available to the suffix as
-`FreeM.outputWith view s₁ path`, since it is determined by the tree and path. -/
-def appendWith (view : PathView.{w} P) {β : Type t} :
-    (s₁ : FreeM P α) →
-    (PathWith view s₁ → FreeM P β) →
-    FreeM P β
-  | .pure _, s₂ => s₂ ⟨⟩
-  | .roll a rest, s₂ =>
-      .roll a fun b => appendWith view (rest b) (fun path => s₂ (view.pack ⟨b, path⟩))
 
 /-- Dependent sequential composition for `FreeM` trees using canonical paths. -/
 def append {β : Type t} :

--- a/ToMathlib/PFunctor/Free/Path.lean
+++ b/ToMathlib/PFunctor/Free/Path.lean
@@ -56,7 +56,7 @@ Relevant references include:
 
 @[expose] public section
 
-universe v w z t uA uB
+universe v w z t uA uB uA₂ uB₂
 
 namespace PFunctor
 namespace FreeM
@@ -119,6 +119,74 @@ theorem output_pure (x : α) (path : Path (FreeM.pure (P := P) x)) :
 theorem output_roll (a : P.A) (rest : P.B a → FreeM P α)
     (b : P.B a) (path : Path (rest b)) :
     output (FreeM.roll a rest) ⟨b, path⟩ = output (rest b) path := rfl
+
+/-! ## Runtime paths along a lens -/
+
+variable {Q : PFunctor.{uA₂, uB₂}}
+
+/-- Runtime path through a `P`-tree executed along a lens `l : Lens P Q`.
+
+The tree's control flow is still governed by `P`, but each node is exposed
+through the concrete/runtime polynomial `Q`: at control position `a`, runtime
+chooses a direction of `Q.B (l.toFunA a)`, which the lens maps back to the
+abstract control branch `P.B a`.
+
+This is defined directly by recursion on the control tree, rather than as
+`Path (s.mapLens l)`, so the constructor equations are the definitional core
+used by interaction semantics. -/
+def PathAlong (l : Lens P Q) : FreeM P α → Type uB₂
+  | .pure _ => PUnit
+  | .roll a rest => (d : Q.B (l.toFunA a)) × PathAlong l (rest (l.toFunB a d))
+
+/-- The leaf payload selected by a runtime path along a lens. -/
+def outputAlong (l : Lens P Q) : (s : FreeM P α) → PathAlong l s → α
+  | .pure x, _ => x
+  | .roll a rest, ⟨d, path⟩ => outputAlong l (rest (l.toFunB a d)) path
+
+@[simp]
+theorem outputAlong_pure (l : Lens P Q) (x : α)
+    (path : PathAlong l (FreeM.pure x : FreeM P α)) :
+    outputAlong l (FreeM.pure x) path = x :=
+  rfl
+
+@[simp]
+theorem outputAlong_roll (l : Lens P Q) (a : P.A)
+    (rest : P.B a → FreeM P α)
+    (d : Q.B (l.toFunA a)) (path : PathAlong l (rest (l.toFunB a d))) :
+    outputAlong l (FreeM.roll a rest) ⟨d, path⟩ =
+      outputAlong l (rest (l.toFunB a d)) path :=
+  rfl
+
+/-- Project a concrete runtime path along a lens back to the abstract
+canonical branch path of the control tree. -/
+def projectPathAlong (l : Lens P Q) :
+    (s : FreeM P α) → PathAlong l s → Path s
+  | .pure _, _ => ⟨⟩
+  | .roll a rest, ⟨d, path⟩ =>
+      ⟨l.toFunB a d, projectPathAlong l (rest (l.toFunB a d)) path⟩
+
+@[simp]
+theorem projectPathAlong_pure (l : Lens P Q) (x : α)
+    (path : PathAlong l (FreeM.pure x : FreeM P α)) :
+    projectPathAlong l (FreeM.pure x) path = ⟨⟩ :=
+  rfl
+
+@[simp]
+theorem projectPathAlong_roll (l : Lens P Q) (a : P.A)
+    (rest : P.B a → FreeM P α)
+    (path : PathAlong l (FreeM.roll a rest)) :
+    projectPathAlong l (FreeM.roll a rest) path =
+      ⟨l.toFunB a path.1,
+        projectPathAlong l (rest (l.toFunB a path.1)) path.2⟩ :=
+  rfl
+
+@[simp]
+theorem output_projectPathAlong (l : Lens P Q) :
+    (s : FreeM P α) → (path : PathAlong l s) →
+      output s (projectPathAlong l s path) = outputAlong l s path
+  | .pure _, _ => rfl
+  | .roll a rest, ⟨d, path⟩ =>
+      output_projectPathAlong l (rest (l.toFunB a d)) path
 
 /-- Dependent sequential composition for `FreeM` trees using an arbitrary path
 view. Run `s₁`, then continue with a suffix selected by the observed path of

--- a/ToMathlib/PFunctor/Free/Path.lean
+++ b/ToMathlib/PFunctor/Free/Path.lean
@@ -188,6 +188,149 @@ theorem output_projectPathAlong (l : Lens P Q) :
   | .roll a rest, ⟨d, path⟩ =>
       output_projectPathAlong l (rest (l.toFunB a d)) path
 
+/-! ## Identity-lens paths -/
+
+/--
+View a canonical path as a runtime path along the identity lens.
+
+Together with `projectPathAlong (Lens.id P)`, this gives the structural
+identification between the existing canonical path API and the generic
+runtime-path API at the identity lens.
+-/
+def pathToPathAlongId :
+    (s : FreeM P α) → Path s → PathAlong (Lens.id P) s
+  | .pure _, _ => ⟨⟩
+  | .roll _ rest, ⟨b, path⟩ =>
+      ⟨b, pathToPathAlongId (rest b) path⟩
+
+@[simp]
+theorem pathToPathAlongId_pure (x : α)
+    (path : Path (FreeM.pure x : FreeM P α)) :
+    pathToPathAlongId (FreeM.pure x) path = ⟨⟩ :=
+  rfl
+
+@[simp]
+theorem pathToPathAlongId_roll (a : P.A) (rest : P.B a → FreeM P α)
+    (b : P.B a) (path : Path (rest b)) :
+    pathToPathAlongId (FreeM.roll a rest) ⟨b, path⟩ =
+      ⟨b, pathToPathAlongId (rest b) path⟩ :=
+  rfl
+
+@[simp]
+theorem projectPathAlong_id_pathToPathAlongId :
+    (s : FreeM P α) → (path : Path s) →
+      projectPathAlong (Lens.id P) s (pathToPathAlongId s path) = path
+  | .pure _, ⟨⟩ => rfl
+  | .roll a rest, ⟨b, path⟩ => by
+      change
+        ⟨b, projectPathAlong (Lens.id P) (rest b) (pathToPathAlongId (rest b) path)⟩ =
+          (⟨b, path⟩ : Path (FreeM.roll a rest))
+      rw [projectPathAlong_id_pathToPathAlongId]
+
+@[simp]
+theorem pathToPathAlongId_projectPathAlong_id :
+    (s : FreeM P α) → (path : PathAlong (Lens.id P) s) →
+      pathToPathAlongId s (projectPathAlong (Lens.id P) s path) = path
+  | .pure _, ⟨⟩ => rfl
+  | .roll a rest, ⟨b, path⟩ => by
+      change
+        ⟨b, pathToPathAlongId (rest b) (projectPathAlong (Lens.id P) (rest b) path)⟩ =
+          (⟨b, path⟩ : PathAlong (Lens.id P) (FreeM.roll a rest))
+      rw [pathToPathAlongId_projectPathAlong_id]
+
+/-! ## Runtime paths and lens-mapped trees -/
+
+/--
+View a runtime path through `s` along `l` as the canonical path through the
+lens-mapped runtime tree `s.mapLens l`.
+
+This is the forward half of the structural identification
+`PathAlong l s ≃ Path (s.mapLens l)`.
+-/
+def pathAlongToMapLensPath (l : Lens P Q) :
+    (s : FreeM P α) → PathAlong l s → Path (s.mapLens l)
+  | .pure _, _ => ⟨⟩
+  | .roll a rest, ⟨d, path⟩ =>
+      ⟨d, pathAlongToMapLensPath l (rest (l.toFunB a d)) path⟩
+
+@[simp]
+theorem pathAlongToMapLensPath_pure (l : Lens P Q) (x : α)
+    (path : PathAlong l (FreeM.pure x : FreeM P α)) :
+    pathAlongToMapLensPath l (FreeM.pure x) path = ⟨⟩ :=
+  rfl
+
+@[simp]
+theorem pathAlongToMapLensPath_roll (l : Lens P Q) (a : P.A)
+    (rest : P.B a → FreeM P α)
+    (d : Q.B (l.toFunA a)) (path : PathAlong l (rest (l.toFunB a d))) :
+    pathAlongToMapLensPath l (FreeM.roll a rest) ⟨d, path⟩ =
+      ⟨d, pathAlongToMapLensPath l (rest (l.toFunB a d)) path⟩ :=
+  rfl
+
+/--
+View a canonical path through the lens-mapped runtime tree `s.mapLens l` as a
+runtime path through the original control tree `s` along `l`.
+
+This is the reverse half of the structural identification
+`PathAlong l s ≃ Path (s.mapLens l)`.
+-/
+def mapLensPathToPathAlong (l : Lens P Q) :
+    (s : FreeM P α) → Path (s.mapLens l) → PathAlong l s
+  | .pure _, _ => ⟨⟩
+  | .roll a rest, ⟨d, path⟩ =>
+      ⟨d, mapLensPathToPathAlong l (rest (l.toFunB a d)) path⟩
+
+@[simp]
+theorem mapLensPathToPathAlong_pure (l : Lens P Q) (x : α)
+    (path : Path ((FreeM.pure x : FreeM P α).mapLens l)) :
+    mapLensPathToPathAlong l (FreeM.pure x) path = ⟨⟩ :=
+  rfl
+
+@[simp]
+theorem mapLensPathToPathAlong_roll (l : Lens P Q) (a : P.A)
+    (rest : P.B a → FreeM P α)
+    (d : Q.B (l.toFunA a))
+    (path : Path ((rest (l.toFunB a d)).mapLens l)) :
+    mapLensPathToPathAlong l (FreeM.roll a rest) ⟨d, path⟩ =
+      ⟨d, mapLensPathToPathAlong l (rest (l.toFunB a d)) path⟩ :=
+  rfl
+
+@[simp]
+theorem mapLensPathToPathAlong_toMapLensPath (l : Lens P Q) :
+    (s : FreeM P α) → (path : PathAlong l s) →
+      mapLensPathToPathAlong l s (pathAlongToMapLensPath l s path) = path
+  | .pure _, ⟨⟩ => rfl
+  | .roll a rest, ⟨d, path⟩ => by
+      simp [pathAlongToMapLensPath,
+        mapLensPathToPathAlong_toMapLensPath l (rest (l.toFunB a d)) path]
+
+@[simp]
+theorem pathAlongToMapLensPath_toPathAlong (l : Lens P Q) :
+    (s : FreeM P α) → (path : Path (s.mapLens l)) →
+      pathAlongToMapLensPath l s (mapLensPathToPathAlong l s path) = path
+  | .pure _, ⟨⟩ => rfl
+  | .roll a rest, ⟨d, path⟩ => by
+      simp [
+        pathAlongToMapLensPath_toPathAlong l (rest (l.toFunB a d)) path]
+
+@[simp]
+theorem output_mapLens_pathAlongToMapLensPath (l : Lens P Q) :
+    (s : FreeM P α) → (path : PathAlong l s) →
+      output (s.mapLens l) (pathAlongToMapLensPath l s path) =
+        outputAlong l s path
+  | .pure _, ⟨⟩ => rfl
+  | .roll a rest, ⟨d, path⟩ =>
+      output_mapLens_pathAlongToMapLensPath l (rest (l.toFunB a d)) path
+
+@[simp]
+theorem outputAlong_mapLensPathToPathAlong (l : Lens P Q) :
+    (s : FreeM P α) → (path : Path (s.mapLens l)) →
+      outputAlong l s (mapLensPathToPathAlong l s path) =
+        output (s.mapLens l) path
+  | .pure _, ⟨⟩ => rfl
+  | .roll a rest, ⟨d, path⟩ =>
+      outputAlong_mapLensPathToPathAlong l (rest (l.toFunB a d)) path
+
 /-- Dependent sequential composition for `FreeM` trees using an arbitrary path
 view. Run `s₁`, then continue with a suffix selected by the observed path of
 `s₁`; the suffix may change the leaf payload from `α` to `β`.

--- a/ToMathlib/PFunctor/Free/Path.lean
+++ b/ToMathlib/PFunctor/Free/Path.lean
@@ -18,8 +18,8 @@ well-founded `P`-branching trees with leaves labelled by `α`. The definitions
 below isolate the branch-object pattern of such a tree:
 
 * `FreeM.Path s` records an explicit polynomial direction at every node.
-* `FreeM.PathAlong l s` records a runtime branch through a control tree
-  executed along a polynomial lens.
+* `FreeM.PathAlong l s` is the canonical path through `s.mapLens l`, i.e. the
+  runtime branch through a control tree executed along a polynomial lens.
 * `FreeM.output s path` recovers the leaf payload selected by that path.
 * `FreeM.append s k` grafts a suffix tree selected by the canonical path of `s`.
 * `FreeM.TelescopeWith` is the state-indexed initial algebra obtained by
@@ -61,28 +61,36 @@ namespace FreeM
 
 variable {P : PFunctor.{uA, uB}} {α : Type v}
 
-/-! ## Runtime paths along a lens -/
+/-! ## Canonical paths -/
 
 variable {Q : PFunctor.{uA₂, uB₂}}
 
+/-- The canonical root-to-leaf path through a `FreeM` tree. -/
+def Path {α : Type v} : FreeM P α → Type uB
+  | .pure _ => PUnit
+  | .roll a rest => (b : P.B a) × Path (rest b)
+
+/-! ## Runtime paths along a lens -/
+
 /-- Runtime path through a `P`-tree executed along a lens `l : Lens P Q`.
 
-The tree's control flow is still governed by `P`, but each node is exposed
-through the concrete/runtime polynomial `Q`: at control position `a`, runtime
-chooses a direction `d : Q.B (l.toFunA a)`, which the lens maps back to the
-abstract control branch `P.B a`.
+This is definitionally the canonical path through the lens-mapped runtime tree
+`s.mapLens l`. The source tree's control flow is still governed by `P`, while
+the mapped tree exposes each node through `Q`; a runtime direction
+`d : Q.B (l.toFunA a)` selects the source branch `l.toFunB a d`. -/
+abbrev PathAlong (l : Lens P Q) (s : FreeM P α) : Type uB₂ :=
+  Path (s.mapLens l)
 
-This is defined directly by recursion on the control tree, rather than as
-`Path (s.mapLens l)`, so the constructor equations are the definitional core
-used by interaction semantics. -/
-def PathAlong (l : Lens P Q) : FreeM P α → Type uB₂
-  | .pure _ => PUnit
-  | .roll a rest => (d : Q.B (l.toFunA a)) × PathAlong l (rest (l.toFunB a d))
+/-- The leaf payload selected by a path. Although the path itself records only
+branch choices, the tree and path together determine the terminal `pure`
+payload. -/
+def output : (s : FreeM P α) → Path s → α
+  | .pure x, _ => x
+  | .roll _ rest, ⟨b, path⟩ => output (rest b) path
 
 /-- The leaf payload selected by a runtime path along a lens. -/
-def outputAlong (l : Lens P Q) : (s : FreeM P α) → PathAlong l s → α
-  | .pure x, _ => x
-  | .roll a rest, ⟨d, path⟩ => outputAlong l (rest (l.toFunB a d)) path
+def outputAlong (l : Lens P Q) (s : FreeM P α) (path : PathAlong l s) : α :=
+  output (s.mapLens l) path
 
 @[simp]
 theorem outputAlong_pure (l : Lens P Q) (x : α)
@@ -97,19 +105,6 @@ theorem outputAlong_roll (l : Lens P Q) (a : P.A)
     outputAlong l (FreeM.roll a rest) ⟨d, path⟩ =
       outputAlong l (rest (l.toFunB a d)) path :=
   rfl
-
-/-- The canonical root-to-leaf path through a `FreeM` tree.
-
-This is the identity-lens specialization of `PathAlong`, so the plain path API
-and the generic runtime-path API share one definitional core. -/
-abbrev Path {α : Type v} (s : FreeM P α) : Type uB :=
-  PathAlong (Lens.id P) s
-
-/-- The leaf payload selected by a path. Although the path itself records only
-branch choices, the tree and path together determine the terminal `pure`
-payload. -/
-def output : (s : FreeM P α) → Path s → α :=
-  outputAlong (Lens.id P)
 
 @[simp]
 theorem output_pure (x : α) (path : Path (FreeM.pure (P := P) x)) :
@@ -157,14 +152,12 @@ theorem output_projectPathAlong (l : Lens P Q) :
 View a runtime path through `s` along `l` as the canonical path through the
 lens-mapped runtime tree `s.mapLens l`.
 
-This is the forward half of the structural identification
-`PathAlong l s ≃ Path (s.mapLens l)`.
+Since `PathAlong l s` is definitionally `Path (s.mapLens l)`, this map is the
+identity. It remains named so downstream code can state intent explicitly.
 -/
-def pathAlongToMapLensPath (l : Lens P Q) :
-    (s : FreeM P α) → PathAlong l s → Path (s.mapLens l)
-  | .pure _, _ => ⟨⟩
-  | .roll a rest, ⟨d, path⟩ =>
-      ⟨d, pathAlongToMapLensPath l (rest (l.toFunB a d)) path⟩
+def pathAlongToMapLensPath (l : Lens P Q)
+    (s : FreeM P α) (path : PathAlong l s) : Path (s.mapLens l) :=
+  path
 
 @[simp]
 theorem pathAlongToMapLensPath_pure (l : Lens P Q) (x : α)
@@ -184,14 +177,12 @@ theorem pathAlongToMapLensPath_roll (l : Lens P Q) (a : P.A)
 View a canonical path through the lens-mapped runtime tree `s.mapLens l` as a
 runtime path through the original control tree `s` along `l`.
 
-This is the reverse half of the structural identification
-`PathAlong l s ≃ Path (s.mapLens l)`.
+Since `PathAlong l s` is definitionally `Path (s.mapLens l)`, this map is the
+identity. It remains named so downstream code can state intent explicitly.
 -/
-def mapLensPathToPathAlong (l : Lens P Q) :
-    (s : FreeM P α) → Path (s.mapLens l) → PathAlong l s
-  | .pure _, _ => ⟨⟩
-  | .roll a rest, ⟨d, path⟩ =>
-      ⟨d, mapLensPathToPathAlong l (rest (l.toFunB a d)) path⟩
+def mapLensPathToPathAlong (l : Lens P Q)
+    (s : FreeM P α) (path : Path (s.mapLens l)) : PathAlong l s :=
+  path
 
 @[simp]
 theorem mapLensPathToPathAlong_pure (l : Lens P Q) (x : α)
@@ -212,37 +203,27 @@ theorem mapLensPathToPathAlong_roll (l : Lens P Q) (a : P.A)
 theorem mapLensPathToPathAlong_toMapLensPath (l : Lens P Q) :
     (s : FreeM P α) → (path : PathAlong l s) →
       mapLensPathToPathAlong l s (pathAlongToMapLensPath l s path) = path
-  | .pure _, ⟨⟩ => rfl
-  | .roll a rest, ⟨d, path⟩ => by
-      simp [pathAlongToMapLensPath,
-        mapLensPathToPathAlong_toMapLensPath l (rest (l.toFunB a d)) path]
+  | _, _ => rfl
 
 @[simp]
 theorem pathAlongToMapLensPath_toPathAlong (l : Lens P Q) :
     (s : FreeM P α) → (path : Path (s.mapLens l)) →
       pathAlongToMapLensPath l s (mapLensPathToPathAlong l s path) = path
-  | .pure _, ⟨⟩ => rfl
-  | .roll a rest, ⟨d, path⟩ => by
-      simp [
-        pathAlongToMapLensPath_toPathAlong l (rest (l.toFunB a d)) path]
+  | _, _ => rfl
 
 @[simp]
 theorem output_mapLens_pathAlongToMapLensPath (l : Lens P Q) :
     (s : FreeM P α) → (path : PathAlong l s) →
       output (s.mapLens l) (pathAlongToMapLensPath l s path) =
         outputAlong l s path
-  | .pure _, ⟨⟩ => rfl
-  | .roll a rest, ⟨d, path⟩ =>
-      output_mapLens_pathAlongToMapLensPath l (rest (l.toFunB a d)) path
+  | _, _ => rfl
 
 @[simp]
 theorem outputAlong_mapLensPathToPathAlong (l : Lens P Q) :
     (s : FreeM P α) → (path : Path (s.mapLens l)) →
       outputAlong l s (mapLensPathToPathAlong l s path) =
         output (s.mapLens l) path
-  | .pure _, ⟨⟩ => rfl
-  | .roll a rest, ⟨d, path⟩ =>
-      outputAlong_mapLensPathToPathAlong l (rest (l.toFunB a d)) path
+  | _, _ => rfl
 
 /-- Dependent sequential composition for `FreeM` trees using canonical paths. -/
 def append {β : Type t} :

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -127,6 +127,7 @@ import VCVio.Interaction.TwoParty.Decoration
 import VCVio.Interaction.TwoParty.Examples
 import VCVio.Interaction.TwoParty.Refine
 import VCVio.Interaction.TwoParty.Role
+import VCVio.Interaction.TwoParty.Syntax
 import VCVio.Interaction.TwoParty.Strategy
 import VCVio.Interaction.TwoParty.Swap
 import VCVio.Interaction.UC.AsyncRuntime

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -127,9 +127,9 @@ import VCVio.Interaction.TwoParty.Decoration
 import VCVio.Interaction.TwoParty.Examples
 import VCVio.Interaction.TwoParty.Refine
 import VCVio.Interaction.TwoParty.Role
-import VCVio.Interaction.TwoParty.Syntax
 import VCVio.Interaction.TwoParty.Strategy
 import VCVio.Interaction.TwoParty.Swap
+import VCVio.Interaction.TwoParty.Syntax
 import VCVio.Interaction.UC.AsyncRuntime
 import VCVio.Interaction.UC.AsyncSecurity
 import VCVio.Interaction.UC.Computational

--- a/VCVio/Interaction/Basic/Append.lean
+++ b/VCVio/Interaction/Basic/Append.lean
@@ -235,9 +235,8 @@ theorem Transcript.collapseAppend_append :
       (fun tr₁ tr₂ => F (Transcript.append s₁ s₂ tr₁ tr₂))
       (Transcript.append s₁ s₂ tr₁ tr₂)) →
     collapseAppend s₁ s₂ F (Transcript.append s₁ s₂ tr₁ tr₂) x =
-      cast (Transcript.liftAppend_append s₁ s₂
-        (fun tr₁ tr₂ => F (Transcript.append s₁ s₂ tr₁ tr₂))
-        tr₁ tr₂) x
+      Transcript.unpackAppend s₁ s₂
+        (fun tr₁ tr₂ => F (Transcript.append s₁ s₂ tr₁ tr₂)) tr₁ tr₂ x
   | .done, _, _, ⟨⟩, _, _ => rfl
   | .node _ rest, s₂, F, ⟨xm, tail₁⟩, tr₂, x => by
       simpa [Transcript.collapseAppend, Transcript.append] using

--- a/VCVio/Interaction/Basic/Decoration.lean
+++ b/VCVio/Interaction/Basic/Decoration.lean
@@ -90,6 +90,23 @@ coalgebraic semantics of `ProcessOver`).
 universe u v w w₂
 
 namespace Interaction
+
+open PFunctor
+
+variable {P : PFunctor.{u, v}} {α : Type w}
+
+/--
+Node-local metadata over an arbitrary polynomial free tree.
+
+At a control node `a : P.A`, the decoration stores one value of type `Γ a`
+and recursively decorates every abstract control continuation `b : P.B a`.
+The plain `Spec.Decoration` below is the specialization to
+`Spec.basePFunctor` and terminal payload `PUnit`.
+-/
+def Decoration (Γ : P.A → Type w₂) : PFunctor.FreeM P α → Type (max v w₂)
+  | .pure _ => PUnit
+  | .roll a rest => Γ a × ((b : P.B a) → Decoration Γ (rest b))
+
 namespace Spec
 
 private theorem prod_mk_heq {α : Type u} {β β' : Type v} {a : α} {b : β} {b' : β'}

--- a/VCVio/Interaction/Basic/Interaction.lean
+++ b/VCVio/Interaction/Basic/Interaction.lean
@@ -32,9 +32,75 @@ trivial-data specialization rather than a base value that `InteractionOver`
 depends on.
 -/
 
-universe u a vΓ w
+universe u a vΓ w uA uB uA₂ uB₂ t
 
 namespace Interaction
+
+open PFunctor
+
+variable {P : PFunctor.{uA, uB}} {Q : PFunctor.{uA₂, uB₂}}
+variable {α : Type t}
+variable {Agent : Type a}
+variable {Γ : P.A → Type vΓ}
+
+/--
+`InteractionOver l Agent Γ syn m` is a one-step operational law for a
+lens-executed polynomial interaction.
+
+At each control node, every agent supplies a local syntax object. The
+interaction law chooses one runtime direction and passes each agent's matching
+continuation to the recursive runner.
+-/
+structure InteractionOver
+    (l : PFunctor.Lens P Q)
+    (Agent : Type a)
+    (Γ : P.A → Type vΓ)
+    (syn : SyntaxOver l Agent Γ)
+    (m : Type (max uB₂ a w) → Type (max uB₂ a w)) where
+  interact :
+    {pos : P.A} →
+    {γ : Γ pos} →
+    {Cont : Agent → Q.B (l.toFunA pos) → Type w} →
+    {Result : Type (max uB₂ a w)} →
+    ((agent : Agent) → syn.Node agent pos γ (Cont agent)) →
+    ((d : Q.B (l.toFunA pos)) → ((agent : Agent) → Cont agent d) → m Result) →
+    m Result
+
+namespace InteractionOver
+
+variable {l : PFunctor.Lens P Q} {syn : SyntaxOver l Agent Γ}
+
+/--
+Run a whole lens-executed protocol from a profile of local participant
+objects, producing the runtime path and each agent's output at that same path.
+-/
+def run
+    {m : Type (max uB₂ a w) → Type (max uB₂ a w)}
+    (I : InteractionOver l Agent Γ syn m) [Monad m]
+    {spec : PFunctor.FreeM P α}
+    (ctxs : Decoration Γ spec)
+    {Out : Agent → PFunctor.FreeM.PathAlong l spec → Type w}
+    (profile :
+      (agent : Agent) → SyntaxOver.Family syn agent spec ctxs (Out agent)) :
+    m ((path : PFunctor.FreeM.PathAlong l spec) × ((agent : Agent) → Out agent path)) :=
+  match spec, ctxs with
+  | .pure _, _ => pure ⟨⟨⟩, profile⟩
+  | .roll pos rest, ⟨γ, ctxs⟩ =>
+      I.interact
+        (γ := γ)
+        (Cont := fun agent d =>
+          SyntaxOver.Family syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
+            (fun path => Out agent ⟨d, path⟩))
+        (fun agent => profile agent)
+        (fun d conts => do
+          let ⟨path, out⟩ ← run I
+            (ctxs := ctxs (l.toFunB pos d))
+            (Out := fun agent path => Out agent ⟨d, path⟩)
+            conts
+          pure ⟨⟨d, path⟩, out⟩)
+
+end InteractionOver
+
 namespace Spec
 
 variable {Agent : Type a}

--- a/VCVio/Interaction/Basic/Interaction.lean
+++ b/VCVio/Interaction/Basic/Interaction.lean
@@ -17,9 +17,8 @@ combined at a single protocol node in order to choose the next move and
 continue the interaction. The node-local information seen by those objects is
 packaged as a realized `Spec.Node.Context`.
 
-The role-based prover/verifier runners used elsewhere in the library are
-specializations of this more general notion, obtained by choosing suitable
-node contexts and syntax objects.
+Role-based prover/verifier runners are specializations of this notion, obtained
+by choosing suitable node contexts and syntax objects.
 
 Just as `SyntaxOver` reindexes contravariantly along node-context morphisms,
 `InteractionOver.comap` transports a local execution law along the same kind
@@ -27,9 +26,8 @@ of context change.
 
 Naming note:
 `InteractionOver` keeps the suffix form for the same reason as `ShapeOver`:
-it is the primary generalized execution notion, while `Interaction` is its
-trivial-data specialization rather than a base value that `InteractionOver`
-depends on.
+it is the generalized execution notion over node-local data, while
+`Interaction` names the plain specialization with trivial node data.
 -/
 
 universe u a vΓ w uA uB uA₂ uB₂ t

--- a/VCVio/Interaction/Basic/Node.lean
+++ b/VCVio/Interaction/Basic/Node.lean
@@ -43,12 +43,11 @@ The rest of the interaction core consumes realized node contexts, not schemas:
   induce canonical forgetful maps on realized contexts.
 
 Worked example:
-if we previously thought of node metadata in two stages,
-first a tag `Tag X` and then dependent data `Data X tag`,
-the corresponding schema is
+node metadata with a tag `Tag X` followed by dependent data `Data X tag`
+is represented by the schema
 `(Spec.Node.Schema.singleton Tag).extend Data`.
 Its realized context is `Spec.Node.Context.extend Tag Data`,
-so a single decoration by that context packages the old staged view into one
+so a decoration by that context provides both pieces of node-local data as one
 semantic object.
 -/
 

--- a/VCVio/Interaction/Basic/Ownership.lean
+++ b/VCVio/Interaction/Basic/Ownership.lean
@@ -16,9 +16,8 @@ objects from two ingredients:
 * a participant-local `LocalView` describing what that agent stores when it
   owns the node versus when it merely observes someone else's move.
 
-This does **not** replace `SyntaxOver` or `InteractionOver`.
-It is only a structured way to construct common owner-driven interaction
-patterns on top of the generic core.
+This is a structured builder on top of `SyntaxOver` and `InteractionOver` for
+common owner-driven interaction patterns.
 
 In particular, this layer is useful for two-party and multiparty interaction
 models where every node has one acting party and the other parties follow the

--- a/VCVio/Interaction/Basic/Ownership.lean
+++ b/VCVio/Interaction/Basic/Ownership.lean
@@ -3,15 +3,16 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
+import VCVio.Interaction.Basic.BundledMonad
 import VCVio.Interaction.Basic.Syntax
 
 /-!
-# Owner-based local syntax builders
+# Ownership-profile local syntax builders
 
 This module provides a small derived API for building `Spec.SyntaxOver`
 objects from two ingredients:
 
-* an `owner` function saying which agent controls a node;
+* a `perspective` function saying whether an agent owns or observes a node;
 * a participant-local `LocalView` describing what that agent stores when it
   owns the node versus when it merely observes someone else's move.
 
@@ -27,11 +28,91 @@ chosen move with their passive continuations.
 universe u a vΓ
 
 namespace Interaction
+
+namespace Ownership
+
+open PFunctor
+
+universe uA uB uA₂ uB₂ w
+
+variable {P : PFunctor.{uA, uB}} {Q : PFunctor.{uA₂, uB₂}}
+variable (l : PFunctor.Lens P Q)
+
+/-- Whether an agent owns a node or observes another agent's move there. -/
+inductive Perspective where
+  | owner
+  | observer
+
+/--
+`LocalView Move` describes one agent's node object shape at a node whose
+runtime directions have type `Move`.
+-/
+structure LocalView (Move : Type uB₂) where
+  own : (Move → Type w) → Type w
+  other : (Move → Type w) → Type w
+
+/-- Select the local node shape determined by an ownership perspective. -/
+def LocalView.node {Move : Type uB₂} (view : LocalView.{uB₂, w} Move) :
+    Perspective → (Move → Type w) → Type w
+  | .owner, Cont => view.own Cont
+  | .observer, Cont => view.other Cont
+
+/-- The standard monadic owner/passive local view. -/
+def LocalView.monadic (bm : BundledMonad.{w, w}) (Move : Type w) :
+    LocalView.{w, w} Move where
+  own Cont := bm.M ((d : Move) × Cont d)
+  other Cont := (d : Move) → bm.M (Cont d)
+
+/--
+Public-coin owner/passive local view, exposing the owned sampler separately
+from its continuation family.
+-/
+def LocalView.publicCoin (bm : BundledMonad.{w, w}) (Move : Type w) :
+    LocalView.{w, w} Move where
+  own Cont := bm.M Move × ((d : Move) → Cont d)
+  other Cont := (d : Move) → bm.M (Cont d)
+
+variable {Agent : Type a} {Γ : P.A → Type vΓ}
+
+/--
+Build lens-indexed local syntax from a node-local ownership profile and
+participant-local views.
+-/
+def syntaxOver
+    (perspective : {pos : P.A} → Γ pos → Agent → Perspective)
+    (view :
+      {pos : P.A} → (γ : Γ pos) → Agent →
+        LocalView.{uB₂, w} (Q.B (l.toFunA pos))) :
+    SyntaxOver l Agent Γ where
+  Node agent _ γ Cont :=
+    (view γ agent).node (perspective γ agent) Cont
+
+/-- Monadic owner/passive syntax over a lens-executed tree. -/
+def monadicSyntax
+    (perspective : {pos : P.A} → Γ pos → Agent → Perspective)
+    (monad :
+      {pos : P.A} → Γ pos → Agent →
+        BundledMonad.{max uB₂ w, max uB₂ w}) :
+    SyntaxOver l Agent Γ where
+  Node agent pos γ Cont :=
+    match perspective γ agent with
+    | .owner =>
+      (monad γ agent).M ((d : Q.B (l.toFunA pos)) × Cont d)
+    | .observer =>
+      (d : Q.B (l.toFunA pos)) → (monad γ agent).M (Cont d)
+
+end Ownership
+
 namespace Spec
 namespace Ownership
 
 variable {Agent : Type a}
 variable {Γ : Node.Context}
+
+/-- Whether an agent owns a node or observes another agent's move there. -/
+inductive Perspective where
+  | owner
+  | observer
 
 /--
 `LocalView X` is the local participant interface at one move space `X`.
@@ -50,6 +131,35 @@ structure LocalView (X : Type u) where
   own : (X → Type u) → Type u
   /-- The node representation used when some other agent owns the current node. -/
   other : (X → Type u) → Type u
+
+/-- Select the local node shape determined by an ownership perspective. -/
+def LocalView.node {X : Type u} (view : LocalView X) :
+    Perspective → (X → Type u) → Type u
+  | .owner, Cont => view.own Cont
+  | .observer, Cont => view.other Cont
+
+/--
+The standard monadic owner/passive local view.
+
+Owners produce an effectful move and continuation. Observers react
+effectfully to every possible move.
+-/
+def LocalView.monadic (bm : BundledMonad.{u, u}) (X : Type u) :
+    LocalView X where
+  own Cont := bm.M ((x : X) × Cont x)
+  other Cont := (x : X) → bm.M (Cont x)
+
+/--
+Public-coin owner/passive local view.
+
+The observing side has the same shape as in `LocalView.monadic`. The owning
+side exposes the sampler separately from the continuation family, so replay can
+ignore the sampler and follow a prescribed public move.
+-/
+def LocalView.publicCoin (bm : BundledMonad.{u, u}) (X : Type u) :
+    LocalView X where
+  own Cont := bm.M X × ((x : X) → Cont x)
+  other Cont := (x : X) → bm.M (Cont x)
 
 /--
 `LocalRunner m V` gives the operational interpretation of a local view `V`
@@ -76,20 +186,30 @@ structure LocalRunner
     (x : X) → m (Cont x)
 
 /--
-Build a `SyntaxOver` from an owner function and participant-local views.
+Build a `SyntaxOver` from a node-local ownership profile and participant-local
+views.
 
-If `owner γ = a`, then agent `a` uses its `own` shape at context `γ`, while
-every other agent uses its `other` shape there.
+Concrete protocols should define `perspective` by pattern matching on their
+node metadata and agent constructors. This keeps owner/observer node shapes in
+the definitional hot path and avoids equality tests such as
+`if agent = owner γ`.
 -/
-def syntaxOver [DecidableEq Agent]
-    (owner : ∀ {X}, Γ X → Agent)
+def syntaxOver
+    (perspective : ∀ {X}, Γ X → Agent → Perspective)
     (view : ∀ {X}, (γ : Γ X) → Agent → LocalView X) :
     SyntaxOver Agent Γ where
   Node agent _ γ Cont :=
-    if agent = owner γ then
-      (view γ agent).own Cont
-    else
-      (view γ agent).other Cont
+    (view γ agent).node (perspective γ agent) Cont
+
+/-- Monadic owner/passive syntax over plain `Spec` trees. -/
+def monadicSyntax
+    (perspective : ∀ {X}, Γ X → Agent → Perspective)
+    (monad : ∀ {X}, Γ X → Agent → BundledMonad.{u, u}) :
+    SyntaxOver Agent Γ where
+  Node agent X γ Cont :=
+    match perspective γ agent with
+    | .owner => (monad γ agent).M ((x : X) × Cont x)
+    | .observer => (x : X) → (monad γ agent).M (Cont x)
 
 end Ownership
 end Spec

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -194,33 +194,6 @@ it is a chosen move `x : X` paired with a transcript for `rest x`. -/
 abbrev Transcript (s : Spec.{u}) : Type u :=
   PFunctor.FreeM.Path s
 
-/--
-View a plain transcript as a runtime path along the identity lens on
-`Spec.basePFunctor`.
--/
-def Transcript.toPathAlongId (s : Spec.{u}) :
-    Transcript s → PFunctor.FreeM.PathAlong (PFunctor.Lens.id Spec.basePFunctor) s :=
-  PFunctor.FreeM.pathToPathAlongId s
-
-/--
-View a runtime path along the identity lens on `Spec.basePFunctor` as a plain
-transcript.
--/
-def Transcript.ofPathAlongId (s : Spec.{u}) :
-    PFunctor.FreeM.PathAlong (PFunctor.Lens.id Spec.basePFunctor) s → Transcript s :=
-  PFunctor.FreeM.projectPathAlong (PFunctor.Lens.id Spec.basePFunctor) s
-
-@[simp]
-theorem Transcript.ofPathAlongId_toPathAlongId (s : Spec.{u}) (tr : Transcript s) :
-    Transcript.ofPathAlongId s (Transcript.toPathAlongId s tr) = tr :=
-  PFunctor.FreeM.projectPathAlong_id_pathToPathAlongId s tr
-
-@[simp]
-theorem Transcript.toPathAlongId_ofPathAlongId (s : Spec.{u})
-    (path : PFunctor.FreeM.PathAlong (PFunctor.Lens.id Spec.basePFunctor) s) :
-    Transcript.toPathAlongId s (Transcript.ofPathAlongId s path) = path :=
-  PFunctor.FreeM.pathToPathAlongId_projectPathAlong_id s path
-
 /-- A straight-line `Spec` with no branching: each move type in the list
 becomes one round, and later rounds do not depend on earlier moves. -/
 def ofList : List (Type u) → Spec

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -25,10 +25,10 @@ moves are computed. Those concerns are separated into companion modules:
 * `Strategy` — one-player strategies with monadic effects
 * `Append`, `Replicate`, `Chain` — sequential composition and iteration
 
-This is the foundation of the entire `Interaction` layer, which replaces
-the old flat `ProtocolSpec n` model with a dependent-type-native design.
-The key advantage is that later rounds can depend on earlier moves, which
-is mathematically forced in protocols like sumcheck and FRI.
+This is the foundation of the `Interaction` layer: a dependent tree of moves
+whose later rounds may depend on earlier choices. That dependence is part of
+the protocol shape itself, matching examples such as sumcheck and FRI where
+later messages and checks are indexed by the preceding transcript.
 
 ## Polynomial substrate
 
@@ -47,10 +47,9 @@ shapes are obtained by replacing `PFunctor.FreeM` with the corresponding
 `PFunctor.FreeM ... α` for nontrivial `α` (see `Strategy` / `StepOver`).
 
 The `Spec` notation, `Spec.done`, and `Spec.node` are tagged with
-`@[match_pattern]` so that downstream definitions and proofs continue to
-pattern-match exactly as before, with no rewrite required at call sites.
-The substrate is the truth; the names are an ergonomic re-skin in the
-spirit of `OracleSpec`/`OracleComp`.
+`@[match_pattern]`, so downstream definitions can pattern-match on the
+interaction constructors while the polynomial substrate remains the canonical
+representation.
 
 ## Module map
 
@@ -132,8 +131,8 @@ Those additional layers are supplied separately by:
 `Spec` is **definitionally** the free monad on `Spec.basePFunctor` at the
 unit payload, exposing the polynomial substrate that the rest of the
 `Interaction` library builds on. The `Spec.done` / `Spec.node` aliases
-are tagged with `@[match_pattern]`, so existing pattern-matching code
-continues to work unchanged. -/
+are tagged with `@[match_pattern]`, so definitions can use constructor-style
+patterns without exposing the underlying `FreeM` representation. -/
 def Spec : Type (u+1) :=
   PFunctor.FreeM Spec.basePFunctor.{u} PUnit.{u+1}
 

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -194,6 +194,33 @@ it is a chosen move `x : X` paired with a transcript for `rest x`. -/
 abbrev Transcript (s : Spec.{u}) : Type u :=
   PFunctor.FreeM.Path s
 
+/--
+View a plain transcript as a runtime path along the identity lens on
+`Spec.basePFunctor`.
+-/
+def Transcript.toPathAlongId (s : Spec.{u}) :
+    Transcript s → PFunctor.FreeM.PathAlong (PFunctor.Lens.id Spec.basePFunctor) s :=
+  PFunctor.FreeM.pathToPathAlongId s
+
+/--
+View a runtime path along the identity lens on `Spec.basePFunctor` as a plain
+transcript.
+-/
+def Transcript.ofPathAlongId (s : Spec.{u}) :
+    PFunctor.FreeM.PathAlong (PFunctor.Lens.id Spec.basePFunctor) s → Transcript s :=
+  PFunctor.FreeM.projectPathAlong (PFunctor.Lens.id Spec.basePFunctor) s
+
+@[simp]
+theorem Transcript.ofPathAlongId_toPathAlongId (s : Spec.{u}) (tr : Transcript s) :
+    Transcript.ofPathAlongId s (Transcript.toPathAlongId s tr) = tr :=
+  PFunctor.FreeM.projectPathAlong_id_pathToPathAlongId s tr
+
+@[simp]
+theorem Transcript.toPathAlongId_ofPathAlongId (s : Spec.{u})
+    (path : PFunctor.FreeM.PathAlong (PFunctor.Lens.id Spec.basePFunctor) s) :
+    Transcript.toPathAlongId s (Transcript.ofPathAlongId s path) = path :=
+  PFunctor.FreeM.pathToPathAlongId_projectPathAlong_id s path
+
 /-- A straight-line `Spec` with no branching: each move type in the list
 becomes one round, and later rounds do not depend on earlier moves. -/
 def ofList : List (Type u) → Spec

--- a/VCVio/Interaction/Basic/Syntax.lean
+++ b/VCVio/Interaction/Basic/Syntax.lean
@@ -30,8 +30,7 @@ local syntax, but they need not support a generic continuation map.
 notion: it adds continuation reindexing when the local syntax really does
 support it.
 
-The existing role-based notions are specializations of this more general
-pattern:
+Role-based APIs are specializations of this pattern:
 * `Spec.Node.Context` is the semantic family of node-local data;
 * `Spec.Node.Schema` is the telescope-style front-end for building such
   contexts;
@@ -42,8 +41,9 @@ pattern:
   syntax objects built on top of this core.
 
 Naming note:
-`SyntaxOver` is the true base local-syntax notion. `ShapeOver` keeps the suffix
-form as the functorial refinement of that syntax, rather than replacing it.
+`SyntaxOver` is the base local-syntax notion. `ShapeOver` uses the same suffix
+to signal that it is the functorial refinement of syntax, with continuation
+reindexing available as part of the interface.
 -/
 
 universe u a vΓ w uA uB uA₂ uB₂ t

--- a/VCVio/Interaction/Basic/Syntax.lean
+++ b/VCVio/Interaction/Basic/Syntax.lean
@@ -46,9 +46,61 @@ Naming note:
 form as the functorial refinement of that syntax, rather than replacing it.
 -/
 
-universe u a vΓ w
+universe u a vΓ w uA uB uA₂ uB₂ t
 
 namespace Interaction
+
+open PFunctor
+
+variable {P : PFunctor.{uA, uB}} {Q : PFunctor.{uA₂, uB₂}}
+variable {α : Type t}
+
+/--
+`SyntaxOver l Agent Γ` is local syntax over an arbitrary control polynomial
+executed through a runtime lens `l`.
+
+At control position `pos : P.A`, node metadata has type `Γ pos`, while the
+local continuation family is indexed by runtime directions
+`Q.B (l.toFunA pos)`. The lens maps each runtime direction back to the
+abstract control branch used for recursion.
+-/
+structure SyntaxOver
+    (l : PFunctor.Lens P Q)
+    (Agent : Type a)
+    (Γ : P.A → Type vΓ) where
+  Node :
+    (agent : Agent) →
+    (pos : P.A) →
+    (γ : Γ pos) →
+    (Q.B (l.toFunA pos) → Type w) →
+    Type w
+
+namespace SyntaxOver
+
+variable {Agent : Type a} {Γ : P.A → Type vΓ}
+
+/--
+Whole-tree participant family induced by lens-indexed local syntax.
+
+At leaves it returns the output family. At control nodes it presents the local
+node with runtime continuations, then recurses through the abstract branch
+selected by the lens.
+-/
+def Family {l : PFunctor.Lens P Q}
+    (syn : SyntaxOver l Agent Γ) :
+    (agent : Agent) →
+    (spec : PFunctor.FreeM P α) →
+    Decoration Γ spec →
+    (PFunctor.FreeM.PathAlong l spec → Type w) →
+    Type w
+  | _, .pure _, _, Out => Out ⟨⟩
+  | agent, .roll pos rest, ⟨γ, ctxs⟩, Out =>
+      syn.Node agent pos γ (fun d =>
+        Family syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
+          (fun path => Out ⟨d, path⟩))
+
+end SyntaxOver
+
 namespace Spec
 
 variable {Agent : Type a}

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -55,6 +55,15 @@ class LawfulCommMonad (m : Type u → Type u) [Monad m] extends LawfulMonad m wh
       let a ← ma
       k a b)
 
+private theorem bind_pure_sigma_mk {m : Type u → Type u} [Monad m] [LawfulMonad m]
+    {α : Type u} {β : α → Type u} (x : α) {tail : β x} {action : m (β x)}
+    (h : action = pure tail) :
+    (do
+      let rest ← action
+      pure (Sigma.mk x rest)) = pure (Sigma.mk x tail) := by
+  rw [h]
+  simp [monad_norm]
+
 /-- Compose role-aware strategies along `Spec.append` with a two-argument output family
 lifted through `Transcript.liftAppend`. The continuation receives the first phase's
 output and produces a second-phase strategy. -/
@@ -158,7 +167,7 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
     | .done, r₁ =>
         cases r₁
         rfl
-    | .node _ rest, ⟨.sender, rRest⟩ =>
+    | .node X rest, ⟨.sender, rRest⟩ =>
         rw [Strategy.compWithRolesFlat.eq_2]
         refine congrArg pure ?_
         refine congrArg (fun k => strat₁ >>= k) ?_
@@ -236,7 +245,7 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
     | .done, r₁ =>
         cases r₁
         rfl
-    | .node _ rest, ⟨.sender, rRest⟩ =>
+    | .node X rest, ⟨.sender, rRest⟩ =>
         rw [Strategy.compWithRolesFlat.eq_2, Strategy.splitPrefixWithRoles.eq_2]
         refine congrArg pure ?_
         simp only [bind_map_left]
@@ -254,10 +263,22 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
               strat >>= fun a => pure ⟨a.1, a.2⟩ := by
                 refine congrArg (fun k => strat >>= k) ?_
                 funext xc
-                rw [go (rest xc.1) (rRest xc.1)
-                  (s₂ := fun p => s₂ ⟨xc.1, p⟩)
-                  (r₂ := fun p => r₂ ⟨xc.1, p⟩) xc.2]
-                simp
+                rcases xc with ⟨x, tail⟩
+                let Suffix : X → Type u := fun y =>
+                  (pairedSyntax m).Family Participant.focal
+                    ((fun b => PFunctor.FreeM.append (rest b) (fun path => s₂ ⟨b, path⟩)) y)
+                    ((fun y => (rRest y).append fun p => r₂ ⟨y, p⟩) y)
+                    (fun tr => Output ⟨y, tr⟩)
+                have hgo :
+                    (Strategy.compWithRolesFlat (Strategy.splitPrefixWithRoles tail)
+                      (fun _ strat₂ => pure strat₂)) = pure tail :=
+                  go (rest x) (rRest x)
+                    (s₂ := fun p => s₂ ⟨x, p⟩)
+                    (r₂ := fun p => r₂ ⟨x, p⟩) tail
+                exact bind_pure_sigma_mk (m := m) (α := X) (β := Suffix)
+                  (x := x) (tail := tail)
+                  (action := Strategy.compWithRolesFlat (Strategy.splitPrefixWithRoles tail)
+                    (fun _ strat₂ => pure strat₂)) hgo
           _ = strat := by
                 simp
     | .node _ rest, ⟨.receiver, rRest⟩ =>

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -55,9 +55,11 @@ def Participant.focal : Participant := ⟨.focal, ⟨PUnit.unit⟩⟩
 
 def Participant.counterpart : Participant := ⟨.counterpart, ⟨PUnit.unit⟩⟩
 
-private def roleOwner : Role → Participant
-  | .sender => Participant.focal
-  | .receiver => Participant.counterpart
+private def rolePerspective : Role → Participant → Ownership.Perspective
+  | .sender, ⟨.focal, _⟩ => .owner
+  | .sender, ⟨.counterpart, _⟩ => .observer
+  | .receiver, ⟨.focal, _⟩ => .observer
+  | .receiver, ⟨.counterpart, _⟩ => .owner
 
 private def focalView (m : Type u → Type u) (X : Type u) :
     Ownership.LocalView X where
@@ -139,7 +141,7 @@ def pairedSyntax (m : Type u → Type u) :
 
 private theorem pairedSyntax_eq_ownerBased (m : Type u → Type u) :
     pairedSyntax m =
-      Ownership.syntaxOver roleOwner (fun {X} _role agent =>
+      Ownership.syntaxOver (fun role agent => rolePerspective role agent) (fun {X} _role agent =>
         match agent.tag with
         | .focal => focalView m X
         | .counterpart => counterpartView m X) := by
@@ -147,7 +149,8 @@ private theorem pairedSyntax_eq_ownerBased (m : Type u → Type u) :
   funext agent X role Cont
   cases agent with
   | mk tag lift =>
-      cases tag <;> cases role <;> rfl
+      cases tag <;> cases role <;>
+        simp [Ownership.LocalView.node, rolePerspective, focalView, counterpartView]
 
 private def pairedInteraction (m : Type u → Type u) [Monad m] :
     InteractionOver Participant (fun _ => Role) (pairedSyntax m) m where
@@ -155,10 +158,10 @@ private def pairedInteraction (m : Type u → Type u) [Monad m] :
     match γ with
     | .sender => do
         let pNode : m ((x : X) × Cont Participant.focal x) := by
-          simpa [pairedSyntax, Ownership.syntaxOver, roleOwner, Participant.focal,
+          simpa [pairedSyntax, Ownership.syntaxOver, rolePerspective, Participant.focal,
             focalView] using profile Participant.focal
         let cNode : (x : X) → m (Cont Participant.counterpart x) := by
-          simpa [pairedSyntax, Ownership.syntaxOver, roleOwner, Participant.focal,
+          simpa [pairedSyntax, Ownership.syntaxOver, rolePerspective, Participant.focal,
             Participant.counterpart, counterpartView] using profile Participant.counterpart
         let ⟨x, pCont⟩ ← (focalRunner m X).runOwn pNode
         let cCont ← (counterpartRunner m X).runOther cNode x
@@ -167,10 +170,10 @@ private def pairedInteraction (m : Type u → Type u) [Monad m] :
           | ⟨.counterpart, _⟩ => cCont)
     | .receiver => do
         let pNode : (x : X) → m (Cont Participant.focal x) := by
-          simpa [pairedSyntax, Ownership.syntaxOver, roleOwner, Participant.focal,
+          simpa [pairedSyntax, Ownership.syntaxOver, rolePerspective, Participant.focal,
             Participant.counterpart, focalView] using profile Participant.focal
         let cNode : m ((x : X) × Cont Participant.counterpart x) := by
-          simpa [pairedSyntax, Ownership.syntaxOver, roleOwner, Participant.counterpart,
+          simpa [pairedSyntax, Ownership.syntaxOver, rolePerspective, Participant.counterpart,
             counterpartView] using profile Participant.counterpart
         let ⟨x, cCont⟩ ← (counterpartRunner m X).runOwn cNode
         let pCont ← (focalRunner m X).runOther pNode x
@@ -218,7 +221,7 @@ def pairedMonadicSyntax :
 
 private theorem pairedMonadicSyntax_eq_ownerBased :
     pairedMonadicSyntax =
-      Ownership.syntaxOver (fun {_} γ => roleOwner γ.1) (fun {X} γ agent =>
+      Ownership.syntaxOver (fun γ agent => rolePerspective γ.1 agent) (fun {X} γ agent =>
         match agent.tag, γ with
         | .focal, ⟨_, ⟨bmP, _⟩⟩ => focalMonadicView bmP X
         | .counterpart, ⟨_, ⟨_, bmC⟩⟩ => counterpartMonadicView bmC X) := by
@@ -228,7 +231,9 @@ private theorem pairedMonadicSyntax_eq_ownerBased :
   | mk tag lift =>
       cases tag <;> cases γ with
       | mk role bms =>
-          cases role <;> rfl
+          cases role <;>
+            simp [Ownership.LocalView.node, rolePerspective, focalMonadicView,
+              counterpartMonadicView]
 
 
 /-- Focal strategy: `Role.Action` at each decorated node (choose vs. respond). -/
@@ -828,10 +833,10 @@ private def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
     match γ with
     | ⟨.sender, ⟨bmP, bmC⟩⟩ => do
         let pNode : bmP.M ((x : X) × Cont Participant.focal x) := by
-          simpa [pairedMonadicSyntax, Ownership.syntaxOver, roleOwner, Participant.focal,
+          simpa [pairedMonadicSyntax, Ownership.syntaxOver, rolePerspective, Participant.focal,
             focalMonadicView] using profile Participant.focal
         let cNode : (x : X) → bmC.M (Cont Participant.counterpart x) := by
-          simpa [pairedMonadicSyntax, Ownership.syntaxOver, roleOwner, Participant.focal,
+          simpa [pairedMonadicSyntax, Ownership.syntaxOver, rolePerspective, Participant.focal,
             Participant.counterpart, counterpartMonadicView] using profile Participant.counterpart
         let ⟨x, pCont⟩ ← liftStrat bmP pNode
         let cCont ← liftCpt bmC (cNode x)

--- a/VCVio/Interaction/TwoParty/Syntax.lean
+++ b/VCVio/Interaction/TwoParty/Syntax.lean
@@ -1,0 +1,172 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.Interaction.Basic.Ownership
+import VCVio.Interaction.TwoParty.Role
+
+/-!
+# Two-party syntax over lens-executed trees
+
+This module provides the two-party ownership profile and common local syntax
+specializations over the generic `Interaction.SyntaxOver` core.
+
+It intentionally does not define another recursive strategy hierarchy:
+whole-tree participant types are always obtained from `SyntaxOver.Family`.
+-/
+
+@[expose] public section
+
+universe uA uB uA₂ uB₂ w
+
+namespace Interaction
+namespace TwoParty
+
+open PFunctor
+
+variable {P : PFunctor.{uA, uB}} {Q : PFunctor.{uA₂, uB₂}}
+variable (l : PFunctor.Lens P Q)
+
+/-- The two agents in a focused two-party interaction. -/
+inductive Participant where
+  | focal
+  | counterpart
+  deriving DecidableEq
+
+/-- Ownership perspective induced by a sender/receiver role. -/
+def perspective : Role → Participant → Ownership.Perspective
+  | .sender, .focal => .owner
+  | .sender, .counterpart => .observer
+  | .receiver, .focal => .observer
+  | .receiver, .counterpart => .owner
+
+/-- Two-party monadic syntax over an arbitrary lens-executed control tree. -/
+def monadicSyntax
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{max uB₂ w, max uB₂ w}) :
+    SyntaxOver l Participant (fun _ : P.A => Role) :=
+  Ownership.monadicSyntax l (fun role agent => perspective role agent)
+    (fun {pos} role agent => monad pos role agent)
+
+/--
+Two-party syntax where the counterpart's owned moves are public coin.
+
+Compared with `monadicSyntax`, only the counterpart-owned receiver node changes:
+instead of an opaque `m ((d : Move) × Cont d)`, it stores
+`m Move × ((d : Move) → Cont d)`. This exposes the continuation family needed
+for replaying prescribed public challenges.
+-/
+def publicCoinCounterpartSyntax
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{uB₂, uB₂}) :
+    SyntaxOver l Participant (fun _ : P.A => Role) :=
+  Ownership.syntaxOver l (fun role agent => perspective role agent)
+    (fun {pos} role agent =>
+      match agent with
+      | Participant.focal =>
+          Ownership.LocalView.monadic (monad pos role Participant.focal) (Q.B (l.toFunA pos))
+      | Participant.counterpart =>
+          Ownership.LocalView.publicCoin (monad pos role Participant.counterpart)
+            (Q.B (l.toFunA pos)))
+
+@[simp]
+theorem monadicSyntax_focal_sender
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{max uB₂ w, max uB₂ w})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type (max uB₂ w)) :
+    (monadicSyntax l monad).Node Participant.focal pos Role.sender Cont =
+      (monad pos Role.sender Participant.focal).M
+        ((d : Q.B (l.toFunA pos)) × Cont d) :=
+  rfl
+
+@[simp]
+theorem monadicSyntax_counterpart_sender
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{max uB₂ w, max uB₂ w})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type (max uB₂ w)) :
+    (monadicSyntax l monad).Node Participant.counterpart pos Role.sender Cont =
+      ((d : Q.B (l.toFunA pos)) →
+        (monad pos Role.sender Participant.counterpart).M (Cont d)) :=
+  rfl
+
+@[simp]
+theorem monadicSyntax_focal_receiver
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{max uB₂ w, max uB₂ w})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type (max uB₂ w)) :
+    (monadicSyntax l monad).Node Participant.focal pos Role.receiver Cont =
+      ((d : Q.B (l.toFunA pos)) →
+        (monad pos Role.receiver Participant.focal).M (Cont d)) :=
+  rfl
+
+@[simp]
+theorem monadicSyntax_counterpart_receiver
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{max uB₂ w, max uB₂ w})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type (max uB₂ w)) :
+    (monadicSyntax l monad).Node Participant.counterpart pos Role.receiver Cont =
+      (monad pos Role.receiver Participant.counterpart).M
+        ((d : Q.B (l.toFunA pos)) × Cont d) :=
+  rfl
+
+@[simp]
+theorem publicCoinCounterpartSyntax_focal_sender
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{uB₂, uB₂})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type uB₂) :
+    (publicCoinCounterpartSyntax l monad).Node Participant.focal pos Role.sender Cont =
+      (monad pos Role.sender Participant.focal).M
+        ((d : Q.B (l.toFunA pos)) × Cont d) :=
+  rfl
+
+@[simp]
+theorem publicCoinCounterpartSyntax_counterpart_sender
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{uB₂, uB₂})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type uB₂) :
+    (publicCoinCounterpartSyntax l monad).Node Participant.counterpart pos Role.sender Cont =
+      ((d : Q.B (l.toFunA pos)) →
+        (monad pos Role.sender Participant.counterpart).M (Cont d)) :=
+  rfl
+
+@[simp]
+theorem publicCoinCounterpartSyntax_focal_receiver
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{uB₂, uB₂})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type uB₂) :
+    (publicCoinCounterpartSyntax l monad).Node Participant.focal pos Role.receiver Cont =
+      ((d : Q.B (l.toFunA pos)) →
+        (monad pos Role.receiver Participant.focal).M (Cont d)) :=
+  rfl
+
+@[simp]
+theorem publicCoinCounterpartSyntax_counterpart_receiver
+    (monad :
+      (pos : P.A) → Role → Participant →
+        BundledMonad.{uB₂, uB₂})
+    (pos : P.A)
+    (Cont : Q.B (l.toFunA pos) → Type uB₂) :
+    (publicCoinCounterpartSyntax l monad).Node Participant.counterpart pos Role.receiver Cont =
+      ((monad pos Role.receiver Participant.counterpart).M (Q.B (l.toFunA pos)) ×
+        ((d : Q.B (l.toFunA pos)) → Cont d)) :=
+  rfl
+
+end TwoParty
+end Interaction


### PR DESCRIPTION
## Summary

Posted by Cursor assistant (model: GPT-5.4) on behalf of the user (Quang Dao) with approval.

This PR generalizes interaction paths through polynomial lenses and keeps the interaction documentation aligned with that model.

- Adds lens-aware path infrastructure around `PFunctor.FreeM.PathAlong`.
- Makes `PathAlong l s` the canonical path through `s.mapLens l`.
- Removes an append-side cast by using structural append packing/unpacking.
- Refreshes core interaction docstrings so they describe the current polynomial-tree and lens-execution viewpoint directly.

## Validation

- `lake env lean ToMathlib/PFunctor/Free/Path.lean`
- `lake env lean VCVio/Interaction/Basic/Append.lean`
- `lake env lean VCVio/Interaction/Basic/Spec.lean`
- `lake env lean VCVio/Interaction/Basic/Node.lean`
- `lake env lean VCVio/Interaction/Basic/Syntax.lean`
- `lake env lean VCVio/Interaction/Basic/Interaction.lean`
- `lake env lean VCVio/Interaction/Basic/Ownership.lean`