### PR TITLE
chore(ci): bump lint-style-action pin to 91923b04

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -42,6 +42,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: leanprover-community/lint-style-action@a7e7428fa44f9635d6eb8e01919d16fd498d387a # 2025-08-18
+      - uses: leanprover-community/lint-style-action@91923b046cc6a468e9ae340f32f8defe586bd08f # 2026-05-12
         with:
           mode: check


### PR DESCRIPTION
This PR bumps the `leanprover-community/lint-style-action` SHA pin from `a7e7428` (2025-08-18) to `91923b04` (2026-05-12) in `.github/workflows/linting.yml`.

The new pin includes https://github.com/leanprover-community/lint-style-action/pull/5 - feat(install-bibtool): use --no-install-recommends with apt-get, which drops the `apt-get install bibtool` download from ~168 MB to ~851 kB on every run of the linting job. `bibtool` only declares `texlive-base` as `Recommends:` (not `Depends:`), and the action invokes `bibtool` directly on `.bib` files without TeX, so the recommended packages are not needed.

No other behaviour changes — same action, same inputs.

🤖 Prepared with Claude Code