### PR TITLE
Refactor interaction strategy hierarchy

### DIFF
--- a/VCVio/Interaction/Basic/Append.lean
+++ b/VCVio/Interaction/Basic/Append.lean
@@ -45,7 +45,7 @@ would need explicit casts between the two-argument and single-argument views.
 This combinator propagates up through the entire stack:
 - `Transcript.stateChainFamily` uses it at each stage of a state chain
 - `Chain.outputFamily` uses it at each round of a continuation chain
-- `Strategy.comp` / `Strategy.compWithRoles` use it for the output type
+- `Strategy.comp` / `Focal.comp` use it for the output type
 - All security composition theorems factor through it -/
 def Transcript.liftAppend :
     (s₁ : Spec) → (s₂ : Transcript s₁ → Spec) →
@@ -453,9 +453,9 @@ def Strategy.comp {m : Type u → Type u} [Monad m] :
     (s₁ : Spec) → (s₂ : Transcript s₁ → Spec) →
     {Mid : Transcript s₁ → Type u} →
     {F : (tr₁ : Transcript s₁) → Transcript (s₂ tr₁) → Type u} →
-    Strategy m s₁ Mid →
-    ((tr₁ : Transcript s₁) → Mid tr₁ → m (Strategy m (s₂ tr₁) (F tr₁))) →
-    m (Strategy m (s₁.append s₂) (Transcript.liftAppend s₁ s₂ F))
+    Strategy.Plain m s₁ Mid →
+    ((tr₁ : Transcript s₁) → Mid tr₁ → m (Strategy.Plain m (s₂ tr₁) (F tr₁))) →
+    m (Strategy.Plain m (s₁.append s₂) (Transcript.liftAppend s₁ s₂ F))
   | .done, _, _, _, mid, f => f ⟨⟩ mid
   | .node _ rest, s₂, _, _, ⟨x, cont⟩, f => pure ⟨x, do
       let next ← cont
@@ -473,10 +473,10 @@ def Strategy.compFlat {m : Type u → Type u} [Monad m] :
     (s₁ : Spec) → (s₂ : Transcript s₁ → Spec) →
     {Mid : Transcript s₁ → Type u} →
     {Output : Transcript (s₁.append s₂) → Type u} →
-    Strategy m s₁ Mid →
+    Strategy.Plain m s₁ Mid →
     ((tr₁ : Transcript s₁) → Mid tr₁ →
-      m (Strategy m (s₂ tr₁) (fun tr₂ => Output (Transcript.append s₁ s₂ tr₁ tr₂)))) →
-    m (Strategy m (s₁.append s₂) Output)
+      m (Strategy.Plain m (s₂ tr₁) (fun tr₂ => Output (Transcript.append s₁ s₂ tr₁ tr₂)))) →
+    m (Strategy.Plain m (s₁.append s₂) Output)
   | .done, _, _, _, mid, f => f ⟨⟩ mid
   | .node _ rest, s₂, _, _, ⟨x, cont⟩, f => pure ⟨x, do
       let next ← cont
@@ -488,9 +488,9 @@ with output indexed by `Transcript.append`. -/
 def Strategy.splitPrefix {m : Type u → Type u} [Functor m] :
     (s₁ : Spec) → (s₂ : Transcript s₁ → Spec) →
     {Output : Transcript (s₁.append s₂) → Type u} →
-    Strategy m (s₁.append s₂) Output →
-    Strategy m s₁ (fun tr₁ =>
-      Strategy m (s₂ tr₁) (fun tr₂ => Output (Transcript.append s₁ s₂ tr₁ tr₂)))
+    Strategy.Plain m (s₁.append s₂) Output →
+    Strategy.Plain m s₁ (fun tr₁ =>
+      Strategy.Plain m (s₂ tr₁) (fun tr₂ => Output (Transcript.append s₁ s₂ tr₁ tr₂)))
   | .done, _, _, p => p
   | .node _ rest, s₂, _, ⟨x, cont⟩ =>
       ⟨x, (splitPrefix (rest x) (fun p => s₂ ⟨x, p⟩) ·) <$> cont⟩

--- a/VCVio/Interaction/Basic/Chain.lean
+++ b/VCVio/Interaction/Basic/Chain.lean
@@ -149,9 +149,9 @@ family member indexed by the transcript of that round. -/
 def strategyComp {m : Type u → Type u} [Monad m]
     {Family : {n : Nat} → Chain n → Type u}
     (step : {n : Nat} → (c : Chain (n + 1)) → Family c →
-      m (Strategy m c.1 (fun tr => Family (c.2 tr)))) :
+      m (Strategy.Plain m c.1 (fun tr => Family (c.2 tr)))) :
     (n : Nat) → (c : Chain n) → Family c →
-    m (Strategy m (toSpec n c) (outputFamily Family n c))
+    m (Strategy.Plain m (toSpec n c) (outputFamily Family n c))
   | 0, _, a => pure a
   | n + 1, ⟨spec, cont⟩, a => do
       let strat ← step ⟨spec, cont⟩ a
@@ -259,7 +259,7 @@ example (i : Fin 2) :
 /-- Pure strategy that follows a prescribed transcript and returns a chosen leaf output. -/
 private def scriptStrategy :
     (spec : Spec) → (tr : Transcript spec) → {Output : Transcript spec → Type u} →
-    Output tr → Strategy Id spec Output
+    Output tr → Strategy.Plain Id spec Output
   | .done, _, _, out => out
   | .node _ rest, ⟨x, trRest⟩, _, out => ⟨x, scriptStrategy (rest x) trRest out⟩
 
@@ -271,13 +271,13 @@ private abbrev ReplayState {n : Nat} (c : Chain.{0} n) : Type :=
 play the current round verbatim, and return the tail transcript. -/
 private def replayStep {n : Nat} (c : Chain.{0} (n + 1))
     (tr : ReplayState c) :
-    Id (Strategy Id c.1 (fun tr₁ => ReplayState (c.2 tr₁))) :=
+    Id (Strategy.Plain Id c.1 (fun tr₁ => ReplayState (c.2 tr₁))) :=
   let ⟨tr₁, trRest⟩ := Chain.splitTranscript n c tr
   scriptStrategy c.1 tr₁ trRest
 
 /-- Replay a full flattened transcript using the intrinsic dependent strategy combinator. -/
 private def replayStrategy (n : Nat) (c : Chain.{0} n) (tr : ReplayState c) :
-    Strategy Id (Chain.toSpec n c)
+    Strategy.Plain Id (Chain.toSpec n c)
       (Chain.outputFamily (Family := fun {_} c => ReplayState c) n c) :=
   Chain.strategyComp (Family := fun {_} c => ReplayState c) replayStep n c tr
 

--- a/VCVio/Interaction/Basic/Decoration.lean
+++ b/VCVio/Interaction/Basic/Decoration.lean
@@ -129,6 +129,11 @@ def Decoration (Γ : Node.Context.{u, v}) : Spec → Type (max u v)
   | .done => PUnit
   | .node X rest => Γ X × (∀ x, Decoration Γ (rest x))
 
+/-- The unique decoration by the empty node context. -/
+def Decoration.empty : (spec : Spec) → Decoration Node.Context.empty spec
+  | .done => PUnit.unit
+  | .node _ rest => ⟨PUnit.unit, fun x => Decoration.empty (rest x)⟩
+
 /-- Natural transformation between per-node decorations, applied recursively. -/
 def Decoration.map {Γ : Node.Context.{u, v}} {Δ : Node.Context.{u, w}}
     (f : Interaction.Spec.Node.ContextHom Γ Δ) :

--- a/VCVio/Interaction/Basic/Interaction.lean
+++ b/VCVio/Interaction/Basic/Interaction.lean
@@ -64,13 +64,14 @@ structure InteractionOver
     ((d : Q.B (l.toFunA pos)) → ((agent : Agent) → Cont agent d) → m Result) →
     m Result
 
-namespace InteractionOver
+namespace StrategyOver
 
 variable {l : PFunctor.Lens P Q} {syn : SyntaxOver l Agent Γ}
 
 /--
 Run a whole lens-executed protocol from a profile of local participant
-objects, producing the runtime path and each agent's output at that same path.
+objects, producing the runtime path and an output collected from all agents at
+that same path.
 -/
 def run
     {m : Type (max uB₂ a w) → Type (max uB₂ a w)}
@@ -78,26 +79,32 @@ def run
     {spec : PFunctor.FreeM P α}
     (ctxs : Decoration Γ spec)
     {Out : Agent → PFunctor.FreeM.PathAlong l spec → Type w}
+    {Result : PFunctor.FreeM.PathAlong l spec → Type (max a w)}
     (profile :
-      (agent : Agent) → SyntaxOver.Family syn agent spec ctxs (Out agent)) :
-    m ((path : PFunctor.FreeM.PathAlong l spec) × ((agent : Agent) → Out agent path)) :=
+      (agent : Agent) → StrategyOver syn agent spec ctxs (Out agent))
+    (collect :
+      (path : PFunctor.FreeM.PathAlong l spec) →
+        ((agent : Agent) → Out agent path) → Result path) :
+    m ((path : PFunctor.FreeM.PathAlong l spec) × Result path) :=
   match spec, ctxs with
-  | .pure _, _ => pure ⟨⟨⟩, profile⟩
+  | .pure _, _ => pure ⟨⟨⟩, collect ⟨⟩ profile⟩
   | .roll pos rest, ⟨γ, ctxs⟩ =>
       I.interact
         (γ := γ)
         (Cont := fun agent d =>
-          SyntaxOver.Family syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
+          StrategyOver syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
             (fun path => Out agent ⟨d, path⟩))
         (fun agent => profile agent)
         (fun d conts => do
           let ⟨path, out⟩ ← run I
             (ctxs := ctxs (l.toFunB pos d))
             (Out := fun agent path => Out agent ⟨d, path⟩)
+            (Result := fun path => Result ⟨d, path⟩)
             conts
+            (fun path out => collect ⟨d, path⟩ out)
           pure ⟨⟨d, path⟩, out⟩)
 
-end InteractionOver
+end StrategyOver
 
 namespace Spec
 
@@ -232,43 +239,48 @@ Inputs:
   agent;
 * `profile` supplies, for every agent, that agent's whole-tree participant
   object induced by `syn`.
+* `collect` assembles the agent outputs at the realized transcript into the
+  result returned by the runner.
 
 Output:
 * a monadic computation producing
   * a concrete transcript `tr`, and
-  * for each agent `a`, the final output `Out a tr` obtained by following that
-    transcript.
+  * the collected output at that transcript.
 
 So `run` is the whole-tree execution induced by the local execution law
 `InteractionOver.interact`. It is the generic profile-level analogue of the
 specialized two-party runners elsewhere in the library.
 
-This first executable version is intentionally specialized to the common
-single-universe setting used throughout the current interaction layer. The
-underlying `SyntaxOver` and `InteractionOver` abstractions remain more general.
+This executable facade uses the single-universe setting used by the `Spec`
+interaction layer. The underlying `SyntaxOver` and `InteractionOver`
+abstractions remain universe-polymorphic.
 -/
-def InteractionOver.run
+def StrategyOver.run
     (I : InteractionOver Agent Γ syn m) [Monad m]
     {spec : Spec}
     (ctxs : Decoration Γ spec)
     {Out : Agent → Transcript spec → Type u}
+    {Result : Transcript spec → Type u}
     (profile :
-      (agent : Agent) → SyntaxOver.Family syn agent spec ctxs (Out agent)) :
-    m ((tr : Transcript spec) × ((agent : Agent) → Out agent tr)) :=
+      (agent : Agent) → StrategyOver syn agent spec ctxs (Out agent))
+    (collect : (tr : Transcript spec) → ((agent : Agent) → Out agent tr) → Result tr) :
+    m ((tr : Transcript spec) × Result tr) :=
   match spec, ctxs with
-  | .done, _ => pure ⟨PUnit.unit, profile⟩
+  | .done, _ => pure ⟨PUnit.unit, collect PUnit.unit profile⟩
   | .node _ next, ⟨γ, ctxs⟩ =>
       I.interact
         (γ := γ)
         (Cont := fun agent x =>
-          SyntaxOver.Family syn agent (next x) (ctxs x)
+          StrategyOver syn agent (next x) (ctxs x)
             (fun tr => Out agent ⟨x, tr⟩))
         (fun agent => profile agent)
         (fun x conts => do
           let ⟨tr, out⟩ ← run I
             (ctxs := ctxs x)
             (Out := fun agent tr => Out agent ⟨x, tr⟩)
+            (Result := fun tr => Result ⟨x, tr⟩)
             conts
+            (fun tr out => collect ⟨x, tr⟩ out)
           pure ⟨⟨x, tr⟩, out⟩)
 
 end Run

--- a/VCVio/Interaction/Basic/Interaction.lean
+++ b/VCVio/Interaction/Basic/Interaction.lean
@@ -64,7 +64,7 @@ structure InteractionOver
     ((d : Q.B (l.toFunA pos)) → ((agent : Agent) → Cont agent d) → m Result) →
     m Result
 
-namespace StrategyOver
+namespace InteractionOver
 
 variable {l : PFunctor.Lens P Q} {syn : SyntaxOver l Agent Γ}
 
@@ -75,7 +75,7 @@ that same path.
 -/
 def run
     {m : Type (max uB₂ a w) → Type (max uB₂ a w)}
-    (I : InteractionOver l Agent Γ syn m) [Monad m]
+    [Monad m]
     {spec : PFunctor.FreeM P α}
     (ctxs : Decoration Γ spec)
     {Out : Agent → PFunctor.FreeM.PathAlong l spec → Type w}
@@ -84,7 +84,8 @@ def run
       (agent : Agent) → StrategyOver syn agent spec ctxs (Out agent))
     (collect :
       (path : PFunctor.FreeM.PathAlong l spec) →
-        ((agent : Agent) → Out agent path) → Result path) :
+        ((agent : Agent) → Out agent path) → Result path)
+    (I : InteractionOver l Agent Γ syn m) :
     m ((path : PFunctor.FreeM.PathAlong l spec) × Result path) :=
   match spec, ctxs with
   | .pure _, _ => pure ⟨⟨⟩, collect ⟨⟩ profile⟩
@@ -96,15 +97,16 @@ def run
             (fun path => Out agent ⟨d, path⟩))
         (fun agent => profile agent)
         (fun d conts => do
-          let ⟨path, out⟩ ← run I
+          let ⟨path, out⟩ ← run
             (ctxs := ctxs (l.toFunB pos d))
             (Out := fun agent path => Out agent ⟨d, path⟩)
             (Result := fun path => Result ⟨d, path⟩)
             conts
             (fun path out => collect ⟨d, path⟩ out)
+            I
           pure ⟨⟨d, path⟩, out⟩)
 
-end StrategyOver
+end InteractionOver
 
 namespace Spec
 
@@ -187,8 +189,8 @@ execution law sees.
 -/
 def InteractionOver.comap {Δ : Node.Context} {syn : SyntaxOver Agent Δ}
     {m : Type w → Type w}
-    (I : InteractionOver Agent Δ syn m) (f : Node.ContextHom Γ Δ) :
-    InteractionOver Agent Γ (syn.comap f) m where
+    (f : Node.ContextHom Γ Δ) (I : InteractionOver Agent Δ syn m) :
+    InteractionOver Agent Γ (SyntaxOver.comap f syn) m where
   interact profile k := I.interact profile k
 
 /--
@@ -199,16 +201,16 @@ abbrev InteractionOver.comapSchema
     {Δ : Node.Context} {S : Node.Schema Γ} {T : Node.Schema Δ}
     {syn : SyntaxOver Agent Δ}
     {m : Type w → Type w}
-    (I : InteractionOver Agent Δ syn m) (f : Node.Schema.SchemaMap S T) :
-    InteractionOver Agent Γ (SyntaxOver.comapSchema syn f) m :=
-  I.comap f.toContextHom
+    (f : Node.Schema.SchemaMap S T) (I : InteractionOver Agent Δ syn m) :
+    InteractionOver Agent Γ (SyntaxOver.comapSchema f syn) m :=
+  InteractionOver.comap f.toContextHom I
 
 @[simp]
 theorem InteractionOver.comap_id
     {syn : SyntaxOver Agent Γ}
     {m : Type w → Type w}
     (I : InteractionOver Agent Γ syn m) :
-    I.comap (Node.ContextHom.id Γ) = I := by
+    InteractionOver.comap (Node.ContextHom.id Γ) I = I := by
   cases I
   rfl
 
@@ -218,7 +220,8 @@ theorem InteractionOver.comap_comp
     {m : Type w → Type w}
     (I : InteractionOver Agent Λ syn m)
     (g : Node.ContextHom Δ Λ) (f : Node.ContextHom Γ Δ) :
-    (I.comap g).comap f = I.comap (Node.ContextHom.comp g f) := by
+    InteractionOver.comap f (InteractionOver.comap g I) =
+      InteractionOver.comap (Node.ContextHom.comp g f) I := by
   cases I
   rfl
 
@@ -255,15 +258,16 @@ This executable facade uses the single-universe setting used by the `Spec`
 interaction layer. The underlying `SyntaxOver` and `InteractionOver`
 abstractions remain universe-polymorphic.
 -/
-def StrategyOver.run
-    (I : InteractionOver Agent Γ syn m) [Monad m]
+def InteractionOver.run
+    [Monad m]
     {spec : Spec}
     (ctxs : Decoration Γ spec)
     {Out : Agent → Transcript spec → Type u}
     {Result : Transcript spec → Type u}
     (profile :
       (agent : Agent) → StrategyOver syn agent spec ctxs (Out agent))
-    (collect : (tr : Transcript spec) → ((agent : Agent) → Out agent tr) → Result tr) :
+    (collect : (tr : Transcript spec) → ((agent : Agent) → Out agent tr) → Result tr)
+    (I : InteractionOver Agent Γ syn m) :
     m ((tr : Transcript spec) × Result tr) :=
   match spec, ctxs with
   | .done, _ => pure ⟨PUnit.unit, collect PUnit.unit profile⟩
@@ -275,12 +279,13 @@ def StrategyOver.run
             (fun tr => Out agent ⟨x, tr⟩))
         (fun agent => profile agent)
         (fun x conts => do
-          let ⟨tr, out⟩ ← run I
+          let ⟨tr, out⟩ ← run
             (ctxs := ctxs x)
             (Out := fun agent tr => Out agent ⟨x, tr⟩)
             (Result := fun tr => Result ⟨x, tr⟩)
             conts
             (fun tr out => collect ⟨x, tr⟩ out)
+            I
           pure ⟨⟨x, tr⟩, out⟩)
 
 end Run

--- a/VCVio/Interaction/Basic/MonadDecoration.lean
+++ b/VCVio/Interaction/Basic/MonadDecoration.lean
@@ -14,9 +14,9 @@ import VCVio.Interaction.Basic.Interaction
 
 The corresponding one-participant syntax, `Strategy.monadicSyntax`, chooses a
 move at a node and places the continuation in the monad recorded by that node.
-Thus `Strategy.withMonads` is a direct `StrategyOver` specialization, and
-`Strategy.runWithMonads` executes it by lifting each node monad into one ambient
-execution monad.
+Use it directly with `StrategyOver` for whole-tree strategies and with
+`StrategyOver.run` through `Strategy.monadicInteraction` for execution in an
+ambient monad.
 -/
 
 universe u
@@ -89,13 +89,6 @@ def Strategy.monadicSyntax :
   Node _ (X : Type u) bm (Cont : X → Type u) :=
     (x : X) × bm.M (Cont x)
 
-/-- Strategy type where each node's continuation uses the monad from its
-`MonadDecoration`. -/
-abbrev Strategy.withMonads
-    (spec : Spec.{u}) (deco : MonadDecoration.{u, u, u} spec)
-    (Output : Transcript spec → Type u) :=
-  StrategyOver Strategy.monadicSyntax PUnit.unit spec deco Output
-
 /-- One-step execution law for `Strategy.monadicSyntax`.
 
 The node selects the next move directly. Its continuation is lifted from the
@@ -108,26 +101,6 @@ def Strategy.monadicInteraction {m : Type u → Type u} [Monad m]
     let node := profile PUnit.unit
     let next ← liftM γ node.2
     k node.1 (fun _ => next)
-
-/-- Execute a `withMonads` strategy, lifting each node's bundled monad into `m`. -/
-def Strategy.runWithMonads {m : Type u → Type u} [Monad m]
-    (liftM : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
-    (spec : Spec) → (deco : MonadDecoration.{u, u, u} spec) →
-    {Output : Transcript spec → Type u} →
-    Strategy.withMonads spec deco Output → m ((tr : Transcript spec) × Output tr)
-  | spec, deco, Output, strat =>
-      StrategyOver.run
-        (Agent := PUnit)
-        (Γ := fun (_ : Type u) => BundledMonad.{u, u})
-        (syn := Strategy.monadicSyntax)
-        (m := m)
-        (Strategy.monadicInteraction liftM)
-        (spec := spec)
-        (Out := fun _ => Output)
-        (Result := Output)
-        deco
-        (fun _ => strat)
-        (fun _ out => out PUnit.unit)
 
 end Spec
 end Interaction

--- a/VCVio/Interaction/Basic/MonadDecoration.lean
+++ b/VCVio/Interaction/Basic/MonadDecoration.lean
@@ -23,6 +23,58 @@ namespace Spec
 abbrev MonadDecoration :=
   Decoration (fun (_ : Type u) => BundledMonad)
 
+namespace MonadDecoration
+
+/--
+Constant monad decoration: every node in the interaction tree uses the same
+bundled monad.
+
+This is the bridge between ordinary single-monad strategies and strategies
+whose node effects are described by a `MonadDecoration`.
+-/
+def constant (bm : BundledMonad.{u, u}) :
+    (spec : Spec.{u}) → MonadDecoration.{u, u, u} spec
+  | .done => PUnit.unit
+  | .node _ rest => ⟨bm, fun x => constant bm (rest x)⟩
+
+/--
+Nodewise monad homomorphism between two monad decorations on the same
+interaction tree.
+
+At each internal node it gives a lift from the source bundled monad to the
+target bundled monad, together with recursive lifts for every continuation
+subtree.
+-/
+def Hom :
+    (spec : Spec.{u}) → MonadDecoration.{u, u, u} spec →
+      MonadDecoration.{u, u, u} spec → Type (u + 1)
+  | .done, _, _ => PUnit
+  | .node X rest, ⟨m₁, md₁⟩, ⟨m₂, md₂⟩ =>
+      (∀ {α : Type u}, m₁.M α → m₂.M α) ×
+        ((x : X) → Hom (rest x) (md₁ x) (md₂ x))
+
+namespace Hom
+
+/-- Identity homomorphism on a monad decoration. -/
+def id :
+    (spec : Spec.{u}) → (md : MonadDecoration.{u, u, u} spec) →
+      Hom spec md md
+  | .done, _ => PUnit.unit
+  | .node _ rest, ⟨_, mdRest⟩ =>
+      ⟨fun x => x, fun x => id (rest x) (mdRest x)⟩
+
+/-- Constant homomorphism induced by a single monad lift. -/
+def constant {bm₁ bm₂ : BundledMonad.{u, u}}
+    (lift : ∀ {α : Type u}, bm₁.M α → bm₂.M α) :
+    (spec : Spec.{u}) →
+      Hom spec (MonadDecoration.constant bm₁ spec) (MonadDecoration.constant bm₂ spec)
+  | .done => PUnit.unit
+  | .node _ rest => ⟨lift, fun x => constant lift (rest x)⟩
+
+end Hom
+
+end MonadDecoration
+
 /-- Strategy type where each node's continuation uses the monad from `MonadDecoration`. -/
 def Strategy.withMonads :
     (spec : Spec.{u}) → MonadDecoration spec → (Transcript spec → Type u) → Type u

--- a/VCVio/Interaction/Basic/MonadDecoration.lean
+++ b/VCVio/Interaction/Basic/MonadDecoration.lean
@@ -15,7 +15,7 @@ import VCVio.Interaction.Basic.Interaction
 The corresponding one-participant syntax, `Strategy.monadicSyntax`, chooses a
 move at a node and places the continuation in the monad recorded by that node.
 Use it directly with `StrategyOver` for whole-tree strategies and with
-`StrategyOver.run` through `Strategy.monadicInteraction` for execution in an
+`InteractionOver.run` through `Strategy.monadicInteraction` for execution in an
 ambient monad.
 -/
 

--- a/VCVio/Interaction/Basic/MonadDecoration.lean
+++ b/VCVio/Interaction/Basic/MonadDecoration.lean
@@ -5,13 +5,18 @@ Authors: Quang Dao
 -/
 import VCVio.Interaction.Basic.BundledMonad
 import VCVio.Interaction.Basic.Decoration
+import VCVio.Interaction.Basic.Interaction
 
 /-!
 # Per-node monad decorations
 
-`MonadDecoration spec` assigns a `BundledMonad` to each internal node. `Strategy.withMonads`
-generalizes `Strategy` so continuations live in the monad recorded at each node; `runWithMonads`
-lifts everything into a single ambient monad.
+`MonadDecoration spec` assigns a `BundledMonad` to each internal node.
+
+The corresponding one-participant syntax, `Strategy.monadicSyntax`, chooses a
+move at a node and places the continuation in the monad recorded by that node.
+Thus `Strategy.withMonads` is a direct `StrategyOver` specialization, and
+`Strategy.runWithMonads` executes it by lifting each node monad into one ambient
+execution monad.
 -/
 
 universe u
@@ -75,24 +80,54 @@ end Hom
 
 end MonadDecoration
 
-/-- Strategy type where each node's continuation uses the monad from `MonadDecoration`. -/
-def Strategy.withMonads :
-    (spec : Spec.{u}) → MonadDecoration spec → (Transcript spec → Type u) → Type u
-  | .done, _, Output => Output ⟨⟩
-  | .node X rest, ⟨bm, dRest⟩, Output =>
-      (x : X) × bm.M (withMonads (rest x) (dRest x) (fun p => Output ⟨x, p⟩))
+/-- One-participant local syntax whose continuation lives in the node monad.
+
+At each node the strategy chooses a move `x` immediately, then supplies the
+continuation in the `BundledMonad` stored by the node decoration. -/
+def Strategy.monadicSyntax :
+    SyntaxOver.{u, u, u, u + 1} PUnit (fun (_ : Type u) => BundledMonad.{u, u}) where
+  Node _ (X : Type u) bm (Cont : X → Type u) :=
+    (x : X) × bm.M (Cont x)
+
+/-- Strategy type where each node's continuation uses the monad from its
+`MonadDecoration`. -/
+abbrev Strategy.withMonads
+    (spec : Spec.{u}) (deco : MonadDecoration.{u, u, u} spec)
+    (Output : Transcript spec → Type u) :=
+  StrategyOver Strategy.monadicSyntax PUnit.unit spec deco Output
+
+/-- One-step execution law for `Strategy.monadicSyntax`.
+
+The node selects the next move directly. Its continuation is lifted from the
+decorated node monad into the ambient execution monad before the generic runner
+continues with the selected subtree. -/
+def Strategy.monadicInteraction {m : Type u → Type u} [Monad m]
+    (liftM : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
+    InteractionOver PUnit (fun (_ : Type u) => BundledMonad.{u, u}) Strategy.monadicSyntax m where
+  interact := fun {_X} {γ} {_Cont} {_Result} profile k => do
+    let node := profile PUnit.unit
+    let next ← liftM γ node.2
+    k node.1 (fun _ => next)
 
 /-- Execute a `withMonads` strategy, lifting each node's bundled monad into `m`. -/
 def Strategy.runWithMonads {m : Type u → Type u} [Monad m]
-    (liftM : ∀ (bm : BundledMonad) {α : Type u}, bm.M α → m α) :
-    (spec : Spec) → (deco : MonadDecoration spec) →
+    (liftM : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
+    (spec : Spec) → (deco : MonadDecoration.{u, u, u} spec) →
     {Output : Transcript spec → Type u} →
     Strategy.withMonads spec deco Output → m ((tr : Transcript spec) × Output tr)
-  | .done, _, _, output => pure ⟨⟨⟩, output⟩
-  | .node _ rest, ⟨bm, dRest⟩, _, ⟨x, cont⟩ => do
-      let next ← liftM bm cont
-      let ⟨tail, out⟩ ← runWithMonads liftM (rest x) (dRest x) next
-      return ⟨⟨x, tail⟩, out⟩
+  | spec, deco, Output, strat =>
+      StrategyOver.run
+        (Agent := PUnit)
+        (Γ := fun (_ : Type u) => BundledMonad.{u, u})
+        (syn := Strategy.monadicSyntax)
+        (m := m)
+        (Strategy.monadicInteraction liftM)
+        (spec := spec)
+        (Out := fun _ => Output)
+        (Result := Output)
+        deco
+        (fun _ => strat)
+        (fun _ out => out PUnit.unit)
 
 end Spec
 end Interaction

--- a/VCVio/Interaction/Basic/Replicate.lean
+++ b/VCVio/Interaction/Basic/Replicate.lean
@@ -164,9 +164,9 @@ variable {m : Type u → Type u}
 def Strategy.iterate {m : Type u → Type u} [Monad m]
     {spec : Spec} {α : Type u} :
     (n : Nat) →
-    (step : Fin n → α → m (Strategy m spec (fun _ => α))) →
+    (step : Fin n → α → m (Strategy.Plain m spec (fun _ => α))) →
     α →
-    m (Strategy m (spec.replicate n) (fun _ => α))
+    m (Strategy.Plain m (spec.replicate n) (fun _ => α))
   | 0, _, a => pure a
   | n + 1, step, a => do
     let strat ← step 0 a

--- a/VCVio/Interaction/Basic/Shape.lean
+++ b/VCVio/Interaction/Basic/Shape.lean
@@ -109,9 +109,9 @@ If `f : Γ → Δ`, then any shape over `Δ` can be viewed as a shape over `Γ` 
 first viewing its underlying syntax through `SyntaxOver.comap f`.
 -/
 def ShapeOver.comap {Δ : Node.Context}
-    (shape : ShapeOver Agent Δ) (f : Node.ContextHom Γ Δ) :
+    (f : Node.ContextHom Γ Δ) (shape : ShapeOver Agent Δ) :
     ShapeOver Agent Γ where
-  toSyntaxOver := shape.toSyntaxOver.comap f
+  toSyntaxOver := SyntaxOver.comap f shape.toSyntaxOver
   map h := shape.map h
 
 /--
@@ -120,14 +120,14 @@ the underlying realized context morphism.
 -/
 abbrev ShapeOver.comapSchema
     {Δ : Node.Context} {S : Node.Schema Γ} {T : Node.Schema Δ}
-    (shape : ShapeOver Agent Δ) (f : Node.Schema.SchemaMap S T) :
+    (f : Node.Schema.SchemaMap S T) (shape : ShapeOver Agent Δ) :
     ShapeOver Agent Γ :=
-  shape.comap f.toContextHom
+  ShapeOver.comap f.toContextHom shape
 
 @[simp]
 theorem ShapeOver.comap_id
     (shape : ShapeOver Agent Γ) :
-    shape.comap (Node.ContextHom.id Γ) = shape := by
+    ShapeOver.comap (Node.ContextHom.id Γ) shape = shape := by
   cases shape
   rfl
 
@@ -135,7 +135,8 @@ theorem ShapeOver.comap_comp
     {Δ : Node.Context} {Λ : Node.Context}
     (shape : ShapeOver Agent Λ)
     (g : Node.ContextHom Δ Λ) (f : Node.ContextHom Γ Δ) :
-    (shape.comap g).comap f = shape.comap (Node.ContextHom.comp g f) := by
+    ShapeOver.comap f (ShapeOver.comap g shape) =
+      ShapeOver.comap (Node.ContextHom.comp g f) shape := by
   cases shape
   rfl
 
@@ -169,14 +170,14 @@ def ShapeOver.mapOutput
           node
 
 /--
-Whole-tree families for `shape.comap f` are exactly families for `shape`
+Whole-tree families for `ShapeOver.comap f shape` are exactly families for `shape`
 evaluated on the mapped decoration `Decoration.map f ctxs`.
 -/
 theorem ShapeOver.family_comap {Δ : Node.Context}
     (shape : ShapeOver Agent Δ) (f : Node.ContextHom Γ Δ) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    StrategyOver (shape.comap f).toSyntaxOver agent spec ctxs Out =
+    StrategyOver (ShapeOver.comap f shape).toSyntaxOver agent spec ctxs Out =
       StrategyOver shape.toSyntaxOver agent spec (Decoration.map f spec ctxs) Out
   := by
     intro agent spec ctxs Out
@@ -189,7 +190,7 @@ theorem ShapeOver.family_comapSchema
     (shape : ShapeOver Agent Δ) (f : Node.Schema.SchemaMap S T) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    StrategyOver (shape.comapSchema f).toSyntaxOver agent spec ctxs Out =
+    StrategyOver (ShapeOver.comapSchema f shape).toSyntaxOver agent spec ctxs Out =
       StrategyOver shape.toSyntaxOver agent spec (Decoration.Schema.map f spec ctxs) Out :=
   by
     intro agent spec ctxs Out

--- a/VCVio/Interaction/Basic/Shape.lean
+++ b/VCVio/Interaction/Basic/Shape.lean
@@ -140,19 +140,6 @@ theorem ShapeOver.comap_comp
   rfl
 
 /--
-Whole-tree families for a shape are inherited from the underlying
-`SyntaxOver`.
--/
-abbrev ShapeOver.Family
-    (shape : ShapeOver Agent Γ) :
-    (agent : Agent) →
-    (spec : Spec) →
-    Decoration Γ spec →
-    (Transcript spec → Type w) →
-    Type w :=
-  SyntaxOver.Family shape.toSyntaxOver
-
-/--
 `ShapeOver.mapOutput` lifts a pointwise transformation of leaf outputs to a
 transformation of whole-tree participant objects.
 
@@ -168,8 +155,8 @@ def ShapeOver.mapOutput
     :
     {A B : Transcript spec → Type w} →
     (∀ tr, A tr → B tr) →
-    ShapeOver.Family shape agent spec ctxs A →
-    ShapeOver.Family shape agent spec ctxs B
+    StrategyOver shape.toSyntaxOver agent spec ctxs A →
+    StrategyOver shape.toSyntaxOver agent spec ctxs B
   :=
     match spec, ctxs with
     | .done, _ => fun f out => f ⟨⟩ out
@@ -189,12 +176,12 @@ theorem ShapeOver.family_comap {Δ : Node.Context}
     (shape : ShapeOver Agent Δ) (f : Node.ContextHom Γ Δ) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    ShapeOver.Family (shape.comap f) agent spec ctxs Out =
-      ShapeOver.Family shape agent spec (Decoration.map f spec ctxs) Out
+    StrategyOver (shape.comap f).toSyntaxOver agent spec ctxs Out =
+      StrategyOver shape.toSyntaxOver agent spec (Decoration.map f spec ctxs) Out
   := by
     intro agent spec ctxs Out
-    simpa [ShapeOver.Family] using
-      (SyntaxOver.family_comap shape.toSyntaxOver f
+    simpa using
+      (StrategyOver.comap shape.toSyntaxOver f
         (agent := agent) (spec := spec) (ctxs := ctxs) (Out := Out))
 
 theorem ShapeOver.family_comapSchema
@@ -202,12 +189,12 @@ theorem ShapeOver.family_comapSchema
     (shape : ShapeOver Agent Δ) (f : Node.Schema.SchemaMap S T) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    ShapeOver.Family (shape.comapSchema f) agent spec ctxs Out =
-      ShapeOver.Family shape agent spec (Decoration.Schema.map f spec ctxs) Out :=
+    StrategyOver (shape.comapSchema f).toSyntaxOver agent spec ctxs Out =
+      StrategyOver shape.toSyntaxOver agent spec (Decoration.Schema.map f spec ctxs) Out :=
   by
     intro agent spec ctxs Out
-    simpa [ShapeOver.Family] using
-      (SyntaxOver.family_comapSchema shape.toSyntaxOver f
+    simpa using
+      (StrategyOver.comapSchema shape.toSyntaxOver f
         (agent := agent) (spec := spec) (ctxs := ctxs) (Out := Out))
 
 end Spec

--- a/VCVio/Interaction/Basic/Shape.lean
+++ b/VCVio/Interaction/Basic/Shape.lean
@@ -103,6 +103,17 @@ instance : Coe (ShapeOver Agent Γ) (SyntaxOver Agent Γ) where
   coe := ShapeOver.toSyntaxOver
 
 /--
+View a functorial shape as a local strategy homomorphism on one agent fiber.
+
+The homomorphism keeps the syntax and agent fixed; it only applies the shape's
+node-level continuation map.
+-/
+def ShapeOver.toStrategyHom
+    (shape : ShapeOver Agent Γ) (agent : Agent) :
+    StrategyOver.Hom shape.toSyntaxOver agent shape.toSyntaxOver agent where
+  mapNode f node := shape.map f node
+
+/--
 Reindex a local syntax object contravariantly along a node-context morphism.
 
 If `f : Γ → Δ`, then any shape over `Δ` can be viewed as a shape over `Γ` by

--- a/VCVio/Interaction/Basic/Spec.lean
+++ b/VCVio/Interaction/Basic/Spec.lean
@@ -65,7 +65,7 @@ representation.
   refinement, bisimulation, packaged equivalence notions, fairness, liveness,
   per-party observation profiles,
   scheduler/control ownership, and current local frontier views
-- `TwoParty/` — sender/receiver roles, `withRoles`, `Counterpart`
+- `TwoParty/` — sender/receiver roles and paired focal/counterpart strategies
 - `Reduction.lean` — prover, verifier, reduction
 - `Oracle/` — oracle decoration, path-dependent oracle access
 - `Security.lean` / `OracleSecurity.lean` — security definitions

--- a/VCVio/Interaction/Basic/StateChain.lean
+++ b/VCVio/Interaction/Basic/StateChain.lean
@@ -302,9 +302,9 @@ def Strategy.stateChainComp {m : Type u → Type u} [Monad m]
     {advance : (i : Nat) → (s : Stage i) → Transcript (spec i s) → Stage (i + 1)}
     {Family : (i : Nat) → Stage i → Type u}
     (step : (i : Nat) → (s : Stage i) → Family i s →
-      m (Strategy m (spec i s) (fun tr => Family (i + 1) (advance i s tr)))) :
+      m (Strategy.Plain m (spec i s) (fun tr => Family (i + 1) (advance i s tr)))) :
     (n : Nat) → (i : Nat) → (s : Stage i) → Family i s →
-    m (Strategy m (Spec.stateChain Stage spec advance n i s)
+    m (Strategy.Plain m (Spec.stateChain Stage spec advance n i s)
       (Transcript.stateChainFamily Family n i s))
   | 0, _, _, a => pure a
   | n + 1, i, s, a => do

--- a/VCVio/Interaction/Basic/Strategy.lean
+++ b/VCVio/Interaction/Basic/Strategy.lean
@@ -8,14 +8,14 @@ import VCVio.Interaction.Basic.Interaction
 /-!
 # One-player strategies
 
-`Strategy m spec Output` is the one-participant strategy induced by
+`Strategy.Plain m spec Output` is the one-participant strategy induced by
 `Strategy.syntax`. At every node it chooses the next move and stores the
 continuation in the ambient monad `m`; at a leaf it produces the
 transcript-dependent output.
 
 This is the singleton-agent specialization of `StrategyOver` over the empty
 node context. `Strategy.run` is the corresponding specialization of the
-generic `StrategyOver.run` runner.
+generic `InteractionOver.run` runner.
 
 Dependent sequential composition `Strategy.comp` requires `Spec.append` from
 `VCVio.Interaction.Basic.Append`.
@@ -37,13 +37,9 @@ def Strategy.syntax (m : Type u → Type u) :
   Node _ X _ Cont := (x : X) × m (Cont x)
 
 /-- One-player strategy with monadic effects. -/
-abbrev Strategy (m : Type u → Type u)
+abbrev Strategy.Plain (m : Type u → Type u)
     (spec : Spec) (Output : Transcript spec → Type u) :=
   StrategyOver (Strategy.syntax m) PUnit.unit spec (Decoration.empty spec) Output
-
-/-- Non-dependent output type `α` at every transcript. -/
-abbrev Strategy' (m : Type u → Type u) (spec : Spec) (α : Type u) :=
-  Strategy m spec (fun _ => α)
 
 /-- One-step execution law for ordinary one-player strategies. -/
 def Strategy.interaction (m : Type u → Type u) [Monad m] :
@@ -56,14 +52,13 @@ def Strategy.interaction (m : Type u → Type u) [Monad m] :
 /-- Run the strategy, returning the full transcript and the dependent output. -/
 def Strategy.run {m : Type u → Type u} [Monad m] :
     (spec : Spec) → {Output : Transcript spec → Type u} →
-    Strategy m spec Output → m ((tr : Transcript spec) × Output tr)
+    Strategy.Plain m spec Output → m ((tr : Transcript spec) × Output tr)
   | spec, Output, strat =>
-      StrategyOver.run
+      InteractionOver.run
         (Agent := PUnit)
         (Γ := Node.Context.empty)
         (syn := Strategy.syntax m)
         (m := m)
-        (Strategy.interaction m)
         (spec := spec)
         (Out := fun _ => Output)
         (Result := Output)
@@ -72,11 +67,12 @@ def Strategy.run {m : Type u → Type u} [Monad m] :
           cases agent
           exact strat)
         (fun _ out => out PUnit.unit)
+        (Strategy.interaction m)
 
 /-- Map the dependent output family along a natural transformation over transcripts. -/
 def Strategy.mapOutput {m : Type u → Type u} [Functor m] :
     {spec : Spec} → {A B : Transcript spec → Type u} →
-    (∀ tr, A tr → B tr) → Strategy m spec A → Strategy m spec B
+    (∀ tr, A tr → B tr) → Strategy.Plain m spec A → Strategy.Plain m spec B
   | .done, _, _, f, a => f ⟨⟩ a
   | .node _ _, _, _, f, ⟨x, cont⟩ =>
       ⟨x, (mapOutput (fun p => f ⟨x, p⟩) ·) <$> cont⟩
@@ -84,7 +80,7 @@ def Strategy.mapOutput {m : Type u → Type u} [Functor m] :
 /-- Pointwise identity on outputs is the identity on strategies (needs a lawful functor). -/
 @[simp, grind =]
 theorem Strategy.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor m] {spec : Spec}
-    {A : Transcript spec → Type u} (σ : Strategy m spec A) :
+    {A : Transcript spec → Type u} (σ : Strategy.Plain m spec A) :
     Strategy.mapOutput (fun _ x => x) σ = σ := by
   induction spec with
   | done => rfl
@@ -94,7 +90,8 @@ theorem Strategy.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor
     congr 1
     have hid :
         (mapOutput (fun (p : Transcript (rest x)) (y : A ⟨x, p⟩) => y) :
-            Strategy m (rest x) (fun p => A ⟨x, p⟩) → Strategy m (rest x) (fun p => A ⟨x, p⟩)) =
+            Strategy.Plain m (rest x) (fun p => A ⟨x, p⟩) →
+              Strategy.Plain m (rest x) (fun p => A ⟨x, p⟩)) =
           id := by
       funext s
       exact ih x s
@@ -104,7 +101,7 @@ theorem Strategy.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor
 /-- `mapOutput` respects composition of output maps (needs a lawful functor). -/
 theorem Strategy.mapOutput_comp {m : Type u → Type u} [Functor m] [LawfulFunctor m] {spec : Spec}
     {A B C : Transcript spec → Type u} (g : ∀ tr, B tr → C tr) (f : ∀ tr, A tr → B tr)
-    (σ : Strategy m spec A) :
+    (σ : Strategy.Plain m spec A) :
     Strategy.mapOutput (fun tr x => g tr (f tr x)) σ =
       Strategy.mapOutput g (Strategy.mapOutput f σ) := by
   induction spec with

--- a/VCVio/Interaction/Basic/Strategy.lean
+++ b/VCVio/Interaction/Basic/Strategy.lean
@@ -3,17 +3,22 @@ Copyright (c) 2026 Quang Dao. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
-import VCVio.Interaction.Basic.Spec
+import VCVio.Interaction.Basic.Interaction
 
 /-!
-# Strategies (`Spec.Strategy`)
+# One-player strategies
 
-A `Strategy m spec Output` plays through `spec`, choosing moves and interleaving effects in `m`,
-producing a transcript-dependent result `Output tr`. Definitions are by structural recursion on
-the spec (Hancock–Setzer), avoiding positivity issues for generic `m`.
+`Strategy m spec Output` is the one-participant strategy induced by
+`Strategy.syntax`. At every node it chooses the next move and stores the
+continuation in the ambient monad `m`; at a leaf it produces the
+transcript-dependent output.
 
-`run` executes a strategy; `mapOutput` is functorial in the output family. Dependent sequential
-composition `Strategy.comp` requires `Spec.append` from `VCVio.Interaction.Basic.Append`.
+This is the singleton-agent specialization of `StrategyOver` over the empty
+node context. `Strategy.run` is the corresponding specialization of the
+generic `StrategyOver.run` runner.
+
+Dependent sequential composition `Strategy.comp` requires `Spec.append` from
+`VCVio.Interaction.Basic.Append`.
 -/
 
 universe u
@@ -23,27 +28,50 @@ namespace Spec
 
 variable {m : Type u → Type u}
 
-/-- One-player strategy with monadic effects: at each node, choose a move `x` and continue in
-`m`. -/
-def Strategy (m : Type u → Type u) :
-    (spec : Spec) → (Transcript spec → Type u) → Type u
-  | .done, Output => Output ⟨⟩
-  | .node X rest, Output =>
-      (x : X) × m (Strategy m (rest x) (fun p => Output ⟨x, p⟩))
+/-- One-participant syntax for ordinary monadic strategies.
+
+At each node the strategy chooses a move `x` and provides the continuation in
+the ambient monad `m`. -/
+def Strategy.syntax (m : Type u → Type u) :
+    SyntaxOver.{u, u, u, u} PUnit Node.Context.empty where
+  Node _ X _ Cont := (x : X) × m (Cont x)
+
+/-- One-player strategy with monadic effects. -/
+abbrev Strategy (m : Type u → Type u)
+    (spec : Spec) (Output : Transcript spec → Type u) :=
+  StrategyOver (Strategy.syntax m) PUnit.unit spec (Decoration.empty spec) Output
 
 /-- Non-dependent output type `α` at every transcript. -/
 abbrev Strategy' (m : Type u → Type u) (spec : Spec) (α : Type u) :=
   Strategy m spec (fun _ => α)
 
+/-- One-step execution law for ordinary one-player strategies. -/
+def Strategy.interaction (m : Type u → Type u) [Monad m] :
+    Interaction PUnit (Strategy.syntax m) m where
+  interact := fun {_X} {_γ} {_Cont} {_Result} profile k => do
+    let node := profile PUnit.unit
+    let next ← node.2
+    k node.1 (fun _ => next)
+
 /-- Run the strategy, returning the full transcript and the dependent output. -/
 def Strategy.run {m : Type u → Type u} [Monad m] :
     (spec : Spec) → {Output : Transcript spec → Type u} →
     Strategy m spec Output → m ((tr : Transcript spec) × Output tr)
-  | .done, _, output => pure ⟨⟨⟩, output⟩
-  | .node _ rest, _, ⟨move, cont⟩ => do
-      let next ← cont
-      let ⟨tail, out⟩ ← run (rest move) next
-      return ⟨⟨move, tail⟩, out⟩
+  | spec, Output, strat =>
+      StrategyOver.run
+        (Agent := PUnit)
+        (Γ := Node.Context.empty)
+        (syn := Strategy.syntax m)
+        (m := m)
+        (Strategy.interaction m)
+        (spec := spec)
+        (Out := fun _ => Output)
+        (Result := Output)
+        (Decoration.empty spec)
+        (fun agent => by
+          cases agent
+          exact strat)
+        (fun _ out => out PUnit.unit)
 
 /-- Map the dependent output family along a natural transformation over transcripts. -/
 def Strategy.mapOutput {m : Type u → Type u} [Functor m] :

--- a/VCVio/Interaction/Basic/Syntax.lean
+++ b/VCVio/Interaction/Basic/Syntax.lean
@@ -102,6 +102,56 @@ def StrategyOver {l : PFunctor.Lens P Q}
         StrategyOver syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
           (fun path => Out ⟨d, path⟩))
 
+namespace StrategyOver
+
+variable {Agent₁ : Type a} {Agent₂ : Type u}
+variable {l : PFunctor.Lens P Q}
+
+/--
+A local homomorphism between two lens-executed `StrategyOver` fibers.
+
+The source and target may use different local syntax objects and different
+agents, while sharing the same control lens and node-context decoration.
+At each node, `mapNode` translates the source node object into the target node
+object after recursive continuations have already been translated.
+-/
+structure Hom
+    (syn₁ : SyntaxOver l Agent₁ Γ) (agent₁ : Agent₁)
+    (syn₂ : SyntaxOver l Agent₂ Γ) (agent₂ : Agent₂) where
+  mapNode :
+    {pos : P.A} →
+    {γ : Γ pos} →
+    {A B : Q.B (l.toFunA pos) → Type w} →
+    (∀ d, A d → B d) →
+    syn₁.Node agent₁ pos γ A →
+    syn₂.Node agent₂ pos γ B
+
+/--
+Map a lens-executed whole-tree strategy along a local homomorphism, while also
+mapping its leaf output family.
+
+The recursion follows runtime directions through `PathAlong l spec`; the lens
+maps each runtime direction back to the corresponding control branch.
+-/
+def map
+    {syn₁ : SyntaxOver l Agent₁ Γ} {agent₁ : Agent₁}
+    {syn₂ : SyntaxOver l Agent₂ Γ} {agent₂ : Agent₂}
+    (η : Hom syn₁ agent₁ syn₂ agent₂) :
+    {spec : PFunctor.FreeM P α} → {ctxs : Decoration Γ spec} →
+    {A B : PFunctor.FreeM.PathAlong l spec → Type w} →
+    (∀ path, A path → B path) →
+    StrategyOver syn₁ agent₁ spec ctxs A →
+    StrategyOver syn₂ agent₂ spec ctxs B
+  | PFunctor.FreeM.pure _, _, _, _, f, out => f ⟨⟩ out
+  | PFunctor.FreeM.roll pos _, ⟨_, ctxs⟩, _, _, f, stratNode =>
+      η.mapNode
+        (fun d =>
+          map η (ctxs := ctxs (l.toFunB pos d))
+            (fun path => f ⟨d, path⟩))
+        stratNode
+
+end StrategyOver
+
 namespace Spec
 
 variable {Agent : Type a}
@@ -239,6 +289,57 @@ def StrategyOver
       syn.Node agent X γ (fun x =>
         StrategyOver syn agent (next x) (ctxs x) (fun tr =>
           Out ⟨x, tr⟩))
+
+namespace StrategyOver
+
+variable {Agent₁ : Type a} {Agent₂ : Type uA}
+
+/--
+A local homomorphism between two `StrategyOver` fibers.
+
+The source and target may use different local syntax objects and different
+agents, but they must live over the same node-context decoration. At each node,
+`mapNode` explains how to translate the source node object into the target
+node object once recursive continuations have already been translated.
+
+This is the generic recursion principle behind output maps and syntax-forgetting
+maps for whole-tree strategies.
+-/
+structure Hom
+    (syn₁ : SyntaxOver Agent₁ Γ) (agent₁ : Agent₁)
+    (syn₂ : SyntaxOver Agent₂ Γ) (agent₂ : Agent₂) where
+  mapNode :
+    {X : Type u} →
+    {γ : Γ X} →
+    {A B : X → Type w} →
+    (∀ x, A x → B x) →
+    syn₁.Node agent₁ X γ A →
+    syn₂.Node agent₂ X γ B
+
+/--
+Map a whole-tree strategy along a local homomorphism, while also mapping its
+leaf output family.
+
+At leaves this is the supplied output map. At internal nodes the local
+homomorphism maps the node object after recursively mapping each child
+continuation.
+-/
+def map
+    {syn₁ : SyntaxOver Agent₁ Γ} {agent₁ : Agent₁}
+    {syn₂ : SyntaxOver Agent₂ Γ} {agent₂ : Agent₂}
+    (η : Hom syn₁ agent₁ syn₂ agent₂) :
+    {spec : Spec} → {ctxs : Decoration Γ spec} →
+    {A B : Transcript spec → Type w} →
+    (∀ tr, A tr → B tr) →
+    StrategyOver syn₁ agent₁ spec ctxs A →
+    StrategyOver syn₂ agent₂ spec ctxs B
+  | PFunctor.FreeM.pure _, _, _, _, f, out => f ⟨⟩ out
+  | PFunctor.FreeM.roll _ _, ⟨_, ctxs⟩, _, _, f, stratNode =>
+      η.mapNode
+        (fun x => map η (ctxs := ctxs x) (fun tr => f ⟨x, tr⟩))
+        stratNode
+
+end StrategyOver
 
 /-- At an internal node, `StrategyOver` unfolds to the local node object
 whose continuations are the recursively induced strategies for each child. -/

--- a/VCVio/Interaction/Basic/Syntax.lean
+++ b/VCVio/Interaction/Basic/Syntax.lean
@@ -180,7 +180,7 @@ then using the original `Δ`-syntax there.
 So `SyntaxOver` is contravariant in its context parameter.
 -/
 def SyntaxOver.comap {Δ : Node.Context}
-    (syn : SyntaxOver Agent Δ) (f : Node.ContextHom Γ Δ) :
+    (f : Node.ContextHom Γ Δ) (syn : SyntaxOver Agent Δ) :
     SyntaxOver Agent Γ where
   Node agent X γ Cont := syn.Node agent X (f X γ) Cont
 
@@ -190,14 +190,14 @@ the underlying realized context morphism.
 -/
 abbrev SyntaxOver.comapSchema
     {Δ : Node.Context} {S : Node.Schema Γ} {T : Node.Schema Δ}
-    (syn : SyntaxOver Agent Δ) (f : Node.Schema.SchemaMap S T) :
+    (f : Node.Schema.SchemaMap S T) (syn : SyntaxOver Agent Δ) :
     SyntaxOver Agent Γ :=
-  syn.comap f.toContextHom
+  SyntaxOver.comap f.toContextHom syn
 
 @[simp]
 theorem SyntaxOver.comap_id
     (syn : SyntaxOver Agent Γ) :
-    syn.comap (Node.ContextHom.id Γ) = syn := by
+    SyntaxOver.comap (Node.ContextHom.id Γ) syn = syn := by
   cases syn
   rfl
 
@@ -205,7 +205,8 @@ theorem SyntaxOver.comap_comp
     {Δ : Node.Context} {Λ : Node.Context}
     (syn : SyntaxOver Agent Λ)
     (g : Node.ContextHom Δ Λ) (f : Node.ContextHom Γ Δ) :
-    (syn.comap g).comap f = syn.comap (Node.ContextHom.comp g f) := by
+    SyntaxOver.comap f (SyntaxOver.comap g syn) =
+      SyntaxOver.comap (Node.ContextHom.comp g f) syn := by
   cases syn
   rfl
 
@@ -252,14 +253,14 @@ theorem StrategyOver.node
   rfl
 
 /--
-Whole-tree families for `syn.comap f` are exactly families for `syn`
+Whole-tree families for `SyntaxOver.comap f syn` are exactly families for `syn`
 evaluated on the mapped decoration `Decoration.map f ctxs`.
 -/
 theorem StrategyOver.comap {Δ : Node.Context}
     (syn : SyntaxOver Agent Δ) (f : Node.ContextHom Γ Δ) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    StrategyOver (syn.comap f) agent spec ctxs Out =
+    StrategyOver (SyntaxOver.comap f syn) agent spec ctxs Out =
       StrategyOver syn agent spec (Decoration.map f spec ctxs) Out
   | _, .done, _, _ => rfl
   | agent, .node _ next, ⟨γ, ctxs⟩, Out => by
@@ -273,7 +274,7 @@ theorem StrategyOver.comapSchema
     (syn : SyntaxOver Agent Δ) (f : Node.Schema.SchemaMap S T) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    StrategyOver (syn.comapSchema f) agent spec ctxs Out =
+    StrategyOver (SyntaxOver.comapSchema f syn) agent spec ctxs Out =
       StrategyOver syn agent spec (Decoration.Schema.map f spec ctxs) Out :=
   StrategyOver.comap syn f.toContextHom
 

--- a/VCVio/Interaction/Basic/Syntax.lean
+++ b/VCVio/Interaction/Basic/Syntax.lean
@@ -37,8 +37,7 @@ Role-based APIs are specializations of this pattern:
 * `Spec.Node.ContextHom` and `SyntaxOver.comap` express contravariant
   reindexing of local syntax along context morphisms;
 * `fun _ => Role` is one example of a simple node context;
-* `withRoles`, `Counterpart`, and `Counterpart.withMonads` are specific
-  syntax objects built on top of this core.
+* `StrategyOver` is the whole-tree local strategy induced by one-node syntax.
 
 Naming note:
 `SyntaxOver` is the base local-syntax notion. `ShapeOver` uses the same suffix
@@ -79,14 +78,18 @@ namespace SyntaxOver
 
 variable {Agent : Type a} {Γ : P.A → Type vΓ}
 
-/--
-Whole-tree participant family induced by lens-indexed local syntax.
+end SyntaxOver
 
-At leaves it returns the output family. At control nodes it presents the local
-node with runtime continuations, then recurses through the abstract branch
-selected by the lens.
+variable {Agent : Type a} {Γ : P.A → Type vΓ}
+
+/--
+Whole-tree local strategy induced by lens-indexed local syntax.
+
+At leaves it returns the output family. At a control node it presents the local
+node object supplied by `syn`, whose continuation family is recursively the
+strategy for the abstract branch selected by the lens.
 -/
-def Family {l : PFunctor.Lens P Q}
+def StrategyOver {l : PFunctor.Lens P Q}
     (syn : SyntaxOver l Agent Γ) :
     (agent : Agent) →
     (spec : PFunctor.FreeM P α) →
@@ -96,10 +99,8 @@ def Family {l : PFunctor.Lens P Q}
   | _, .pure _, _, Out => Out ⟨⟩
   | agent, .roll pos rest, ⟨γ, ctxs⟩, Out =>
       syn.Node agent pos γ (fun d =>
-        Family syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
+        StrategyOver syn agent (rest (l.toFunB pos d)) (ctxs (l.toFunB pos d))
           (fun path => Out ⟨d, path⟩))
-
-end SyntaxOver
 
 namespace Spec
 
@@ -125,7 +126,7 @@ It describes the type of one local node object, uniformly for every possible:
 * continuation family.
 
 The whole-tree notion is obtained later by structural recursion on `Spec` via
-`SyntaxOver.Family`.
+`StrategyOver`.
 
 This is the most general local syntax layer because:
 * binary and multiparty interaction are both recovered by the choice of
@@ -209,8 +210,8 @@ theorem SyntaxOver.comap_comp
   rfl
 
 /--
-`SyntaxOver.Family syn a spec ctxs Out` is the whole-tree participant
-type for agent `a` induced by the local syntax `syn`.
+`StrategyOver syn a spec ctxs Out` is the whole-tree local strategy
+for agent `a` induced by the one-node syntax `syn`.
 
 Inputs:
 * `spec` is the underlying protocol tree;
@@ -222,10 +223,10 @@ The result is obtained by structural recursion on `spec`:
 * at an internal node, the family is `syn.Node ...` applied to the
   recursively defined continuation family for each child subtree.
 
-So `SyntaxOver` is the **local syntax specification**, while `Family` is the
-induced **whole-tree syntax** for one agent.
+So `SyntaxOver` is local and one-step, while `StrategyOver` is the induced
+whole-tree object for one agent.
 -/
-def SyntaxOver.Family
+def StrategyOver
     (syn : SyntaxOver Agent Γ) :
     (agent : Agent) →
     (spec : Spec) →
@@ -235,34 +236,46 @@ def SyntaxOver.Family
   | _, .done, _, Out => Out ⟨⟩
   | agent, .node X next, ⟨γ, ctxs⟩, Out =>
       syn.Node agent X γ (fun x =>
-        Family syn agent (next x) (ctxs x) (fun tr =>
+        StrategyOver syn agent (next x) (ctxs x) (fun tr =>
           Out ⟨x, tr⟩))
+
+/-- At an internal node, `StrategyOver` unfolds to the local node object
+whose continuations are the recursively induced strategies for each child. -/
+theorem StrategyOver.node
+    (syn : SyntaxOver Agent Γ)
+    {agent : Agent} {X : Type u} {next : X → Spec}
+    {γ : Γ X} {ctxs : (x : X) → Decoration Γ (next x)}
+    {Out : Transcript (Spec.node X next) → Type w} :
+    StrategyOver syn agent (Spec.node X next) ⟨γ, ctxs⟩ Out =
+      syn.Node agent X γ (fun x =>
+        StrategyOver syn agent (next x) (ctxs x) (fun tr => Out ⟨x, tr⟩)) :=
+  rfl
 
 /--
 Whole-tree families for `syn.comap f` are exactly families for `syn`
 evaluated on the mapped decoration `Decoration.map f ctxs`.
 -/
-theorem SyntaxOver.family_comap {Δ : Node.Context}
+theorem StrategyOver.comap {Δ : Node.Context}
     (syn : SyntaxOver Agent Δ) (f : Node.ContextHom Γ Δ) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    SyntaxOver.Family (syn.comap f) agent spec ctxs Out =
-      SyntaxOver.Family syn agent spec (Decoration.map f spec ctxs) Out
+    StrategyOver (syn.comap f) agent spec ctxs Out =
+      StrategyOver syn agent spec (Decoration.map f spec ctxs) Out
   | _, .done, _, _ => rfl
   | agent, .node _ next, ⟨γ, ctxs⟩, Out => by
-      simp only [SyntaxOver.Family, SyntaxOver.comap, Decoration.map]
+      simp only [StrategyOver, SyntaxOver.comap, Decoration.map]
       congr 1
       funext x
-      exact family_comap syn f (agent := agent) (ctxs := ctxs x)
+      exact StrategyOver.comap syn f (agent := agent) (ctxs := ctxs x)
 
-theorem SyntaxOver.family_comapSchema
+theorem StrategyOver.comapSchema
     {Δ : Node.Context} {S : Node.Schema Γ} {T : Node.Schema Δ}
     (syn : SyntaxOver Agent Δ) (f : Node.Schema.SchemaMap S T) :
     {agent : Agent} → {spec : Spec} → (ctxs : Decoration Γ spec) →
     {Out : Transcript spec → Type w} →
-    SyntaxOver.Family (syn.comapSchema f) agent spec ctxs Out =
-      SyntaxOver.Family syn agent spec (Decoration.Schema.map f spec ctxs) Out :=
-  SyntaxOver.family_comap syn f.toContextHom
+    StrategyOver (syn.comapSchema f) agent spec ctxs Out =
+      StrategyOver syn agent spec (Decoration.Schema.map f spec ctxs) Out :=
+  StrategyOver.comap syn f.toContextHom
 
 end Spec
 end Interaction

--- a/VCVio/Interaction/Multiparty/Core.lean
+++ b/VCVio/Interaction/Multiparty/Core.lean
@@ -407,7 +407,7 @@ abbrev Strategy
     (resolve : Spec.Node.ContextHom Γ (fun X : Type u => ViewMode X))
     (spec : Spec) (ctxs : Spec.Decoration Γ spec)
     (Output : Spec.Transcript spec → Type u) :=
-  Spec.SyntaxOver.Family ((localSyntax m).comap resolve) PUnit.unit spec ctxs Output
+  Spec.StrategyOver ((localSyntax m).comap resolve) PUnit.unit spec ctxs Output
 
 end Multiparty
 end Interaction

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -383,31 +383,6 @@ theorem Counterpart.append_eq_appendFlat_mapOutput
       simp only [Transcript.packAppend]; congr 1
       exact append_eq_appendFlat_mapOutput cRest (fun p o => c₂ ⟨x, p⟩ o)
 
-/-- Compose per-node-monad counterparts along `Spec.append` with a two-argument
-output family lifted through `Transcript.liftAppend`. At each node, the recursive
-composition is lifted through the node's `BundledMonad` via `Functor.map`. -/
-def Counterpart.withMonads.append
-    {s₁ : Spec} {s₂ : Transcript s₁ → Spec}
-    {r₁ : RoleDecoration s₁}
-    {r₂ : (tr₁ : Transcript s₁) → RoleDecoration (s₂ tr₁)}
-    {md₁ : MonadDecoration s₁}
-    {md₂ : (tr₁ : Transcript s₁) → MonadDecoration (s₂ tr₁)}
-    {Output₁ : Transcript s₁ → Type u}
-    {F : (tr₁ : Transcript s₁) → Transcript (s₂ tr₁) → Type u} :
-    Counterpart.withMonads s₁ r₁ md₁ Output₁ →
-    ((tr₁ : Transcript s₁) → Output₁ tr₁ →
-      Counterpart.withMonads (s₂ tr₁) (r₂ tr₁) (md₂ tr₁) (F tr₁)) →
-    Counterpart.withMonads (s₁.append s₂) (r₁.append r₂)
-      (Decoration.append md₁ md₂) (Transcript.liftAppend s₁ s₂ F) :=
-  match s₁, r₁, md₁ with
-  | .done, _, _ => fun out₁ c₂ => c₂ ⟨⟩ out₁
-  | .node _ _, ⟨.sender, _⟩, ⟨_, _⟩ => fun c₁ c₂ =>
-      fun x => Functor.map
-        (fun rec => append rec (fun p o => c₂ ⟨x, p⟩ o)) (c₁ x)
-  | .node _ _, ⟨.receiver, _⟩, ⟨_, _⟩ => fun c₁ c₂ =>
-      Functor.map
-        (fun ⟨x, rec⟩ => ⟨x, append rec (fun p o => c₂ ⟨x, p⟩ o)⟩) c₁
-
 /-- Executing a flat composed strategy/counterpart factors into first executing
 the prefix interaction and then executing the suffix continuation. -/
 theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
@@ -831,29 +806,6 @@ def Strategy.stateChainCompWithRoles {m : Type u → Type u} [Monad m]
     let strat ← step i s a
     compWithRoles strat
       (fun tr mid => stateChainCompWithRoles step n (i + 1) (advance i s tr) mid)
-
-/-- Compose per-node-monad counterparts along a state chain with stage-dependent output.
-At each stage, the step transforms `Family i s` into a counterpart whose output is
-`Family (i+1) (advance i s tr)`. The full state chain output is
-`Transcript.stateChainFamily Family`. -/
-def Counterpart.withMonads.stateChainComp
-    {Stage : Nat → Type u} {spec : (i : Nat) → Stage i → Spec}
-    {advance : (i : Nat) → (s : Stage i) → Spec.Transcript (spec i s) → Stage (i + 1)}
-    {roles : (i : Nat) → (s : Stage i) → RoleDecoration (spec i s)}
-    {md : (i : Nat) → (s : Stage i) → MonadDecoration (spec i s)}
-    {Family : (i : Nat) → Stage i → Type u}
-    (step : (i : Nat) → (s : Stage i) → Family i s →
-      Counterpart.withMonads (spec i s) (roles i s) (md i s)
-        (fun tr => Family (i + 1) (advance i s tr))) :
-    (n : Nat) → (i : Nat) → (s : Stage i) → Family i s →
-    Counterpart.withMonads (Spec.stateChain Stage spec advance n i s)
-      (Spec.Decoration.stateChain roles n i s)
-      (Decoration.stateChain md n i s)
-      (Spec.Transcript.stateChainFamily Family n i s)
-  | 0, _, _, b => b
-  | n + 1, i, s, b =>
-      Counterpart.withMonads.append (step i s b)
-        (fun tr b' => stateChainComp step n (i + 1) (advance i s tr) b')
 
 end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -19,8 +19,8 @@ Role-aware composition of strategies and counterparts along `Spec.append`, `Spec
 and `Spec.stateChain`. Each combinator dispatches on the role at each node (sending or receiving)
 to compose the two-party strategies correctly.
 
-For binary composition, `compWithRoles` and `Counterpart.append` use `Transcript.liftAppend`
-for the output type (factored form). The flat variants (`compWithRolesFlat`,
+For binary composition, `comp` and `Counterpart.append` use `Transcript.liftAppend`
+for the output type (factored form). The flat variants (`compFlat`,
 `Counterpart.appendFlat`) take a single output family on the combined transcript.
 -/
 
@@ -30,9 +30,10 @@ universe u v
 
 namespace Interaction
 namespace Spec
+namespace TwoParty
 
 variable {m : Type u → Type u}
-open TwoParty
+open _root_.Interaction.TwoParty
 
 /-- A lawful monad whose independent effects may be swapped.
 
@@ -68,7 +69,7 @@ private theorem bind_pure_sigma_mk {m : Type u → Type u} [Monad m] [LawfulMona
 /-- Compose role-aware strategies along `Spec.append` with a two-argument output family
 lifted through `Transcript.liftAppend`. The continuation receives the first phase's
 output and produces a second-phase strategy. -/
-def Strategy.compWithRoles {m : Type u → Type u} [Monad m]
+def Focal.comp {m : Type u → Type u} [Monad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
@@ -84,16 +85,16 @@ def Strategy.compWithRoles {m : Type u → Type u} [Monad m]
   | .node _ _, ⟨.sender, _⟩ =>
       pure <| do
         let ⟨x, next⟩ ← strat₁
-        let rest ← compWithRoles next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
+        let rest ← comp next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
         pure ⟨x, rest⟩
   | .node _ _, ⟨.receiver, _⟩ =>
       pure fun x => do
         let next ← strat₁ x
-        compWithRoles next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
+        comp next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
 
 /-- Compose role-aware strategies along `Spec.append` with a single output family
 on the combined transcript. The continuation indexes via `Transcript.append`. -/
-def Strategy.compWithRolesFlat {m : Type u → Type u} [Monad m]
+def Focal.compFlat {m : Type u → Type u} [Monad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
@@ -109,16 +110,16 @@ def Strategy.compWithRolesFlat {m : Type u → Type u} [Monad m]
   | .node _ _, ⟨.sender, _⟩ =>
       pure <| do
         let ⟨x, next⟩ ← strat₁
-        let rest ← compWithRolesFlat next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
+        let rest ← compFlat next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
         pure ⟨x, rest⟩
   | .node _ _, ⟨.receiver, _⟩ =>
       pure fun x => do
         let next ← strat₁ x
-        compWithRolesFlat next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
+        compFlat next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
 
-/-- Pure continuation specialization of `compWithRolesFlat`. This stays private:
+/-- Pure continuation specialization of `compFlat`. This stays private:
 it only serves the weaker `[LawfulMonad]` execution theorem below. -/
-private def Strategy.compWithRolesFlatPure {m : Type u → Type u} [Monad m]
+private def Focal.compFlatPure {m : Type u → Type u} [Monad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
@@ -133,13 +134,13 @@ private def Strategy.compWithRolesFlatPure {m : Type u → Type u} [Monad m]
   | .done, _ => f ⟨⟩ strat₁
   | .node _ _, ⟨.sender, _⟩ => do
       let ⟨x, next⟩ ← strat₁
-      pure ⟨x, compWithRolesFlatPure next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)⟩
+      pure ⟨x, compFlatPure next (fun tr₁ mid => f ⟨x, tr₁⟩ mid)⟩
   | .node _ _, ⟨.receiver, _⟩ =>
       fun x => do
         let next ← strat₁ x
-        pure (compWithRolesFlatPure next (fun tr₁ mid => f ⟨x, tr₁⟩ mid))
+        pure (compFlatPure next (fun tr₁ mid => f ⟨x, tr₁⟩ mid))
 
-private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
+private theorem Focal.compFlat_eq_pure_compFlatPure
     {m : Type u → Type u} [Monad m] [LawfulMonad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
@@ -150,8 +151,8 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
     (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
       StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
-    Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid)) =
-      pure (Strategy.compWithRolesFlatPure strat₁ f) := by
+    Focal.compFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid)) =
+      pure (Focal.compFlatPure strat₁ f) := by
   let rec go
       (s₁ : Spec) (r₁ : RoleDecoration s₁)
       {s₂ : Spec.Transcript s₁ → Spec}
@@ -162,14 +163,14 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
       (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
         StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
           (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
-      Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid)) =
-        pure (Strategy.compWithRolesFlatPure strat₁ f) := by
+      Focal.compFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid)) =
+        pure (Focal.compFlatPure strat₁ f) := by
     match s₁, r₁ with
     | .done, r₁ =>
         cases r₁
         rfl
     | .node X rest, ⟨.sender, rRest⟩ =>
-        rw [Strategy.compWithRolesFlat.eq_2]
+        rw [Focal.compFlat.eq_2]
         refine congrArg pure ?_
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
@@ -184,7 +185,7 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
               (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
             exact (congrArg (fun z => Sigma.mk x <$> z) hgo).trans (map_pure _ _)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
-        rw [Strategy.compWithRolesFlat.eq_3]
+        rw [Focal.compFlat.eq_3]
         refine congrArg pure ?_
         funext x
         refine congrArg (fun k => strat₁ x >>= k) ?_
@@ -200,7 +201,7 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
 /-- Extract the first-phase role-aware strategy from a strategy on a composed
 interaction. At each first-phase transcript `tr₁`, the remainder is the
 second-phase strategy with output indexed by `Transcript.append`. -/
-def Strategy.splitPrefixWithRoles {m : Type u → Type u} [Functor m] :
+def Focal.splitPrefix {m : Type u → Type u} [Functor m] :
     {s₁ : Spec} → {s₂ : Spec.Transcript s₁ → Spec} →
     {r₁ : RoleDecoration s₁} →
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)} →
@@ -212,26 +213,26 @@ def Strategy.splitPrefixWithRoles {m : Type u → Type u} [Functor m] :
   | .done, _, _, _, _, strat => strat
   | .node _ _, s₂, ⟨.sender, rRest⟩, r₂, _, strat =>
       (fun ⟨x, cont⟩ =>
-        ⟨x, splitPrefixWithRoles
+        ⟨x, splitPrefix
           (s₂ := fun p => s₂ ⟨x, p⟩)
           (r₁ := rRest x)
           (r₂ := fun p => r₂ ⟨x, p⟩) cont⟩) <$> strat
   | .node _ _, s₂, ⟨.receiver, rRest⟩, r₂, _, respond =>
-      fun x => (splitPrefixWithRoles
+      fun x => (splitPrefix
         (s₂ := fun p => s₂ ⟨x, p⟩)
         (r₁ := rRest x)
         (r₂ := fun p => r₂ ⟨x, p⟩) ·) <$> respond x
 
 /-- Recompose a role-aware strategy from its prefix decomposition. -/
-theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
+theorem Focal.compFlat_splitPrefix
     {m : Type u → Type u} [Monad m] [LawfulMonad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Output : Spec.Transcript (s₁.append s₂) → Type u}
     (strat : StrategyOver (pairedSyntax m) Participant.focal (s₁.append s₂) (r₁.append r₂) Output) :
-    Strategy.compWithRolesFlat
-      (Strategy.splitPrefixWithRoles (s₂ := s₂) (r₁ := r₁) (r₂ := r₂) strat)
+    Focal.compFlat
+      (Focal.splitPrefix (s₂ := s₂) (r₁ := r₁) (r₂ := r₂) strat)
       (fun _ strat₂ => pure strat₂) = pure strat := by
   let rec go
       (s₁ : Spec) (r₁ : RoleDecoration s₁)
@@ -240,23 +241,23 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
       {Output : Spec.Transcript (s₁.append s₂) → Type u}
       (strat : StrategyOver (pairedSyntax m) Participant.focal
         (s₁.append s₂) (r₁.append r₂) Output) :
-      Strategy.compWithRolesFlat
-        (Strategy.splitPrefixWithRoles (s₂ := s₂) (r₁ := r₁) (r₂ := r₂) strat)
+      Focal.compFlat
+        (Focal.splitPrefix (s₂ := s₂) (r₁ := r₁) (r₂ := r₂) strat)
         (fun _ strat₂ => pure strat₂) = pure strat := by
     match s₁, r₁ with
     | .done, r₁ =>
         cases r₁
         rfl
     | .node X rest, ⟨.sender, rRest⟩ =>
-        rw [Strategy.compWithRolesFlat.eq_2, Strategy.splitPrefixWithRoles.eq_2]
+        rw [Focal.compFlat.eq_2, Focal.splitPrefix.eq_2]
         refine congrArg pure ?_
         simp only [bind_map_left]
         calc
           (do
             let a ← strat
             let rest_1 ←
-              Strategy.compWithRolesFlat
-                (Strategy.splitPrefixWithRoles
+              Focal.compFlat
+                (Focal.splitPrefix
                   (s₂ := fun p => s₂ ⟨a.1, p⟩)
                   (r₁ := rRest a.1)
                   (r₂ := fun p => r₂ ⟨a.1, p⟩) a.2)
@@ -272,25 +273,25 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
                     ((fun y => (rRest y).append fun p => r₂ ⟨y, p⟩) y)
                     (fun tr => Output ⟨y, tr⟩)
                 have hgo :
-                    (Strategy.compWithRolesFlat (Strategy.splitPrefixWithRoles tail)
+                    (Focal.compFlat (Focal.splitPrefix tail)
                       (fun _ strat₂ => pure strat₂)) = pure tail :=
                   go (rest x) (rRest x)
                     (s₂ := fun p => s₂ ⟨x, p⟩)
                     (r₂ := fun p => r₂ ⟨x, p⟩) tail
                 exact bind_pure_sigma_mk (m := m) (α := X) (β := Suffix)
                   (x := x) (tail := tail)
-                  (action := Strategy.compWithRolesFlat (Strategy.splitPrefixWithRoles tail)
+                  (action := Focal.compFlat (Focal.splitPrefix tail)
                     (fun _ strat₂ => pure strat₂)) hgo
           _ = strat := by
                 simp
     | .node _ rest, ⟨.receiver, rRest⟩ =>
         refine congrArg pure ?_
         funext x
-        simp only [Strategy.splitPrefixWithRoles.eq_3]
+        simp only [Focal.splitPrefix.eq_3]
         have hcont :
             strat x >>= (fun next =>
-              Strategy.compWithRolesFlat
-                (Strategy.splitPrefixWithRoles
+              Focal.compFlat
+                (Focal.splitPrefix
                   (s₂ := fun p => s₂ ⟨x, p⟩)
                   (r₁ := rRest x)
                   (r₂ := fun p => r₂ ⟨x, p⟩) next)
@@ -353,7 +354,7 @@ def Counterpart.appendFlat {m : Type u → Type u} [Monad m]
       return ⟨x, Counterpart.appendFlat cRest (fun p o => c₂ ⟨x, p⟩ o)⟩
 
 /-- `Counterpart.append` equals `appendFlat` composed with `mapOutput packAppend`.
-This lets proofs that decompose an arbitrary strategy via `splitPrefixWithRoles` +
+This lets proofs that decompose an arbitrary strategy via `splitPrefix` +
 `appendFlat` still work when `Reduction.comp` uses the non-flat `append`. -/
 theorem Counterpart.append_eq_appendFlat_mapOutput
     {m : Type u → Type u} [Monad m] [LawfulMonad m] :
@@ -387,7 +388,7 @@ theorem Counterpart.append_eq_appendFlat_mapOutput
 
 /-- Executing a flat composed strategy/counterpart factors into first executing
 the prefix interaction and then executing the suffix continuation. -/
-theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
+theorem run_compFlat_appendFlat_pure
     {m : Type u → Type u} [Monad m] [LawfulMonad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
@@ -403,13 +404,13 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
       StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => OutputC (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
     (do
-      let strat ← Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid))
-      Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
+      let strat ← Focal.compFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid))
+      run (s₁.append s₂) (r₁.append r₂) strat
         (Counterpart.appendFlat cpt₁ cpt₂)) =
       (do
-        let ⟨tr₁, mid, out₁⟩ ← Strategy.runWithRoles s₁ r₁ strat₁ cpt₁
+        let ⟨tr₁, mid, out₁⟩ ← run s₁ r₁ strat₁ cpt₁
         let ⟨tr₂, outP, outC⟩ ←
-          Strategy.runWithRoles (s₂ tr₁) (r₂ tr₁) (f tr₁ mid) (cpt₂ tr₁ out₁)
+          run (s₂ tr₁) (r₂ tr₁) (f tr₁ mid) (cpt₂ tr₁ out₁)
         pure ⟨Spec.Transcript.append s₁ s₂ tr₁ tr₂, outP, outC⟩) := by
   let rec go
       (s₁ : Spec) (r₁ : RoleDecoration s₁)
@@ -429,27 +430,27 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
       (g : ((tr : Spec.Transcript (s₁.append s₂)) × OutputP tr × OutputC tr) → m β) :
       (do
         let r ←
-          do let strat ← Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid))
-             Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
+          do let strat ← Focal.compFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid))
+             run (s₁.append s₂) (r₁.append r₂) strat
                (Counterpart.appendFlat cpt₁ cpt₂)
         g r) =
         (do
-          let r₁ ← Strategy.runWithRoles s₁ r₁ strat₁ cpt₁
+          let r₁ ← run s₁ r₁ strat₁ cpt₁
           let r₂ ←
-            Strategy.runWithRoles (s₂ r₁.1) (r₂ r₁.1) (f r₁.1 r₁.2.1) (cpt₂ r₁.1 r₁.2.2)
+            run (s₂ r₁.1) (r₂ r₁.1) (f r₁.1 r₁.2.1) (cpt₂ r₁.1 r₁.2.2)
           g ⟨Spec.Transcript.append s₁ s₂ r₁.1 r₂.1, r₂.2.1, r₂.2.2⟩) := by
     match s₁, r₁ with
     | .done, r₁ =>
         cases r₁
-        simp [Strategy.compWithRolesFlat.eq_1, Counterpart.appendFlat.eq_1,
-          Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
+        simp [Focal.compFlat.eq_1, Counterpart.appendFlat.eq_1,
+          run_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
     | .node _ rest, ⟨.sender, rRest⟩ =>
-        simp only [Strategy.compWithRolesFlat.eq_2, Counterpart.appendFlat.eq_2]
+        simp only [Focal.compFlat.eq_2, Counterpart.appendFlat.eq_2]
         simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
-          Strategy.runWithRoles_sender]
+          run_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
-        have hpure := @Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure m _ _
+        have hpure := @Focal.compFlat_eq_pure_compFlatPure m _ _
           (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) (rRest xc.fst) (fun p => r₂ ⟨xc.fst, p⟩)
           (fun tr => MidP ⟨xc.fst, tr⟩) (fun tr => OutputP ⟨xc.fst, tr⟩)
           xc.snd
@@ -481,12 +482,12 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
-        simp only [Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure, pure_bind] at ih
+        simp only [Focal.compFlat_eq_pure_compFlatPure, pure_bind] at ih
         exact ih
     | .node _ rest, ⟨.receiver, rRest⟩ =>
-        simp only [Strategy.compWithRolesFlat.eq_3, Counterpart.appendFlat.eq_3]
+        simp only [Focal.compFlat.eq_3, Counterpart.appendFlat.eq_3]
         simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
-          Strategy.runWithRoles_receiver]
+          run_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -514,7 +515,7 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
 
 /-- Executing a flat composed strategy/counterpart factors into first executing
 the prefix interaction and then executing the suffix continuation. -/
-theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
+theorem run_compFlat_appendFlat
     {m : Type u → Type u} [Monad m] [LawfulCommMonad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
@@ -530,14 +531,14 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
       StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => OutputC (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
     (do
-      let strat ← Strategy.compWithRolesFlat strat₁ f
-      Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
+      let strat ← Focal.compFlat strat₁ f
+      run (s₁.append s₂) (r₁.append r₂) strat
         (Counterpart.appendFlat cpt₁ cpt₂)) =
       (do
-        let ⟨tr₁, mid, out₁⟩ ← Strategy.runWithRoles s₁ r₁ strat₁ cpt₁
+        let ⟨tr₁, mid, out₁⟩ ← run s₁ r₁ strat₁ cpt₁
         let strat₂ ← f tr₁ mid
         let ⟨tr₂, outP, outC⟩ ←
-          Strategy.runWithRoles (s₂ tr₁) (r₂ tr₁) strat₂ (cpt₂ tr₁ out₁)
+          run (s₂ tr₁) (r₂ tr₁) strat₂ (cpt₂ tr₁ out₁)
         pure ⟨Spec.Transcript.append s₁ s₂ tr₁ tr₂, outP, outC⟩) := by
   let rec go
       (s₁ : Spec) (r₁ : RoleDecoration s₁)
@@ -557,25 +558,25 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
       (g : ((tr : Spec.Transcript (s₁.append s₂)) × OutputP tr × OutputC tr) → m β) :
       (do
         let r ←
-          do let strat ← Strategy.compWithRolesFlat strat₁ f
-             Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
+          do let strat ← Focal.compFlat strat₁ f
+             run (s₁.append s₂) (r₁.append r₂) strat
                (Counterpart.appendFlat cpt₁ cpt₂)
         g r) =
         (do
-          let r₁ ← Strategy.runWithRoles s₁ r₁ strat₁ cpt₁
+          let r₁ ← run s₁ r₁ strat₁ cpt₁
           let strat₂ ← f r₁.1 r₁.2.1
           let r₂ ←
-            Strategy.runWithRoles (s₂ r₁.1) (r₂ r₁.1) strat₂ (cpt₂ r₁.1 r₁.2.2)
+            run (s₂ r₁.1) (r₂ r₁.1) strat₂ (cpt₂ r₁.1 r₁.2.2)
           g ⟨Spec.Transcript.append s₁ s₂ r₁.1 r₂.1, r₂.2.1, r₂.2.2⟩) := by
     match s₁, r₁ with
     | .done, r₁ =>
         cases r₁
-        simp [Strategy.compWithRolesFlat.eq_1, Counterpart.appendFlat.eq_1,
-          Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
+        simp [Focal.compFlat.eq_1, Counterpart.appendFlat.eq_1,
+          run_done, Spec.append, Spec.Decoration.append, Spec.Transcript.append]
     | .node _ rest, ⟨.sender, rRest⟩ =>
-        simp only [Strategy.compWithRolesFlat.eq_2, Counterpart.appendFlat.eq_2]
+        simp only [Focal.compFlat.eq_2, Counterpart.appendFlat.eq_2]
         simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
-          Strategy.runWithRoles_sender]
+          run_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         rw [LawfulCommMonad.bind_comm]
@@ -601,9 +602,9 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
-        simp only [Strategy.compWithRolesFlat.eq_3, Counterpart.appendFlat.eq_3]
+        simp only [Focal.compFlat.eq_3, Counterpart.appendFlat.eq_3]
         simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
-          Strategy.runWithRoles_receiver]
+          run_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -629,10 +630,10 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
   simpa [monad_norm] using go s₁ r₁ strat₁ f cpt₁ cpt₂ pure
 
-/-- Executing a factored composed strategy/counterpart (using `compWithRoles` and
+/-- Executing a factored composed strategy/counterpart (using `comp` and
 `Counterpart.append`) factors into first executing the prefix interaction and then
 executing the suffix continuation. Outputs are transported via `packAppend`. -/
-theorem Strategy.runWithRoles_compWithRoles_append
+theorem run_comp_append
     {m : Type u → Type u} [Monad m] [LawfulCommMonad m]
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     {r₁ : RoleDecoration s₁}
@@ -646,14 +647,14 @@ theorem Strategy.runWithRoles_compWithRoles_append
     (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
       StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁) (FC tr₁)) :
     (do
-      let strat ← Strategy.compWithRoles strat₁ f
-      Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
+      let strat ← Focal.comp strat₁ f
+      run (s₁.append s₂) (r₁.append r₂) strat
         (Counterpart.append cpt₁ cpt₂)) =
       (do
-        let ⟨tr₁, mid, out₁⟩ ← Strategy.runWithRoles s₁ r₁ strat₁ cpt₁
+        let ⟨tr₁, mid, out₁⟩ ← run s₁ r₁ strat₁ cpt₁
         let strat₂ ← f tr₁ mid
         let ⟨tr₂, outP, outC⟩ ←
-          Strategy.runWithRoles (s₂ tr₁) (r₂ tr₁) strat₂ (cpt₂ tr₁ out₁)
+          run (s₂ tr₁) (r₂ tr₁) strat₂ (cpt₂ tr₁ out₁)
         pure ⟨Spec.Transcript.append s₁ s₂ tr₁ tr₂,
           Spec.Transcript.packAppend s₁ s₂ FP tr₁ tr₂ outP,
           Spec.Transcript.packAppend s₁ s₂ FC tr₁ tr₂ outC⟩) := by
@@ -675,28 +676,28 @@ theorem Strategy.runWithRoles_compWithRoles_append
         Spec.Transcript.liftAppend s₁ s₂ FC tr) → m β) :
       (do
         let r ←
-          do let strat ← Strategy.compWithRoles strat₁ f
-             Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
+          do let strat ← Focal.comp strat₁ f
+             run (s₁.append s₂) (r₁.append r₂) strat
                (Counterpart.append cpt₁ cpt₂)
         g r) =
         (do
-          let r₁ ← Strategy.runWithRoles s₁ r₁ strat₁ cpt₁
+          let r₁ ← run s₁ r₁ strat₁ cpt₁
           let strat₂ ← f r₁.1 r₁.2.1
           let r₂ ←
-            Strategy.runWithRoles (s₂ r₁.1) (r₂ r₁.1) strat₂ (cpt₂ r₁.1 r₁.2.2)
+            run (s₂ r₁.1) (r₂ r₁.1) strat₂ (cpt₂ r₁.1 r₁.2.2)
           g ⟨Spec.Transcript.append s₁ s₂ r₁.1 r₂.1,
             Spec.Transcript.packAppend s₁ s₂ FP r₁.1 r₂.1 r₂.2.1,
             Spec.Transcript.packAppend s₁ s₂ FC r₁.1 r₂.1 r₂.2.2⟩) := by
     match s₁, r₁ with
     | .done, r₁ =>
         cases r₁
-        simp [Strategy.compWithRoles, Counterpart.append,
-          Strategy.runWithRoles_done, Spec.append, Spec.Decoration.append,
+        simp [Focal.comp, Counterpart.append,
+          run_done, Spec.append, Spec.Decoration.append,
           Spec.Transcript.append, Spec.Transcript.liftAppend, Spec.Transcript.packAppend]
     | .node _ rest, ⟨.sender, rRest⟩ =>
-        simp only [Strategy.compWithRoles, Counterpart.append]
+        simp only [Focal.comp, Counterpart.append]
         simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
-          Strategy.runWithRoles_sender]
+          run_sender]
         refine congrArg (fun k => strat₁ >>= k) ?_
         funext xc
         rw [LawfulCommMonad.bind_comm]
@@ -721,9 +722,9 @@ theorem Strategy.runWithRoles_compWithRoles_append
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
-        simp only [Strategy.compWithRoles, Counterpart.append]
+        simp only [Focal.comp, Counterpart.append]
         simp only [monad_norm, Spec.append, PFunctor.FreeM.append, Spec.Decoration.append,
-          Strategy.runWithRoles_receiver]
+          run_receiver]
         refine congrArg (fun k => cpt₁ >>= k) ?_
         funext xc
         refine congrArg (fun k => strat₁ xc.1 >>= k) ?_
@@ -751,7 +752,7 @@ theorem Strategy.runWithRoles_compWithRoles_append
 /-- Role swapping commutes with replication. -/
 theorem RoleDecoration.swap_replicate {spec : Spec}
     (roles : RoleDecoration spec) (n : Nat) :
-    (roles.replicate n).swap = (roles.swap).replicate n :=
+    RoleDecoration.swap (roles.replicate n) = (RoleDecoration.swap roles).replicate n :=
   Spec.Decoration.map_replicate (fun _ => Role.swap) roles n
 
 /-- `n`-fold counterpart iteration on `spec.replicate n`, threading state `β`
@@ -770,7 +771,7 @@ def Counterpart.iterate {m : Type u → Type u} [Monad m]
 
 /-- `n`-fold role-aware strategy iteration on `spec.replicate n`, threading state `α`
 through each round. -/
-def Strategy.iterateWithRoles {m : Type u → Type u} [Monad m]
+def Focal.iterate {m : Type u → Type u} [Monad m]
     {spec : Spec} {roles : RoleDecoration spec} {α : Type u} :
     (n : Nat) →
     (step : Fin n → α →
@@ -781,13 +782,7 @@ def Strategy.iterateWithRoles {m : Type u → Type u} [Monad m]
   | 0, _, a => pure a
   | n + 1, step, a => do
     let strat ← step 0 a
-    compWithRolesFlat strat (fun _ mid => iterateWithRoles n (fun i => step i.succ) mid)
-
-end Spec
-
-namespace Spec
-
-open TwoParty
+    compFlat strat (fun _ mid => iterate n (fun i => step i.succ) mid)
 
 /-- Compose counterparts along a state chain with stage-dependent output. At each stage,
 the step transforms `Family i s` into a counterpart whose output is
@@ -814,7 +809,7 @@ def Counterpart.stateChainComp {m : Type u → Type u} [Monad m]
 At each stage, the step transforms `Family i s` into a strategy whose output is
 `Family (i+1) (advance i s tr)`. The full state chain output is
 `Transcript.stateChainFamily Family`. -/
-def Strategy.stateChainCompWithRoles {m : Type u → Type u} [Monad m]
+def Focal.stateChainComp {m : Type u → Type u} [Monad m]
     {Stage : Nat → Type u} {spec : (i : Nat) → Stage i → Spec}
     {advance : (i : Nat) → (s : Stage i) → Spec.Transcript (spec i s) → Stage (i + 1)}
     {roles : (i : Nat) → (s : Stage i) → RoleDecoration (spec i s)}
@@ -828,8 +823,9 @@ def Strategy.stateChainCompWithRoles {m : Type u → Type u} [Monad m]
   | 0, _, _, a => pure a
   | n + 1, i, s, a => do
     let strat ← step i s a
-    compWithRoles strat
-      (fun tr mid => stateChainCompWithRoles step n (i + 1) (advance i s tr) mid)
+    comp strat
+      (fun tr mid => stateChainComp step n (i + 1) (advance i s tr) mid)
 
+end TwoParty
 end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -265,7 +265,7 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
                 funext xc
                 rcases xc with ⟨x, tail⟩
                 let Suffix : X → Type u := fun y =>
-                  StrategyOver (pairedSyntax m) Participant.focal
+                  StrategyOver (pairedSyntax m) TwoParty.Participant.focal
                     ((fun b => PFunctor.FreeM.append (rest b) (fun path => s₂ ⟨b, path⟩)) y)
                     ((fun y => (rRest y).append fun p => r₂ ⟨y, p⟩) y)
                     (fun tr => Output ⟨y, tr⟩)

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -32,6 +32,7 @@ namespace Interaction
 namespace Spec
 
 variable {m : Type u → Type u}
+open TwoParty
 
 /-- A lawful monad whose independent effects may be swapped.
 
@@ -73,10 +74,10 @@ def Strategy.compWithRoles {m : Type u → Type u} [Monad m]
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Mid : Spec.Transcript s₁ → Type u}
     {F : (tr₁ : Spec.Transcript s₁) → Spec.Transcript (s₂ tr₁) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ Mid)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ Mid)
     (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
-      m (Strategy.withRoles m (s₂ tr₁) (r₂ tr₁) (F tr₁))) :
-    m (Strategy.withRoles m (s₁.append s₂) (r₁.append r₂)
+      m (StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁) (F tr₁))) :
+    m (StrategyOver (pairedSyntax m) Participant.focal (s₁.append s₂) (r₁.append r₂)
       (Spec.Transcript.liftAppend s₁ s₂ F)) :=
   match s₁, r₁ with
   | .done, _ => f ⟨⟩ strat₁
@@ -98,11 +99,11 @@ def Strategy.compWithRolesFlat {m : Type u → Type u} [Monad m]
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Mid : Spec.Transcript s₁ → Type u}
     {Output : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ Mid)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ Mid)
     (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
-      m (Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+      m (StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))) :
-    m (Strategy.withRoles m (s₁.append s₂) (r₁.append r₂) Output) :=
+    m (StrategyOver (pairedSyntax m) Participant.focal (s₁.append s₂) (r₁.append r₂) Output) :=
   match s₁, r₁ with
   | .done, _ => f ⟨⟩ strat₁
   | .node _ _, ⟨.sender, _⟩ =>
@@ -123,11 +124,11 @@ private def Strategy.compWithRolesFlatPure {m : Type u → Type u} [Monad m]
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Mid : Spec.Transcript s₁ → Type u}
     {Output : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ Mid)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ Mid)
     (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
-      Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+      StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
-    Strategy.withRoles m (s₁.append s₂) (r₁.append r₂) Output :=
+    StrategyOver (pairedSyntax m) Participant.focal (s₁.append s₂) (r₁.append r₂) Output :=
   match s₁, r₁ with
   | .done, _ => f ⟨⟩ strat₁
   | .node _ _, ⟨.sender, _⟩ => do
@@ -145,9 +146,9 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Mid : Spec.Transcript s₁ → Type u}
     {Output : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ Mid)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ Mid)
     (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
-      Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+      StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
     Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid)) =
       pure (Strategy.compWithRolesFlatPure strat₁ f) := by
@@ -157,9 +158,9 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
       {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
       {Mid : Spec.Transcript s₁ → Type u}
       {Output : Spec.Transcript (s₁.append s₂) → Type u}
-      (strat₁ : Strategy.withRoles m s₁ r₁ Mid)
+      (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ Mid)
       (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
-        Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+        StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
           (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
       Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid)) =
         pure (Strategy.compWithRolesFlatPure strat₁ f) := by
@@ -204,9 +205,9 @@ def Strategy.splitPrefixWithRoles {m : Type u → Type u} [Functor m] :
     {r₁ : RoleDecoration s₁} →
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)} →
     {Output : Spec.Transcript (s₁.append s₂) → Type u} →
-    Strategy.withRoles m (s₁.append s₂) (r₁.append r₂) Output →
-    Strategy.withRoles m s₁ r₁ (fun tr₁ =>
-      Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+    StrategyOver (pairedSyntax m) Participant.focal (s₁.append s₂) (r₁.append r₂) Output →
+    StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ (fun tr₁ =>
+      StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))
   | .done, _, _, _, _, strat => strat
   | .node _ _, s₂, ⟨.sender, rRest⟩, r₂, _, strat =>
@@ -228,7 +229,7 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
     {r₁ : RoleDecoration s₁}
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Output : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat : Strategy.withRoles m (s₁.append s₂) (r₁.append r₂) Output) :
+    (strat : StrategyOver (pairedSyntax m) Participant.focal (s₁.append s₂) (r₁.append r₂) Output) :
     Strategy.compWithRolesFlat
       (Strategy.splitPrefixWithRoles (s₂ := s₂) (r₁ := r₁) (r₂ := r₂) strat)
       (fun _ strat₂ => pure strat₂) = pure strat := by
@@ -237,7 +238,8 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
       {s₂ : Spec.Transcript s₁ → Spec}
       {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
       {Output : Spec.Transcript (s₁.append s₂) → Type u}
-      (strat : Strategy.withRoles m (s₁.append s₂) (r₁.append r₂) Output) :
+      (strat : StrategyOver (pairedSyntax m) Participant.focal
+        (s₁.append s₂) (r₁.append r₂) Output) :
       Strategy.compWithRolesFlat
         (Strategy.splitPrefixWithRoles (s₂ := s₂) (r₁ := r₁) (r₂ := r₂) strat)
         (fun _ strat₂ => pure strat₂) = pure strat := by
@@ -312,10 +314,10 @@ def Counterpart.append {m : Type u → Type u} [Monad m]
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Output₁ : Spec.Transcript s₁ → Type u}
     {F : (tr₁ : Spec.Transcript s₁) → Spec.Transcript (s₂ tr₁) → Type u} :
-    Counterpart m s₁ r₁ Output₁ →
+    StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ Output₁ →
     ((tr₁ : Spec.Transcript s₁) → Output₁ tr₁ →
-      Counterpart m (s₂ tr₁) (r₂ tr₁) (F tr₁)) →
-    Counterpart m (s₁.append s₂) (r₁.append r₂)
+      StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁) (F tr₁)) →
+    StrategyOver (pairedSyntax m) Participant.counterpart (s₁.append s₂) (r₁.append r₂)
       (Spec.Transcript.liftAppend s₁ s₂ F) :=
   match s₁, r₁ with
   | .done, _ => fun out₁ c₂ => c₂ ⟨⟩ out₁
@@ -335,11 +337,11 @@ def Counterpart.appendFlat {m : Type u → Type u} [Monad m]
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {Output₁ : Spec.Transcript s₁ → Type u}
     {Output₂ : Spec.Transcript (s₁.append s₂) → Type u} :
-    Counterpart m s₁ r₁ Output₁ →
+    StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ Output₁ →
     ((tr₁ : Spec.Transcript s₁) → Output₁ tr₁ →
-      Counterpart m (s₂ tr₁) (r₂ tr₁)
+      StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => Output₂ (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) →
-    Counterpart m (s₁.append s₂) (r₁.append r₂) Output₂ :=
+    StrategyOver (pairedSyntax m) Participant.counterpart (s₁.append s₂) (r₁.append r₂) Output₂ :=
   match s₁, r₁ with
   | .done, _ => fun out₁ c₂ => c₂ ⟨⟩ out₁
   | .node _ _, ⟨.sender, _⟩ => fun c₁ c₂ =>
@@ -360,9 +362,9 @@ theorem Counterpart.append_eq_appendFlat_mapOutput
     {r₂ : (tr₁ : Transcript s₁) → RoleDecoration (s₂ tr₁)} →
     {Output₁ : Transcript s₁ → Type u} →
     {F : (tr₁ : Transcript s₁) → Transcript (s₂ tr₁) → Type u} →
-    (c₁ : Counterpart m s₁ r₁ Output₁) →
+    (c₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ Output₁) →
     (c₂ : (tr₁ : Transcript s₁) → Output₁ tr₁ →
-      Counterpart m (s₂ tr₁) (r₂ tr₁) (F tr₁)) →
+      StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁) (F tr₁)) →
     Counterpart.append c₁ c₂ =
       Counterpart.appendFlat c₁ (fun tr₁ o =>
         Counterpart.mapOutput
@@ -392,13 +394,13 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {MidP MidC : Spec.Transcript s₁ → Type u}
     {OutputP OutputC : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ MidP)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ MidP)
     (f : (tr₁ : Spec.Transcript s₁) → MidP tr₁ →
-      Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+      StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => OutputP (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))
-    (cpt₁ : Counterpart m s₁ r₁ MidC)
+    (cpt₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ MidC)
     (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
-      Counterpart m (s₂ tr₁) (r₂ tr₁)
+      StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => OutputC (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
     (do
       let strat ← Strategy.compWithRolesFlat strat₁ (fun tr₁ mid => pure (f tr₁ mid))
@@ -416,13 +418,13 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
       {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
       {OutputP OutputC : Spec.Transcript (s₁.append s₂) → Type u}
       {β : Type u}
-      (strat₁ : Strategy.withRoles m s₁ r₁ MidP)
+      (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ MidP)
       (f : (tr₁ : Spec.Transcript s₁) → MidP tr₁ →
-        Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+        StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
           (fun tr₂ => OutputP (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))
-      (cpt₁ : Counterpart m s₁ r₁ MidC)
+      (cpt₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ MidC)
       (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
-        Counterpart m (s₂ tr₁) (r₂ tr₁)
+        StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
           (fun tr₂ => OutputC (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))
       (g : ((tr : Spec.Transcript (s₁.append s₂)) × OutputP tr × OutputC tr) → m β) :
       (do
@@ -452,7 +454,8 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
           (fun tr => MidP ⟨xc.fst, tr⟩) (fun tr => OutputP ⟨xc.fst, tr⟩)
           xc.snd
           (fun tr₁ mid =>
-            show Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show StrategyOver (pairedSyntax m) Participant.focal
+                (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (fun tr₂ => OutputP ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) tr₁ tr₂⟩)
             from f ⟨xc.fst, tr₁⟩ mid)
@@ -465,13 +468,15 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
           (fun tr => OutputP ⟨xc.fst, tr⟩) (fun tr => OutputC ⟨xc.fst, tr⟩)
           β xc.snd
           (fun tr₁ mid =>
-            show Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show StrategyOver (pairedSyntax m) Participant.focal
+                (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (fun tr₂ => OutputP ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) tr₁ tr₂⟩)
             from f ⟨xc.fst, tr₁⟩ mid)
           cRest
           (fun p o =>
-            show Counterpart m (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
+            show StrategyOver (pairedSyntax m) Participant.counterpart
+                (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
               (fun tr₂ => OutputC ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
@@ -492,13 +497,15 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat_pure
           (fun tr => OutputP ⟨xc.fst, tr⟩) (fun tr => OutputC ⟨xc.fst, tr⟩)
           β next
           (fun tr₁ mid =>
-            show Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show StrategyOver (pairedSyntax m) Participant.focal
+                (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (fun tr₂ => OutputP ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) tr₁ tr₂⟩)
             from f ⟨xc.fst, tr₁⟩ mid)
           xc.snd
           (fun p o =>
-            show Counterpart m (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
+            show StrategyOver (pairedSyntax m) Participant.counterpart
+                (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
               (fun tr₂ => OutputC ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
@@ -514,13 +521,13 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {MidP MidC : Spec.Transcript s₁ → Type u}
     {OutputP OutputC : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ MidP)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ MidP)
     (f : (tr₁ : Spec.Transcript s₁) → MidP tr₁ →
-      m (Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+      m (StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => OutputP (Spec.Transcript.append s₁ s₂ tr₁ tr₂))))
-    (cpt₁ : Counterpart m s₁ r₁ MidC)
+    (cpt₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ MidC)
     (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
-      Counterpart m (s₂ tr₁) (r₂ tr₁)
+      StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
         (fun tr₂ => OutputC (Spec.Transcript.append s₁ s₂ tr₁ tr₂))) :
     (do
       let strat ← Strategy.compWithRolesFlat strat₁ f
@@ -539,13 +546,13 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
       {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
       {OutputP OutputC : Spec.Transcript (s₁.append s₂) → Type u}
       {β : Type u}
-      (strat₁ : Strategy.withRoles m s₁ r₁ MidP)
+      (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ MidP)
       (f : (tr₁ : Spec.Transcript s₁) → MidP tr₁ →
-        m (Strategy.withRoles m (s₂ tr₁) (r₂ tr₁)
+        m (StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁)
           (fun tr₂ => OutputP (Spec.Transcript.append s₁ s₂ tr₁ tr₂))))
-      (cpt₁ : Counterpart m s₁ r₁ MidC)
+      (cpt₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ MidC)
       (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
-        Counterpart m (s₂ tr₁) (r₂ tr₁)
+        StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁)
           (fun tr₂ => OutputC (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))
       (g : ((tr : Spec.Transcript (s₁.append s₂)) × OutputP tr × OutputC tr) → m β) :
       (do
@@ -580,13 +587,15 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           (fun tr => OutputP ⟨xc.fst, tr⟩) (fun tr => OutputC ⟨xc.fst, tr⟩)
           β xc.snd
           (fun tr₁ mid =>
-            show m (Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show m (StrategyOver (pairedSyntax m) Participant.focal
+              (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (fun tr₂ => OutputP ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) tr₁ tr₂⟩))
             from f ⟨xc.fst, tr₁⟩ mid)
           cRest
           (fun p o =>
-            show Counterpart m (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
+            show StrategyOver (pairedSyntax m) Participant.counterpart
+                (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
               (fun tr₂ => OutputC ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
@@ -605,13 +614,15 @@ theorem Strategy.runWithRoles_compWithRolesFlat_appendFlat
           (fun tr => OutputP ⟨xc.fst, tr⟩) (fun tr => OutputC ⟨xc.fst, tr⟩)
           β next
           (fun tr₁ mid =>
-            show m (Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show m (StrategyOver (pairedSyntax m) Participant.focal
+              (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (fun tr₂ => OutputP ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun p => s₂ ⟨xc.fst, p⟩) tr₁ tr₂⟩))
             from f ⟨xc.fst, tr₁⟩ mid)
           xc.snd
           (fun p o =>
-            show Counterpart m (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
+            show StrategyOver (pairedSyntax m) Participant.counterpart
+                (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
               (fun tr₂ => OutputC ⟨xc.fst,
                 Spec.Transcript.append (rest xc.fst) (fun q => s₂ ⟨xc.fst, q⟩) p tr₂⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
@@ -628,12 +639,12 @@ theorem Strategy.runWithRoles_compWithRoles_append
     {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
     {MidP MidC : Spec.Transcript s₁ → Type u}
     {FP FC : (tr₁ : Spec.Transcript s₁) → Spec.Transcript (s₂ tr₁) → Type u}
-    (strat₁ : Strategy.withRoles m s₁ r₁ MidP)
+    (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ MidP)
     (f : (tr₁ : Spec.Transcript s₁) → MidP tr₁ →
-      m (Strategy.withRoles m (s₂ tr₁) (r₂ tr₁) (FP tr₁)))
-    (cpt₁ : Counterpart m s₁ r₁ MidC)
+      m (StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁) (FP tr₁)))
+    (cpt₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ MidC)
     (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
-      Counterpart m (s₂ tr₁) (r₂ tr₁) (FC tr₁)) :
+      StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁) (FC tr₁)) :
     (do
       let strat ← Strategy.compWithRoles strat₁ f
       Strategy.runWithRoles (s₁.append s₂) (r₁.append r₂) strat
@@ -653,12 +664,12 @@ theorem Strategy.runWithRoles_compWithRoles_append
       {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
       {FP FC : (tr₁ : Spec.Transcript s₁) → Spec.Transcript (s₂ tr₁) → Type u}
       {β : Type u}
-      (strat₁ : Strategy.withRoles m s₁ r₁ MidP)
+      (strat₁ : StrategyOver (pairedSyntax m) Participant.focal s₁ r₁ MidP)
       (f : (tr₁ : Spec.Transcript s₁) → MidP tr₁ →
-        m (Strategy.withRoles m (s₂ tr₁) (r₂ tr₁) (FP tr₁)))
-      (cpt₁ : Counterpart m s₁ r₁ MidC)
+        m (StrategyOver (pairedSyntax m) Participant.focal (s₂ tr₁) (r₂ tr₁) (FP tr₁)))
+      (cpt₁ : StrategyOver (pairedSyntax m) Participant.counterpart s₁ r₁ MidC)
       (cpt₂ : (tr₁ : Spec.Transcript s₁) → MidC tr₁ →
-        Counterpart m (s₂ tr₁) (r₂ tr₁) (FC tr₁))
+        StrategyOver (pairedSyntax m) Participant.counterpart (s₂ tr₁) (r₂ tr₁) (FC tr₁))
       (g : ((tr : Spec.Transcript (s₁.append s₂)) ×
         Spec.Transcript.liftAppend s₁ s₂ FP tr ×
         Spec.Transcript.liftAppend s₁ s₂ FC tr) → m β) :
@@ -694,15 +705,18 @@ theorem Strategy.runWithRoles_compWithRoles_append
         exact @go (rest xc.fst) (rRest xc.fst)
           (fun tr => MidP ⟨xc.fst, tr⟩) (fun tr => MidC ⟨xc.fst, tr⟩)
           (fun p => s₂ ⟨xc.fst, p⟩) (fun p => r₂ ⟨xc.fst, p⟩)
-          (fun tr₁ tr₂ => FP ⟨xc.fst, tr₁⟩ tr₂) (fun tr₁ tr₂ => FC ⟨xc.fst, tr₁⟩ tr₂)
+          (fun tr₁ tr₂ => FP ⟨xc.fst, tr₁⟩ tr₂)
+          (fun tr₁ tr₂ => FC ⟨xc.fst, tr₁⟩ tr₂)
           β xc.snd
           (fun tr₁ mid =>
-            show m (Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show m (StrategyOver (pairedSyntax m) Participant.focal
+              (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (FP ⟨xc.fst, tr₁⟩))
             from f ⟨xc.fst, tr₁⟩ mid)
           cRest
           (fun p o =>
-            show Counterpart m (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
+            show StrategyOver (pairedSyntax m) Participant.counterpart
+                (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
               (FC ⟨xc.fst, p⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
@@ -717,15 +731,18 @@ theorem Strategy.runWithRoles_compWithRoles_append
         exact @go (rest xc.fst) (rRest xc.fst)
           (fun tr => MidP ⟨xc.fst, tr⟩) (fun tr => MidC ⟨xc.fst, tr⟩)
           (fun p => s₂ ⟨xc.fst, p⟩) (fun p => r₂ ⟨xc.fst, p⟩)
-          (fun tr₁ tr₂ => FP ⟨xc.fst, tr₁⟩ tr₂) (fun tr₁ tr₂ => FC ⟨xc.fst, tr₁⟩ tr₂)
+          (fun tr₁ tr₂ => FP ⟨xc.fst, tr₁⟩ tr₂)
+          (fun tr₁ tr₂ => FC ⟨xc.fst, tr₁⟩ tr₂)
           β next
           (fun tr₁ mid =>
-            show m (Strategy.withRoles m (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
+            show m (StrategyOver (pairedSyntax m) Participant.focal
+              (s₂ ⟨xc.fst, tr₁⟩) (r₂ ⟨xc.fst, tr₁⟩)
               (FP ⟨xc.fst, tr₁⟩))
             from f ⟨xc.fst, tr₁⟩ mid)
           xc.snd
           (fun p o =>
-            show Counterpart m (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
+            show StrategyOver (pairedSyntax m) Participant.counterpart
+                (s₂ ⟨xc.fst, p⟩) (r₂ ⟨xc.fst, p⟩)
               (FC ⟨xc.fst, p⟩)
             from cpt₂ ⟨xc.fst, p⟩ o)
           (fun r => g ⟨⟨xc.fst, r.1⟩, r.2.1, r.2.2⟩)
@@ -742,9 +759,11 @@ through each round. -/
 def Counterpart.iterate {m : Type u → Type u} [Monad m]
     {spec : Spec} {roles : RoleDecoration spec} {β : Type u} :
     (n : Nat) →
-    (Fin n → β → Counterpart m spec roles (fun _ => β)) →
+    (Fin n → β →
+      StrategyOver (pairedSyntax m) Participant.counterpart spec roles (fun _ => β)) →
     β →
-    Counterpart m (spec.replicate n) (roles.replicate n) (fun _ => β)
+    StrategyOver (pairedSyntax m) Participant.counterpart
+      (spec.replicate n) (roles.replicate n) (fun _ => β)
   | 0, _, b => b
   | n + 1, step, b =>
       Counterpart.appendFlat (step 0 b) (fun _ b' => iterate n (fun i => step i.succ) b')
@@ -755,9 +774,10 @@ def Strategy.iterateWithRoles {m : Type u → Type u} [Monad m]
     {spec : Spec} {roles : RoleDecoration spec} {α : Type u} :
     (n : Nat) →
     (step : Fin n → α →
-      m (Strategy.withRoles m spec roles (fun _ => α))) →
+      m (StrategyOver (pairedSyntax m) Participant.focal spec roles (fun _ => α))) →
     α →
-    m (Strategy.withRoles m (spec.replicate n) (roles.replicate n) (fun _ => α))
+    m (StrategyOver (pairedSyntax m) Participant.focal
+      (spec.replicate n) (roles.replicate n) (fun _ => α))
   | 0, _, a => pure a
   | n + 1, step, a => do
     let strat ← step 0 a
@@ -766,6 +786,8 @@ def Strategy.iterateWithRoles {m : Type u → Type u} [Monad m]
 end Spec
 
 namespace Spec
+
+open TwoParty
 
 /-- Compose counterparts along a state chain with stage-dependent output. At each stage,
 the step transforms `Family i s` into a counterpart whose output is
@@ -777,9 +799,11 @@ def Counterpart.stateChainComp {m : Type u → Type u} [Monad m]
     {roles : (i : Nat) → (s : Stage i) → RoleDecoration (spec i s)}
     {Family : (i : Nat) → Stage i → Type u}
     (step : (i : Nat) → (s : Stage i) → Family i s →
-      Counterpart m (spec i s) (roles i s) (fun tr => Family (i + 1) (advance i s tr))) :
+      StrategyOver (pairedSyntax m) Participant.counterpart
+        (spec i s) (roles i s) (fun tr => Family (i + 1) (advance i s tr))) :
     (n : Nat) → (i : Nat) → (s : Stage i) → Family i s →
-    Counterpart m (Spec.stateChain Stage spec advance n i s)
+    StrategyOver (pairedSyntax m) Participant.counterpart
+      (Spec.stateChain Stage spec advance n i s)
       (Spec.Decoration.stateChain roles n i s) (Spec.Transcript.stateChainFamily Family n i s)
   | 0, _, _, b => b
   | n + 1, i, s, b =>
@@ -796,10 +820,10 @@ def Strategy.stateChainCompWithRoles {m : Type u → Type u} [Monad m]
     {roles : (i : Nat) → (s : Stage i) → RoleDecoration (spec i s)}
     {Family : (i : Nat) → Stage i → Type u}
     (step : (i : Nat) → (s : Stage i) → Family i s →
-      m (Strategy.withRoles m (spec i s) (roles i s)
+      m (StrategyOver (pairedSyntax m) Participant.focal (spec i s) (roles i s)
         (fun tr => Family (i + 1) (advance i s tr)))) :
     (n : Nat) → (i : Nat) → (s : Stage i) → Family i s →
-    m (Strategy.withRoles m (Spec.stateChain Stage spec advance n i s)
+    m (StrategyOver (pairedSyntax m) Participant.focal (Spec.stateChain Stage spec advance n i s)
       (Spec.Decoration.stateChain roles n i s) (Spec.Transcript.stateChainFamily Family n i s))
   | 0, _, _, a => pure a
   | n + 1, i, s, a => do

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -196,46 +196,6 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
           (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
   exact go s₁ r₁ strat₁ f
 
-/--
-Compose monad-decorated role strategies along `Spec.append`.
-
-The continuation that builds the suffix strategy runs in a construction monad
-`m`. To splice that construction into the first-phase strategy tree, callers
-provide a nodewise homomorphism from the constant `m` decoration into the
-first phase's strategy decoration.
--/
-def Strategy.withRolesAndMonads.compFlat {m : Type u → Type u} [Monad m]
-    {s₁ : Spec.{u}} {s₂ : Spec.Transcript s₁ → Spec.{u}}
-    {r₁ : RoleDecoration s₁}
-    {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
-    {md₁ : MonadDecoration s₁}
-    {md₂ : (tr₁ : Spec.Transcript s₁) → MonadDecoration (s₂ tr₁)}
-    (setupLift :
-      MonadDecoration.Hom s₁ (MonadDecoration.constant ⟨m, inferInstance⟩ s₁) md₁)
-    {Mid : Spec.Transcript s₁ → Type u}
-    {Output : Spec.Transcript (s₁.append s₂) → Type u}
-    (strat₁ : Strategy.withRolesAndMonads s₁ r₁ md₁ Mid)
-    (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
-      m (Strategy.withRolesAndMonads (s₂ tr₁) (r₂ tr₁) (md₂ tr₁)
-        (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))) :
-    m (Strategy.withRolesAndMonads (s₁.append s₂) (r₁.append r₂)
-      (Decoration.append md₁ md₂) Output) :=
-  match s₁, r₁, md₁, setupLift with
-  | .done, _, _, _ => f ⟨⟩ strat₁
-  | .node _ _, ⟨.sender, _⟩, ⟨_, _⟩, ⟨liftSetup, liftRest⟩ =>
-      pure <| do
-        let ⟨x, next⟩ ← strat₁
-        let restStrat ← liftSetup <|
-          compFlat (setupLift := liftRest x) next
-            (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
-        pure ⟨x, restStrat⟩
-  | .node _ _, ⟨.receiver, _⟩, ⟨_, _⟩, ⟨liftSetup, liftRest⟩ =>
-      pure fun x => do
-        let next ← strat₁ x
-        liftSetup <|
-          compFlat (setupLift := liftRest x) next
-            (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
-
 /-- Extract the first-phase role-aware strategy from a strategy on a composed
 interaction. At each first-phase transcript `tr₁`, the remainder is the
 second-phase strategy with output indexed by `Transcript.append`. -/

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -196,6 +196,46 @@ private theorem Strategy.compWithRolesFlat_eq_pure_compWithRolesFlatPure
           (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
   exact go s₁ r₁ strat₁ f
 
+/--
+Compose monad-decorated role strategies along `Spec.append`.
+
+The continuation that builds the suffix strategy runs in a construction monad
+`m`. To splice that construction into the first-phase strategy tree, callers
+provide a nodewise homomorphism from the constant `m` decoration into the
+first phase's strategy decoration.
+-/
+def Strategy.withRolesAndMonads.compFlat {m : Type u → Type u} [Monad m]
+    {s₁ : Spec.{u}} {s₂ : Spec.Transcript s₁ → Spec.{u}}
+    {r₁ : RoleDecoration s₁}
+    {r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)}
+    {md₁ : MonadDecoration s₁}
+    {md₂ : (tr₁ : Spec.Transcript s₁) → MonadDecoration (s₂ tr₁)}
+    (setupLift :
+      MonadDecoration.Hom s₁ (MonadDecoration.constant ⟨m, inferInstance⟩ s₁) md₁)
+    {Mid : Spec.Transcript s₁ → Type u}
+    {Output : Spec.Transcript (s₁.append s₂) → Type u}
+    (strat₁ : Strategy.withRolesAndMonads s₁ r₁ md₁ Mid)
+    (f : (tr₁ : Spec.Transcript s₁) → Mid tr₁ →
+      m (Strategy.withRolesAndMonads (s₂ tr₁) (r₂ tr₁) (md₂ tr₁)
+        (fun tr₂ => Output (Spec.Transcript.append s₁ s₂ tr₁ tr₂)))) :
+    m (Strategy.withRolesAndMonads (s₁.append s₂) (r₁.append r₂)
+      (Decoration.append md₁ md₂) Output) :=
+  match s₁, r₁, md₁, setupLift with
+  | .done, _, _, _ => f ⟨⟩ strat₁
+  | .node _ _, ⟨.sender, _⟩, ⟨_, _⟩, ⟨liftSetup, liftRest⟩ =>
+      pure <| do
+        let ⟨x, next⟩ ← strat₁
+        let restStrat ← liftSetup <|
+          compFlat (setupLift := liftRest x) next
+            (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
+        pure ⟨x, restStrat⟩
+  | .node _ _, ⟨.receiver, _⟩, ⟨_, _⟩, ⟨liftSetup, liftRest⟩ =>
+      pure fun x => do
+        let next ← strat₁ x
+        liftSetup <|
+          compFlat (setupLift := liftRest x) next
+            (fun tr₁ mid => f ⟨x, tr₁⟩ mid)
+
 /-- Extract the first-phase role-aware strategy from a strategy on a composed
 interaction. At each first-phase transcript `tr₁`, the remainder is the
 second-phase strategy with output indexed by `Transcript.append`. -/

--- a/VCVio/Interaction/TwoParty/Compose.lean
+++ b/VCVio/Interaction/TwoParty/Compose.lean
@@ -265,7 +265,7 @@ theorem Strategy.compWithRolesFlat_splitPrefixWithRoles
                 funext xc
                 rcases xc with ⟨x, tail⟩
                 let Suffix : X → Type u := fun y =>
-                  (pairedSyntax m).Family Participant.focal
+                  StrategyOver (pairedSyntax m) Participant.focal
                     ((fun b => PFunctor.FreeM.append (rest b) (fun path => s₂ ⟨b, path⟩)) y)
                     ((fun y => (rRest y).append fun p => r₂ ⟨y, p⟩) y)
                     (fun tr => Output ⟨y, tr⟩)

--- a/VCVio/Interaction/TwoParty/Decoration.lean
+++ b/VCVio/Interaction/TwoParty/Decoration.lean
@@ -11,18 +11,18 @@ import VCVio.Interaction.TwoParty.Role
 /-!
 # Role decorations and common role-based node contexts
 
-A `RoleDecoration spec` is a `Spec.Decoration` with fiber `fun _ => Role`: each internal node is
-labeled sender or receiver. It adds two-party control information to an ordinary
-interaction tree while reusing the surrounding `Spec` infrastructure
+A `RoleDecoration spec` is a `Spec.Decoration` with fiber `fun _ => Role`:
+each internal node is labeled sender or receiver. It adds two-party control
+information to an ordinary interaction tree while reusing the surrounding `Spec` infrastructure
 (`Transcript`, `append`, etc.).
 
-This file also packages the most common role-based node contexts used by the two-party interaction
-layer:
+This file also packages the most common role-based node contexts used by the
+two-party interaction layer:
 * `RoleContext` / `RoleSchema` for plain sender/receiver metadata;
 * `RoleMonadContext` for one bundled monad over each role-labeled node;
-* `RolePairedMonadContext` for paired prover/verifier monads;
-* `RolePairedMonadContext.fst` / `RolePairedMonadContext.snd` for forgetting one side of the
-  paired monadic context.
+* `RolePairedMonadContext` for paired focal/counterpart monads;
+* `RolePairedMonadContext.fst` / `RolePairedMonadContext.snd` for forgetting
+  one side of the paired monadic context.
 
 Only the plain role layer is exposed as a schema here. The monadic extensions are exported as
 realized node contexts, because `BundledMonad` lives in a higher universe than `Role`, while
@@ -35,78 +35,73 @@ move, and monad decorations say which node effect is used by each participant.
 universe u
 
 namespace Interaction
+namespace Spec
+namespace TwoParty
+
+open _root_.Interaction.TwoParty
 
 /-- The plain role-labeled node context. -/
-abbrev RoleContext : Spec.Node.Context := fun _ => Role
+abbrev RoleContext : Node.Context := fun _ => Role
 
 /-- The singleton schema presenting `RoleContext`. -/
-abbrev RoleSchema : Spec.Node.Schema RoleContext :=
+abbrev RoleSchema : Node.Schema RoleContext :=
   .singleton RoleContext
 
 /-- Role context extended by one bundled monad field. -/
-abbrev RoleMonadContext : Spec.Node.Context.{u, u + 1} :=
-  Spec.Node.Context.extend RoleContext (fun _ _ => BundledMonad.{u, u})
+abbrev RoleMonadContext : Node.Context.{u, u + 1} :=
+  Node.Context.extend RoleContext (fun _ _ => BundledMonad.{u, u})
 
 /-- Role context extended by a pair of bundled monads. -/
-abbrev RolePairedMonadContext : Spec.Node.Context.{u, u + 1} :=
-  Spec.Node.Context.extend
+abbrev RolePairedMonadContext : Node.Context.{u, u + 1} :=
+  Node.Context.extend
     RoleContext (fun _ _ => BundledMonad.{u, u} × BundledMonad.{u, u})
 
 namespace RolePairedMonadContext
 
 /-- Forget the counterpart monad from a paired role/monad context. -/
-abbrev fst : Spec.Node.ContextHom RolePairedMonadContext RoleMonadContext :=
-  Spec.Node.Context.extendMap
-    (Spec.Node.ContextHom.id RoleContext)
+abbrev fst : Node.ContextHom RolePairedMonadContext RoleMonadContext :=
+  Node.Context.extendMap
+    (Node.ContextHom.id RoleContext)
     (fun _ _ (bms : BundledMonad.{u, u} × BundledMonad.{u, u}) => bms.1)
 
 /-- Forget the focal monad from a paired role/monad context. -/
-abbrev snd : Spec.Node.ContextHom RolePairedMonadContext RoleMonadContext :=
-  Spec.Node.Context.extendMap
-    (Spec.Node.ContextHom.id RoleContext)
+abbrev snd : Node.ContextHom RolePairedMonadContext RoleMonadContext :=
+  Node.Context.extendMap
+    (Node.ContextHom.id RoleContext)
     (fun _ _ (bms : BundledMonad.{u, u} × BundledMonad.{u, u}) => bms.2)
 
 end RolePairedMonadContext
 
 /-- Per-node sender/receiver assignment on a `Spec`. -/
-abbrev RoleDecoration := Spec.Decoration (fun _ => Role)
+abbrev RoleDecoration := Decoration (fun _ => Role)
 
-namespace Spec
-namespace Decoration
-
-/-- Swap sender ↔ receiver at each node.
-
-Because `RoleDecoration` is an `abbrev` of `Decoration (fun _ => Role)`, dot notation on
-`roles : RoleDecoration spec` resolves this `Spec.Decoration.swap`. -/
-def swap {spec : Spec} (roles : Decoration (fun _ => Role) spec) :
-    Decoration (fun _ => Role) spec :=
-  map (fun _ => Role.swap) spec roles
-
-end Decoration
-end Spec
+/-- Swap sender and receiver at each node of a role decoration. -/
+def RoleDecoration.swap {spec : Spec} (roles : RoleDecoration spec) :
+    RoleDecoration spec :=
+  Decoration.map (fun _ => Role.swap) spec roles
 
 namespace RoleDecoration
 
 /-- View a plain monad decoration as one displayed layer over an existing role decoration. -/
 def monadsOver :
-    (spec : Spec.{u}) → (roles : RoleDecoration spec) → (md : Spec.MonadDecoration spec) →
-    Spec.Decoration.Over (fun _ (_ : Role) => BundledMonad.{u, u}) spec roles
+    (spec : Spec.{u}) → (roles : RoleDecoration spec) → (md : MonadDecoration spec) →
+    Decoration.Over (fun _ (_ : Role) => BundledMonad.{u, u}) spec roles
   | .done, _, _ => ⟨⟩
   | .node _ rest, ⟨_, rRest⟩, ⟨bm, mRest⟩ =>
       ⟨bm, fun x => monadsOver (rest x) (rRest x) (mRest x)⟩
 
 /-- Pack roles together with one bundled monad per node into `RoleMonadContext`. -/
 def withMonads {spec : Spec.{u}}
-    (roles : RoleDecoration spec) (md : Spec.MonadDecoration spec) :
-    Spec.Decoration RoleMonadContext spec :=
-  Spec.Decoration.ofOver (fun _ (_ : Role) => BundledMonad.{u, u}) spec roles
+    (roles : RoleDecoration spec) (md : MonadDecoration spec) :
+    Decoration RoleMonadContext spec :=
+  Decoration.ofOver (fun _ (_ : Role) => BundledMonad.{u, u}) spec roles
     (monadsOver spec roles md)
 
 /-- View a pair of monad decorations as one displayed layer over an existing role decoration. -/
 def pairedMonadsOver :
     (spec : Spec.{u}) → (roles : RoleDecoration spec) →
-    (stratDeco : Spec.MonadDecoration spec) → (cptDeco : Spec.MonadDecoration spec) →
-    Spec.Decoration.Over
+    (stratDeco : MonadDecoration spec) → (cptDeco : MonadDecoration spec) →
+    Decoration.Over
       (fun _ (_ : Role) => BundledMonad.{u, u} × BundledMonad.{u, u}) spec roles
   | .done, _, _, _ => ⟨⟩
   | .node _ rest, ⟨_, rRest⟩, ⟨bmS, mRestS⟩, ⟨bmC, mRestC⟩ =>
@@ -114,18 +109,18 @@ def pairedMonadsOver :
 
 /-- Pack roles together with paired prover/counterpart monads into `RolePairedMonadContext`. -/
 def withPairedMonads {spec : Spec.{u}}
-    (roles : RoleDecoration spec) (stratDeco : Spec.MonadDecoration spec)
-    (cptDeco : Spec.MonadDecoration spec) :
-    Spec.Decoration RolePairedMonadContext spec :=
-  Spec.Decoration.ofOver
+    (roles : RoleDecoration spec) (stratDeco : MonadDecoration spec)
+    (cptDeco : MonadDecoration spec) :
+    Decoration RolePairedMonadContext spec :=
+  Decoration.ofOver
     (fun _ (_ : Role) => BundledMonad.{u, u} × BundledMonad.{u, u})
     spec roles (pairedMonadsOver spec roles stratDeco cptDeco)
 
 @[simp]
 theorem withPairedMonads_map_fst :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
-    {stratDeco cptDeco : Spec.MonadDecoration spec} →
-    Spec.Decoration.map RolePairedMonadContext.fst spec
+    {stratDeco cptDeco : MonadDecoration spec} →
+    Decoration.map RolePairedMonadContext.fst spec
         (RoleDecoration.withPairedMonads roles stratDeco cptDeco) =
       RoleDecoration.withMonads roles stratDeco
   | .done, _, _, _ => rfl
@@ -143,8 +138,8 @@ theorem withPairedMonads_map_fst :
 @[simp]
 theorem withPairedMonads_map_snd :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
-    {stratDeco cptDeco : Spec.MonadDecoration spec} →
-    Spec.Decoration.map RolePairedMonadContext.snd spec
+    {stratDeco cptDeco : MonadDecoration spec} →
+    Decoration.map RolePairedMonadContext.snd spec
         (RoleDecoration.withPairedMonads roles stratDeco cptDeco) =
       RoleDecoration.withMonads roles cptDeco
   | .done, _, _, _ => rfl
@@ -161,4 +156,6 @@ theorem withPairedMonads_map_snd :
 
 end RoleDecoration
 
+end TwoParty
+end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Decoration.lean
+++ b/VCVio/Interaction/TwoParty/Decoration.lean
@@ -12,8 +12,9 @@ import VCVio.Interaction.TwoParty.Role
 # Role decorations and common role-based node contexts
 
 A `RoleDecoration spec` is a `Spec.Decoration` with fiber `fun _ => Role`: each internal node is
-labeled sender or receiver. This replaces a separate two-party interaction inductive while reusing
-all `Spec` infrastructure (`Transcript`, `append`, etc.).
+labeled sender or receiver. It adds two-party control information to an ordinary
+interaction tree while reusing the surrounding `Spec` infrastructure
+(`Transcript`, `append`, etc.).
 
 This file also packages the most common role-based node contexts used by the two-party interaction
 layer:
@@ -27,8 +28,8 @@ Only the plain role layer is exposed as a schema here. The monadic extensions ar
 realized node contexts, because `BundledMonad` lives in a higher universe than `Role`, while
 `Spec.Node.Schema` currently uses one fixed universe for all staged fields.
 
-These are the outward-facing schema/context names used by `Strategy.withRolesAndMonads`,
-`Counterpart.withMonads`, and the monadic execution layer.
+These contexts are ordinary inputs to `StrategyOver`: roles say who owns the
+move, and monad decorations say which node effect is used by each participant.
 -/
 
 universe u

--- a/VCVio/Interaction/TwoParty/Examples.lean
+++ b/VCVio/Interaction/TwoParty/Examples.lean
@@ -24,14 +24,14 @@ variable (m : Type u → Type u) [Monad m]
 variable (T U : Type u) (α : Type u)
 
 private def exSpec := Spec.node T fun _ => .node U fun _ => .done
-private def exRoles : RoleDecoration (exSpec T U) :=
+private def exRoles : Spec.TwoParty.RoleDecoration (exSpec T U) :=
   ⟨.sender, fun _ => ⟨.receiver, fun _ => ⟨⟩⟩⟩
 
-example : Spec.StrategyOver (Spec.pairedSyntax m) TwoParty.Participant.focal
+example : Spec.StrategyOver (Spec.TwoParty.pairedSyntax m) TwoParty.Participant.focal
     (exSpec T U) (exRoles T U) (fun _ => α)
     = m ((_ : T) × ((_ : U) → m α)) := rfl
 
-example : Spec.StrategyOver (Spec.pairedSyntax m) TwoParty.Participant.counterpart
+example : Spec.StrategyOver (Spec.TwoParty.pairedSyntax m) TwoParty.Participant.counterpart
     (exSpec T U) (exRoles T U) (fun _ => α)
     = ((_ : T) → m (m ((_ : U) × α))) := rfl
 

--- a/VCVio/Interaction/TwoParty/Examples.lean
+++ b/VCVio/Interaction/TwoParty/Examples.lean
@@ -9,7 +9,7 @@ import VCVio.Interaction.TwoParty.Decoration
 import VCVio.Interaction.TwoParty.Strategy
 
 /-!
-# Examples: computing `withRoles` / `Counterpart` types
+# Examples: computing paired two-party strategy types
 
 Small hand-crafted specs show how role-dependent strategy types unfold.
 -/
@@ -27,10 +27,12 @@ private def exSpec := Spec.node T fun _ => .node U fun _ => .done
 private def exRoles : RoleDecoration (exSpec T U) :=
   ⟨.sender, fun _ => ⟨.receiver, fun _ => ⟨⟩⟩⟩
 
-example : Spec.Strategy.withRoles m (exSpec T U) (exRoles T U) (fun _ => α)
+example : Spec.StrategyOver (Spec.pairedSyntax m) TwoParty.Participant.focal
+    (exSpec T U) (exRoles T U) (fun _ => α)
     = m ((_ : T) × ((_ : U) → m α)) := rfl
 
-example : Spec.Counterpart m (exSpec T U) (exRoles T U) (fun _ => α)
+example : Spec.StrategyOver (Spec.pairedSyntax m) TwoParty.Participant.counterpart
+    (exSpec T U) (exRoles T U) (fun _ => α)
     = ((_ : T) → m (m ((_ : U) × α))) := rfl
 
 end Examples

--- a/VCVio/Interaction/TwoParty/Refine.lean
+++ b/VCVio/Interaction/TwoParty/Refine.lean
@@ -21,6 +21,10 @@ to `Spec.Decoration.Over` with fiber `Role.SenderData` is an equivalence; `map` 
 universe u v w w₂
 
 namespace Interaction
+namespace Spec
+namespace TwoParty
+
+open _root_.Interaction.TwoParty
 
 /-- Role-aware displayed data: `S X` at sender nodes; `∀` recursion at receiver nodes. -/
 @[reducible] def Role.Refine (S : Type u → Type v) :
@@ -283,4 +287,6 @@ theorem ofDecorationOver_map {S T : Type u → Type v} (f : ∀ X, S X → T X) 
       exact ofDecorationOver_map f (rest x) (rRest x) (rr x)
 
 end Role.Refine
+end TwoParty
+end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Role.lean
+++ b/VCVio/Interaction/TwoParty/Role.lean
@@ -15,6 +15,7 @@ and its environment; `interact` runs one round.
 universe u
 
 namespace Interaction
+namespace TwoParty
 
 /-- Which side speaks at a protocol node: sender (proposes a move) or receiver (observes). -/
 inductive Role where
@@ -57,4 +58,5 @@ def interact {m : Type u → Type u} [Monad m] {X : Type u}
       k x cont dualCont
 
 end Role
+end TwoParty
 end Interaction

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -677,6 +677,103 @@ abbrev Strategy.withRolesAndMonads
   StrategyOver strategyMonadicSyntax PUnit.unit spec
     (RoleDecoration.withMonads roles md) Output
 
+/-- Map the transcript-indexed output of a monadic role strategy. -/
+def Strategy.withRolesAndMonads.mapOutput
+    (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
+    {Output₁ Output₂ : Spec.Transcript spec → Type u}
+    (f : ∀ tr, Output₁ tr → Output₂ tr) :
+    Strategy.withRolesAndMonads spec roles md Output₁ →
+    Strategy.withRolesAndMonads spec roles md Output₂ :=
+  match spec, roles, md with
+  | .done, _, _ => fun strat => f ⟨⟩ strat
+  | .node _ rest, ⟨.sender, rRest⟩, ⟨_, mdRest⟩ =>
+      fun strat =>
+        Functor.map
+          (fun msgAndRest =>
+            ⟨msgAndRest.1,
+              mapOutput (rest msgAndRest.1) (rRest msgAndRest.1) (mdRest msgAndRest.1)
+                (fun tr => f ⟨msgAndRest.1, tr⟩) msgAndRest.2⟩)
+          strat
+  | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, mdRest⟩ =>
+      fun strat x =>
+        Functor.map
+          (mapOutput (rest x) (rRest x) (mdRest x) (fun tr => f ⟨x, tr⟩))
+          (strat x)
+
+/--
+Retarget a monadic role strategy along a nodewise monad homomorphism.
+
+The protocol tree and output family stay fixed; only the node effects are
+lifted from the source monad decoration to the target decoration.
+-/
+def Strategy.withRolesAndMonads.mapDecoration
+    (spec : Spec.{u}) (roles : RoleDecoration spec)
+    {md₁ md₂ : MonadDecoration spec}
+    (hom : MonadDecoration.Hom spec md₁ md₂)
+    {Output : Spec.Transcript spec → Type u} :
+    Strategy.withRolesAndMonads spec roles md₁ Output →
+    Strategy.withRolesAndMonads spec roles md₂ Output :=
+  match spec, roles, md₁, md₂, hom with
+  | .done, _, _, _, _ => fun strat => strat
+  | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
+      fun strat =>
+        lift <| Functor.map
+          (fun msgAndRest =>
+            ⟨msgAndRest.1,
+              mapDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
+                (homRest msgAndRest.1) msgAndRest.2⟩)
+          strat
+  | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
+      fun strat x =>
+        lift <| Functor.map
+          (mapDecoration (rest x) (rRest x) (homRest x)) (strat x)
+
+/--
+View a strategy over a constant monad decoration as an ordinary single-monad
+role strategy.
+-/
+def Strategy.withRolesAndMonads.toWithRolesConstant {m : Type u → Type u} [Monad m]
+    (spec : Spec.{u}) (roles : RoleDecoration spec)
+    {Output : Spec.Transcript spec → Type u} :
+    Strategy.withRolesAndMonads spec roles
+      (MonadDecoration.constant ⟨m, inferInstance⟩ spec) Output →
+    Strategy.withRoles m spec roles Output :=
+  match spec, roles with
+  | .done, _ => fun strat => strat
+  | .node _ rest, ⟨.sender, rRest⟩ =>
+      fun strat =>
+        Functor.map
+          (fun msgAndRest =>
+            ⟨msgAndRest.1,
+              toWithRolesConstant (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
+          strat
+  | .node _ rest, ⟨.receiver, rRest⟩ =>
+      fun strat x =>
+        Functor.map (toWithRolesConstant (rest x) (rRest x)) (strat x)
+
+/--
+View an ordinary single-monad role strategy as a strategy over a constant monad
+decoration.
+-/
+def Strategy.withRolesAndMonads.ofWithRolesConstant {m : Type u → Type u} [Monad m]
+    (spec : Spec.{u}) (roles : RoleDecoration spec)
+    {Output : Spec.Transcript spec → Type u} :
+    Strategy.withRoles m spec roles Output →
+    Strategy.withRolesAndMonads spec roles
+      (MonadDecoration.constant ⟨m, inferInstance⟩ spec) Output :=
+  match spec, roles with
+  | .done, _ => fun strat => strat
+  | .node _ rest, ⟨.sender, rRest⟩ =>
+      fun strat =>
+        Functor.map
+          (fun msgAndRest =>
+            ⟨msgAndRest.1,
+              ofWithRolesConstant (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
+          strat
+  | .node _ rest, ⟨.receiver, rRest⟩ =>
+      fun strat x =>
+        Functor.map (ofWithRolesConstant (rest x) (rRest x)) (strat x)
+
 /-- Counterpart with per-node monads and transcript-dependent output.
 
 This is the primary type for oracle verifiers: `OracleCounterpart` (in
@@ -736,6 +833,34 @@ theorem Counterpart.withMonads.mapOutput_receiver_eq
         ⟨xc.1,
           Counterpart.withMonads.mapOutput
             (rest xc.1) (rRest xc.1) (mdRest xc.1) (fun tr => f ⟨xc.1, tr⟩) xc.2⟩) <$> cpt := rfl
+
+/--
+Retarget a monadic counterpart along a nodewise monad homomorphism.
+
+This traverses the counterpart tree structurally, applying the supplied lift at
+each node and recursing through the selected continuation.
+-/
+def Counterpart.withMonads.mapDecoration
+    (spec : Spec.{u}) (roles : RoleDecoration spec)
+    {md₁ md₂ : MonadDecoration spec}
+    (hom : MonadDecoration.Hom spec md₁ md₂)
+    {Output : Spec.Transcript spec → Type u} :
+    Counterpart.withMonads spec roles md₁ Output →
+    Counterpart.withMonads spec roles md₂ Output :=
+  match spec, roles, md₁, md₂, hom with
+  | .done, _, _, _, _ => fun cpt => cpt
+  | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
+      fun cpt x =>
+        lift <| Functor.map
+          (mapDecoration (rest x) (rRest x) (homRest x)) (cpt x)
+  | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
+      fun cpt =>
+        lift <| Functor.map
+          (fun msgAndRest =>
+            ⟨msgAndRest.1,
+              mapDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
+                (homRest msgAndRest.1) msgAndRest.2⟩)
+          cpt
 
 private theorem pairedMonadicSyntax_forAgent_focal :
     pairedMonadicSyntax.forAgent Participant.focal =

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -179,6 +179,30 @@ def focalMonadicSyntax :
     | ⟨role, bm⟩ => role.Action bm.M X Cont
 
 /--
+Functorial shape for the focal side of a role-decorated tree with per-node
+monads.
+
+The local node syntax is `focalMonadicSyntax`; the map operation transports
+only recursive continuations, leaving the role, node monad, and selected move
+unchanged.
+-/
+def focalMonadicShape :
+    ShapeOver.{u, 0, u, u + 1} PUnit RoleMonadContext where
+  toSyntaxOver := focalMonadicSyntax
+  map := fun {agent} {X} {γ} {A} {B} f node =>
+    match γ with
+    | ⟨.sender, bm⟩ =>
+        let send : bm.M ((x : X) × A x) := by
+          simpa [focalMonadicSyntax] using node
+        show focalMonadicSyntax.Node agent X ⟨.sender, bm⟩ B from
+          ((fun xa => ⟨xa.1, f xa.1 xa.2⟩) <$> send : bm.M ((x : X) × B x))
+    | ⟨.receiver, bm⟩ =>
+        let observe : (x : X) → bm.M (A x) := by
+          simpa [focalMonadicSyntax] using node
+        show focalMonadicSyntax.Node agent X ⟨.receiver, bm⟩ B from
+          (fun x => f x <$> observe x : (x : X) → bm.M (B x))
+
+/--
 One-participant syntax for the counterpart side of a role-decorated tree with
 per-node monads.
 
@@ -193,7 +217,15 @@ def counterpartMonadicSyntax :
     | ⟨.sender, bm⟩ => (x : X) → bm.M (Cont x)
     | ⟨.receiver, bm⟩ => bm.M ((x : X) × Cont x)
 
-private def counterpartMonadicShape :
+/--
+Functorial shape for the counterpart side of a role-decorated tree with
+per-node monads.
+
+The local node syntax is `counterpartMonadicSyntax`; the map operation
+transports only recursive continuations, preserving the role, node monad, and
+message/challenge choice.
+-/
+def counterpartMonadicShape :
     ShapeOver.{u, 0, u, u + 1} PUnit RoleMonadContext where
   toSyntaxOver := counterpartMonadicSyntax
   map := fun {agent} {X} {γ} {A} {B} f node =>
@@ -691,21 +723,9 @@ def Strategy.withRolesAndMonads.mapOutput
     (f : ∀ tr, Output₁ tr → Output₂ tr) :
     Strategy.withRolesAndMonads spec roles md Output₁ →
     Strategy.withRolesAndMonads spec roles md Output₂ :=
-  match spec, roles, md with
-  | .done, _, _ => fun strat => f ⟨⟩ strat
-  | .node _ rest, ⟨.sender, rRest⟩, ⟨_, mdRest⟩ =>
-      fun strat =>
-        Functor.map
-          (fun msgAndRest =>
-            ⟨msgAndRest.1,
-              mapOutput (rest msgAndRest.1) (rRest msgAndRest.1) (mdRest msgAndRest.1)
-                (fun tr => f ⟨msgAndRest.1, tr⟩) msgAndRest.2⟩)
-          strat
-  | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, mdRest⟩ =>
-      fun strat x =>
-        Functor.map
-          (mapOutput (rest x) (rRest x) (mdRest x) (fun tr => f ⟨x, tr⟩))
-          (strat x)
+  ShapeOver.mapOutput focalMonadicShape
+    (agent := PUnit.unit) (spec := spec) (ctxs := RoleDecoration.withMonads roles md)
+    (A := Output₁) (B := Output₂) f
 
 /--
 Retarget a monadic role strategy along a nodewise monad homomorphism.

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -763,6 +763,52 @@ def Strategy.withRolesAndMonads.ofWithRolesConstant {m : Type u → Type u} [Mon
         Functor.map (ofWithRolesConstant (rest x) (rRest x)) (strat x)
 
 /--
+Lifting an ordinary role strategy into a constant monad decoration commutes
+with output maps.
+
+This is the naturality property used at boundaries that still accept ordinary
+single-monad strategies while internal execution is phrased over nodewise
+monad decorations.
+-/
+theorem Strategy.withRolesAndMonads.ofWithRolesConstant_mapOutputWithRoles
+    {m : Type u → Type u} [Monad m] [LawfulFunctor m]
+    (spec : Spec.{u}) (roles : RoleDecoration spec)
+    {Output Output' : Spec.Transcript spec → Type u}
+    (f : ∀ tr, Output tr → Output' tr)
+    (strat : Strategy.withRoles m spec roles Output) :
+    Strategy.withRolesAndMonads.ofWithRolesConstant spec roles
+        (Strategy.mapOutputWithRoles f strat) =
+      ShapeOver.mapOutput focalMonadicShape
+        (agent := PUnit.unit)
+        (spec := spec)
+        (ctxs := RoleDecoration.withMonads roles
+          (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
+        f
+        (Strategy.withRolesAndMonads.ofWithRolesConstant spec roles strat) := by
+  match spec, roles with
+  | .done, _ =>
+      rfl
+  | .node _ rest, ⟨.sender, rRest⟩ =>
+      simp only [Strategy.mapOutputWithRoles, Counterpart.mapReceiver,
+        ofWithRolesConstant, ShapeOver.mapOutput, focalMonadicShape,
+        focalMonadicSyntax, RoleDecoration.withMonads, RoleDecoration.monadsOver,
+        Spec.MonadDecoration.constant, Spec.Decoration.ofOver, Functor.map_map]
+      apply congrArg (fun g => g <$> strat)
+      funext msgAndRest
+      rw [ofWithRolesConstant_mapOutputWithRoles (rest msgAndRest.1) (rRest msgAndRest.1)]
+      rfl
+  | .node _ rest, ⟨.receiver, rRest⟩ =>
+      funext x
+      simp only [Strategy.mapOutputWithRoles, ofWithRolesConstant,
+        ShapeOver.mapOutput, focalMonadicShape, focalMonadicSyntax,
+        RoleDecoration.withMonads, RoleDecoration.monadsOver,
+        Spec.MonadDecoration.constant, Spec.Decoration.ofOver, Functor.map_map]
+      apply congrArg (fun g => g <$> strat x)
+      funext next
+      rw [ofWithRolesConstant_mapOutputWithRoles (rest x) (rRest x)]
+      rfl
+
+/--
 Counterpart strategy whose node effects are supplied by a `MonadDecoration`.
 
 At sender-owned nodes the counterpart observes the focal move and continues in

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -716,17 +716,6 @@ abbrev Strategy.withRolesAndMonads
   StrategyOver focalMonadicSyntax PUnit.unit spec
     (RoleDecoration.withMonads roles md) Output
 
-/-- Map the transcript-indexed output of a monadic role strategy. -/
-def Strategy.withRolesAndMonads.mapOutput
-    (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
-    {Output₁ Output₂ : Spec.Transcript spec → Type u}
-    (f : ∀ tr, Output₁ tr → Output₂ tr) :
-    Strategy.withRolesAndMonads spec roles md Output₁ →
-    Strategy.withRolesAndMonads spec roles md Output₂ :=
-  ShapeOver.mapOutput focalMonadicShape
-    (agent := PUnit.unit) (spec := spec) (ctxs := RoleDecoration.withMonads roles md)
-    (A := Output₁) (B := Output₂) f
-
 /--
 Retarget a monadic role strategy along a nodewise monad homomorphism.
 
@@ -813,51 +802,6 @@ abbrev Counterpart.withMonads
     (Output : Transcript spec → Type u) :=
   StrategyOver counterpartMonadicSyntax PUnit.unit spec
     (RoleDecoration.withMonads roles md) Output
-
-/-- Map the transcript-indexed output of a monadic counterpart. This is the
-counterpart-side analog of `Strategy.mapOutputWithRoles`, specialized to
-`Counterpart.withMonads`. -/
-def Counterpart.withMonads.mapOutput
-    (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
-    {Output₁ Output₂ : Transcript spec → Type u}
-    (f : ∀ tr, Output₁ tr → Output₂ tr) :
-    Counterpart.withMonads spec roles md Output₁ →
-    Counterpart.withMonads spec roles md Output₂ :=
-  ShapeOver.mapOutput counterpartMonadicShape
-    (agent := PUnit.unit) (spec := spec) (ctxs := RoleDecoration.withMonads roles md)
-    (A := Output₁) (B := Output₂) f
-
-@[simp]
-theorem Counterpart.withMonads.mapOutput_done
-    {Output₁ Output₂ : PUnit → Type u}
-    (md : PUnit) (f : ∀ tr, Output₁ tr → Output₂ tr)
-    (cpt : Counterpart.withMonads .done PUnit.unit md Output₁) :
-    Counterpart.withMonads.mapOutput .done PUnit.unit md f cpt = f ⟨⟩ cpt := rfl
-
-@[simp]
-theorem Counterpart.withMonads.mapOutput_sender_eq
-    {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
-    {bm : BundledMonad} {mdRest : (x : X) → MonadDecoration (rest x)}
-    {Output₁ Output₂ : Transcript (.node X rest) → Type u}
-    (f : ∀ tr, Output₁ tr → Output₂ tr)
-    (cpt : Counterpart.withMonads (.node X rest) ⟨.sender, rRest⟩ ⟨bm, mdRest⟩ Output₁) :
-    Counterpart.withMonads.mapOutput (.node X rest) ⟨.sender, rRest⟩ ⟨bm, mdRest⟩ f cpt =
-      fun x =>
-        Counterpart.withMonads.mapOutput
-          (rest x) (rRest x) (mdRest x) (fun tr => f ⟨x, tr⟩) <$> cpt x := rfl
-
-@[simp]
-theorem Counterpart.withMonads.mapOutput_receiver_eq
-    {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
-    {bm : BundledMonad} {mdRest : (x : X) → MonadDecoration (rest x)}
-    {Output₁ Output₂ : Transcript (.node X rest) → Type u}
-    (f : ∀ tr, Output₁ tr → Output₂ tr)
-    (cpt : Counterpart.withMonads (.node X rest) ⟨.receiver, rRest⟩ ⟨bm, mdRest⟩ Output₁) :
-    Counterpart.withMonads.mapOutput (.node X rest) ⟨.receiver, rRest⟩ ⟨bm, mdRest⟩ f cpt =
-      (fun xc =>
-        ⟨xc.1,
-          Counterpart.withMonads.mapOutput
-            (rest xc.1) (rRest xc.1) (mdRest xc.1) (fun tr => f ⟨xc.1, tr⟩) xc.2⟩) <$> cpt := rfl
 
 /--
 Retarget a monadic counterpart along a nodewise monad homomorphism.

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -809,6 +809,34 @@ theorem Strategy.withRolesAndMonads.ofWithRolesConstant_mapOutputWithRoles
       rfl
 
 /--
+Retarget a monadic focal strategy along a nodewise monad homomorphism.
+
+This traverses the strategy tree structurally, applying the supplied lift at
+each node and recursing through the selected continuation.
+-/
+def Strategy.withRolesAndMonads.mapDecoration
+    (spec : Spec.{u}) (roles : RoleDecoration spec)
+    {md₁ md₂ : MonadDecoration spec}
+    (hom : MonadDecoration.Hom spec md₁ md₂)
+    {Output : Spec.Transcript spec → Type u} :
+    Strategy.withRolesAndMonads spec roles md₁ Output →
+    Strategy.withRolesAndMonads spec roles md₂ Output :=
+  match spec, roles, md₁, md₂, hom with
+  | .done, _, _, _, _ => fun strat => strat
+  | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
+      fun strat =>
+        lift <| Functor.map
+          (fun msgAndRest =>
+            ⟨msgAndRest.1,
+              mapDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
+                (homRest msgAndRest.1) msgAndRest.2⟩)
+          strat
+  | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
+      fun strat x =>
+        lift <| Functor.map
+          (mapDecoration (rest x) (rRest x) (homRest x)) (strat x)
+
+/--
 Counterpart strategy whose node effects are supplied by a `MonadDecoration`.
 
 At sender-owned nodes the counterpart observes the focal move and continues in

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -410,6 +410,30 @@ private def publicCoinCounterpartShape (m : Type u → Type u) [Functor m] :
     (fun X Cont => m X × ((x : X) → Cont x))
     Counterpart.mapSender mapReceiver
 
+/--
+Local syntax-forgetting map from replayable public-coin counterparts to
+ordinary executable counterparts.
+
+At sender nodes the observer continuation is unchanged except for the recursive
+translation. At receiver nodes the explicit sampler/continuation pair is
+packed into the ordinary monadic action that samples a challenge and returns
+the translated continuation for that challenge.
+-/
+def toCounterpartHom {m : Type u → Type u} [Monad m] :
+    StrategyOver.Hom (PublicCoinCounterpart.syntax m) PUnit.unit
+      (pairedSyntax m) Participant.counterpart where
+  mapNode := fun {X} {γ} {A} {B} f node =>
+    match γ with
+    | .sender =>
+        Counterpart.mapSender f node
+    | .receiver =>
+        let receiver : m X × ((x : X) → A x) := by
+          simpa [PublicCoinCounterpart.syntax, counterpartFamilySyntax] using node
+        show (pairedSyntax m).Node Participant.counterpart X .receiver B from
+          do
+            let x ← receiver.1
+            pure ⟨x, f x (receiver.2 x)⟩
+
 /-- Functorial output map for public-coin counterparts. The challenge samplers
 are unchanged; only the terminal output carried by continuations is mapped. -/
 def mapOutput {m : Type u → Type u} [Functor m] :
@@ -430,14 +454,11 @@ def toCounterpart {m : Type u → Type u} [Monad m] :
     {Output : Transcript spec → Type u} →
     StrategyOver (PublicCoinCounterpart.syntax m) PUnit.unit spec roles Output →
     StrategyOver (pairedSyntax m) Participant.counterpart spec roles Output
-  | .done, _, _, c => c
-  | .node _ _, ⟨.sender, _⟩, _, observe =>
-      fun x => do
-        let next ← observe x
-        pure <| toCounterpart next
-  | .node _ _, ⟨.receiver, _⟩, _, ⟨sample, next⟩ => do
-      let x ← sample
-      pure ⟨x, toCounterpart (next x)⟩
+  :=
+    fun {spec} {roles} {Output} =>
+      StrategyOver.map toCounterpartHom
+        (spec := spec) (ctxs := roles)
+        (A := Output) (B := Output) (fun _ out => out)
 
 /-- Replay a prescribed transcript through a public-coin counterpart. Sender
 messages are read from the transcript; receiver samplers are ignored and the

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -26,7 +26,7 @@ decoration still determines which participant owns each move.
 
 This module also contains a public-coin counterpart syntax. An executable
 counterpart samples a receiver move together with its continuation as one
-opaque action; `Spec.PublicCoinCounterpart` exposes the sampler and
+opaque action; `Spec.publicCoinCounterpartSyntax` exposes the sampler and
 challenge-indexed continuation separately:
 
 - `sample : m X` — how the next public challenge is chosen
@@ -406,7 +406,7 @@ right shape for execution, but it is too weak for verifier-side Fiat-Shamir:
 given a prescribed challenge `x`, there is no way to recover the continuation
 for `x` unless that continuation is exposed separately.
 
-`PublicCoinCounterpart` factors each receiver node into:
+`publicCoinCounterpartSyntax` factors each receiver node into:
 - `sample : m X` — how the verifier samples the next public challenge
 - `next : (x : X) → ...` — how the rest of the verifier depends on that challenge
 
@@ -416,11 +416,6 @@ def publicCoinCounterpartSyntax (m : Type u → Type u) :
     SyntaxOver.{u, 0, u, 0} PUnit (fun _ => Role) :=
   counterpartFamilySyntax (fun X Cont => (x : X) → m (Cont x))
     (fun X Cont => m X × ((x : X) → Cont x))
-
-/-- Whole-tree public-coin counterpart induced by `publicCoinCounterpartSyntax`. -/
-abbrev PublicCoinCounterpart (m : Type u → Type u)
-    (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output
 
 namespace PublicCoinCounterpart
 
@@ -441,8 +436,8 @@ def mapOutput {m : Type u → Type u} [Functor m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {A B : Transcript spec → Type u} →
     (∀ tr, A tr → B tr) →
-    PublicCoinCounterpart m spec roles A →
-    PublicCoinCounterpart m spec roles B :=
+    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles A →
+    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles B :=
   fun {spec} {roles} {A} {B} f =>
     ShapeOver.mapOutput (publicCoinCounterpartShape m)
       (agent := PUnit.unit) (spec := spec) roles
@@ -453,7 +448,8 @@ counterpart. -/
 def toCounterpart {m : Type u → Type u} [Monad m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
-    PublicCoinCounterpart m spec roles Output → Counterpart m spec roles Output
+    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output →
+    Counterpart m spec roles Output
   | .done, _, _, c => c
   | .node _ _, ⟨.sender, _⟩, _, observe =>
       fun x => do
@@ -469,7 +465,7 @@ stored continuation family is followed at the recorded challenge. -/
 def replay {m : Type u → Type u} [Monad m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
-    PublicCoinCounterpart m spec roles Output →
+    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output →
     (tr : Transcript spec) → m (Output tr)
   | .done, _, _, c, _ => pure c
   | .node _ _, ⟨.sender, _⟩, _, observe, ⟨x, tr⟩ =>

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -17,9 +17,10 @@ import VCVio.Interaction.Basic.Shape
 # Role-dependent strategies and counterparts
 
 Two-party strategies are `StrategyOver` specializations over role-decorated
-interaction trees. `Spec.Strategy.withRoles` is the focal participant: owned
-nodes are effectful move/continuation packages, while non-owned nodes respond
-to the counterpart's move. `Spec.Counterpart` is the dual participant view.
+interaction trees. The focal participant is the `Participant.focal` fiber of
+`pairedSyntax`; owned nodes are effectful move/continuation packages, while
+non-owned nodes respond to the counterpart's move. The counterpart participant
+is the `Participant.counterpart` fiber of the same syntax.
 
 The monadic variants add a `MonadDecoration`, so each node can use the effect
 recorded in the decoration instead of one ambient monad. The same role
@@ -131,7 +132,15 @@ private theorem pairedSyntax_eq_ownerBased (m : Type u → Type u) :
   cases agent <;> cases role <;>
         simp [Ownership.LocalView.node, rolePerspective, focalView, counterpartView]
 
-private def pairedInteraction (m : Type u → Type u) [Monad m] :
+/-- Local execution law for the two participants of `pairedSyntax`.
+
+At a sender node, the focal participant supplies the move and continuation,
+while the counterpart observes that move. At a receiver node, the counterpart
+supplies the move and continuation, while the focal participant observes it.
+Together with `StrategyOver.run`, this is the canonical whole-protocol runner
+for two-party role-decorated strategies.
+-/
+def pairedInteraction (m : Type u → Type u) [Monad m] :
     InteractionOver Participant.{u} (fun _ => Role) (pairedSyntax m) m where
   interact := fun {X} {γ : Role} {Cont} {Result} profile k =>
     match γ with
@@ -260,38 +269,12 @@ private theorem pairedMonadicSyntax_eq_ownerBased :
             simp [Ownership.LocalView.node, rolePerspective, focalMonadicView,
               counterpartMonadicView]
 
-
-/-- Focal strategy: `Role.Action` at each decorated node (choose vs. respond). -/
-abbrev Strategy.withRoles (m : Type u → Type u)
-    (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  StrategyOver (pairedSyntax m) Participant.focal spec roles Output
-
-@[simp]
-theorem Strategy.withRoles_done {m : Type u → Type u} {Output : PUnit → Type u} :
-    Strategy.withRoles m .done PUnit.unit Output = Output PUnit.unit := rfl
-
-@[simp]
-theorem Strategy.withRoles_sender_eq
-    {m : Type u → Type u}
-    {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
-    {Output : Transcript (.node X rest) → Type u} :
-    Strategy.withRoles m (.node X rest) ⟨.sender, rRest⟩ Output =
-      m ((x : X) × Strategy.withRoles m (rest x) (rRest x) (fun tr => Output ⟨x, tr⟩)) := rfl
-
-@[simp]
-theorem Strategy.withRoles_receiver_eq
-    {m : Type u → Type u}
-    {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
-    {Output : Transcript (.node X rest) → Type u} :
-    Strategy.withRoles m (.node X rest) ⟨.receiver, rRest⟩ Output =
-      ((x : X) → m (Strategy.withRoles m (rest x) (rRest x) (fun tr => Output ⟨x, tr⟩))) := rfl
-
 /-- A generic counterpart family parameterized by separate sender- and
 receiver-side node representations.
 
 Sender nodes model how the environment follows a move chosen by the focal
 party. Receiver nodes model how the environment chooses a move itself. Both
-ordinary `Counterpart` and replayable public-coin syntax are both direct
+ordinary counterpart syntax and replayable public-coin syntax are direct
 `StrategyOver` specializations. -/
 private def counterpartFamilyShape
     (Sender : (X : Type u) → (X → Type u) → Type u)
@@ -311,15 +294,6 @@ private def counterpartFamilyShape
     | .receiver =>
         mapReceiver f node
 
-/-- Counterpart / environment type with transcript-dependent output: dual
-actions at each node, producing `Output ⟨⟩` at `.done`.
-
-For a counterpart that carries no final data, take
-`Output := fun _ => PUnit`. -/
-abbrev Counterpart (m : Type u → Type u)
-    (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  StrategyOver (pairedSyntax m) Participant.counterpart spec roles Output
-
 /-- Map a receiver-family output through a sender-owned sampled move. -/
 def Counterpart.mapReceiver {m : Type u → Type u} [Functor m] :
     {X : Type u} → {A B : X → Type u} →
@@ -336,7 +310,9 @@ def Counterpart.mapSender {m : Type u → Type u} [Functor m] :
 def Strategy.mapOutputWithRoles {m : Type u → Type u} [Functor m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {A B : Transcript spec → Type u} →
-    (∀ tr, A tr → B tr) → Strategy.withRoles m spec roles A → Strategy.withRoles m spec roles B
+    (∀ tr, A tr → B tr) →
+      StrategyOver (pairedSyntax m) Participant.focal spec roles A →
+      StrategyOver (pairedSyntax m) Participant.focal spec roles B
   | .done, _, _, _, f, a => f ⟨⟩ a
   | .node _ _, ⟨.sender, _⟩, _, _, f, send =>
       Counterpart.mapReceiver (fun x => mapOutputWithRoles (fun p => f ⟨x, p⟩)) send
@@ -347,7 +323,7 @@ def Strategy.mapOutputWithRoles {m : Type u → Type u} [Functor m] :
 @[simp]
 theorem Strategy.mapOutputWithRoles_id {m : Type u → Type u} [Functor m] [LawfulFunctor m]
     {spec : Spec} {roles : RoleDecoration spec} {A : Transcript spec → Type u}
-    (σ : Strategy.withRoles m spec roles A) :
+    (σ : StrategyOver (pairedSyntax m) Participant.focal spec roles A) :
     Strategy.mapOutputWithRoles (fun _ x => x) σ = σ := by
   match spec, roles with
   | .done, roles =>
@@ -355,8 +331,10 @@ theorem Strategy.mapOutputWithRoles_id {m : Type u → Type u} [Functor m] [Lawf
       rfl
   | .node X rest, ⟨.sender, rRest⟩ =>
       let F :
-          ((x : X) × Strategy.withRoles m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) →
-          ((x : X) × Strategy.withRoles m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) :=
+          ((x : X) × StrategyOver (pairedSyntax m) Participant.focal
+            (rest x) (rRest x) (fun p => A ⟨x, p⟩)) →
+          ((x : X) × StrategyOver (pairedSyntax m) Participant.focal
+            (rest x) (rRest x) (fun p => A ⟨x, p⟩)) :=
         fun xc => ⟨xc.1,
           Strategy.mapOutputWithRoles
             (fun (p : Transcript (rest xc.1)) (y : A ⟨xc.1, p⟩) => y) xc.2⟩
@@ -375,8 +353,10 @@ theorem Strategy.mapOutputWithRoles_id {m : Type u → Type u} [Functor m] [Lawf
       funext x
       have hid :
           (mapOutputWithRoles (fun (p : Transcript (rest x)) (y : A ⟨x, p⟩) => y) :
-              Strategy.withRoles m (rest x) (rRest x) (fun p => A ⟨x, p⟩) →
-                Strategy.withRoles m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) =
+              StrategyOver (pairedSyntax m) Participant.focal
+                (rest x) (rRest x) (fun p => A ⟨x, p⟩) →
+                StrategyOver (pairedSyntax m) Participant.focal
+                  (rest x) (rRest x) (fun p => A ⟨x, p⟩)) =
             id := by
         funext s
         exact @mapOutputWithRoles_id m _ _ (rest x) (rRest x) (fun p => A ⟨x, p⟩) s
@@ -387,7 +367,9 @@ theorem Strategy.mapOutputWithRoles_id {m : Type u → Type u} [Functor m] [Lawf
 def Counterpart.mapOutput {m : Type u → Type u} [Functor m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {A B : Transcript spec → Type u} →
-    (∀ tr, A tr → B tr) → Counterpart m spec roles A → Counterpart m spec roles B
+    (∀ tr, A tr → B tr) →
+      StrategyOver (pairedSyntax m) Participant.counterpart spec roles A →
+      StrategyOver (pairedSyntax m) Participant.counterpart spec roles B
   | .done, _, _, _, f, a => f ⟨⟩ a
   | .node _ _, ⟨.sender, _⟩, _, _, f, observe =>
       Counterpart.mapSender (fun x => mapOutput (fun p => f ⟨x, p⟩)) observe
@@ -396,11 +378,12 @@ def Counterpart.mapOutput {m : Type u → Type u} [Functor m] :
 
 /-- A verifier counterpart with replayable public-coin receiver nodes.
 
-An ordinary `Counterpart m` represents a receiver node as an opaque monadic
-action returning both the sampled challenge and the continuation. That is the
-right shape for execution, but it is too weak for verifier-side Fiat-Shamir:
-given a prescribed challenge `x`, there is no way to recover the continuation
-for `x` unless that continuation is exposed separately.
+An ordinary `StrategyOver (pairedSyntax m) Participant.counterpart` represents
+a receiver node as an opaque monadic action returning both the sampled challenge
+and the continuation. That is the right shape for execution, but it is too weak
+for verifier-side Fiat-Shamir: given a prescribed challenge `x`, there is no
+way to recover the continuation for `x` unless that continuation is exposed
+separately.
 
 `publicCoinCounterpartSyntax` factors each receiver node into:
 - `sample : m X` — how the verifier samples the next public challenge
@@ -445,7 +428,7 @@ def toCounterpart {m : Type u → Type u} [Monad m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
     StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output →
-    Counterpart m spec roles Output
+    StrategyOver (pairedSyntax m) Participant.counterpart spec roles Output
   | .done, _, _, c => c
   | .node _ _, ⟨.sender, _⟩, _, observe =>
       fun x => do
@@ -477,7 +460,7 @@ end PublicCoinCounterpart
 @[simp]
 theorem Counterpart.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor m]
     {spec : Spec} {roles : RoleDecoration spec} {A : Transcript spec → Type u}
-    (c : Counterpart m spec roles A) :
+    (c : StrategyOver (pairedSyntax m) Participant.counterpart spec roles A) :
     Counterpart.mapOutput (fun _ x => x) c = c := by
   match spec, roles with
   | .done, roles =>
@@ -488,8 +471,10 @@ theorem Counterpart.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunc
       have hid :
           (Counterpart.mapOutput
             (fun (p : Transcript (rest x)) (y : A ⟨x, p⟩) => y) :
-              Counterpart m (rest x) (rRest x) (fun p => A ⟨x, p⟩) →
-                Counterpart m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) =
+              StrategyOver (pairedSyntax m) Participant.counterpart
+                (rest x) (rRest x) (fun p => A ⟨x, p⟩) →
+                StrategyOver (pairedSyntax m) Participant.counterpart
+                  (rest x) (rRest x) (fun p => A ⟨x, p⟩)) =
             id := by
         funext c'
         exact @Counterpart.mapOutput_id m _ _ (rest x) (rRest x) (fun p => A ⟨x, p⟩) c'
@@ -499,8 +484,11 @@ theorem Counterpart.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunc
       rw [hid]
       exact LawfulFunctor.id_map (c x)
   | .node X rest, ⟨.receiver, rRest⟩ =>
-      let F : ((x : X) × Counterpart m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) →
-          ((x : X) × Counterpart m (rest x) (rRest x) (fun p => A ⟨x, p⟩)) :=
+      let F :
+          ((x : X) × StrategyOver (pairedSyntax m) Participant.counterpart
+            (rest x) (rRest x) (fun p => A ⟨x, p⟩)) →
+          ((x : X) × StrategyOver (pairedSyntax m) Participant.counterpart
+            (rest x) (rRest x) (fun p => A ⟨x, p⟩)) :=
         fun xc => ⟨xc.1,
           Counterpart.mapOutput
             (fun (p : Transcript (rest xc.1)) (y : A ⟨xc.1, p⟩) => y) xc.2⟩
@@ -517,16 +505,17 @@ theorem Counterpart.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunc
       rw [hpair]
       exact LawfulFunctor.id_map c
 
-/-- Lift a deterministic counterpart (`Counterpart Id`) into any monad.
+/-- Lift a deterministic counterpart into any monad.
 
 At sender nodes the observational branch structure is unchanged. At receiver
 nodes the chosen move and continuation are simply wrapped in `pure`. This is a
 generic utility for reusing deterministic environments inside monadic execution
-machinery such as `runWithRoles`. -/
+machinery built from `StrategyOver.run`. -/
 def Counterpart.liftId {m : Type u → Type u} [Monad m] :
     {spec : Spec} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
-    Counterpart Id spec roles Output → Counterpart m spec roles Output
+    StrategyOver (pairedSyntax Id) Participant.counterpart spec roles Output →
+      StrategyOver (pairedSyntax m) Participant.counterpart spec roles Output
   | .done, _, _, c => c
   | .node _ _, ⟨.sender, _⟩, _, observe =>
       fun x => pure <| liftId (observe x)
@@ -560,51 +549,58 @@ participant-indexed profile for the generic runner. -/
 def participantProfile
     {m : Type u → Type u} {spec : Spec} {roles : RoleDecoration spec}
     {OutputP OutputC : Transcript spec → Type u}
-    (strat : Strategy.withRoles m spec roles OutputP)
-    (cpt : Counterpart m spec roles OutputC) :
+    (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
+    (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
     (agent : Participant.{u}) →
       StrategyOver (pairedSyntax m) agent spec roles (participantOutputFamily OutputP OutputC agent)
   | .focal => strat
   | .counterpart => cpt
 
-/-- Execute a two-party role-decorated profile.
+/-- Execute a focal/counterpart pair over a role-decorated interaction tree.
 
-This is the generic `StrategyOver.run` specialized to `pairedSyntax`. The focal
-and counterpart strategies are assembled into one participant profile, then the
-runner collects the two participant outputs into a pair at the realized
-transcript. -/
+This is the generic `StrategyOver.run` specialized to `pairedSyntax`, with the
+two participant fibers assembled by `participantProfile` and collected by
+`collectParticipantOutputs`.
+-/
 def Strategy.runWithRoles {m : Type u → Type u} [Monad m]
     (spec : Spec) (roles : RoleDecoration spec)
     {OutputP : Transcript spec → Type u}
     {OutputC : Transcript spec → Type u}
-    (strat : Strategy.withRoles m spec roles OutputP)
-    (cpt : Counterpart m spec roles OutputC) :
+    (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
+    (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
     m ((tr : Transcript spec) × OutputP tr × OutputC tr) :=
   StrategyOver.run (pairedInteraction m) roles (participantProfile strat cpt)
     collectParticipantOutputs
 
 @[simp]
-theorem Strategy.runWithRoles_done {m : Type u → Type u} [Monad m]
+theorem StrategyOver.run_paired_done {m : Type u → Type u} [Monad m]
     {OutputP OutputC : Transcript Spec.done → Type u}
     (outP : OutputP ⟨⟩) (outC : OutputC ⟨⟩) :
-    Strategy.runWithRoles .done PUnit.unit outP outC =
+    StrategyOver.run (pairedInteraction m) (spec := Spec.done) (ctxs := PUnit.unit)
+      (participantProfile outP outC) collectParticipantOutputs =
       (pure ⟨⟨⟩, outP, outC⟩ :
         m ((tr : Transcript Spec.done) × OutputP tr × OutputC tr)) := by
   rfl
 
 @[simp]
-theorem Strategy.runWithRoles_sender {m : Type u → Type u} [Monad m]
+theorem StrategyOver.run_paired_sender {m : Type u → Type u} [Monad m]
     {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
     {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
     (send :
-      m ((x : X) × Strategy.withRoles m (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
-    (dualFn : (x : X) → m (Counterpart m (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
-    Strategy.runWithRoles (Spec.node X rest) ⟨.sender, rRest⟩ send dualFn = (do
+      m ((x : X) × StrategyOver (pairedSyntax m) Participant.focal
+        (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
+    (dualFn : (x : X) → m (StrategyOver (pairedSyntax m) Participant.counterpart
+      (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
+    StrategyOver.run (pairedInteraction m) (spec := Spec.node X rest)
+      (ctxs := ⟨.sender, rRest⟩)
+      (participantProfile send dualFn) collectParticipantOutputs = (do
       let xc ← send
       let dualNext ← dualFn xc.1
-      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) xc.2 dualNext
+      let tailOut ← StrategyOver.run (pairedInteraction m) (spec := rest xc.1)
+        (ctxs := rRest xc.1)
+        (participantProfile xc.2 dualNext) collectParticipantOutputs
       pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
-  simp only [Strategy.runWithRoles, StrategyOver.run, pairedInteraction, pairedSyntax,
+  simp only [StrategyOver.run, pairedInteraction, pairedSyntax,
     participantOutputFamily, participantProfile, collectParticipantOutputs,
     focalRunner, counterpartRunner]
   apply congrArg (fun k => send >>= k)
@@ -614,18 +610,24 @@ theorem Strategy.runWithRoles_sender {m : Type u → Type u} [Monad m]
   rfl
 
 @[simp]
-theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
+theorem StrategyOver.run_paired_receiver {m : Type u → Type u} [Monad m]
     {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
     {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
-    (respond : (x : X) → m (Strategy.withRoles m (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
+    (respond : (x : X) → m (StrategyOver (pairedSyntax m) Participant.focal
+      (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
     (dualSample :
-      m ((x : X) × Counterpart m (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
-    Strategy.runWithRoles (Spec.node X rest) ⟨.receiver, rRest⟩ respond dualSample = (do
+      m ((x : X) × StrategyOver (pairedSyntax m) Participant.counterpart
+        (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
+    StrategyOver.run (pairedInteraction m) (spec := Spec.node X rest)
+      (ctxs := ⟨.receiver, rRest⟩)
+      (participantProfile respond dualSample) collectParticipantOutputs = (do
       let xc ← dualSample
       let next ← respond xc.1
-      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) next xc.2
+      let tailOut ← StrategyOver.run (pairedInteraction m) (spec := rest xc.1)
+        (ctxs := rRest xc.1)
+        (participantProfile next xc.2) collectParticipantOutputs
       pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
-  simp only [Strategy.runWithRoles, StrategyOver.run, pairedInteraction, pairedSyntax,
+  simp only [StrategyOver.run, pairedInteraction, pairedSyntax,
     participantOutputFamily, participantProfile, collectParticipantOutputs,
     focalRunner, counterpartRunner]
   apply congrArg (fun k => dualSample >>= k)
@@ -634,39 +636,44 @@ theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
   funext next
   rfl
 
-/-- Running `runWithRoles` after mapping both participant outputs is the same as
-running first and mapping the final triple. -/
-theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
+/-- Running a paired profile after mapping both participant outputs is the same
+as running first and mapping the final triple. -/
+theorem StrategyOver.run_paired_mapOutputWithRoles_mapOutput
     {m : Type u → Type u} [Monad m] [LawfulMonad m]
     {spec : Spec} {roles : RoleDecoration spec}
     {OutputP OutputP' OutputC OutputC' : Transcript spec → Type u}
     (fP : ∀ tr, OutputP tr → OutputP' tr)
     (fC : ∀ tr, OutputC tr → OutputC' tr)
-    (strat : Strategy.withRoles m spec roles OutputP)
-    (cpt : Counterpart m spec roles OutputC) :
-    Strategy.runWithRoles spec roles (Strategy.mapOutputWithRoles fP strat)
-      (Counterpart.mapOutput fC cpt) =
+    (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
+    (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
+    StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
+      (participantProfile (Strategy.mapOutputWithRoles fP strat) (Counterpart.mapOutput fC cpt))
+      collectParticipantOutputs =
       (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-        Strategy.runWithRoles spec roles strat cpt := by
+        StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
+          (participantProfile strat cpt) collectParticipantOutputs := by
   let rec go
       (spec : Spec) (roles : RoleDecoration spec)
       {OutputP OutputP' OutputC OutputC' : Transcript spec → Type u}
       (fP : ∀ tr, OutputP tr → OutputP' tr)
       (fC : ∀ tr, OutputC tr → OutputC' tr)
-      (strat : Strategy.withRoles m spec roles OutputP)
-      (cpt : Counterpart m spec roles OutputC) :
-      Strategy.runWithRoles spec roles (Strategy.mapOutputWithRoles fP strat)
-        (Counterpart.mapOutput fC cpt) =
+      (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
+      (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
+      StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
+        (participantProfile (Strategy.mapOutputWithRoles fP strat) (Counterpart.mapOutput fC cpt))
+        collectParticipantOutputs =
         (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-          Strategy.runWithRoles spec roles strat cpt := by
+          StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
+            (participantProfile strat cpt) collectParticipantOutputs := by
     match spec, roles with
     | .done, roles =>
         cases roles
-        simp [Strategy.mapOutputWithRoles, Counterpart.mapOutput, Strategy.runWithRoles_done]
+        simp [Strategy.mapOutputWithRoles, Counterpart.mapOutput, StrategyOver.run_paired_done]
     | .node _ rest, ⟨.sender, rRest⟩ =>
         simp only [Strategy.mapOutputWithRoles, Counterpart.mapOutput, Counterpart.mapReceiver,
           Counterpart.mapSender]
-        simp only [runWithRoles_sender, bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
+        simp only [StrategyOver.run_paired_sender, bind_pure_comp, bind_map_left, map_bind,
+          Functor.map_map]
         refine congrArg (fun k => strat >>= k) ?_
         funext xc
         refine congrArg (fun k => cpt xc.1 >>= k) ?_
@@ -684,7 +691,8 @@ theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
         simp only [Strategy.mapOutputWithRoles, Counterpart.mapOutput,
           Counterpart.mapReceiver]
         simp only
-          [runWithRoles_receiver, bind_pure_comp, bind_map_left, map_bind, Functor.map_map]
+          [StrategyOver.run_paired_receiver, bind_pure_comp, bind_map_left, map_bind,
+            Functor.map_map]
         refine congrArg (fun k => cpt >>= k) ?_
         funext xc
         refine congrArg (fun k => strat xc.1 >>= k) ?_
@@ -700,6 +708,63 @@ theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
               next xc.2)
   exact go spec roles fP fC strat cpt
 
+@[simp]
+theorem Strategy.runWithRoles_done {m : Type u → Type u} [Monad m]
+    {OutputP OutputC : Transcript Spec.done → Type u}
+    (outP : OutputP ⟨⟩) (outC : OutputC ⟨⟩) :
+    Strategy.runWithRoles .done PUnit.unit outP outC =
+      (pure ⟨⟨⟩, outP, outC⟩ :
+        m ((tr : Transcript Spec.done) × OutputP tr × OutputC tr)) := by
+  simp [Strategy.runWithRoles]
+
+@[simp]
+theorem Strategy.runWithRoles_sender {m : Type u → Type u} [Monad m]
+    {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
+    {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
+    (send :
+      m ((x : X) × StrategyOver (pairedSyntax m) Participant.focal (rest x) (rRest x)
+        (fun tr => OutputP ⟨x, tr⟩)))
+    (dualFn : (x : X) → m (StrategyOver (pairedSyntax m) Participant.counterpart
+      (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
+    Strategy.runWithRoles (Spec.node X rest) ⟨.sender, rRest⟩ send dualFn = (do
+      let xc ← send
+      let dualNext ← dualFn xc.1
+      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) xc.2 dualNext
+      pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
+  simp [Strategy.runWithRoles, StrategyOver.run_paired_sender]
+
+@[simp]
+theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
+    {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
+    {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
+    (respond : (x : X) → m (StrategyOver (pairedSyntax m) Participant.focal
+      (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
+    (dualSample :
+      m ((x : X) × StrategyOver (pairedSyntax m) Participant.counterpart
+        (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
+    Strategy.runWithRoles (Spec.node X rest) ⟨.receiver, rRest⟩ respond dualSample = (do
+      let xc ← dualSample
+      let next ← respond xc.1
+      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) next xc.2
+      pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
+  simp [Strategy.runWithRoles, StrategyOver.run_paired_receiver]
+
+theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
+    {m : Type u → Type u} [Monad m] [LawfulMonad m]
+    {spec : Spec} {roles : RoleDecoration spec}
+    {OutputP OutputP' OutputC OutputC' : Transcript spec → Type u}
+    (fP : ∀ tr, OutputP tr → OutputP' tr)
+    (fC : ∀ tr, OutputC tr → OutputC' tr)
+    (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
+    (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
+    Strategy.runWithRoles spec roles (Strategy.mapOutputWithRoles fP strat)
+      (Counterpart.mapOutput fC cpt) =
+      (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
+        Strategy.runWithRoles spec roles strat cpt := by
+  simpa [Strategy.runWithRoles] using
+    (StrategyOver.run_paired_mapOutputWithRoles_mapOutput (m := m)
+      fP fC strat cpt)
+
 /--
 View a strategy over a constant monad decoration as an ordinary single-monad
 role strategy.
@@ -710,7 +775,7 @@ def Strategy.constantMonadsToWithRoles {m : Type u → Type u} [Monad m]
     StrategyOver focalMonadicSyntax PUnit.unit spec
       (RoleDecoration.withMonads roles (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
       Output →
-    Strategy.withRoles m spec roles Output :=
+    StrategyOver (pairedSyntax m) Participant.focal spec roles Output :=
   match spec, roles with
   | .done, _ => fun strat => strat
   | .node _ rest, ⟨.sender, rRest⟩ =>
@@ -732,7 +797,7 @@ decoration.
 def Strategy.withRolesToConstantMonads {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
-    Strategy.withRoles m spec roles Output →
+    StrategyOver (pairedSyntax m) Participant.focal spec roles Output →
     StrategyOver focalMonadicSyntax PUnit.unit spec
       (RoleDecoration.withMonads roles (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
       Output :=
@@ -763,7 +828,7 @@ theorem Strategy.withRolesToConstantMonads_mapOutputWithRoles
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output Output' : Spec.Transcript spec → Type u}
     (f : ∀ tr, Output tr → Output' tr)
-    (strat : Strategy.withRoles m spec roles Output) :
+    (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles Output) :
     Strategy.withRolesToConstantMonads spec roles
         (Strategy.mapOutputWithRoles f strat) =
       ShapeOver.mapOutput focalMonadicShape

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -41,25 +41,17 @@ namespace Spec
 
 variable {m : Type u → Type u}
 
-inductive ParticipantBase where
+/-- The two agents in a focused two-party interaction. -/
+inductive Participant : Type u where
   | focal
   | counterpart
   deriving DecidableEq
 
-structure Participant : Type u where
-  tag : ParticipantBase
-  lift : ULift.{u, 0} PUnit := ⟨PUnit.unit⟩
-  deriving DecidableEq
-
-def Participant.focal : Participant := ⟨.focal, ⟨PUnit.unit⟩⟩
-
-def Participant.counterpart : Participant := ⟨.counterpart, ⟨PUnit.unit⟩⟩
-
 private def rolePerspective : Role → Participant → Ownership.Perspective
-  | .sender, ⟨.focal, _⟩ => .owner
-  | .sender, ⟨.counterpart, _⟩ => .observer
-  | .receiver, ⟨.focal, _⟩ => .observer
-  | .receiver, ⟨.counterpart, _⟩ => .owner
+  | .sender, .focal => .owner
+  | .sender, .counterpart => .observer
+  | .receiver, .focal => .observer
+  | .receiver, .counterpart => .owner
 
 private def focalView (m : Type u → Type u) (X : Type u) :
     Ownership.LocalView X where
@@ -100,27 +92,18 @@ private def SyntaxOver.forAgent {Agent : Type u} {Γ : Node.Context}
     SyntaxOver PUnit Γ where
   Node _ X γ Cont := syn.Node agent X γ Cont
 
-private theorem SyntaxOver.family_forAgent {Agent : Type u} {Γ : Node.Context}
+private theorem StrategyOver.forAgent {Agent : Type u} {Γ : Node.Context}
     (syn : SyntaxOver Agent Γ) (agent : Agent) :
     {spec : Spec} → {ctxs : Decoration Γ spec} → {Out : Transcript spec → Type u} →
-    SyntaxOver.Family (syn.forAgent agent) PUnit.unit spec ctxs Out =
-      SyntaxOver.Family syn agent spec ctxs Out
+    StrategyOver (syn.forAgent agent) PUnit.unit spec ctxs Out =
+      StrategyOver syn agent spec ctxs Out
   | .done, _, _ => rfl
   | .node _ next, ⟨γ, ctxs⟩, Out => by
-      simp only [SyntaxOver.Family, SyntaxOver.forAgent]
+      simp only [StrategyOver, SyntaxOver.forAgent]
       congr 1
       funext x
-      exact SyntaxOver.family_forAgent syn agent (spec := next x) (ctxs := ctxs x)
+      exact StrategyOver.forAgent syn agent (spec := next x) (ctxs := ctxs x)
         (Out := fun tr => Out ⟨x, tr⟩)
-
-private theorem SyntaxOver.family_node {Agent : Type u} {Γ : Node.Context}
-    (syn : SyntaxOver Agent Γ)
-    {agent : Agent} {X : Type u} {next : X → Spec}
-    {γ : Γ X} {ctxs : (x : X) → Decoration Γ (next x)}
-    {Out : Transcript (Spec.node X next) → Type u} :
-    SyntaxOver.Family syn agent (Spec.node X next) ⟨γ, ctxs⟩ Out =
-      syn.Node agent X γ (fun x =>
-        SyntaxOver.Family syn agent (next x) (ctxs x) (fun tr => Out ⟨x, tr⟩)) := rfl
 
 private def counterpartFamilySyntax
     (Sender Receiver : (X : Type u) → (X → Type u) → Type u) :
@@ -133,7 +116,7 @@ private def counterpartFamilySyntax
 def pairedSyntax (m : Type u → Type u) :
     SyntaxOver.{u, u, u, 0} Participant (fun _ => Role) where
   Node agent X role Cont :=
-    match agent.tag, role with
+    match agent, role with
     | .focal, .sender => m ((x : X) × Cont x)
     | .focal, .receiver => (x : X) → m (Cont x)
     | .counterpart, .sender => (x : X) → m (Cont x)
@@ -142,14 +125,12 @@ def pairedSyntax (m : Type u → Type u) :
 private theorem pairedSyntax_eq_ownerBased (m : Type u → Type u) :
     pairedSyntax m =
       Ownership.syntaxOver (fun role agent => rolePerspective role agent) (fun {X} _role agent =>
-        match agent.tag with
+        match agent with
         | .focal => focalView m X
         | .counterpart => counterpartView m X) := by
   apply congrArg SyntaxOver.mk
   funext agent X role Cont
-  cases agent with
-  | mk tag lift =>
-      cases tag <;> cases role <;>
+  cases agent <;> cases role <;>
         simp [Ownership.LocalView.node, rolePerspective, focalView, counterpartView]
 
 private def pairedInteraction (m : Type u → Type u) [Monad m] :
@@ -166,8 +147,8 @@ private def pairedInteraction (m : Type u → Type u) [Monad m] :
         let ⟨x, pCont⟩ ← (focalRunner m X).runOwn pNode
         let cCont ← (counterpartRunner m X).runOther cNode x
         k x (fun
-          | ⟨.focal, _⟩ => pCont
-          | ⟨.counterpart, _⟩ => cCont)
+          | .focal => pCont
+          | .counterpart => cCont)
     | .receiver => do
         let pNode : (x : X) → m (Cont Participant.focal x) := by
           simpa [pairedSyntax, Ownership.syntaxOver, rolePerspective, Participant.focal,
@@ -178,8 +159,8 @@ private def pairedInteraction (m : Type u → Type u) [Monad m] :
         let ⟨x, cCont⟩ ← (counterpartRunner m X).runOwn cNode
         let pCont ← (focalRunner m X).runOther pNode x
         k x (fun
-          | ⟨.focal, _⟩ => pCont
-          | ⟨.counterpart, _⟩ => cCont)
+          | .focal => pCont
+          | .counterpart => cCont)
 
 private def strategyMonadicSyntax :
     SyntaxOver.{u, 0, u, u + 1} PUnit RoleMonadContext where
@@ -213,7 +194,7 @@ private def counterpartMonadicShape :
 def pairedMonadicSyntax :
     SyntaxOver.{u, u, u, u + 1} Participant RolePairedMonadContext where
   Node agent X γ Cont :=
-    match agent.tag, γ with
+    match agent, γ with
     | .focal, ⟨.sender, ⟨bmP, _⟩⟩ => bmP.M ((x : X) × Cont x)
     | .focal, ⟨.receiver, ⟨bmP, _⟩⟩ => (x : X) → bmP.M (Cont x)
     | .counterpart, ⟨.sender, ⟨_, bmC⟩⟩ => (x : X) → bmC.M (Cont x)
@@ -222,14 +203,12 @@ def pairedMonadicSyntax :
 private theorem pairedMonadicSyntax_eq_ownerBased :
     pairedMonadicSyntax =
       Ownership.syntaxOver (fun γ agent => rolePerspective γ.1 agent) (fun {X} γ agent =>
-        match agent.tag, γ with
+        match agent, γ with
         | .focal, ⟨_, ⟨bmP, _⟩⟩ => focalMonadicView bmP X
         | .counterpart, ⟨_, ⟨_, bmC⟩⟩ => counterpartMonadicView bmC X) := by
   apply congrArg SyntaxOver.mk
   funext agent X γ Cont
-  cases agent with
-  | mk tag lift =>
-      cases tag <;> cases γ with
+  cases agent <;> cases γ with
       | mk role bms =>
           cases role <;>
             simp [Ownership.LocalView.node, rolePerspective, focalMonadicView,
@@ -239,7 +218,7 @@ private theorem pairedMonadicSyntax_eq_ownerBased :
 /-- Focal strategy: `Role.Action` at each decorated node (choose vs. respond). -/
 abbrev Strategy.withRoles (m : Type u → Type u)
     (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  SyntaxOver.Family (pairedSyntax m) Participant.focal spec roles Output
+  StrategyOver (pairedSyntax m) Participant.focal spec roles Output
 
 @[simp]
 theorem Strategy.withRoles_done {m : Type u → Type u} {Output : PUnit → Type u} :
@@ -271,7 +250,7 @@ specializations of this single recursion. -/
 abbrev CounterpartFamily
     (Sender Receiver : (X : Type u) → (X → Type u) → Type u)
     (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  SyntaxOver.Family (counterpartFamilySyntax Sender Receiver) PUnit.unit spec roles Output
+  StrategyOver (counterpartFamilySyntax Sender Receiver) PUnit.unit spec roles Output
 
 /-- Functorial output map for a generic counterpart family. -/
 private def counterpartFamilyShape
@@ -312,12 +291,14 @@ def CounterpartFamily.mapOutput
       (agent := PUnit.unit) (spec := spec) roles
       (A := A) (B := B) f
 
-/-- Counterpart / environment type with transcript-dependent output: dual actions at
-each node, producing `Output ⟨⟩` at `.done`. For a no-output counterpart (the old
-behavior), use `Counterpart m spec roles (fun _ => PUnit)`. -/
+/-- Counterpart / environment type with transcript-dependent output: dual
+actions at each node, producing `Output ⟨⟩` at `.done`.
+
+For a counterpart that carries no final data, take
+`Output := fun _ => PUnit`. -/
 abbrev Counterpart (m : Type u → Type u)
     (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  SyntaxOver.Family (pairedSyntax m) Participant.counterpart spec roles Output
+  StrategyOver (pairedSyntax m) Participant.counterpart spec roles Output
 
 /-- Map a receiver-family output through a sender-owned sampled move. -/
 def Counterpart.mapReceiver {m : Type u → Type u} [Functor m] :
@@ -521,47 +502,55 @@ def Counterpart.liftId {m : Type u → Type u} [Monad m] :
   | .node _ _, ⟨.receiver, _⟩, _, ⟨x, c⟩ =>
       pure ⟨x, liftId c⟩
 
-private def Strategy.runWithRolesAux {m : Type u → Type u} [Monad m]
+/-- The participant-indexed output family for a two-party run.
+
+The focal participant carries `OutputP`, while the counterpart carries
+`OutputC`. Naming this family gives the runner, profiles, and computation
+rules a single canonical shape for participant outputs, which keeps dependent
+function arguments definitionally aligned. -/
+def participantOutputFamily
+    {spec : Spec} (OutputP OutputC : Transcript spec → Type u)
+    (agent : Participant) (tr : Transcript spec) : Type u :=
+  match agent with
+  | .focal => OutputP tr
+  | .counterpart => OutputC tr
+
+/-- Collect the two participant-indexed outputs into the result pair of a
+two-party run. -/
+def collectParticipantOutputs
+    {spec : Spec} {OutputP OutputC : Transcript spec → Type u} :
+    (tr : Transcript spec) →
+      ((agent : Participant) → participantOutputFamily OutputP OutputC agent tr) →
+      OutputP tr × OutputC tr :=
+  fun _ out => (out Participant.focal, out Participant.counterpart)
+
+/-- Assemble the focal strategy and counterpart strategy into a
+participant-indexed profile for the generic runner. -/
+def participantProfile
+    {m : Type u → Type u} {spec : Spec} {roles : RoleDecoration spec}
+    {OutputP OutputC : Transcript spec → Type u}
+    (strat : Strategy.withRoles m spec roles OutputP)
+    (cpt : Counterpart m spec roles OutputC) :
+    (agent : Participant) →
+      StrategyOver (pairedSyntax m) agent spec roles (participantOutputFamily OutputP OutputC agent)
+  | .focal => strat
+  | .counterpart => cpt
+
+/-- Execute a two-party role-decorated profile.
+
+This is the generic `StrategyOver.run` specialized to `pairedSyntax`. The focal
+and counterpart strategies are assembled into one participant profile, then the
+runner collects the two participant outputs into a pair at the realized
+transcript. -/
+def Strategy.runWithRoles {m : Type u → Type u} [Monad m]
     (spec : Spec) (roles : RoleDecoration spec)
-    (OutputP : Transcript spec → Type u)
-    (OutputC : Transcript spec → Type u)
+    {OutputP : Transcript spec → Type u}
+    {OutputC : Transcript spec → Type u}
     (strat : Strategy.withRoles m spec roles OutputP)
     (cpt : Counterpart m spec roles OutputC) :
     m ((tr : Transcript spec) × OutputP tr × OutputC tr) :=
-  match spec, roles with
-  | .done, _ => pure ⟨⟨⟩, strat, cpt⟩
-  | .node _ rest, ⟨role, rRest⟩ =>
-      (pairedInteraction m).interact (γ := role)
-        (Cont := fun agent x =>
-          match agent.tag with
-          | .focal =>
-              Strategy.withRoles m (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)
-          | .counterpart =>
-              Counterpart m (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))
-        (fun
-          | ⟨.focal, _⟩ => strat
-          | ⟨.counterpart, _⟩ => cpt)
-        (fun x conts => do
-          let ⟨tail, outP, outC⟩ ←
-            Strategy.runWithRolesAux
-              (rest x) (rRest x)
-              (fun tr => OutputP ⟨x, tr⟩)
-              (fun tr => OutputC ⟨x, tr⟩)
-              (conts Participant.focal)
-              (conts Participant.counterpart)
-          pure ⟨⟨x, tail⟩, outP, outC⟩)
-
-/-- Execute `withRoles` against a `Counterpart`, producing transcript, prover output,
-and counterpart output. -/
-def Strategy.runWithRoles {m : Type u → Type u} [Monad m] :
-    (spec : Spec) → (roles : RoleDecoration spec) →
-    {OutputP : Transcript spec → Type u} →
-    {OutputC : Transcript spec → Type u} →
-    Strategy.withRoles m spec roles OutputP →
-    Counterpart m spec roles OutputC →
-    m ((tr : Transcript spec) × OutputP tr × OutputC tr)
-  | spec, roles, OutputP, OutputC, strat, cpt =>
-      Strategy.runWithRolesAux spec roles OutputP OutputC strat cpt
+  StrategyOver.run (pairedInteraction m) roles (participantProfile strat cpt)
+    collectParticipantOutputs
 
 @[simp]
 theorem Strategy.runWithRoles_done {m : Type u → Type u} [Monad m]
@@ -580,12 +569,18 @@ theorem Strategy.runWithRoles_sender {m : Type u → Type u} [Monad m]
       m ((x : X) × Strategy.withRoles m (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
     (dualFn : (x : X) → m (Counterpart m (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
     Strategy.runWithRoles (Spec.node X rest) ⟨.sender, rRest⟩ send dualFn = (do
-      let ⟨x, next⟩ ← send
-      let dualNext ← dualFn x
-      let ⟨tail, outP, outC⟩ ← Strategy.runWithRoles (rest x) (rRest x) next dualNext
-      pure ⟨⟨x, tail⟩, outP, outC⟩) := by
-  simp [Strategy.runWithRoles, Strategy.runWithRolesAux, pairedInteraction,
-    Participant.focal, Participant.counterpart, pairedSyntax, focalRunner, counterpartRunner]
+      let xc ← send
+      let dualNext ← dualFn xc.1
+      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) xc.2 dualNext
+      pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
+  simp only [Strategy.runWithRoles, StrategyOver.run, pairedInteraction, pairedSyntax,
+    participantOutputFamily, participantProfile, collectParticipantOutputs,
+    focalRunner, counterpartRunner]
+  apply congrArg (fun k => send >>= k)
+  funext xc
+  apply congrArg (fun k => dualFn xc.1 >>= k)
+  funext dualNext
+  rfl
 
 @[simp]
 theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
@@ -595,12 +590,18 @@ theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
     (dualSample :
       m ((x : X) × Counterpart m (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
     Strategy.runWithRoles (Spec.node X rest) ⟨.receiver, rRest⟩ respond dualSample = (do
-      let ⟨x, dualRest⟩ ← dualSample
-      let next ← respond x
-      let ⟨tail, outP, outC⟩ ← Strategy.runWithRoles (rest x) (rRest x) next dualRest
-      pure ⟨⟨x, tail⟩, outP, outC⟩) := by
-  simp [Strategy.runWithRoles, Strategy.runWithRolesAux, pairedInteraction,
-    Participant.focal, Participant.counterpart, focalRunner, counterpartRunner]
+      let xc ← dualSample
+      let next ← respond xc.1
+      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) next xc.2
+      pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
+  simp only [Strategy.runWithRoles, StrategyOver.run, pairedInteraction, pairedSyntax,
+    participantOutputFamily, participantProfile, collectParticipantOutputs,
+    focalRunner, counterpartRunner]
+  apply congrArg (fun k => dualSample >>= k)
+  funext xc
+  apply congrArg (fun k => respond xc.1 >>= k)
+  funext next
+  rfl
 
 /-- Running `runWithRoles` after mapping both participant outputs is the same as
 running first and mapping the final triple. -/
@@ -673,7 +674,7 @@ See `Counterpart.withMonads` for the dual. -/
 abbrev Strategy.withRolesAndMonads
     (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
     (Output : Transcript spec → Type u) :=
-  SyntaxOver.Family strategyMonadicSyntax PUnit.unit spec
+  StrategyOver strategyMonadicSyntax PUnit.unit spec
     (RoleDecoration.withMonads roles md) Output
 
 /-- Counterpart with per-node monads and transcript-dependent output.
@@ -688,7 +689,7 @@ At sender nodes the monad is `Id` (pure observation); at receiver nodes it is
 abbrev Counterpart.withMonads
     (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
     (Output : Transcript spec → Type u) :=
-  SyntaxOver.Family counterpartMonadicSyntax PUnit.unit spec
+  StrategyOver counterpartMonadicSyntax PUnit.unit spec
     (RoleDecoration.withMonads roles md) Output
 
 /-- Map the transcript-indexed output of a monadic counterpart. This is the
@@ -744,7 +745,7 @@ private theorem pairedMonadicSyntax_forAgent_focal :
   cases γ with
   | mk role bms =>
       cases role <;> cases bms <;>
-        simp [Participant.focal, pairedMonadicSyntax, strategyMonadicSyntax,
+        simp [pairedMonadicSyntax, strategyMonadicSyntax,
           RolePairedMonadContext.fst, Spec.Node.Context.extendMap,
           Spec.Node.ContextHom.id, Role.Action]
 
@@ -756,23 +757,23 @@ private theorem pairedMonadicSyntax_forAgent_counterpart :
   cases γ with
   | mk role bms =>
       cases role <;> cases bms <;>
-        simp [Participant.counterpart, pairedMonadicSyntax, counterpartMonadicSyntax,
+        simp [pairedMonadicSyntax, counterpartMonadicSyntax,
           RolePairedMonadContext.snd, Spec.Node.Context.extendMap, Spec.Node.ContextHom.id]
 
-private theorem pairedMonadicSyntax_family_focal :
+private theorem pairedMonadicStrategy_focal :
     {spec : Spec} → {roles : RoleDecoration spec} →
     {stratDeco cptDeco : MonadDecoration spec} →
     {Output : Transcript spec → Type u} →
-    SyntaxOver.Family pairedMonadicSyntax Participant.focal spec
+    StrategyOver pairedMonadicSyntax Participant.focal spec
       (RoleDecoration.withPairedMonads roles stratDeco cptDeco) Output =
       Strategy.withRolesAndMonads spec roles stratDeco Output
   | spec, roles, stratDeco, cptDeco, Output => by
-      rw [← SyntaxOver.family_forAgent pairedMonadicSyntax Participant.focal
+      rw [← StrategyOver.forAgent pairedMonadicSyntax Participant.focal
         (spec := spec)
         (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
         (Out := Output)]
       rw [pairedMonadicSyntax_forAgent_focal]
-      rw [SyntaxOver.family_comap strategyMonadicSyntax RolePairedMonadContext.fst
+      rw [StrategyOver.comap strategyMonadicSyntax RolePairedMonadContext.fst
         (agent := PUnit.unit)
         (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
         (Out := Output)]
@@ -780,20 +781,20 @@ private theorem pairedMonadicSyntax_family_focal :
         (spec := spec) (roles := roles)
         (stratDeco := stratDeco) (cptDeco := cptDeco)]
 
-private theorem pairedMonadicSyntax_family_counterpart :
+private theorem pairedMonadicStrategy_counterpart :
     {spec : Spec} → {roles : RoleDecoration spec} →
     {stratDeco cptDeco : MonadDecoration spec} →
     {Output : Transcript spec → Type u} →
-    SyntaxOver.Family pairedMonadicSyntax Participant.counterpart spec
+    StrategyOver pairedMonadicSyntax Participant.counterpart spec
       (RoleDecoration.withPairedMonads roles stratDeco cptDeco) Output =
       Counterpart.withMonads spec roles cptDeco Output
   | spec, roles, stratDeco, cptDeco, Output => by
-      rw [← SyntaxOver.family_forAgent pairedMonadicSyntax Participant.counterpart
+      rw [← StrategyOver.forAgent pairedMonadicSyntax Participant.counterpart
         (spec := spec)
         (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
         (Out := Output)]
       rw [pairedMonadicSyntax_forAgent_counterpart]
-      rw [SyntaxOver.family_comap counterpartMonadicSyntax RolePairedMonadContext.snd
+      rw [StrategyOver.comap counterpartMonadicSyntax RolePairedMonadContext.snd
         (agent := PUnit.unit)
         (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
         (Out := Output)]
@@ -801,30 +802,34 @@ private theorem pairedMonadicSyntax_family_counterpart :
         (spec := spec) (roles := roles)
         (stratDeco := stratDeco) (cptDeco := cptDeco)]
 
-private def pairedMonadicProfile {spec : Spec} {roles : RoleDecoration spec}
+/-- Assemble a focal monadic strategy and counterpart monadic strategy into a
+participant-indexed profile for the paired monadic runner. -/
+def monadicParticipantProfile {spec : Spec} {roles : RoleDecoration spec}
     {stratDeco cptDeco : MonadDecoration spec}
     {OutputP OutputC : Transcript spec → Type u}
     (strat : Strategy.withRolesAndMonads spec roles stratDeco OutputP)
     (cpt : Counterpart.withMonads spec roles cptDeco OutputC) :
     (agent : Participant) →
-      SyntaxOver.Family pairedMonadicSyntax agent spec
+      StrategyOver pairedMonadicSyntax agent spec
         (RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-        (match agent.tag with
-          | .focal => OutputP
-          | .counterpart => OutputC)
-  | ⟨.focal, _⟩ => by
+        (participantOutputFamily OutputP OutputC agent)
+  | .focal => by
       exact cast
-        (pairedMonadicSyntax_family_focal (spec := spec) (roles := roles)
+        (pairedMonadicStrategy_focal (spec := spec) (roles := roles)
           (stratDeco := stratDeco) (cptDeco := cptDeco) (Output := OutputP)).symm
         strat
-  | ⟨.counterpart, _⟩ => by
+  | .counterpart => by
       exact cast
-        (pairedMonadicSyntax_family_counterpart (spec := spec) (roles := roles)
+        (pairedMonadicStrategy_counterpart (spec := spec) (roles := roles)
           (stratDeco := stratDeco) (cptDeco := cptDeco) (Output := OutputC)).symm
         cpt
 
-/-- Run `withRolesAndMonads` vs. `Counterpart.withMonads`, lifting both sides into
-one monad `m`. Returns transcript, prover output, and counterpart output. -/
+/-- One-step execution law for paired monadic two-party profiles.
+
+At each node, the participant that owns the move runs in its decorated monad.
+The supplied lifts embed the focal and counterpart node monads into the common
+execution monad `m`; the resulting continuations are then passed to the generic
+tree runner. -/
 private def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
     (liftStrat : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
     (liftCpt : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
@@ -841,136 +846,35 @@ private def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
         let ⟨x, pCont⟩ ← liftStrat bmP pNode
         let cCont ← liftCpt bmC (cNode x)
         k x (fun
-          | ⟨.focal, _⟩ => pCont
-          | ⟨.counterpart, _⟩ => cCont)
+          | .focal => pCont
+          | .counterpart => cCont)
     | ⟨.receiver, ⟨bmP, bmC⟩⟩ => do
         let ⟨x, cCont⟩ ← liftCpt bmC (profile Participant.counterpart)
         let pCont ← liftStrat bmP ((profile Participant.focal) x)
         k x (fun
-          | ⟨.focal, _⟩ => pCont
-          | ⟨.counterpart, _⟩ => cCont)
+          | .focal => pCont
+          | .counterpart => cCont)
 
-private def Strategy.runWithRolesAndMonadsAux {m : Type u → Type u} [Monad m]
+/-- Execute a focal monadic strategy against a monadic counterpart.
+
+This is the generic `StrategyOver.run` specialized to `pairedMonadicSyntax`.
+`liftStrat` and `liftCpt` embed the per-node monads for the focal strategy and
+the counterpart into the common execution monad `m`; the result contains the
+realized transcript and both participant outputs at that transcript. -/
+def Strategy.runWithRolesAndMonads {m : Type u → Type u} [Monad m]
     (liftStrat : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
     (liftCpt : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     (stratDeco : MonadDecoration spec) (cptDeco : MonadDecoration spec)
-    (OutputP : Transcript spec → Type u)
-    (OutputC : Transcript spec → Type u)
+    {OutputP : Transcript spec → Type u}
+    {OutputC : Transcript spec → Type u}
     (strat : Strategy.withRolesAndMonads spec roles stratDeco OutputP)
     (cpt : Counterpart.withMonads spec roles cptDeco OutputC) :
     m ((tr : Transcript spec) × OutputP tr × OutputC tr) :=
-  match spec, roles, stratDeco, cptDeco with
-  | .done, _, _, _ => pure ⟨⟨⟩, strat, cpt⟩
-  | .node _ rest, ⟨role, rRest⟩, ⟨bmP, mRestS⟩, ⟨bmC, mRestC⟩ =>
-      (pairedMonadicInteraction liftStrat liftCpt).interact
-        (γ := ⟨role, (bmP, bmC)⟩)
-        (Cont := fun agent x =>
-          match agent.tag with
-          | .focal =>
-              SyntaxOver.Family pairedMonadicSyntax Participant.focal (rest x)
-                (RoleDecoration.withPairedMonads (rRest x) (mRestS x) (mRestC x))
-                (fun tr => OutputP ⟨x, tr⟩)
-          | .counterpart =>
-              SyntaxOver.Family pairedMonadicSyntax Participant.counterpart (rest x)
-                (RoleDecoration.withPairedMonads (rRest x) (mRestS x) (mRestC x))
-                (fun tr => OutputC ⟨x, tr⟩))
-        (fun
-          | ⟨.focal, _⟩ => by
-              have h :
-                  pairedMonadicSyntax.Family Participant.focal (.node _ rest)
-                    (RoleDecoration.withPairedMonads ⟨role, rRest⟩ ⟨bmP, mRestS⟩ ⟨bmC, mRestC⟩)
-                    OutputP :=
-                pairedMonadicProfile
-                  (spec := .node _ rest) (roles := ⟨role, rRest⟩)
-                  (stratDeco := ⟨bmP, mRestS⟩) (cptDeco := ⟨bmC, mRestC⟩)
-                  (OutputP := OutputP) (OutputC := OutputC)
-                  strat cpt Participant.focal
-              have hFamily :
-                  pairedMonadicSyntax.Family Participant.focal (.node _ rest)
-                    (RoleDecoration.withPairedMonads ⟨role, rRest⟩ ⟨bmP, mRestS⟩ ⟨bmC, mRestC⟩)
-                    OutputP =
-                  pairedMonadicSyntax.Node Participant.focal _ ⟨role, (bmP, bmC)⟩
-                    (fun x =>
-                      pairedMonadicSyntax.Family Participant.focal (rest x)
-                        (RoleDecoration.withPairedMonads (rRest x) (mRestS x) (mRestC x))
-                        (fun tr => OutputP ⟨x, tr⟩)) := by
-                simpa [RoleDecoration.withPairedMonads, RoleDecoration.pairedMonadsOver] using
-                  (SyntaxOver.family_node pairedMonadicSyntax
-                    (agent := Participant.focal)
-                    (γ := ⟨role, (bmP, bmC)⟩)
-                    (ctxs := fun x => RoleDecoration.withPairedMonads
-                      (rRest x) (mRestS x) (mRestC x))
-                    (Out := OutputP))
-              exact cast hFamily.symm h
-          | ⟨.counterpart, _⟩ => by
-              have h :
-                  pairedMonadicSyntax.Family Participant.counterpart (.node _ rest)
-                    (RoleDecoration.withPairedMonads ⟨role, rRest⟩ ⟨bmP, mRestS⟩ ⟨bmC, mRestC⟩)
-                    OutputC :=
-                pairedMonadicProfile
-                  (spec := .node _ rest) (roles := ⟨role, rRest⟩)
-                  (stratDeco := ⟨bmP, mRestS⟩) (cptDeco := ⟨bmC, mRestC⟩)
-                  (OutputP := OutputP) (OutputC := OutputC)
-                  strat cpt Participant.counterpart
-              have hFamily :
-                  pairedMonadicSyntax.Family Participant.counterpart (.node _ rest)
-                    (RoleDecoration.withPairedMonads ⟨role, rRest⟩ ⟨bmP, mRestS⟩ ⟨bmC, mRestC⟩)
-                    OutputC =
-                  pairedMonadicSyntax.Node Participant.counterpart _ ⟨role, (bmP, bmC)⟩
-                    (fun x =>
-                      pairedMonadicSyntax.Family Participant.counterpart (rest x)
-                        (RoleDecoration.withPairedMonads (rRest x) (mRestS x) (mRestC x))
-                        (fun tr => OutputC ⟨x, tr⟩)) := by
-                simpa [RoleDecoration.withPairedMonads, RoleDecoration.pairedMonadsOver] using
-                  (SyntaxOver.family_node pairedMonadicSyntax
-                    (agent := Participant.counterpart)
-                    (γ := ⟨role, (bmP, bmC)⟩)
-                    (ctxs := fun x => RoleDecoration.withPairedMonads
-                      (rRest x) (mRestS x) (mRestC x))
-                    (Out := OutputC))
-              exact cast hFamily.symm h)
-        (fun x conts => do
-          let strat' :
-              Strategy.withRolesAndMonads (rest x) (rRest x) (mRestS x)
-                (fun tr => OutputP ⟨x, tr⟩) :=
-            cast
-              (pairedMonadicSyntax_family_focal
-                (spec := rest x) (roles := rRest x)
-                (stratDeco := mRestS x) (cptDeco := mRestC x)
-                (Output := fun tr => OutputP ⟨x, tr⟩))
-              (conts Participant.focal)
-          let cpt' :
-              Counterpart.withMonads (rest x) (rRest x) (mRestC x)
-                (fun tr => OutputC ⟨x, tr⟩) :=
-            cast
-              (pairedMonadicSyntax_family_counterpart
-                (spec := rest x) (roles := rRest x)
-                (stratDeco := mRestS x) (cptDeco := mRestC x)
-                (Output := fun tr => OutputC ⟨x, tr⟩))
-              (conts Participant.counterpart)
-          let ⟨tail, outP, outC⟩ ←
-            Strategy.runWithRolesAndMonadsAux
-              liftStrat liftCpt
-              (rest x) (rRest x) (mRestS x) (mRestC x)
-              (fun tr => OutputP ⟨x, tr⟩)
-              (fun tr => OutputC ⟨x, tr⟩)
-              strat' cpt'
-          pure ⟨⟨x, tail⟩, outP, outC⟩)
-
-def Strategy.runWithRolesAndMonads {m : Type u → Type u} [Monad m]
-    (liftStrat : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
-    (liftCpt : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
-    (spec : Spec.{u}) → (roles : RoleDecoration spec) →
-    (stratDeco : MonadDecoration spec) → (cptDeco : MonadDecoration spec) →
-    {OutputP : Transcript spec → Type u} →
-    {OutputC : Transcript spec → Type u} →
-    Strategy.withRolesAndMonads spec roles stratDeco OutputP →
-    Counterpart.withMonads spec roles cptDeco OutputC →
-    m ((tr : Transcript spec) × OutputP tr × OutputC tr)
-  | spec, roles, stratDeco, cptDeco, OutputP, OutputC, strat, cpt =>
-      Strategy.runWithRolesAndMonadsAux
-        liftStrat liftCpt spec roles stratDeco cptDeco OutputP OutputC strat cpt
+  StrategyOver.run (pairedMonadicInteraction liftStrat liftCpt)
+    (RoleDecoration.withPairedMonads roles stratDeco cptDeco)
+    (monadicParticipantProfile strat cpt)
+    collectParticipantOutputs
 
 end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -836,19 +836,6 @@ def Strategy.mapMonadDecoration
           (mapMonadDecoration (rest x) (rRest x) (homRest x)) (strat x)
 
 /--
-Counterpart strategy whose node effects are supplied by a `MonadDecoration`.
-
-At sender-owned nodes the counterpart observes the focal move and continues in
-the decorated node monad. At receiver-owned nodes it samples its own move and
-continuation in the decorated node monad.
--/
-abbrev Counterpart.withMonads
-    (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
-    (Output : Transcript spec → Type u) :=
-  StrategyOver counterpartMonadicSyntax PUnit.unit spec
-    (RoleDecoration.withMonads roles md) Output
-
-/--
 Retarget a monadic counterpart along a nodewise monad homomorphism.
 
 This traverses the counterpart tree structurally, applying the supplied lift at
@@ -859,8 +846,10 @@ def Counterpart.mapMonadDecoration
     {md₁ md₂ : MonadDecoration spec}
     (hom : MonadDecoration.Hom spec md₁ md₂)
     {Output : Spec.Transcript spec → Type u} :
-    Counterpart.withMonads spec roles md₁ Output →
-    Counterpart.withMonads spec roles md₂ Output :=
+    StrategyOver counterpartMonadicSyntax PUnit.unit spec
+      (RoleDecoration.withMonads roles md₁) Output →
+    StrategyOver counterpartMonadicSyntax PUnit.unit spec
+      (RoleDecoration.withMonads roles md₂) Output :=
   match spec, roles, md₁, md₂, hom with
   | .done, _, _, _, _ => fun cpt => cpt
   | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -15,23 +15,25 @@ import VCVio.Interaction.Basic.Shape
 /-!
 # Role-dependent strategies and counterparts
 
-`Spec.Strategy.withRoles` is the prover / focal party: owned nodes are
-effectful move/continuation packages, while non-owned nodes respond to the
-other party's move. `Spec.Counterpart` is the dual type. `withRolesAndMonads` and
-`runWithRolesAndMonads` extend this with per-node `BundledMonad` data from
-`MonadDecoration`.
+Two-party strategies are `StrategyOver` specializations over role-decorated
+interaction trees. `Spec.Strategy.withRoles` is the focal participant: owned
+nodes are effectful move/continuation packages, while non-owned nodes respond
+to the counterpart's move. `Spec.Counterpart` is the dual participant view.
 
-This module also contains the public-coin specialization needed for
-verifier-side Fiat-Shamir. The ordinary `Counterpart` type is the right shape
-for execution, but at receiver nodes it hides the continuation behind an
-opaque monadic sample. `Spec.PublicCoinCounterpart` refines that node shape to
-expose:
+The monadic variants add a `MonadDecoration`, so each node can use the effect
+recorded in the decoration instead of one ambient monad. The same role
+decoration still determines which participant owns each move.
+
+This module also contains a public-coin counterpart syntax. An executable
+counterpart samples a receiver move together with its continuation as one
+opaque action; `Spec.PublicCoinCounterpart` exposes the sampler and
+challenge-indexed continuation separately:
 
 - `sample : m X` — how the next public challenge is chosen
 - `next : (x : X) → ...` — how the rest of the verifier depends on that challenge
 
-This makes transcript replay definable without changing the core two-party
-interaction model.
+This is the structure needed for replay against a prescribed public transcript
+while keeping execution itself in the ordinary two-party model.
 -/
 
 universe u
@@ -774,15 +776,13 @@ def Strategy.withRolesAndMonads.ofWithRolesConstant {m : Type u → Type u} [Mon
       fun strat x =>
         Functor.map (ofWithRolesConstant (rest x) (rRest x)) (strat x)
 
-/-- Counterpart with per-node monads and transcript-dependent output.
+/--
+Counterpart strategy whose node effects are supplied by a `MonadDecoration`.
 
-This is the primary type for oracle verifiers: `OracleCounterpart` (in
-`Oracle/Core.lean`) is defined as `Counterpart.withMonads` with a
-`MonadDecoration` computed from the oracle decoration via `toMonadDecoration`.
-At sender nodes the monad is `Id` (pure observation); at receiver nodes it is
-`OracleComp` with the accumulated oracle access. All generic
-`Counterpart.withMonads` composition combinators (e.g., `withMonads.append`,
-`withMonads.stateChainComp`) therefore apply directly to oracle counterparts. -/
+At sender-owned nodes the counterpart observes the focal move and continues in
+the decorated node monad. At receiver-owned nodes it samples its own move and
+continuation in the decorated node monad.
+-/
 abbrev Counterpart.withMonads
     (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
     (Output : Transcript spec → Type u) :=

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -717,34 +717,6 @@ abbrev Strategy.withRolesAndMonads
     (RoleDecoration.withMonads roles md) Output
 
 /--
-Retarget a monadic role strategy along a nodewise monad homomorphism.
-
-The protocol tree and output family stay fixed; only the node effects are
-lifted from the source monad decoration to the target decoration.
--/
-def Strategy.withRolesAndMonads.mapDecoration
-    (spec : Spec.{u}) (roles : RoleDecoration spec)
-    {md₁ md₂ : MonadDecoration spec}
-    (hom : MonadDecoration.Hom spec md₁ md₂)
-    {Output : Spec.Transcript spec → Type u} :
-    Strategy.withRolesAndMonads spec roles md₁ Output →
-    Strategy.withRolesAndMonads spec roles md₂ Output :=
-  match spec, roles, md₁, md₂, hom with
-  | .done, _, _, _, _ => fun strat => strat
-  | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
-      fun strat =>
-        lift <| Functor.map
-          (fun msgAndRest =>
-            ⟨msgAndRest.1,
-              mapDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
-                (homRest msgAndRest.1) msgAndRest.2⟩)
-          strat
-  | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
-      fun strat x =>
-        lift <| Functor.map
-          (mapDecoration (rest x) (rRest x) (homRest x)) (strat x)
-
-/--
 View a strategy over a constant monad decoration as an ordinary single-monad
 role strategy.
 -/

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -263,14 +263,8 @@ receiver-side node representations.
 
 Sender nodes model how the environment follows a move chosen by the focal
 party. Receiver nodes model how the environment chooses a move itself. Both
-ordinary `Counterpart` and replayable `PublicCoinCounterpart` are
-specializations of this single recursion. -/
-abbrev CounterpartFamily
-    (Sender Receiver : (X : Type u) → (X → Type u) → Type u)
-    (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
-  StrategyOver (counterpartFamilySyntax Sender Receiver) PUnit.unit spec roles Output
-
-/-- Functorial output map for a generic counterpart family. -/
+ordinary `Counterpart` and replayable public-coin syntax are both direct
+`StrategyOver` specializations. -/
 private def counterpartFamilyShape
     (Sender : (X : Type u) → (X → Type u) → Type u)
     (Receiver : (X : Type u) → (X → Type u) → Type u)
@@ -288,26 +282,6 @@ private def counterpartFamilyShape
         mapSender f node
     | .receiver =>
         mapReceiver f node
-
-def CounterpartFamily.mapOutput
-    (Sender : (X : Type u) → (X → Type u) → Type u)
-    (Receiver : (X : Type u) → (X → Type u) → Type u)
-    (mapSender :
-      {X : Type u} → {A B : X → Type u} →
-      (∀ x, A x → B x) → Sender X A → Sender X B)
-    (mapReceiver :
-      {X : Type u} → {A B : X → Type u} →
-      (∀ x, A x → B x) → Receiver X A → Receiver X B) :
-    {spec : Spec.{u}} → {roles : RoleDecoration spec} →
-    {A B : Transcript spec → Type u} →
-    (∀ tr, A tr → B tr) →
-    CounterpartFamily Sender Receiver spec roles A →
-    CounterpartFamily Sender Receiver spec roles B :=
-  fun {spec} {roles} {A} {B} f =>
-    ShapeOver.mapOutput
-      (counterpartFamilyShape Sender Receiver mapSender mapReceiver)
-      (agent := PUnit.unit) (spec := spec) roles
-      (A := A) (B := B) f
 
 /-- Counterpart / environment type with transcript-dependent output: dual
 actions at each node, producing `Output ⟨⟩` at `.done`.
@@ -406,9 +380,15 @@ for `x` unless that continuation is exposed separately.
 
 This is exactly the extra structure needed to replay a prescribed transcript
 through the verifier. -/
-abbrev PublicCoinCounterpart (m : Type u → Type u) :=
-  CounterpartFamily (fun X Cont => (x : X) → m (Cont x))
+def publicCoinCounterpartSyntax (m : Type u → Type u) :
+    SyntaxOver.{u, 0, u, 0} PUnit (fun _ => Role) :=
+  counterpartFamilySyntax (fun X Cont => (x : X) → m (Cont x))
     (fun X Cont => m X × ((x : X) → Cont x))
+
+/-- Whole-tree public-coin counterpart induced by `publicCoinCounterpartSyntax`. -/
+abbrev PublicCoinCounterpart (m : Type u → Type u)
+    (spec : Spec) (roles : RoleDecoration spec) (Output : Transcript spec → Type u) :=
+  StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output
 
 namespace PublicCoinCounterpart
 
@@ -416,6 +396,12 @@ private def mapReceiver {m : Type u → Type u} :
     {X : Type u} → {A B : X → Type u} →
     (∀ x, A x → B x) → (m X × ((x : X) → A x)) → (m X × ((x : X) → B x))
   | _, _, _, f, ⟨sample, next⟩ => ⟨sample, fun x => f x (next x)⟩
+
+private def publicCoinCounterpartShape (m : Type u → Type u) [Functor m] :
+    ShapeOver PUnit (fun _ => Role) :=
+  counterpartFamilyShape (fun X Cont => (x : X) → m (Cont x))
+    (fun X Cont => m X × ((x : X) → Cont x))
+    Counterpart.mapSender mapReceiver
 
 /-- Functorial output map for public-coin counterparts. The challenge samplers
 are unchanged; only the terminal output carried by continuations is mapped. -/
@@ -425,7 +411,10 @@ def mapOutput {m : Type u → Type u} [Functor m] :
     (∀ tr, A tr → B tr) →
     PublicCoinCounterpart m spec roles A →
     PublicCoinCounterpart m spec roles B :=
-  CounterpartFamily.mapOutput _ _ Counterpart.mapSender mapReceiver
+  fun {spec} {roles} {A} {B} f =>
+    ShapeOver.mapOutput (publicCoinCounterpartShape m)
+      (agent := PUnit.unit) (spec := spec) roles
+      (A := A) (B := B) f
 
 /-- Forget the public-coin factorization and recover the ordinary executable
 counterpart. -/

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -708,14 +708,6 @@ theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
               next xc.2)
   exact go spec roles fP fC strat cpt
 
-/-- `withRoles` using the monad attached at each node (from `MonadDecoration`).
-See `Counterpart.withMonads` for the dual. -/
-abbrev Strategy.withRolesAndMonads
-    (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
-    (Output : Transcript spec → Type u) :=
-  StrategyOver focalMonadicSyntax PUnit.unit spec
-    (RoleDecoration.withMonads roles md) Output
-
 /--
 View a strategy over a constant monad decoration as an ordinary single-monad
 role strategy.
@@ -723,8 +715,9 @@ role strategy.
 def Strategy.constantMonadsToWithRoles {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
-    Strategy.withRolesAndMonads spec roles
-      (MonadDecoration.constant ⟨m, inferInstance⟩ spec) Output →
+    StrategyOver focalMonadicSyntax PUnit.unit spec
+      (RoleDecoration.withMonads roles (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
+      Output →
     Strategy.withRoles m spec roles Output :=
   match spec, roles with
   | .done, _ => fun strat => strat
@@ -748,8 +741,9 @@ def Strategy.withRolesToConstantMonads {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
     Strategy.withRoles m spec roles Output →
-    Strategy.withRolesAndMonads spec roles
-      (MonadDecoration.constant ⟨m, inferInstance⟩ spec) Output :=
+    StrategyOver focalMonadicSyntax PUnit.unit spec
+      (RoleDecoration.withMonads roles (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
+      Output :=
   match spec, roles with
   | .done, _ => fun strat => strat
   | .node _ rest, ⟨.sender, rRest⟩ =>
@@ -822,8 +816,10 @@ def Strategy.mapMonadDecoration
     {md₁ md₂ : MonadDecoration spec}
     (hom : MonadDecoration.Hom spec md₁ md₂)
     {Output : Spec.Transcript spec → Type u} :
-    Strategy.withRolesAndMonads spec roles md₁ Output →
-    Strategy.withRolesAndMonads spec roles md₂ Output :=
+    StrategyOver focalMonadicSyntax PUnit.unit spec
+      (RoleDecoration.withMonads roles md₁) Output →
+    StrategyOver focalMonadicSyntax PUnit.unit spec
+      (RoleDecoration.withMonads roles md₂) Output :=
   match spec, roles, md₁, md₂, hom with
   | .done, _, _, _, _ => fun strat => strat
   | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -28,7 +28,7 @@ decoration still determines which participant owns each move.
 
 This module also contains a public-coin counterpart syntax. An executable
 counterpart samples a receiver move together with its continuation as one
-opaque action; `Spec.publicCoinCounterpartSyntax` exposes the sampler and
+opaque action; `Spec.TwoParty.PublicCoinCounterpart.syntax` exposes the sampler and
 challenge-indexed continuation separately:
 
 - `sample : m X` — how the next public challenge is chosen
@@ -42,9 +42,10 @@ universe u
 
 namespace Interaction
 namespace Spec
+namespace TwoParty
 
 variable {m : Type u → Type u}
-open TwoParty
+open _root_.Interaction.TwoParty
 
 private def rolePerspective : Role → Participant.{u} → Ownership.Perspective
   | .sender, .focal => .owner
@@ -94,7 +95,7 @@ private def SyntaxOver.forAgent {Agent : Type u} {Γ : Node.Context}
 private theorem StrategyOver.forAgent {Agent : Type u} {Γ : Node.Context}
     (syn : SyntaxOver Agent Γ) (agent : Agent) :
     {spec : Spec} → {ctxs : Decoration Γ spec} → {Out : Transcript spec → Type u} →
-    StrategyOver (syn.forAgent agent) PUnit.unit spec ctxs Out =
+    StrategyOver (SyntaxOver.forAgent syn agent) PUnit.unit spec ctxs Out =
       StrategyOver syn agent spec ctxs Out
   | .done, _, _ => rfl
   | .node _ next, ⟨γ, ctxs⟩, Out => by
@@ -137,7 +138,7 @@ private theorem pairedSyntax_eq_ownerBased (m : Type u → Type u) :
 At a sender node, the focal participant supplies the move and continuation,
 while the counterpart observes that move. At a receiver node, the counterpart
 supplies the move and continuation, while the focal participant observes it.
-Together with `StrategyOver.run`, this is the canonical whole-protocol runner
+Together with `InteractionOver.run`, this is the canonical whole-protocol runner
 for two-party role-decorated strategies.
 -/
 def pairedInteraction (m : Type u → Type u) [Monad m] :
@@ -307,7 +308,7 @@ def Counterpart.mapSender {m : Type u → Type u} [Functor m] :
   | _, _, _, f, observe => fun x => f x <$> observe x
 
 /-- Functorial output map for role-dependent strategies. -/
-def Strategy.mapOutputWithRoles {m : Type u → Type u} [Functor m] :
+def Focal.mapOutput {m : Type u → Type u} [Functor m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {A B : Transcript spec → Type u} →
     (∀ tr, A tr → B tr) →
@@ -315,16 +316,16 @@ def Strategy.mapOutputWithRoles {m : Type u → Type u} [Functor m] :
       StrategyOver (pairedSyntax m) Participant.focal spec roles B
   | .done, _, _, _, f, a => f ⟨⟩ a
   | .node _ _, ⟨.sender, _⟩, _, _, f, send =>
-      Counterpart.mapReceiver (fun x => mapOutputWithRoles (fun p => f ⟨x, p⟩)) send
+      Counterpart.mapReceiver (fun x => mapOutput (fun p => f ⟨x, p⟩)) send
   | .node _ _, ⟨.receiver, _⟩, _, _, f, respond =>
-      fun x => (mapOutputWithRoles (fun p => f ⟨x, p⟩) ·) <$> respond x
+      fun x => (mapOutput (fun p => f ⟨x, p⟩) ·) <$> respond x
 
 /-- Pointwise identity on outputs is the identity on role-dependent strategies. -/
 @[simp]
-theorem Strategy.mapOutputWithRoles_id {m : Type u → Type u} [Functor m] [LawfulFunctor m]
+theorem Focal.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunctor m]
     {spec : Spec} {roles : RoleDecoration spec} {A : Transcript spec → Type u}
     (σ : StrategyOver (pairedSyntax m) Participant.focal spec roles A) :
-    Strategy.mapOutputWithRoles (fun _ x => x) σ = σ := by
+    Focal.mapOutput (fun _ x => x) σ = σ := by
   match spec, roles with
   | .done, roles =>
       cases roles
@@ -336,31 +337,31 @@ theorem Strategy.mapOutputWithRoles_id {m : Type u → Type u} [Functor m] [Lawf
           ((x : X) × StrategyOver (pairedSyntax m) Participant.focal
             (rest x) (rRest x) (fun p => A ⟨x, p⟩)) :=
         fun xc => ⟨xc.1,
-          Strategy.mapOutputWithRoles
+          Focal.mapOutput
             (fun (p : Transcript (rest xc.1)) (y : A ⟨xc.1, p⟩) => y) xc.2⟩
       have hpair : F = id := by
         funext xc
         cases xc with
         | mk x σ' =>
             simp only [F]
-            rw [Strategy.mapOutputWithRoles_id]
+            rw [Focal.mapOutput_id]
             rfl
-      rw [Strategy.mapOutputWithRoles, Counterpart.mapReceiver]
+      rw [Focal.mapOutput, Counterpart.mapReceiver]
       change F <$> σ = σ
       rw [hpair]
       exact LawfulFunctor.id_map σ
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       funext x
       have hid :
-          (mapOutputWithRoles (fun (p : Transcript (rest x)) (y : A ⟨x, p⟩) => y) :
+          (mapOutput (fun (p : Transcript (rest x)) (y : A ⟨x, p⟩) => y) :
               StrategyOver (pairedSyntax m) Participant.focal
                 (rest x) (rRest x) (fun p => A ⟨x, p⟩) →
                 StrategyOver (pairedSyntax m) Participant.focal
                   (rest x) (rRest x) (fun p => A ⟨x, p⟩)) =
             id := by
         funext s
-        exact @mapOutputWithRoles_id m _ _ (rest x) (rRest x) (fun p => A ⟨x, p⟩) s
-      simp only [Strategy.mapOutputWithRoles, hid]
+        exact @mapOutput_id m _ _ (rest x) (rRest x) (fun p => A ⟨x, p⟩) s
+      simp only [Focal.mapOutput, hid]
       exact LawfulFunctor.id_map (σ x)
 
 /-- Functorial output map for counterparts. -/
@@ -385,13 +386,13 @@ for verifier-side Fiat-Shamir: given a prescribed challenge `x`, there is no
 way to recover the continuation for `x` unless that continuation is exposed
 separately.
 
-`publicCoinCounterpartSyntax` factors each receiver node into:
+`PublicCoinCounterpart.syntax` factors each receiver node into:
 - `sample : m X` — how the verifier samples the next public challenge
 - `next : (x : X) → ...` — how the rest of the verifier depends on that challenge
 
 This is exactly the extra structure needed to replay a prescribed transcript
 through the verifier. -/
-def publicCoinCounterpartSyntax (m : Type u → Type u) :
+def PublicCoinCounterpart.syntax (m : Type u → Type u) :
     SyntaxOver.{u, 0, u, 0} PUnit (fun _ => Role) :=
   counterpartFamilySyntax (fun X Cont => (x : X) → m (Cont x))
     (fun X Cont => m X × ((x : X) → Cont x))
@@ -415,8 +416,8 @@ def mapOutput {m : Type u → Type u} [Functor m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {A B : Transcript spec → Type u} →
     (∀ tr, A tr → B tr) →
-    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles A →
-    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles B :=
+    StrategyOver (PublicCoinCounterpart.syntax m) PUnit.unit spec roles A →
+    StrategyOver (PublicCoinCounterpart.syntax m) PUnit.unit spec roles B :=
   fun {spec} {roles} {A} {B} f =>
     ShapeOver.mapOutput (publicCoinCounterpartShape m)
       (agent := PUnit.unit) (spec := spec) roles
@@ -427,7 +428,7 @@ counterpart. -/
 def toCounterpart {m : Type u → Type u} [Monad m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
-    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output →
+    StrategyOver (PublicCoinCounterpart.syntax m) PUnit.unit spec roles Output →
     StrategyOver (pairedSyntax m) Participant.counterpart spec roles Output
   | .done, _, _, c => c
   | .node _ _, ⟨.sender, _⟩, _, observe =>
@@ -444,7 +445,7 @@ stored continuation family is followed at the recorded challenge. -/
 def replay {m : Type u → Type u} [Monad m] :
     {spec : Spec.{u}} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
-    StrategyOver (publicCoinCounterpartSyntax m) PUnit.unit spec roles Output →
+    StrategyOver (PublicCoinCounterpart.syntax m) PUnit.unit spec roles Output →
     (tr : Transcript spec) → m (Output tr)
   | .done, _, _, c, _ => pure c
   | .node _ _, ⟨.sender, _⟩, _, observe, ⟨x, tr⟩ =>
@@ -510,7 +511,7 @@ theorem Counterpart.mapOutput_id {m : Type u → Type u} [Functor m] [LawfulFunc
 At sender nodes the observational branch structure is unchanged. At receiver
 nodes the chosen move and continuation are simply wrapped in `pure`. This is a
 generic utility for reusing deterministic environments inside monadic execution
-machinery built from `StrategyOver.run`. -/
+machinery built from `InteractionOver.run`. -/
 def Counterpart.liftId {m : Type u → Type u} [Monad m] :
     {spec : Spec} → {roles : RoleDecoration spec} →
     {Output : Transcript spec → Type u} →
@@ -558,32 +559,32 @@ def participantProfile
 
 /-- Execute a focal/counterpart pair over a role-decorated interaction tree.
 
-This is the generic `StrategyOver.run` specialized to `pairedSyntax`, with the
+This is the generic `InteractionOver.run` specialized to `pairedSyntax`, with the
 two participant fibers assembled by `participantProfile` and collected by
 `collectParticipantOutputs`.
 -/
-def Strategy.runWithRoles {m : Type u → Type u} [Monad m]
+def run {m : Type u → Type u} [Monad m]
     (spec : Spec) (roles : RoleDecoration spec)
     {OutputP : Transcript spec → Type u}
     {OutputC : Transcript spec → Type u}
     (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
     (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
     m ((tr : Transcript spec) × OutputP tr × OutputC tr) :=
-  StrategyOver.run (pairedInteraction m) roles (participantProfile strat cpt)
+  InteractionOver.run (I := pairedInteraction m) roles (participantProfile strat cpt)
     collectParticipantOutputs
 
 @[simp]
-theorem StrategyOver.run_paired_done {m : Type u → Type u} [Monad m]
+theorem InteractionOver.run_paired_done {m : Type u → Type u} [Monad m]
     {OutputP OutputC : Transcript Spec.done → Type u}
     (outP : OutputP ⟨⟩) (outC : OutputC ⟨⟩) :
-    StrategyOver.run (pairedInteraction m) (spec := Spec.done) (ctxs := PUnit.unit)
+    InteractionOver.run (I := pairedInteraction m) (spec := Spec.done) (ctxs := PUnit.unit)
       (participantProfile outP outC) collectParticipantOutputs =
       (pure ⟨⟨⟩, outP, outC⟩ :
         m ((tr : Transcript Spec.done) × OutputP tr × OutputC tr)) := by
   rfl
 
 @[simp]
-theorem StrategyOver.run_paired_sender {m : Type u → Type u} [Monad m]
+theorem InteractionOver.run_paired_sender {m : Type u → Type u} [Monad m]
     {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
     {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
     (send :
@@ -591,16 +592,21 @@ theorem StrategyOver.run_paired_sender {m : Type u → Type u} [Monad m]
         (rest x) (rRest x) (fun tr => OutputP ⟨x, tr⟩)))
     (dualFn : (x : X) → m (StrategyOver (pairedSyntax m) Participant.counterpart
       (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
-    StrategyOver.run (pairedInteraction m) (spec := Spec.node X rest)
+    InteractionOver.run (I := pairedInteraction m) (spec := Spec.node X rest)
       (ctxs := ⟨.sender, rRest⟩)
-      (participantProfile send dualFn) collectParticipantOutputs = (do
+      (participantProfile
+        (show StrategyOver (pairedSyntax m) Participant.focal
+          (Spec.node X rest) ⟨.sender, rRest⟩ OutputP from send)
+        (show StrategyOver (pairedSyntax m) Participant.counterpart
+          (Spec.node X rest) ⟨.sender, rRest⟩ OutputC from dualFn))
+      collectParticipantOutputs = (do
       let xc ← send
       let dualNext ← dualFn xc.1
-      let tailOut ← StrategyOver.run (pairedInteraction m) (spec := rest xc.1)
+      let tailOut ← InteractionOver.run (I := pairedInteraction m) (spec := rest xc.1)
         (ctxs := rRest xc.1)
         (participantProfile xc.2 dualNext) collectParticipantOutputs
       pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
-  simp only [StrategyOver.run, pairedInteraction, pairedSyntax,
+  simp only [InteractionOver.run, pairedInteraction, pairedSyntax,
     participantOutputFamily, participantProfile, collectParticipantOutputs,
     focalRunner, counterpartRunner]
   apply congrArg (fun k => send >>= k)
@@ -610,7 +616,7 @@ theorem StrategyOver.run_paired_sender {m : Type u → Type u} [Monad m]
   rfl
 
 @[simp]
-theorem StrategyOver.run_paired_receiver {m : Type u → Type u} [Monad m]
+theorem InteractionOver.run_paired_receiver {m : Type u → Type u} [Monad m]
     {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
     {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
     (respond : (x : X) → m (StrategyOver (pairedSyntax m) Participant.focal
@@ -618,16 +624,21 @@ theorem StrategyOver.run_paired_receiver {m : Type u → Type u} [Monad m]
     (dualSample :
       m ((x : X) × StrategyOver (pairedSyntax m) Participant.counterpart
         (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
-    StrategyOver.run (pairedInteraction m) (spec := Spec.node X rest)
+    InteractionOver.run (I := pairedInteraction m) (spec := Spec.node X rest)
       (ctxs := ⟨.receiver, rRest⟩)
-      (participantProfile respond dualSample) collectParticipantOutputs = (do
+      (participantProfile
+        (show StrategyOver (pairedSyntax m) Participant.focal
+          (Spec.node X rest) ⟨.receiver, rRest⟩ OutputP from respond)
+        (show StrategyOver (pairedSyntax m) Participant.counterpart
+          (Spec.node X rest) ⟨.receiver, rRest⟩ OutputC from dualSample))
+      collectParticipantOutputs = (do
       let xc ← dualSample
       let next ← respond xc.1
-      let tailOut ← StrategyOver.run (pairedInteraction m) (spec := rest xc.1)
+      let tailOut ← InteractionOver.run (I := pairedInteraction m) (spec := rest xc.1)
         (ctxs := rRest xc.1)
         (participantProfile next xc.2) collectParticipantOutputs
       pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
-  simp only [StrategyOver.run, pairedInteraction, pairedSyntax,
+  simp only [InteractionOver.run, pairedInteraction, pairedSyntax,
     participantOutputFamily, participantProfile, collectParticipantOutputs,
     focalRunner, counterpartRunner]
   apply congrArg (fun k => dualSample >>= k)
@@ -638,7 +649,7 @@ theorem StrategyOver.run_paired_receiver {m : Type u → Type u} [Monad m]
 
 /-- Running a paired profile after mapping both participant outputs is the same
 as running first and mapping the final triple. -/
-theorem StrategyOver.run_paired_mapOutputWithRoles_mapOutput
+theorem InteractionOver.run_paired_mapOutput_mapOutput
     {m : Type u → Type u} [Monad m] [LawfulMonad m]
     {spec : Spec} {roles : RoleDecoration spec}
     {OutputP OutputP' OutputC OutputC' : Transcript spec → Type u}
@@ -646,11 +657,11 @@ theorem StrategyOver.run_paired_mapOutputWithRoles_mapOutput
     (fC : ∀ tr, OutputC tr → OutputC' tr)
     (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
     (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
-    StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
-      (participantProfile (Strategy.mapOutputWithRoles fP strat) (Counterpart.mapOutput fC cpt))
+    InteractionOver.run (I := pairedInteraction m) (spec := spec) (ctxs := roles)
+      (participantProfile (Focal.mapOutput fP strat) (Counterpart.mapOutput fC cpt))
       collectParticipantOutputs =
       (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-        StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
+        InteractionOver.run (I := pairedInteraction m) (spec := spec) (ctxs := roles)
           (participantProfile strat cpt) collectParticipantOutputs := by
   let rec go
       (spec : Spec) (roles : RoleDecoration spec)
@@ -659,20 +670,20 @@ theorem StrategyOver.run_paired_mapOutputWithRoles_mapOutput
       (fC : ∀ tr, OutputC tr → OutputC' tr)
       (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
       (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
-      StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
-        (participantProfile (Strategy.mapOutputWithRoles fP strat) (Counterpart.mapOutput fC cpt))
+      InteractionOver.run (I := pairedInteraction m) (spec := spec) (ctxs := roles)
+        (participantProfile (Focal.mapOutput fP strat) (Counterpart.mapOutput fC cpt))
         collectParticipantOutputs =
         (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-          StrategyOver.run (pairedInteraction m) (spec := spec) (ctxs := roles)
+          InteractionOver.run (I := pairedInteraction m) (spec := spec) (ctxs := roles)
             (participantProfile strat cpt) collectParticipantOutputs := by
     match spec, roles with
     | .done, roles =>
         cases roles
-        simp [Strategy.mapOutputWithRoles, Counterpart.mapOutput, StrategyOver.run_paired_done]
+        simp [Focal.mapOutput, Counterpart.mapOutput, InteractionOver.run_paired_done]
     | .node _ rest, ⟨.sender, rRest⟩ =>
-        simp only [Strategy.mapOutputWithRoles, Counterpart.mapOutput, Counterpart.mapReceiver,
+        simp only [Focal.mapOutput, Counterpart.mapOutput, Counterpart.mapReceiver,
           Counterpart.mapSender]
-        simp only [StrategyOver.run_paired_sender, bind_pure_comp, bind_map_left, map_bind,
+        simp only [InteractionOver.run_paired_sender, bind_pure_comp, bind_map_left, map_bind,
           Functor.map_map]
         refine congrArg (fun k => strat >>= k) ?_
         funext xc
@@ -688,10 +699,10 @@ theorem StrategyOver.run_paired_mapOutputWithRoles_mapOutput
             (go (rest xc.1) (rRest xc.1) (fun tr => fP ⟨xc.1, tr⟩) (fun tr => fC ⟨xc.1, tr⟩)
               xc.2 cNext)
     | .node _ rest, ⟨.receiver, rRest⟩ =>
-        simp only [Strategy.mapOutputWithRoles, Counterpart.mapOutput,
+        simp only [Focal.mapOutput, Counterpart.mapOutput,
           Counterpart.mapReceiver]
         simp only
-          [StrategyOver.run_paired_receiver, bind_pure_comp, bind_map_left, map_bind,
+          [InteractionOver.run_paired_receiver, bind_pure_comp, bind_map_left, map_bind,
             Functor.map_map]
         refine congrArg (fun k => cpt >>= k) ?_
         funext xc
@@ -709,16 +720,16 @@ theorem StrategyOver.run_paired_mapOutputWithRoles_mapOutput
   exact go spec roles fP fC strat cpt
 
 @[simp]
-theorem Strategy.runWithRoles_done {m : Type u → Type u} [Monad m]
+theorem run_done {m : Type u → Type u} [Monad m]
     {OutputP OutputC : Transcript Spec.done → Type u}
     (outP : OutputP ⟨⟩) (outC : OutputC ⟨⟩) :
-    Strategy.runWithRoles .done PUnit.unit outP outC =
+    run .done PUnit.unit outP outC =
       (pure ⟨⟨⟩, outP, outC⟩ :
         m ((tr : Transcript Spec.done) × OutputP tr × OutputC tr)) := by
-  simp [Strategy.runWithRoles]
+  simp [run]
 
 @[simp]
-theorem Strategy.runWithRoles_sender {m : Type u → Type u} [Monad m]
+theorem run_sender {m : Type u → Type u} [Monad m]
     {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
     {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
     (send :
@@ -726,15 +737,15 @@ theorem Strategy.runWithRoles_sender {m : Type u → Type u} [Monad m]
         (fun tr => OutputP ⟨x, tr⟩)))
     (dualFn : (x : X) → m (StrategyOver (pairedSyntax m) Participant.counterpart
       (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
-    Strategy.runWithRoles (Spec.node X rest) ⟨.sender, rRest⟩ send dualFn = (do
+    run (Spec.node X rest) ⟨.sender, rRest⟩ send dualFn = (do
       let xc ← send
       let dualNext ← dualFn xc.1
-      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) xc.2 dualNext
+      let tailOut ← run (rest xc.1) (rRest xc.1) xc.2 dualNext
       pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
-  simp [Strategy.runWithRoles, StrategyOver.run_paired_sender]
+  simp [run, InteractionOver.run_paired_sender]
 
 @[simp]
-theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
+theorem run_receiver {m : Type u → Type u} [Monad m]
     {X : Type u} {rest : X → Spec} {rRest : (x : X) → RoleDecoration (rest x)}
     {OutputP OutputC : Transcript (Spec.node X rest) → Type u}
     (respond : (x : X) → m (StrategyOver (pairedSyntax m) Participant.focal
@@ -742,14 +753,14 @@ theorem Strategy.runWithRoles_receiver {m : Type u → Type u} [Monad m]
     (dualSample :
       m ((x : X) × StrategyOver (pairedSyntax m) Participant.counterpart
         (rest x) (rRest x) (fun tr => OutputC ⟨x, tr⟩))) :
-    Strategy.runWithRoles (Spec.node X rest) ⟨.receiver, rRest⟩ respond dualSample = (do
+    run (Spec.node X rest) ⟨.receiver, rRest⟩ respond dualSample = (do
       let xc ← dualSample
       let next ← respond xc.1
-      let tailOut ← Strategy.runWithRoles (rest xc.1) (rRest xc.1) next xc.2
+      let tailOut ← run (rest xc.1) (rRest xc.1) next xc.2
       pure ⟨⟨xc.1, tailOut.1⟩, tailOut.2⟩) := by
-  simp [Strategy.runWithRoles, StrategyOver.run_paired_receiver]
+  simp [run, InteractionOver.run_paired_receiver]
 
-theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
+theorem run_mapOutput_mapOutput
     {m : Type u → Type u} [Monad m] [LawfulMonad m]
     {spec : Spec} {roles : RoleDecoration spec}
     {OutputP OutputP' OutputC OutputC' : Transcript spec → Type u}
@@ -757,19 +768,19 @@ theorem Strategy.runWithRoles_mapOutputWithRoles_mapOutput
     (fC : ∀ tr, OutputC tr → OutputC' tr)
     (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles OutputP)
     (cpt : StrategyOver (pairedSyntax m) Participant.counterpart spec roles OutputC) :
-    Strategy.runWithRoles spec roles (Strategy.mapOutputWithRoles fP strat)
+    run spec roles (Focal.mapOutput fP strat)
       (Counterpart.mapOutput fC cpt) =
       (fun z => ⟨z.1, fP z.1 z.2.1, fC z.1 z.2.2⟩) <$>
-        Strategy.runWithRoles spec roles strat cpt := by
-  simpa [Strategy.runWithRoles] using
-    (StrategyOver.run_paired_mapOutputWithRoles_mapOutput (m := m)
+        run spec roles strat cpt := by
+  simpa [run] using
+    (InteractionOver.run_paired_mapOutput_mapOutput (m := m)
       fP fC strat cpt)
 
 /--
 View a strategy over a constant monad decoration as an ordinary single-monad
 role strategy.
 -/
-def Strategy.constantMonadsToWithRoles {m : Type u → Type u} [Monad m]
+def Focal.ofConstantMonads {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
     StrategyOver focalMonadicSyntax PUnit.unit spec
@@ -783,18 +794,18 @@ def Strategy.constantMonadsToWithRoles {m : Type u → Type u} [Monad m]
         Functor.map
           (fun msgAndRest =>
             ⟨msgAndRest.1,
-              constantMonadsToWithRoles
+              ofConstantMonads
                 (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
           strat
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       fun strat x =>
-        Functor.map (constantMonadsToWithRoles (rest x) (rRest x)) (strat x)
+        Functor.map (ofConstantMonads (rest x) (rRest x)) (strat x)
 
 /--
 View an ordinary single-monad role strategy as a strategy over a constant monad
 decoration.
 -/
-def Strategy.withRolesToConstantMonads {m : Type u → Type u} [Monad m]
+def Focal.toConstantMonads {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
     StrategyOver (pairedSyntax m) Participant.focal spec roles Output →
@@ -808,12 +819,12 @@ def Strategy.withRolesToConstantMonads {m : Type u → Type u} [Monad m]
         Functor.map
           (fun msgAndRest =>
             ⟨msgAndRest.1,
-              withRolesToConstantMonads
+              toConstantMonads
                 (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
           strat
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       fun strat x =>
-        Functor.map (withRolesToConstantMonads (rest x) (rRest x)) (strat x)
+        Functor.map (toConstantMonads (rest x) (rRest x)) (strat x)
 
 /--
 Lifting an ordinary role strategy into a constant monad decoration commutes
@@ -823,43 +834,43 @@ This is the naturality property used at boundaries that still accept ordinary
 single-monad strategies while internal execution is phrased over nodewise
 monad decorations.
 -/
-theorem Strategy.withRolesToConstantMonads_mapOutputWithRoles
+theorem Focal.toConstantMonads_mapOutput
     {m : Type u → Type u} [Monad m] [LawfulFunctor m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output Output' : Spec.Transcript spec → Type u}
     (f : ∀ tr, Output tr → Output' tr)
     (strat : StrategyOver (pairedSyntax m) Participant.focal spec roles Output) :
-    Strategy.withRolesToConstantMonads spec roles
-        (Strategy.mapOutputWithRoles f strat) =
+    Focal.toConstantMonads spec roles
+        (Focal.mapOutput f strat) =
       ShapeOver.mapOutput focalMonadicShape
         (agent := PUnit.unit)
         (spec := spec)
         (ctxs := RoleDecoration.withMonads roles
           (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
         f
-        (Strategy.withRolesToConstantMonads spec roles strat) := by
+        (Focal.toConstantMonads spec roles strat) := by
   match spec, roles with
   | .done, _ =>
       rfl
   | .node _ rest, ⟨.sender, rRest⟩ =>
-      simp only [Strategy.mapOutputWithRoles, Counterpart.mapReceiver,
-        withRolesToConstantMonads, ShapeOver.mapOutput, focalMonadicShape,
+      simp only [Focal.mapOutput, Counterpart.mapReceiver,
+        toConstantMonads, ShapeOver.mapOutput, focalMonadicShape,
         focalMonadicSyntax, RoleDecoration.withMonads, RoleDecoration.monadsOver,
         Spec.MonadDecoration.constant, Spec.Decoration.ofOver, Functor.map_map]
       apply congrArg (fun g => g <$> strat)
       funext msgAndRest
-      rw [withRolesToConstantMonads_mapOutputWithRoles
+      rw [toConstantMonads_mapOutput
         (rest msgAndRest.1) (rRest msgAndRest.1)]
       rfl
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       funext x
-      simp only [Strategy.mapOutputWithRoles, withRolesToConstantMonads,
+      simp only [Focal.mapOutput, toConstantMonads,
         ShapeOver.mapOutput, focalMonadicShape, focalMonadicSyntax,
         RoleDecoration.withMonads, RoleDecoration.monadsOver,
         Spec.MonadDecoration.constant, Spec.Decoration.ofOver, Functor.map_map]
       apply congrArg (fun g => g <$> strat x)
       funext next
-      rw [withRolesToConstantMonads_mapOutputWithRoles (rest x) (rRest x)]
+      rw [toConstantMonads_mapOutput (rest x) (rRest x)]
       rfl
 
 /--
@@ -868,7 +879,7 @@ Retarget a monadic focal strategy along a nodewise monad homomorphism.
 This traverses the strategy tree structurally, applying the supplied lift at
 each node and recursing through the selected continuation.
 -/
-def Strategy.mapMonadDecoration
+def Focal.mapMonadDecoration
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {md₁ md₂ : MonadDecoration spec}
     (hom : MonadDecoration.Hom spec md₁ md₂)
@@ -953,5 +964,6 @@ def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
           | .focal => pCont
           | .counterpart => cCont)
 
+end TwoParty
 end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -164,13 +164,29 @@ private def pairedInteraction (m : Type u → Type u) [Monad m] :
           | .focal => pCont
           | .counterpart => cCont)
 
-private def strategyMonadicSyntax :
+/--
+One-participant syntax for the focal side of a role-decorated tree with
+per-node monads.
+
+At sender nodes the focal participant owns the move and returns a message
+together with the continuation in the node monad. At receiver nodes it observes
+the counterpart's message and returns the continuation in the node monad.
+-/
+def focalMonadicSyntax :
     SyntaxOver.{u, 0, u, u + 1} PUnit RoleMonadContext where
   Node _ (X : Type u) γ (Cont : X → Type u) :=
     match γ with
     | ⟨role, bm⟩ => role.Action bm.M X Cont
 
-private def counterpartMonadicSyntax :
+/--
+One-participant syntax for the counterpart side of a role-decorated tree with
+per-node monads.
+
+At sender nodes the counterpart observes the focal participant's move. At
+receiver nodes it owns the move and returns a message together with the
+continuation in the node monad.
+-/
+def counterpartMonadicSyntax :
     SyntaxOver.{u, 0, u, u + 1} PUnit RoleMonadContext where
   Node _ (X : Type u) γ (Cont : X → Type u) :=
     match γ with
@@ -676,7 +692,7 @@ See `Counterpart.withMonads` for the dual. -/
 abbrev Strategy.withRolesAndMonads
     (spec : Spec.{u}) (roles : RoleDecoration spec) (md : MonadDecoration spec)
     (Output : Transcript spec → Type u) :=
-  StrategyOver strategyMonadicSyntax PUnit.unit spec
+  StrategyOver focalMonadicSyntax PUnit.unit spec
     (RoleDecoration.withMonads roles md) Output
 
 /-- Map the transcript-indexed output of a monadic role strategy. -/
@@ -864,13 +880,13 @@ def Counterpart.withMonads.mapDecoration
 
 private theorem pairedMonadicSyntax_forAgent_focal :
     pairedMonadicSyntax.forAgent Participant.focal =
-      strategyMonadicSyntax.comap RolePairedMonadContext.fst := by
+      focalMonadicSyntax.comap RolePairedMonadContext.fst := by
   apply congrArg SyntaxOver.mk
   funext _ X γ Cont
   cases γ with
   | mk role bms =>
       cases role <;> cases bms <;>
-        simp [pairedMonadicSyntax, strategyMonadicSyntax,
+        simp [pairedMonadicSyntax, focalMonadicSyntax,
           RolePairedMonadContext.fst, Spec.Node.Context.extendMap,
           Spec.Node.ContextHom.id, Role.Action]
 
@@ -898,7 +914,7 @@ private theorem pairedMonadicStrategy_focal :
         (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
         (Out := Output)]
       rw [pairedMonadicSyntax_forAgent_focal]
-      rw [StrategyOver.comap strategyMonadicSyntax RolePairedMonadContext.fst
+      rw [StrategyOver.comap focalMonadicSyntax RolePairedMonadContext.fst
         (agent := PUnit.unit)
         (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
         (Out := Output)]

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -720,7 +720,7 @@ abbrev Strategy.withRolesAndMonads
 View a strategy over a constant monad decoration as an ordinary single-monad
 role strategy.
 -/
-def Strategy.withRolesAndMonads.toWithRolesConstant {m : Type u → Type u} [Monad m]
+def Strategy.constantMonadsToWithRoles {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
     Strategy.withRolesAndMonads spec roles
@@ -733,17 +733,18 @@ def Strategy.withRolesAndMonads.toWithRolesConstant {m : Type u → Type u} [Mon
         Functor.map
           (fun msgAndRest =>
             ⟨msgAndRest.1,
-              toWithRolesConstant (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
+              constantMonadsToWithRoles
+                (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
           strat
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       fun strat x =>
-        Functor.map (toWithRolesConstant (rest x) (rRest x)) (strat x)
+        Functor.map (constantMonadsToWithRoles (rest x) (rRest x)) (strat x)
 
 /--
 View an ordinary single-monad role strategy as a strategy over a constant monad
 decoration.
 -/
-def Strategy.withRolesAndMonads.ofWithRolesConstant {m : Type u → Type u} [Monad m]
+def Strategy.withRolesToConstantMonads {m : Type u → Type u} [Monad m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output : Spec.Transcript spec → Type u} :
     Strategy.withRoles m spec roles Output →
@@ -756,11 +757,12 @@ def Strategy.withRolesAndMonads.ofWithRolesConstant {m : Type u → Type u} [Mon
         Functor.map
           (fun msgAndRest =>
             ⟨msgAndRest.1,
-              ofWithRolesConstant (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
+              withRolesToConstantMonads
+                (rest msgAndRest.1) (rRest msgAndRest.1) msgAndRest.2⟩)
           strat
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       fun strat x =>
-        Functor.map (ofWithRolesConstant (rest x) (rRest x)) (strat x)
+        Functor.map (withRolesToConstantMonads (rest x) (rRest x)) (strat x)
 
 /--
 Lifting an ordinary role strategy into a constant monad decoration commutes
@@ -770,13 +772,13 @@ This is the naturality property used at boundaries that still accept ordinary
 single-monad strategies while internal execution is phrased over nodewise
 monad decorations.
 -/
-theorem Strategy.withRolesAndMonads.ofWithRolesConstant_mapOutputWithRoles
+theorem Strategy.withRolesToConstantMonads_mapOutputWithRoles
     {m : Type u → Type u} [Monad m] [LawfulFunctor m]
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {Output Output' : Spec.Transcript spec → Type u}
     (f : ∀ tr, Output tr → Output' tr)
     (strat : Strategy.withRoles m spec roles Output) :
-    Strategy.withRolesAndMonads.ofWithRolesConstant spec roles
+    Strategy.withRolesToConstantMonads spec roles
         (Strategy.mapOutputWithRoles f strat) =
       ShapeOver.mapOutput focalMonadicShape
         (agent := PUnit.unit)
@@ -784,28 +786,29 @@ theorem Strategy.withRolesAndMonads.ofWithRolesConstant_mapOutputWithRoles
         (ctxs := RoleDecoration.withMonads roles
           (MonadDecoration.constant ⟨m, inferInstance⟩ spec))
         f
-        (Strategy.withRolesAndMonads.ofWithRolesConstant spec roles strat) := by
+        (Strategy.withRolesToConstantMonads spec roles strat) := by
   match spec, roles with
   | .done, _ =>
       rfl
   | .node _ rest, ⟨.sender, rRest⟩ =>
       simp only [Strategy.mapOutputWithRoles, Counterpart.mapReceiver,
-        ofWithRolesConstant, ShapeOver.mapOutput, focalMonadicShape,
+        withRolesToConstantMonads, ShapeOver.mapOutput, focalMonadicShape,
         focalMonadicSyntax, RoleDecoration.withMonads, RoleDecoration.monadsOver,
         Spec.MonadDecoration.constant, Spec.Decoration.ofOver, Functor.map_map]
       apply congrArg (fun g => g <$> strat)
       funext msgAndRest
-      rw [ofWithRolesConstant_mapOutputWithRoles (rest msgAndRest.1) (rRest msgAndRest.1)]
+      rw [withRolesToConstantMonads_mapOutputWithRoles
+        (rest msgAndRest.1) (rRest msgAndRest.1)]
       rfl
   | .node _ rest, ⟨.receiver, rRest⟩ =>
       funext x
-      simp only [Strategy.mapOutputWithRoles, ofWithRolesConstant,
+      simp only [Strategy.mapOutputWithRoles, withRolesToConstantMonads,
         ShapeOver.mapOutput, focalMonadicShape, focalMonadicSyntax,
         RoleDecoration.withMonads, RoleDecoration.monadsOver,
         Spec.MonadDecoration.constant, Spec.Decoration.ofOver, Functor.map_map]
       apply congrArg (fun g => g <$> strat x)
       funext next
-      rw [ofWithRolesConstant_mapOutputWithRoles (rest x) (rRest x)]
+      rw [withRolesToConstantMonads_mapOutputWithRoles (rest x) (rRest x)]
       rfl
 
 /--
@@ -814,7 +817,7 @@ Retarget a monadic focal strategy along a nodewise monad homomorphism.
 This traverses the strategy tree structurally, applying the supplied lift at
 each node and recursing through the selected continuation.
 -/
-def Strategy.withRolesAndMonads.mapDecoration
+def Strategy.mapMonadDecoration
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {md₁ md₂ : MonadDecoration spec}
     (hom : MonadDecoration.Hom spec md₁ md₂)
@@ -828,13 +831,13 @@ def Strategy.withRolesAndMonads.mapDecoration
         lift <| Functor.map
           (fun msgAndRest =>
             ⟨msgAndRest.1,
-              mapDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
+              mapMonadDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
                 (homRest msgAndRest.1) msgAndRest.2⟩)
           strat
   | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
       fun strat x =>
         lift <| Functor.map
-          (mapDecoration (rest x) (rRest x) (homRest x)) (strat x)
+          (mapMonadDecoration (rest x) (rRest x) (homRest x)) (strat x)
 
 /--
 Counterpart strategy whose node effects are supplied by a `MonadDecoration`.
@@ -855,7 +858,7 @@ Retarget a monadic counterpart along a nodewise monad homomorphism.
 This traverses the counterpart tree structurally, applying the supplied lift at
 each node and recursing through the selected continuation.
 -/
-def Counterpart.withMonads.mapDecoration
+def Counterpart.mapMonadDecoration
     (spec : Spec.{u}) (roles : RoleDecoration spec)
     {md₁ md₂ : MonadDecoration spec}
     (hom : MonadDecoration.Hom spec md₁ md₂)
@@ -867,13 +870,13 @@ def Counterpart.withMonads.mapDecoration
   | .node _ rest, ⟨.sender, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
       fun cpt x =>
         lift <| Functor.map
-          (mapDecoration (rest x) (rRest x) (homRest x)) (cpt x)
+          (mapMonadDecoration (rest x) (rRest x) (homRest x)) (cpt x)
   | .node _ rest, ⟨.receiver, rRest⟩, ⟨_, _⟩, ⟨_, _⟩, ⟨lift, homRest⟩ =>
       fun cpt =>
         lift <| Functor.map
           (fun msgAndRest =>
             ⟨msgAndRest.1,
-              mapDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
+              mapMonadDecoration (rest msgAndRest.1) (rRest msgAndRest.1)
                 (homRest msgAndRest.1) msgAndRest.2⟩)
           cpt
 

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -10,6 +10,7 @@ import VCVio.Interaction.Basic.Ownership
 import VCVio.Interaction.Basic.Interaction
 import VCVio.Interaction.Basic.MonadDecoration
 import VCVio.Interaction.TwoParty.Decoration
+import VCVio.Interaction.TwoParty.Syntax
 import VCVio.Interaction.Basic.Shape
 
 /-!
@@ -42,14 +43,9 @@ namespace Interaction
 namespace Spec
 
 variable {m : Type u → Type u}
+open TwoParty
 
-/-- The two agents in a focused two-party interaction. -/
-inductive Participant : Type u where
-  | focal
-  | counterpart
-  deriving DecidableEq
-
-private def rolePerspective : Role → Participant → Ownership.Perspective
+private def rolePerspective : Role → Participant.{u} → Ownership.Perspective
   | .sender, .focal => .owner
   | .sender, .counterpart => .observer
   | .receiver, .focal => .observer
@@ -116,7 +112,7 @@ private def counterpartFamilySyntax
     | .receiver => Receiver X Cont
 
 def pairedSyntax (m : Type u → Type u) :
-    SyntaxOver.{u, u, u, 0} Participant (fun _ => Role) where
+    SyntaxOver.{u, u, u, 0} Participant.{u} (fun _ => Role) where
   Node agent X role Cont :=
     match agent, role with
     | .focal, .sender => m ((x : X) × Cont x)
@@ -136,7 +132,7 @@ private theorem pairedSyntax_eq_ownerBased (m : Type u → Type u) :
         simp [Ownership.LocalView.node, rolePerspective, focalView, counterpartView]
 
 private def pairedInteraction (m : Type u → Type u) [Monad m] :
-    InteractionOver Participant (fun _ => Role) (pairedSyntax m) m where
+    InteractionOver Participant.{u} (fun _ => Role) (pairedSyntax m) m where
   interact := fun {X} {γ : Role} {Cont} {Result} profile k =>
     match γ with
     | .sender => do
@@ -242,7 +238,7 @@ def counterpartMonadicShape :
           ((fun xc => ⟨xc.1, f xc.1 xc.2⟩) <$> receive : bm.M ((x : X) × B x))
 
 def pairedMonadicSyntax :
-    SyntaxOver.{u, u, u, u + 1} Participant RolePairedMonadContext where
+    SyntaxOver.{u, u, u, u + 1} Participant.{u} RolePairedMonadContext where
   Node agent X γ Cont :=
     match agent, γ with
     | .focal, ⟨.sender, ⟨bmP, _⟩⟩ => bmP.M ((x : X) × Cont x)
@@ -545,7 +541,7 @@ rules a single canonical shape for participant outputs, which keeps dependent
 function arguments definitionally aligned. -/
 def participantOutputFamily
     {spec : Spec} (OutputP OutputC : Transcript spec → Type u)
-    (agent : Participant) (tr : Transcript spec) : Type u :=
+    (agent : Participant.{u}) (tr : Transcript spec) : Type u :=
   match agent with
   | .focal => OutputP tr
   | .counterpart => OutputC tr
@@ -555,7 +551,7 @@ two-party run. -/
 def collectParticipantOutputs
     {spec : Spec} {OutputP OutputC : Transcript spec → Type u} :
     (tr : Transcript spec) →
-      ((agent : Participant) → participantOutputFamily OutputP OutputC agent tr) →
+      ((agent : Participant.{u}) → participantOutputFamily OutputP OutputC agent tr) →
       OutputP tr × OutputC tr :=
   fun _ out => (out Participant.focal, out Participant.counterpart)
 
@@ -566,7 +562,7 @@ def participantProfile
     {OutputP OutputC : Transcript spec → Type u}
     (strat : Strategy.withRoles m spec roles OutputP)
     (cpt : Counterpart m spec roles OutputC) :
-    (agent : Participant) →
+    (agent : Participant.{u}) →
       StrategyOver (pairedSyntax m) agent spec roles (participantOutputFamily OutputP OutputC agent)
   | .focal => strat
   | .counterpart => cpt
@@ -870,7 +866,7 @@ tree runner. -/
 def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
     (liftStrat : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
     (liftCpt : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
-    InteractionOver Participant RolePairedMonadContext pairedMonadicSyntax m where
+    InteractionOver Participant.{u} RolePairedMonadContext pairedMonadicSyntax m where
   interact := fun {X} {γ : RolePairedMonadContext X} {Cont} {Result} profile k =>
     match γ with
     | ⟨.sender, ⟨bmP, bmC⟩⟩ => do

--- a/VCVio/Interaction/TwoParty/Strategy.lean
+++ b/VCVio/Interaction/TwoParty/Strategy.lean
@@ -878,100 +878,13 @@ def Counterpart.withMonads.mapDecoration
                 (homRest msgAndRest.1) msgAndRest.2⟩)
           cpt
 
-private theorem pairedMonadicSyntax_forAgent_focal :
-    pairedMonadicSyntax.forAgent Participant.focal =
-      focalMonadicSyntax.comap RolePairedMonadContext.fst := by
-  apply congrArg SyntaxOver.mk
-  funext _ X γ Cont
-  cases γ with
-  | mk role bms =>
-      cases role <;> cases bms <;>
-        simp [pairedMonadicSyntax, focalMonadicSyntax,
-          RolePairedMonadContext.fst, Spec.Node.Context.extendMap,
-          Spec.Node.ContextHom.id, Role.Action]
-
-private theorem pairedMonadicSyntax_forAgent_counterpart :
-    pairedMonadicSyntax.forAgent Participant.counterpart =
-      counterpartMonadicSyntax.comap RolePairedMonadContext.snd := by
-  apply congrArg SyntaxOver.mk
-  funext _ X γ Cont
-  cases γ with
-  | mk role bms =>
-      cases role <;> cases bms <;>
-        simp [pairedMonadicSyntax, counterpartMonadicSyntax,
-          RolePairedMonadContext.snd, Spec.Node.Context.extendMap, Spec.Node.ContextHom.id]
-
-private theorem pairedMonadicStrategy_focal :
-    {spec : Spec} → {roles : RoleDecoration spec} →
-    {stratDeco cptDeco : MonadDecoration spec} →
-    {Output : Transcript spec → Type u} →
-    StrategyOver pairedMonadicSyntax Participant.focal spec
-      (RoleDecoration.withPairedMonads roles stratDeco cptDeco) Output =
-      Strategy.withRolesAndMonads spec roles stratDeco Output
-  | spec, roles, stratDeco, cptDeco, Output => by
-      rw [← StrategyOver.forAgent pairedMonadicSyntax Participant.focal
-        (spec := spec)
-        (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-        (Out := Output)]
-      rw [pairedMonadicSyntax_forAgent_focal]
-      rw [StrategyOver.comap focalMonadicSyntax RolePairedMonadContext.fst
-        (agent := PUnit.unit)
-        (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-        (Out := Output)]
-      rw [RoleDecoration.withPairedMonads_map_fst
-        (spec := spec) (roles := roles)
-        (stratDeco := stratDeco) (cptDeco := cptDeco)]
-
-private theorem pairedMonadicStrategy_counterpart :
-    {spec : Spec} → {roles : RoleDecoration spec} →
-    {stratDeco cptDeco : MonadDecoration spec} →
-    {Output : Transcript spec → Type u} →
-    StrategyOver pairedMonadicSyntax Participant.counterpart spec
-      (RoleDecoration.withPairedMonads roles stratDeco cptDeco) Output =
-      Counterpart.withMonads spec roles cptDeco Output
-  | spec, roles, stratDeco, cptDeco, Output => by
-      rw [← StrategyOver.forAgent pairedMonadicSyntax Participant.counterpart
-        (spec := spec)
-        (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-        (Out := Output)]
-      rw [pairedMonadicSyntax_forAgent_counterpart]
-      rw [StrategyOver.comap counterpartMonadicSyntax RolePairedMonadContext.snd
-        (agent := PUnit.unit)
-        (ctxs := RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-        (Out := Output)]
-      rw [RoleDecoration.withPairedMonads_map_snd
-        (spec := spec) (roles := roles)
-        (stratDeco := stratDeco) (cptDeco := cptDeco)]
-
-/-- Assemble a focal monadic strategy and counterpart monadic strategy into a
-participant-indexed profile for the paired monadic runner. -/
-def monadicParticipantProfile {spec : Spec} {roles : RoleDecoration spec}
-    {stratDeco cptDeco : MonadDecoration spec}
-    {OutputP OutputC : Transcript spec → Type u}
-    (strat : Strategy.withRolesAndMonads spec roles stratDeco OutputP)
-    (cpt : Counterpart.withMonads spec roles cptDeco OutputC) :
-    (agent : Participant) →
-      StrategyOver pairedMonadicSyntax agent spec
-        (RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-        (participantOutputFamily OutputP OutputC agent)
-  | .focal => by
-      exact cast
-        (pairedMonadicStrategy_focal (spec := spec) (roles := roles)
-          (stratDeco := stratDeco) (cptDeco := cptDeco) (Output := OutputP)).symm
-        strat
-  | .counterpart => by
-      exact cast
-        (pairedMonadicStrategy_counterpart (spec := spec) (roles := roles)
-          (stratDeco := stratDeco) (cptDeco := cptDeco) (Output := OutputC)).symm
-        cpt
-
 /-- One-step execution law for paired monadic two-party profiles.
 
 At each node, the participant that owns the move runs in its decorated monad.
 The supplied lifts embed the focal and counterpart node monads into the common
 execution monad `m`; the resulting continuations are then passed to the generic
 tree runner. -/
-private def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
+def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
     (liftStrat : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
     (liftCpt : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α) :
     InteractionOver Participant RolePairedMonadContext pairedMonadicSyntax m where
@@ -995,27 +908,6 @@ private def pairedMonadicInteraction {m : Type u → Type u} [Monad m]
         k x (fun
           | .focal => pCont
           | .counterpart => cCont)
-
-/-- Execute a focal monadic strategy against a monadic counterpart.
-
-This is the generic `StrategyOver.run` specialized to `pairedMonadicSyntax`.
-`liftStrat` and `liftCpt` embed the per-node monads for the focal strategy and
-the counterpart into the common execution monad `m`; the result contains the
-realized transcript and both participant outputs at that transcript. -/
-def Strategy.runWithRolesAndMonads {m : Type u → Type u} [Monad m]
-    (liftStrat : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
-    (liftCpt : ∀ (bm : BundledMonad.{u, u}) {α : Type u}, bm.M α → m α)
-    (spec : Spec.{u}) (roles : RoleDecoration spec)
-    (stratDeco : MonadDecoration spec) (cptDeco : MonadDecoration spec)
-    {OutputP : Transcript spec → Type u}
-    {OutputC : Transcript spec → Type u}
-    (strat : Strategy.withRolesAndMonads spec roles stratDeco OutputP)
-    (cpt : Counterpart.withMonads spec roles cptDeco OutputC) :
-    m ((tr : Transcript spec) × OutputP tr × OutputC tr) :=
-  StrategyOver.run (pairedMonadicInteraction liftStrat liftCpt)
-    (RoleDecoration.withPairedMonads roles stratDeco cptDeco)
-    (monadicParticipantProfile strat cpt)
-    collectParticipantOutputs
 
 end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Swap.lean
+++ b/VCVio/Interaction/TwoParty/Swap.lean
@@ -19,6 +19,10 @@ appended role decorations.
 universe u
 
 namespace Interaction
+namespace Spec
+namespace TwoParty
+
+open _root_.Interaction.TwoParty
 
 @[simp, grind =]
 theorem Role.swap_swap (r : Role) : r.swap.swap = r := by cases r <;> rfl
@@ -29,7 +33,7 @@ theorem RoleDecoration.swap_swap :
     roles.swap.swap = roles
   | .done, _ => rfl
   | .node _ rest, ⟨r, rRest⟩ => by
-      simp only [Spec.Decoration.swap, Spec.Decoration.map, Role.swap_swap]
+      simp only [RoleDecoration.swap, Spec.Decoration.map, Role.swap_swap]
       congr 1; funext x
       exact RoleDecoration.swap_swap (rest x) (rRest x)
 
@@ -38,7 +42,10 @@ theorem RoleDecoration.swap_append
     {s₁ : Spec} {s₂ : Spec.Transcript s₁ → Spec}
     (r₁ : RoleDecoration s₁)
     (r₂ : (tr₁ : Spec.Transcript s₁) → RoleDecoration (s₂ tr₁)) :
-    (r₁.append r₂).swap = r₁.swap.append (fun tr₁ => (r₂ tr₁).swap) :=
+    RoleDecoration.swap (r₁.append r₂) =
+      (RoleDecoration.swap r₁).append (fun tr₁ => RoleDecoration.swap (r₂ tr₁)) :=
   Spec.Decoration.map_append (fun _ => Role.swap) s₁ s₂ r₁ r₂
 
+end TwoParty
+end Spec
 end Interaction

--- a/VCVio/Interaction/TwoParty/Syntax.lean
+++ b/VCVio/Interaction/TwoParty/Syntax.lean
@@ -18,7 +18,7 @@ whole-tree participant types are always obtained from `StrategyOver`.
 
 @[expose] public section
 
-universe uA uB uA₂ uB₂ w
+universe u uA uB uA₂ uB₂ w
 
 namespace Interaction
 namespace TwoParty
@@ -29,7 +29,7 @@ variable {P : PFunctor.{uA, uB}} {Q : PFunctor.{uA₂, uB₂}}
 variable (l : PFunctor.Lens P Q)
 
 /-- The two agents in a focused two-party interaction. -/
-inductive Participant where
+inductive Participant : Type u where
   | focal
   | counterpart
   deriving DecidableEq

--- a/VCVio/Interaction/TwoParty/Syntax.lean
+++ b/VCVio/Interaction/TwoParty/Syntax.lean
@@ -58,7 +58,7 @@ instead of an opaque `m ((d : Move) × Cont d)`, it stores
 `m Move × ((d : Move) → Cont d)`. This exposes the continuation family needed
 for replaying prescribed public challenges.
 -/
-def publicCoinCounterpartSyntax
+def PublicCoinCounterpart.syntax
     (monad :
       (pos : P.A) → Role → Participant →
         BundledMonad.{uB₂, uB₂}) :
@@ -121,49 +121,49 @@ theorem monadicSyntax_counterpart_receiver
   rfl
 
 @[simp]
-theorem publicCoinCounterpartSyntax_focal_sender
+theorem PublicCoinCounterpart.syntax_focal_sender
     (monad :
       (pos : P.A) → Role → Participant →
         BundledMonad.{uB₂, uB₂})
     (pos : P.A)
     (Cont : Q.B (l.toFunA pos) → Type uB₂) :
-    (publicCoinCounterpartSyntax l monad).Node Participant.focal pos Role.sender Cont =
+    (PublicCoinCounterpart.syntax l monad).Node Participant.focal pos Role.sender Cont =
       (monad pos Role.sender Participant.focal).M
         ((d : Q.B (l.toFunA pos)) × Cont d) :=
   rfl
 
 @[simp]
-theorem publicCoinCounterpartSyntax_counterpart_sender
+theorem PublicCoinCounterpart.syntax_counterpart_sender
     (monad :
       (pos : P.A) → Role → Participant →
         BundledMonad.{uB₂, uB₂})
     (pos : P.A)
     (Cont : Q.B (l.toFunA pos) → Type uB₂) :
-    (publicCoinCounterpartSyntax l monad).Node Participant.counterpart pos Role.sender Cont =
+    (PublicCoinCounterpart.syntax l monad).Node Participant.counterpart pos Role.sender Cont =
       ((d : Q.B (l.toFunA pos)) →
         (monad pos Role.sender Participant.counterpart).M (Cont d)) :=
   rfl
 
 @[simp]
-theorem publicCoinCounterpartSyntax_focal_receiver
+theorem PublicCoinCounterpart.syntax_focal_receiver
     (monad :
       (pos : P.A) → Role → Participant →
         BundledMonad.{uB₂, uB₂})
     (pos : P.A)
     (Cont : Q.B (l.toFunA pos) → Type uB₂) :
-    (publicCoinCounterpartSyntax l monad).Node Participant.focal pos Role.receiver Cont =
+    (PublicCoinCounterpart.syntax l monad).Node Participant.focal pos Role.receiver Cont =
       ((d : Q.B (l.toFunA pos)) →
         (monad pos Role.receiver Participant.focal).M (Cont d)) :=
   rfl
 
 @[simp]
-theorem publicCoinCounterpartSyntax_counterpart_receiver
+theorem PublicCoinCounterpart.syntax_counterpart_receiver
     (monad :
       (pos : P.A) → Role → Participant →
         BundledMonad.{uB₂, uB₂})
     (pos : P.A)
     (Cont : Q.B (l.toFunA pos) → Type uB₂) :
-    (publicCoinCounterpartSyntax l monad).Node Participant.counterpart pos Role.receiver Cont =
+    (PublicCoinCounterpart.syntax l monad).Node Participant.counterpart pos Role.receiver Cont =
       ((monad pos Role.receiver Participant.counterpart).M (Q.B (l.toFunA pos)) ×
         ((d : Q.B (l.toFunA pos)) → Cont d)) :=
   rfl

--- a/VCVio/Interaction/TwoParty/Syntax.lean
+++ b/VCVio/Interaction/TwoParty/Syntax.lean
@@ -13,7 +13,7 @@ This module provides the two-party ownership profile and common local syntax
 specializations over the generic `Interaction.SyntaxOver` core.
 
 It intentionally does not define another recursive strategy hierarchy:
-whole-tree participant types are always obtained from `SyntaxOver.Family`.
+whole-tree participant types are always obtained from `StrategyOver`.
 -/
 
 @[expose] public section


### PR DESCRIPTION
## Summary
- move the generic whole-tree runner onto `InteractionOver.run` with the execution law argument last
- make the one-player strategy type explicit as `Strategy.Plain` and remove the primed variant
- consolidate two-party focal operations under `Interaction.Spec.TwoParty.Focal`, keep counterpart operations under `Counterpart`, and expose a single `Interaction.Spec.TwoParty.run`
- split generic two-party roles/syntax from role-decorated spec operations through `Interaction.TwoParty` and `Interaction.Spec.TwoParty`
- add `StrategyOver.Hom` / `StrategyOver.map` for local-node homomorphisms at both the generic `PFunctor.FreeM` layer and the `Spec` layer
- rewrite public-coin counterpart forgetting through `PublicCoinCounterpart.toCounterpartHom`
- refresh docstrings around the current strategy-over-syntax and focal/counterpart viewpoint

## Validation
- `lake build VCVio`

Posted by Cursor assistant (model: GPT-5) on behalf of the user (Quang Dao) with approval.
