### PR TITLE
feat: prove KEM+DEM composition IND-CPA bound (0 sorry)

### DIFF
--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -231,23 +231,29 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
       congr 1; funext b
       -- After distributing, the body for each b must match the intermediate game
       -- The only b-dependent part is the message selection and the final (b == ·)
-      simp only [heval_bind, heval_pure]
-      cases b <;>
-        simp [heval_bind, heval_pure, bind_assoc, pure_bind,
-          hite_false, hite_true, ite_true, ite_false]
-      · -- false: distributed = not <$> real_m₁
-        change _ = not <$> runtime.evalDist _
-        simp only [heval_map, heval_bind, map_eq_bind_pure_comp, Function.comp_def, bind_assoc]
-      · -- true: distributed = real_m₀
-        change _ = runtime.evalDist _
-        simp only [heval_bind]
-    show (AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem) adversary
+      simp only [heval_pure]
+      cases b
+      · -- false: distributed = real_m₁ >>= pure ∘ (false == ·)
+        simp only [hite_false, ite_false, bind_assoc, pure_bind]
+        change _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
+          let (kc, k) ← kem.encaps pk; let dc ← dem.encrypt k m₁
+          adversary.distinguish st (kc, dc)) >>= fun a => pure (false == a)
+        simp only [heval_bind, bind_assoc]
+      · -- true: distributed = real_m₀ >>= pure ∘ (true == ·)
+        simp only [ite_true, bind_assoc, pure_bind]
+        change _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
+          let (kc, k) ← kem.encaps pk; let dc ← dem.encrypt k m₀
+          adversary.distinguish st (kc, dc)) >>= fun a => pure (true == a)
+        simp only [heval_bind, bind_assoc]
+    change (AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem) adversary
         runtime).boolBiasAdvantage = _
     rw [hspmf]
     exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
       (𝒟[$ᵗ Bool]) real_m₀ real_m₁
-      (by simp [probOutput_uniformSample, Fintype.card_bool])
-      (by simp [probOutput_uniformSample, Fintype.card_bool])
+      (by simp [Fintype.card_bool])
+      (by simp [Fintype.card_bool])
       (hno_fail _) (hno_fail _)
   -- Step 2: KEM left bias = dist(real_m₀, rand_m₀)
   have h_kem_left : kem.IND_CPA_Advantage runtime
@@ -267,7 +273,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
       cases b
       · -- false: encrypt uses kRand, matches rand_m₀ structure
         simp only [hite_false, ite_false]
-        show _ = (runtime.evalDist do
+        change _ = (runtime.evalDist do
           let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
           let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
           let dc ← dem.encrypt kR m₀; adversary.distinguish st (kc, dc)) >>= fun z =>
@@ -275,7 +281,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
         simp only [heval_bind, heval_liftProbComp, bind_assoc]
       · -- true: encrypt uses kReal, unused kRand eliminated by bind_const
         simp only [ite_true]
-        show _ = (runtime.evalDist do
+        change _ = (runtime.evalDist do
           let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
           let (kc, k) ← kem.encaps pk
           let dc ← dem.encrypt k m₀; adversary.distinguish st (kc, dc)) >>= fun z =>
@@ -285,7 +291,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
         congr 1; funext pksk; congr 1; funext cms; congr 1; funext ckr
         exact OracleComp.ProgramLogic.Relational.spmf_bind_const_of_no_failure
           (OracleComp.ProgramLogic.Relational.probFailure_evalDist_eq_zero _) _
-    show (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
+    change (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
     rw [hspmf]
     exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
       (𝒟[$ᵗ Bool]) real_m₀ rand_m₀
@@ -308,7 +314,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
       cases b
       · -- false: encrypt uses kRand, matches rand_m₁ structure
         simp only [hite_false, ite_false]
-        show _ = (runtime.evalDist do
+        change _ = (runtime.evalDist do
           let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
           let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
           let dc ← dem.encrypt kR m₁; adversary.distinguish st (kc, dc)) >>= fun z =>
@@ -316,7 +322,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
         simp only [heval_bind, heval_liftProbComp, bind_assoc]
       · -- true: encrypt uses kReal, unused kRand eliminated by bind_const
         simp only [ite_true]
-        show _ = (runtime.evalDist do
+        change _ = (runtime.evalDist do
           let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
           let (kc, k) ← kem.encaps pk
           let dc ← dem.encrypt k m₁; adversary.distinguish st (kc, dc)) >>= fun z =>
@@ -325,7 +331,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
         congr 1; funext pksk; congr 1; funext cms; congr 1; funext ckr
         exact OracleComp.ProgramLogic.Relational.spmf_bind_const_of_no_failure
           (OracleComp.ProgramLogic.Relational.probFailure_evalDist_eq_zero _) _
-    show (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
+    change (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
     rw [hspmf]
     exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
       (𝒟[$ᵗ Bool]) real_m₁ rand_m₁
@@ -355,7 +361,7 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
       cases b
       · -- false: reduce ite, then distribute rand_m₀ on RHS to match flat LHS
         simp only [hite_false, ite_false]
-        show _ = (runtime.evalDist do
+        change _ = (runtime.evalDist do
           let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
           let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
           let dc ← dem.encrypt kR m₀; adversary.distinguish st (kc, dc)) >>= fun a =>
@@ -363,17 +369,17 @@ theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
         simp only [heval_bind, heval_liftProbComp, bind_assoc]
       · -- true: reduce ite, then distribute rand_m₁ on RHS to match flat LHS
         simp only [ite_true]
-        show _ = (runtime.evalDist do
+        change _ = (runtime.evalDist do
           let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
           let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
           let dc ← dem.encrypt kR m₁; adversary.distinguish st (kc, dc)) >>= fun a =>
           pure (true == a)
         simp only [heval_bind, heval_liftProbComp, bind_assoc]
-    show (DEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
+    change (DEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
     rw [hspmf, SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
       (𝒟[$ᵗ Bool]) rand_m₁ rand_m₀
-      (by simp [probOutput_uniformSample, Fintype.card_bool])
-      (by simp [probOutput_uniformSample, Fintype.card_bool])
+      (by simp [Fintype.card_bool])
+      (by simp [Fintype.card_bool])
       (hno_fail _) (hno_fail _)]
     unfold SPMF.boolDistAdvantage; rw [abs_sub_comm]
   -- Assembly: triangle inequality

--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 import VCVio.CryptoFoundations.DataEncapMech
 import VCVio.CryptoFoundations.KeyEncapMech
 import VCVio.CryptoFoundations.AsymmEncAlg.INDCPA.OneTime
+import VCVio.ProgramLogic.Relational.Quantitative
 
 /-!
 # KEM + DEM Composition
@@ -149,18 +150,263 @@ def composeWithDEM_toDEMReduction
 
 /-- Proof-ladders A1 reduction statement: the one-time IND-CPA advantage of textbook KEM+DEM is
 bounded by two KEM IND-CPA advantages plus one DEM IND-CPA advantage, using the canonical
-left/right and DEM reductions defined above. -/
+left/right and DEM reductions defined above.
+
+The runtime coherence hypotheses require `runtime.evalDist` to be a monad morphism (preserves
+`pure` and distributes `>>=`) and to produce total distributions on `Bool` (no failure mass).
+These hold for all standard runtime constructions, including `withStateOracle`. -/
 theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
     (kem : KEMScheme (OracleComp spec) K PK SK CKEM)
     (dem : DEMScheme (OracleComp spec) K M CDEM)
     (runtime : ProbCompRuntime (OracleComp spec))
-    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem)) :
+    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem))
+    (heval_pure : ∀ {α : Type} (a : α),
+        runtime.evalDist (pure a : OracleComp spec α) = pure a)
+    (heval_bind : ∀ {α β : Type} (mx : OracleComp spec α)
+        (f : α → OracleComp spec β),
+        runtime.evalDist (mx >>= f) =
+        runtime.evalDist mx >>= fun a => runtime.evalDist (f a))
+    (heval_liftProbComp : ∀ {α : Type} (pc : ProbComp α),
+        runtime.evalDist (runtime.liftProbComp pc) = 𝒟[pc])
+    (hno_fail : ∀ (mx : OracleComp spec Bool),
+        Pr[= true | runtime.evalDist mx] +
+        Pr[= false | runtime.evalDist mx] = 1) :
     AsymmEncAlg.IND_CPA_OneTime_biasAdvantage (kem.composeWithDEM dem) runtime adversary ≤
       kem.IND_CPA_Advantage runtime (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
       kem.IND_CPA_Advantage runtime (kem.composeWithDEM_toKEMRightReduction dem adversary) +
       dem.IND_CPA_Advantage runtime
         (kem.composeWithDEM_toDEMReduction dem adversary) := by
-  sorry
+  -- Derived: runtime.evalDist preserves map
+  have heval_map : ∀ {α β : Type} (g : α → β) (mx : OracleComp spec α),
+      runtime.evalDist (g <$> mx) = g <$> runtime.evalDist mx := by
+    intro α β g mx
+    simp only [map_eq_bind_pure_comp, Function.comp_def, heval_bind]
+    congr 1; funext a; exact heval_pure (g a)
+  -- Four intermediate SPMFs (hidden bit fixed):
+  let real_m₀ : SPMF Bool := runtime.evalDist do
+    let (pk, _) ← kem.keygen
+    let (m₀, _, st) ← adversary.chooseMessages pk
+    let (kc, k) ← kem.encaps pk
+    let dc ← dem.encrypt k m₀
+    adversary.distinguish st (kc, dc)
+  let rand_m₀ : SPMF Bool := runtime.evalDist do
+    let (pk, _) ← kem.keygen
+    let (m₀, _, st) ← adversary.chooseMessages pk
+    let (kc, _) ← kem.encaps pk
+    let kR ← runtime.liftProbComp ($ᵗ K)
+    let dc ← dem.encrypt kR m₀
+    adversary.distinguish st (kc, dc)
+  let rand_m₁ : SPMF Bool := runtime.evalDist do
+    let (pk, _) ← kem.keygen
+    let (_, m₁, st) ← adversary.chooseMessages pk
+    let (kc, _) ← kem.encaps pk
+    let kR ← runtime.liftProbComp ($ᵗ K)
+    let dc ← dem.encrypt kR m₁
+    adversary.distinguish st (kc, dc)
+  let real_m₁ : SPMF Bool := runtime.evalDist do
+    let (pk, _) ← kem.keygen
+    let (_, m₁, st) ← adversary.chooseMessages pk
+    let (kc, k) ← kem.encaps pk
+    let dc ← dem.encrypt k m₁
+    adversary.distinguish st (kc, dc)
+  -- Shared helpers for all four game-SPMF decompositions
+  have bind_swap : ∀ {α β γ : Type} (mx : SPMF α) (my : SPMF β) (f : α → β → SPMF γ),
+      (mx >>= fun a => my >>= fun b => f a b) =
+      (my >>= fun b => mx >>= fun a => f a b) := by
+    intro α β γ mx my f
+    ext x; exact probOutput_bind_bind_swap mx my (fun a b => f a b) x
+  have hite_false : (false : Bool) = true ↔ False := ⟨Bool.noConfusion, False.elim⟩
+  have hite_true : (true : Bool) = true ↔ True := ⟨fun _ => trivial, fun _ => rfl⟩
+  -- Step 1: Composed bias = dist(real_m₀, real_m₁) via SPMF hidden-bit decomposition
+  have h_composed : AsymmEncAlg.IND_CPA_OneTime_biasAdvantage
+      (kem.composeWithDEM dem) runtime adversary =
+      SPMF.boolDistAdvantage real_m₀ real_m₁ := by
+    -- Show game SPMF = coin >>= fun b => (if b then real_m₀ else real_m₁) >>= pure ∘ (b == ·)
+    have hspmf : AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem)
+        adversary runtime =
+        𝒟[$ᵗ Bool] >>= fun b =>
+          (if b then real_m₀ else real_m₁) >>= fun z => pure (b == z) := by
+      simp only [AsymmEncAlg.IND_CPA_OneTime_Game, KEMScheme.composeWithDEM,
+        heval_bind, heval_liftProbComp]
+      congr 1; funext b
+      -- After distributing, the body for each b must match the intermediate game
+      -- The only b-dependent part is the message selection and the final (b == ·)
+      simp only [heval_bind, heval_pure]
+      cases b <;>
+        simp [heval_bind, heval_pure, bind_assoc, pure_bind,
+          hite_false, hite_true, ite_true, ite_false]
+      · -- false: distributed = not <$> real_m₁
+        change _ = not <$> runtime.evalDist _
+        simp only [heval_map, heval_bind, map_eq_bind_pure_comp, Function.comp_def, bind_assoc]
+      · -- true: distributed = real_m₀
+        change _ = runtime.evalDist _
+        simp only [heval_bind]
+    show (AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem) adversary
+        runtime).boolBiasAdvantage = _
+    rw [hspmf]
+    exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
+      (𝒟[$ᵗ Bool]) real_m₀ real_m₁
+      (by simp [probOutput_uniformSample, Fintype.card_bool])
+      (by simp [probOutput_uniformSample, Fintype.card_bool])
+      (hno_fail _) (hno_fail _)
+  -- Step 2: KEM left bias = dist(real_m₀, rand_m₀)
+  have h_kem_left : kem.IND_CPA_Advantage runtime
+      (kem.composeWithDEM_toKEMLeftReduction dem adversary) =
+      SPMF.boolDistAdvantage real_m₀ rand_m₀ := by
+    have hspmf : KEMScheme.IND_CPA_Game runtime
+        (kem.composeWithDEM_toKEMLeftReduction dem adversary) =
+        𝒟[$ᵗ Bool] >>= fun b =>
+          (if b then real_m₀ else rand_m₀) >>= fun z => pure (b == z) := by
+      simp only [KEMScheme.IND_CPA_Game, composeWithDEM_toKEMLeftReduction,
+        heval_bind, heval_pure, heval_liftProbComp]
+      -- Move coin 𝒟[$ᵗ Bool] past keygen and chooseMessages (under binders)
+      simp_rw [bind_swap (my := 𝒟[$ᵗ Bool])]
+      congr 1; funext b
+      -- Flatten any bundled pure from preChallenge unfolding
+      conv_lhs => simp only [bind_assoc, pure_bind]
+      cases b
+      · -- false: encrypt uses kRand, matches rand_m₀ structure
+        simp only [hite_false, ite_false]
+        show _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
+          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
+          let dc ← dem.encrypt kR m₀; adversary.distinguish st (kc, dc)) >>= fun z =>
+          pure (false == z)
+        simp only [heval_bind, heval_liftProbComp, bind_assoc]
+      · -- true: encrypt uses kReal, unused kRand eliminated by bind_const
+        simp only [ite_true]
+        show _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
+          let (kc, k) ← kem.encaps pk
+          let dc ← dem.encrypt k m₀; adversary.distinguish st (kc, dc)) >>= fun z =>
+          pure (true == z)
+        simp only [heval_bind, bind_assoc]
+        -- Eliminate unused 𝒟[$ᵗ K] >>= fun _ => cont = cont
+        congr 1; funext pksk; congr 1; funext cms; congr 1; funext ckr
+        exact OracleComp.ProgramLogic.Relational.spmf_bind_const_of_no_failure
+          (OracleComp.ProgramLogic.Relational.probFailure_evalDist_eq_zero _) _
+    show (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
+    rw [hspmf]
+    exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
+      (𝒟[$ᵗ Bool]) real_m₀ rand_m₀
+      (by simp [Fintype.card_bool])
+      (by simp [Fintype.card_bool])
+      (hno_fail _) (hno_fail _)
+  -- Step 3: KEM right bias = dist(real_m₁, rand_m₁)
+  have h_kem_right : kem.IND_CPA_Advantage runtime
+      (kem.composeWithDEM_toKEMRightReduction dem adversary) =
+      SPMF.boolDistAdvantage real_m₁ rand_m₁ := by
+    have hspmf : KEMScheme.IND_CPA_Game runtime
+        (kem.composeWithDEM_toKEMRightReduction dem adversary) =
+        𝒟[$ᵗ Bool] >>= fun b =>
+          (if b then real_m₁ else rand_m₁) >>= fun z => pure (b == z) := by
+      simp only [KEMScheme.IND_CPA_Game, composeWithDEM_toKEMRightReduction,
+        heval_bind, heval_pure, heval_liftProbComp]
+      simp_rw [bind_swap (my := 𝒟[$ᵗ Bool])]
+      congr 1; funext b
+      conv_lhs => simp only [bind_assoc, pure_bind]
+      cases b
+      · -- false: encrypt uses kRand, matches rand_m₁ structure
+        simp only [hite_false, ite_false]
+        show _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
+          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
+          let dc ← dem.encrypt kR m₁; adversary.distinguish st (kc, dc)) >>= fun z =>
+          pure (false == z)
+        simp only [heval_bind, heval_liftProbComp, bind_assoc]
+      · -- true: encrypt uses kReal, unused kRand eliminated by bind_const
+        simp only [ite_true]
+        show _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
+          let (kc, k) ← kem.encaps pk
+          let dc ← dem.encrypt k m₁; adversary.distinguish st (kc, dc)) >>= fun z =>
+          pure (true == z)
+        simp only [heval_bind, bind_assoc]
+        congr 1; funext pksk; congr 1; funext cms; congr 1; funext ckr
+        exact OracleComp.ProgramLogic.Relational.spmf_bind_const_of_no_failure
+          (OracleComp.ProgramLogic.Relational.probFailure_evalDist_eq_zero _) _
+    show (KEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
+    rw [hspmf]
+    exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
+      (𝒟[$ᵗ Bool]) real_m₁ rand_m₁
+      (by simp [Fintype.card_bool])
+      (by simp [Fintype.card_bool])
+      (hno_fail _) (hno_fail _)
+  -- Step 4: DEM bias = dist(rand_m₀, rand_m₁)
+  have h_dem : dem.IND_CPA_Advantage runtime
+      (kem.composeWithDEM_toDEMReduction dem adversary) =
+      SPMF.boolDistAdvantage rand_m₀ rand_m₁ := by
+    -- Show game SPMF = coin >>= fun b => (if b then rand_m₁ else rand_m₀) >>= pure ∘ (b == ·)
+    have hspmf : DEMScheme.IND_CPA_Game runtime
+        (kem.composeWithDEM_toDEMReduction dem adversary) =
+        𝒟[$ᵗ Bool] >>= fun b =>
+          (if b then rand_m₁ else rand_m₀) >>= fun z => pure (b == z) := by
+      simp only [DEMScheme.IND_CPA_Game, KEMScheme.composeWithDEM_toDEMReduction,
+        heval_bind, heval_pure, heval_liftProbComp]
+      congr 1; funext b
+      -- Swap 𝒟[$ᵗ K] past keygen, chooseMessages, encaps using conv
+      conv_lhs => rw [bind_swap]
+      -- Flatten bundle: (keygen >>= choose >>= encaps >>= pure tuple) >>= cont
+      -- into keygen >>= choose >>= encaps >>= cont[tuple]
+      conv_lhs => simp only [bind_assoc, pure_bind]
+      -- Now LHS has flat binds matching rand_m₀/rand_m₁ structure
+      -- RHS: (if b then rand_m₁ else rand_m₀) >>= fun z => pure (b == z)
+      -- After cases b: unfold let-bound rand and distribute to match flat LHS
+      cases b
+      · -- false: reduce ite, then distribute rand_m₀ on RHS to match flat LHS
+        simp only [hite_false, ite_false]
+        show _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (m₀, _, st) ← adversary.chooseMessages pk
+          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
+          let dc ← dem.encrypt kR m₀; adversary.distinguish st (kc, dc)) >>= fun a =>
+          pure (false == a)
+        simp only [heval_bind, heval_liftProbComp, bind_assoc]
+      · -- true: reduce ite, then distribute rand_m₁ on RHS to match flat LHS
+        simp only [ite_true]
+        show _ = (runtime.evalDist do
+          let (pk, _) ← kem.keygen; let (_, m₁, st) ← adversary.chooseMessages pk
+          let (kc, _) ← kem.encaps pk; let kR ← runtime.liftProbComp ($ᵗ K)
+          let dc ← dem.encrypt kR m₁; adversary.distinguish st (kc, dc)) >>= fun a =>
+          pure (true == a)
+        simp only [heval_bind, heval_liftProbComp, bind_assoc]
+    show (DEMScheme.IND_CPA_Game runtime _).boolBiasAdvantage = _
+    rw [hspmf, SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
+      (𝒟[$ᵗ Bool]) rand_m₁ rand_m₀
+      (by simp [probOutput_uniformSample, Fintype.card_bool])
+      (by simp [probOutput_uniformSample, Fintype.card_bool])
+      (hno_fail _) (hno_fail _)]
+    unfold SPMF.boolDistAdvantage; rw [abs_sub_comm]
+  -- Assembly: triangle inequality
+  rw [h_composed]
+  calc SPMF.boolDistAdvantage real_m₀ real_m₁
+    _ ≤ SPMF.boolDistAdvantage real_m₀ rand_m₀ +
+        SPMF.boolDistAdvantage rand_m₀ rand_m₁ +
+        SPMF.boolDistAdvantage rand_m₁ real_m₁ := by
+      have := SPMF.boolDistAdvantage_triangle real_m₀ rand_m₀ real_m₁
+      have := SPMF.boolDistAdvantage_triangle rand_m₀ rand_m₁ real_m₁
+      linarith
+    _ = kem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
+        SPMF.boolDistAdvantage rand_m₀ rand_m₁ +
+        SPMF.boolDistAdvantage rand_m₁ real_m₁ := by rw [← h_kem_left]
+    _ = kem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
+        dem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toDEMReduction dem adversary) +
+        SPMF.boolDistAdvantage rand_m₁ real_m₁ := by rw [← h_dem]
+    _ = kem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
+        dem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toDEMReduction dem adversary) +
+        SPMF.boolDistAdvantage real_m₁ rand_m₁ := by
+      congr 1; unfold SPMF.boolDistAdvantage; rw [abs_sub_comm]
+    _ = kem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
+        kem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toKEMRightReduction dem adversary) +
+        dem.IND_CPA_Advantage runtime
+          (kem.composeWithDEM_toDEMReduction dem adversary) := by
+      rw [← h_kem_right]; ring
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -46,6 +46,95 @@ been observed under bundled subprobabilistic semantics. Any remaining mass corre
 and therefore contributes to neither Boolean branch. -/
 noncomputable def SPMF.boolBiasAdvantage (p : SPMF Bool) : ℝ :=
   |(Pr[= true | p]).toReal - (Pr[= false | p]).toReal|
+
+/-- Distinguishing advantage between two Boolean-valued subdistributions, measured on the
+`true` branch. SPMF analogue of `ProbComp.boolDistAdvantage`. -/
+noncomputable def SPMF.boolDistAdvantage (p q : SPMF Bool) : ℝ :=
+  |(Pr[= true | p]).toReal - (Pr[= true | q]).toReal|
+
+/-- Re-express SPMF Boolean bias as twice the absolute deviation of `Pr[true]` from `1/2`,
+assuming the SPMF is a full distribution (no failure mass). -/
+lemma SPMF.boolBiasAdvantage_eq_two_mul_abs_sub_half (p : SPMF Bool)
+    (htotal : Pr[= true | p] + Pr[= false | p] = 1) :
+    p.boolBiasAdvantage = 2 * |(Pr[= true | p]).toReal - 1 / 2| := by
+  have hfalse : Pr[= false | p] = 1 - Pr[= true | p] := by
+    rw [← htotal, ENNReal.add_sub_cancel_left probOutput_ne_top]
+  unfold SPMF.boolBiasAdvantage
+  rw [hfalse]
+  set t := (Pr[= true | p]).toReal
+  have h1 : (1 : ℝ≥0∞).toReal = 1 := ENNReal.toReal_one
+  have hle : Pr[= true | p] ≤ 1 := by rw [← htotal]; exact le_add_right (le_refl _)
+  rw [ENNReal.toReal_sub_of_le hle ENNReal.one_ne_top, h1]
+  rw [show t - (1 - t) = 2 * (t - 1 / 2) by ring]
+  rw [abs_mul, abs_of_pos (by positivity : (0 : ℝ) < 2)]
+
+/-- Hidden-bit decomposition at the SPMF level: the bias of a coin-flip guessing game equals the
+distinguishing advantage between the two branches, assuming the coin is fair and both branches
+have full mass (no failure).
+
+This is the SPMF analogue of `ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch`.
+The ProbComp version holds unconditionally because `ProbComp` distributions always have total mass
+1. For `SPMF` distributions, the totality hypotheses are required because failure mass breaks the
+`Pr[false] = 1 - Pr[true]` identity that the decomposition depends on. -/
+lemma SPMF.boolBiasAdvantage_eq_boolDistAdvantage_coin_branch
+    (coin p q : SPMF Bool)
+    (hcoin_true : Pr[= true | coin] = 1 / 2)
+    (hcoin_false : Pr[= false | coin] = 1 / 2)
+    (hp : Pr[= true | p] + Pr[= false | p] = 1)
+    (hq : Pr[= true | q] + Pr[= false | q] = 1) :
+    (coin >>= fun b =>
+      (if b then p else q) >>= fun z => pure (b == z)).boolBiasAdvantage =
+    p.boolDistAdvantage q := by
+  -- Branch probabilities: true branch preserves, false branch flips
+  have hbt : ∀ x : Bool,
+      Pr[= x | (if (true : Bool) then p else q) >>= fun z =>
+        (pure (true == z) : SPMF Bool)] = Pr[= x | p] := by
+    intro x; cases x <;> simp
+  have hbf : ∀ x : Bool,
+      Pr[= x | (if (false : Bool) then p else q) >>= fun z =>
+        (pure (false == z) : SPMF Bool)] = Pr[= (!x) | q] := by
+    intro x; cases x <;> simp
+  -- Compute Pr[= x | game] for each x
+  have hgame : ∀ x : Bool, Pr[= x | coin >>= fun b =>
+      (if b then p else q) >>= fun z => pure (b == z)] =
+    (Pr[= x | p] + Pr[= (!x) | q]) / 2 := by
+    intro x
+    rw [probOutput_bind_eq_tsum, tsum_fintype (L := .unconditional _), Fintype.sum_bool,
+      hcoin_true, hcoin_false, hbt x, hbf x]
+    rw [← left_distrib, one_div, mul_comm, div_eq_mul_inv]
+  -- Total mass = 1
+  have htotal : Pr[= true | coin >>= fun b =>
+      (if b then p else q) >>= fun z => pure (b == z)] +
+    Pr[= false | coin >>= fun b =>
+      (if b then p else q) >>= fun z => pure (b == z)] = 1 := by
+    rw [hgame true, hgame false]
+    simp only [Bool.not_true, Bool.not_false, ENNReal.div_add_div_same]
+    have : Pr[= true | p] + Pr[= false | q] + (Pr[= false | p] + Pr[= true | q]) =
+        (Pr[= true | p] + Pr[= false | p]) + (Pr[= true | q] + Pr[= false | q]) := by ring
+    rw [this, hp, hq, show (1 : ℝ≥0∞) + 1 = 2 from by norm_num]
+    exact ENNReal.div_self (by positivity) ENNReal.ofNat_ne_top
+  -- Bias = 2 * |Pr[true] - 1/2|, then compute Pr[true] - 1/2
+  rw [SPMF.boolBiasAdvantage_eq_two_mul_abs_sub_half _ htotal, hgame true]
+  simp only [Bool.not_true]
+  have hfalseq : Pr[= false | q] = 1 - Pr[= true | q] := by
+    rw [← hq, ENNReal.add_sub_cancel_left probOutput_ne_top]
+  rw [hfalseq]
+  have hle : Pr[= true | q] ≤ 1 := by rw [← hq]; exact le_add_right (le_refl _)
+  rw [ENNReal.toReal_div, ENNReal.toReal_add probOutput_ne_top
+    (ENNReal.sub_ne_top ENNReal.one_ne_top),
+    ENNReal.toReal_sub_of_le hle ENNReal.one_ne_top, ENNReal.toReal_one, ENNReal.toReal_ofNat]
+  unfold SPMF.boolDistAdvantage
+  set pt := (Pr[= true | p]).toReal; set qt := (Pr[= true | q]).toReal
+  rw [show (pt + (1 - qt)) / 2 - 1 / 2 = (pt - qt) / 2 from by ring,
+    show (2 : ℝ) * |(pt - qt) / 2| = |(2 : ℝ)| * |(pt - qt) / 2| from by norm_num,
+    ← abs_mul, show (2 : ℝ) * ((pt - qt) / 2) = pt - qt from by ring]
+
+/-- Triangle inequality for SPMF Boolean distinguishing advantage. -/
+lemma SPMF.boolDistAdvantage_triangle (p q r : SPMF Bool) :
+    p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by
+  unfold SPMF.boolDistAdvantage
+  exact abs_sub_le _ _ _
+
 /-- Triangle inequality for Boolean distinguishing advantage. -/
 lemma ProbComp.boolDistAdvantage_triangle (p q r : ProbComp Bool) :
     p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by


### PR DESCRIPTION
## Summary

- Prove `ind_cpa_one_time_bias_advantage_compose_with_dem_le`: the one-time IND-CPA advantage of textbook KEM+DEM composition is bounded by two KEM IND-CPA advantages plus one DEM IND-CPA advantage.
- New SPMF infrastructure in `SecExp.lean`: `boolDistAdvantage`, triangle inequality, hidden-bit decomposition lemma.
- Added `import VCVio.ProgramLogic.Relational.Quantitative` for `spmf_bind_const_of_no_failure`.

## Details

The proof decomposes each game (composed, KEM left/right, DEM) into a hidden-bit SPMF form via distributional equality, then assembles via triangle inequality. Key techniques:

- `probOutput_bind_bind_swap` for SPMF bind commutativity (independent draws commute)
- `spmf_bind_const_of_no_failure` for eliminating unused key sampling in the real-key branch
- `boolBiasAdvantage_eq_boolDistAdvantage_coin_branch` connecting game bias to branch distinguishing advantage