### PR TITLE
feat(KEMDEM): prove KEM+DEM IND-CPA composition (closes #197)

### DIFF
--- a/VCVio/CryptoFoundations/DataEncapMech.lean
+++ b/VCVio/CryptoFoundations/DataEncapMech.lean
@@ -6,6 +6,7 @@ Authors: Quang Dao
 import VCVio.CryptoFoundations.SecExp
 import VCVio.OracleComp.ProbCompLift
 import VCVio.OracleComp.ProbComp
+import VCVio.OracleComp.Constructions.SampleableType
 
 /-!
 # Data Encapsulation Mechanisms
@@ -92,6 +93,28 @@ theorem IND_CPA_Advantage_eq_game_bias {dem : DEMScheme (OracleComp spec) K M C}
     (adversary : dem.IND_CPA_Adversary) :
     dem.IND_CPA_Advantage runtime adversary =
       (dem.IND_CPA_Game runtime adversary).boolBiasAdvantage := rfl
+
+/-! ### Game ↔ Exp connector
+
+The DEM single-game SPMF factors directly into a hidden-bit branching game over the two
+fixed-branch experiments. Unlike the KEM case, the challenge bit is already the first sample
+in the DEM game, so no commutativity is needed; only `LawfulProbCompRuntime` bind-distribution
+plus the canonical denotation of the uniform-bool sample. -/
+
+/-- The DEM single-game SPMF factors as `bool >>= fun b => Exp b >>= fun b' => pure (b == b')`
+under a `LawfulProbCompRuntime`. -/
+lemma IND_CPA_Game_eq_branch {dem : DEMScheme (OracleComp spec) K M C}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h : LawfulProbCompRuntime runtime)
+    (adversary : dem.IND_CPA_Adversary) :
+    dem.IND_CPA_Game runtime adversary =
+      (liftM (PMF.uniformOfFintype Bool) : SPMF Bool) >>= fun b =>
+        dem.IND_CPA_Exp runtime adversary b >>= fun b' =>
+          pure (b == b') := by
+  unfold IND_CPA_Game IND_CPA_Exp
+  rw [h.evalDist_bind, h.evalDist_liftProbComp, evalDist_uniformSample]
+  refine bind_congr fun b => ?_
+  simp only [h.evalDist_bind, h.evalDist_pure, bind_assoc]
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -110,8 +110,8 @@ def composeWithDEM_toKEMLeftReduction
     kem.IND_CPA_Adversary where
   State := M × adversary.State
   preChallenge pk := do
-    let (m₀, _m₁, st) ← adversary.chooseMessages pk
-    return (m₀, st)
+    let (m₁, _m₂, st) ← adversary.chooseMessages pk
+    return (m₁, st)
   postChallenge st kc k := do
     let dc ← dem.encrypt k st.1
     adversary.distinguish st.2 (kc, dc)
@@ -124,8 +124,8 @@ def composeWithDEM_toKEMRightReduction
     kem.IND_CPA_Adversary where
   State := M × adversary.State
   preChallenge pk := do
-    let (_m₀, m₁, st) ← adversary.chooseMessages pk
-    return (m₁, st)
+    let (_m₁, m₂, st) ← adversary.chooseMessages pk
+    return (m₂, st)
   postChallenge st kc k := do
     let dc ← dem.encrypt k st.1
     adversary.distinguish st.2 (kc, dc)
@@ -141,26 +141,281 @@ def composeWithDEM_toDEMReduction
   State := CKEM × adversary.State
   chooseMessages := do
     let (pk, _sk) ← kem.keygen
-    let (m₀, m₁, st) ← adversary.chooseMessages pk
+    let (m₁, m₂, st) ← adversary.chooseMessages pk
     let (kc, _k) ← kem.encaps pk
-    return (m₀, m₁, (kc, st))
+    return (m₁, m₂, (kc, st))
   distinguish st dc := do
     adversary.distinguish st.2 (st.1, dc)
 
+/-- Equivalence between the DEM-reduction's `b = false` experiment and the KEM-left reduction's
+`b = false` experiment. Both compute the same probability of the underlying composed-game
+adversary outputting `true` on `(KEM-ciphertext, encrypt uniform-key first-message)`, just with
+the `uniform-key` sample placed differently in the bind chain. -/
+private lemma probOutput_dem_exp_false_eq_kem_left_exp_false
+    (kem : KEMScheme (OracleComp spec) K PK SK CKEM)
+    (dem : DEMScheme (OracleComp spec) K M CDEM)
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h : LawfulProbCompRuntime runtime)
+    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem)) :
+    Pr[= true | dem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toDEMReduction dem adversary) false] =
+    Pr[= true | kem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toKEMLeftReduction dem adversary) false] := by
+  congr 1
+  -- Unfold both Exp definitions into raw `runtime.evalDist do …` blocks, then expand each
+  -- via `h.evalDist_bind` so that we are working at the SPMF level with explicit binds.
+  simp only [DEMScheme.IND_CPA_Exp, KEMScheme.IND_CPA_Exp,
+    composeWithDEM_toDEMReduction, composeWithDEM_toKEMLeftReduction,
+    h.evalDist_bind, h.evalDist_liftProbComp,
+    Bool.false_eq_true, ↓reduceIte, bind_assoc, pure_bind]
+  -- Both sides are now SPMF bind chains over the same atomic SPMFs (in different orders).
+  -- Pull the uniform-key sample to a common position by `SPMF.bind_bind_swap`.
+  rw [SPMF.bind_bind_swap (𝒟[$ᵗ K] : SPMF K) (runtime.evalDist kem.keygen)]
+  refine bind_congr fun ⟨pk, _sk⟩ => ?_
+  rw [SPMF.bind_bind_swap (𝒟[$ᵗ K] : SPMF K)
+    (runtime.evalDist (adversary.chooseMessages pk))]
+  refine bind_congr fun ⟨m₁, _m₂, st⟩ => ?_
+  rw [SPMF.bind_bind_swap (𝒟[$ᵗ K] : SPMF K)
+    (runtime.evalDist (kem.encaps pk))]
+
+/-- Equivalence between the DEM-reduction's `b = true` experiment and the KEM-right reduction's
+`b = false` experiment. Symmetric to `probOutput_dem_exp_false_eq_kem_left_exp_false`, with the
+second message in place of the first. -/
+private lemma probOutput_dem_exp_true_eq_kem_right_exp_false
+    (kem : KEMScheme (OracleComp spec) K PK SK CKEM)
+    (dem : DEMScheme (OracleComp spec) K M CDEM)
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h : LawfulProbCompRuntime runtime)
+    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem)) :
+    Pr[= true | dem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toDEMReduction dem adversary) true] =
+    Pr[= true | kem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toKEMRightReduction dem adversary) false] := by
+  congr 1
+  simp only [DEMScheme.IND_CPA_Exp, KEMScheme.IND_CPA_Exp,
+    composeWithDEM_toDEMReduction, composeWithDEM_toKEMRightReduction,
+    h.evalDist_bind, h.evalDist_liftProbComp,
+    Bool.false_eq_true, ↓reduceIte, bind_assoc, pure_bind]
+  rw [SPMF.bind_bind_swap (𝒟[$ᵗ K] : SPMF K) (runtime.evalDist kem.keygen)]
+  refine bind_congr fun ⟨pk, _sk⟩ => ?_
+  rw [SPMF.bind_bind_swap (𝒟[$ᵗ K] : SPMF K)
+    (runtime.evalDist (adversary.chooseMessages pk))]
+  refine bind_congr fun ⟨_m₁, m₂, st⟩ => ?_
+  rw [SPMF.bind_bind_swap (𝒟[$ᵗ K] : SPMF K)
+    (runtime.evalDist (kem.encaps pk))]
+
+/-- The inner composed-game body (everything after the random bit `b` and before
+`pure (b == b')`). Used as the `Bool`-indexed family to apply the pi-form branch lemma in the
+composition theorem; callers also need `NeverFail` on this for `b = true` and `b = false`. -/
+def composedInner
+    (kem : KEMScheme (OracleComp spec) K PK SK CKEM)
+    (dem : DEMScheme (OracleComp spec) K M CDEM)
+    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem)) (b : Bool) :
+    OracleComp spec Bool := do
+  let (pk, _sk) ← kem.keygen
+  let (m₁, m₂, state) ← adversary.chooseMessages pk
+  let (c₁, k) ← kem.encaps pk
+  let c₂ ← dem.encrypt k (if b then m₁ else m₂)
+  adversary.distinguish state (c₁, c₂)
+
+/-- The composed-game `Pr[= true]` decomposes against the two KEM-side fixed-branch
+experiments. The proof has three movements: factor the composed game so the random bit `b` is
+at the top, apply `SPMF.probOutput_true_uniformBool_pi_branch_toReal`, then drop the unused
+`kRand ← uniformK` sample from each KEM Exp body. -/
+private lemma probOutput_composed_eq_half_left_plus_half_right
+    (kem : KEMScheme (OracleComp spec) K PK SK CKEM)
+    (dem : DEMScheme (OracleComp spec) K M CDEM)
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h : LawfulProbCompRuntime runtime)
+    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem))
+    [NeverFail (runtime.evalDist (composedInner kem dem adversary true))]
+    [NeverFail (runtime.evalDist (composedInner kem dem adversary false))] :
+    (Pr[= true | AsymmEncAlg.IND_CPA_OneTime_Game
+        (encAlg := kem.composeWithDEM dem) adversary runtime]).toReal =
+      1 / 2 * (Pr[= true | kem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toKEMLeftReduction dem adversary) true]).toReal +
+      1 / 2 * (1 - (Pr[= true | kem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toKEMRightReduction dem adversary) true]).toReal) := by
+  -- Step 1: rewrite the composed game so it has the form
+  -- `bool >>= fun b => runtime.evalDist (composedInner b) >>= fun b' => pure (b == b')`.
+  have hfactor : AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem)
+      adversary runtime =
+      (liftM (PMF.uniformOfFintype Bool) : SPMF Bool) >>= fun b =>
+        runtime.evalDist (composedInner kem dem adversary b) >>= fun b' =>
+          pure (b == b') := by
+    simp only [AsymmEncAlg.IND_CPA_OneTime_Game, KEMScheme.composeWithDEM,
+      composedInner, h.evalDist_bind, h.evalDist_liftProbComp, h.evalDist_pure,
+      bind_assoc, pure_bind, evalDist_uniformSample]
+  rw [hfactor]
+  -- Step 2: apply the pi-form `Pr[= true]` branch helper.
+  rw [SPMF.probOutput_true_uniformBool_pi_branch_toReal
+    (fun b => runtime.evalDist (composedInner kem dem adversary b))]
+  -- Step 3: reduce each inner probability to the corresponding KEM-side `Pr[= true]`.
+  -- For b=true (LHS): drop the unused `kRand ← uniformK` from `KEMLeft Exp true`.
+  have h_true : Pr[= true | runtime.evalDist (composedInner kem dem adversary true)] =
+      Pr[= true | kem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toKEMLeftReduction dem adversary) true] := by
+    congr 1
+    simp only [composedInner, KEMScheme.IND_CPA_Exp, composeWithDEM_toKEMLeftReduction,
+      h.evalDist_bind, h.evalDist_liftProbComp,
+      ↓reduceIte, bind_assoc, pure_bind]
+    -- Both SPMFs now have the same atomic operations. The KEM side has an extra
+    -- `𝒟[$ᵗ K] >>= fun _ => …` step that drops via `SPMF.bind_const_of_neverFail`.
+    refine bind_congr fun ⟨pk, _sk⟩ => ?_
+    refine bind_congr fun ⟨m₁, _m₂, st⟩ => ?_
+    refine bind_congr fun ⟨c₁, k⟩ => ?_
+    haveI hNF : NeverFail (𝒟[$ᵗ K] : SPMF K) := by
+      refine NeverFail.of_probFailure_eq_zero _ ?_
+      change Pr[⊥ | ($ᵗ K : ProbComp K)] = 0
+      exact probFailure_uniformSample K
+    rw [SPMF.bind_const_of_neverFail (𝒟[$ᵗ K] : SPMF K)]
+  -- For b=false: same drop-unused, plus convert `Pr[= false | _]` to `1 - Pr[= true | _]`.
+  have h_false : (Pr[= false | runtime.evalDist (composedInner kem dem adversary false)]).toReal =
+      1 - (Pr[= true | kem.IND_CPA_Exp runtime
+        (kem.composeWithDEM_toKEMRightReduction dem adversary) true]).toReal := by
+    have h_eq : Pr[= true | runtime.evalDist (composedInner kem dem adversary false)] =
+        Pr[= true | kem.IND_CPA_Exp runtime
+          (kem.composeWithDEM_toKEMRightReduction dem adversary) true] := by
+      congr 1
+      simp only [composedInner, KEMScheme.IND_CPA_Exp, composeWithDEM_toKEMRightReduction,
+        h.evalDist_bind, h.evalDist_liftProbComp,
+        Bool.false_eq_true, ↓reduceIte, bind_assoc, pure_bind]
+      refine bind_congr fun ⟨pk, _sk⟩ => ?_
+      refine bind_congr fun ⟨_m₁, m₂, st⟩ => ?_
+      refine bind_congr fun ⟨c₁, k⟩ => ?_
+      haveI hNF : NeverFail (𝒟[$ᵗ K] : SPMF K) := by
+        refine NeverFail.of_probFailure_eq_zero _ ?_
+        change Pr[⊥ | ($ᵗ K : ProbComp K)] = 0
+        exact probFailure_uniformSample K
+      rw [SPMF.bind_const_of_neverFail (𝒟[$ᵗ K] : SPMF K)]
+    have hsum : Pr[= true | runtime.evalDist (composedInner kem dem adversary false)] +
+        Pr[= false | runtime.evalDist (composedInner kem dem adversary false)] = 1 :=
+      probOutput_true_add_false_of_neverFail
+    have hr : (Pr[= true | runtime.evalDist
+        (composedInner kem dem adversary false)]).toReal +
+        (Pr[= false | runtime.evalDist
+          (composedInner kem dem adversary false)]).toReal = 1 := by
+      rw [← ENNReal.toReal_add probOutput_ne_top probOutput_ne_top, hsum,
+        ENNReal.toReal_one]
+    rw [← h_eq]; linarith
+  rw [h_true, h_false]
+
 /-- Proof-ladders A1 reduction statement: the one-time IND-CPA advantage of textbook KEM+DEM is
 bounded by two KEM IND-CPA advantages plus one DEM IND-CPA advantage, using the canonical
-left/right and DEM reductions defined above. -/
+left/right and DEM reductions defined above.
+
+**Hypotheses.** The runtime must be `LawfulProbCompRuntime` (i.e. its `evalDist` is a monad
+homomorphism), and the four games involved must never fail. These conditions hold for the
+canonical `ProbCompRuntime.probComp` and for any adversary built from `pure` / sampling / oracle
+queries without explicit `failure`.
+
+**Proof outline.** Following the parent `IND_CPA_OneTime_Game` convention where
+`(m₁, m₂, _) ← chooseMessages pk` and `b = true` encrypts `m₁`, let
+`A := Pr[adv true | encrypt m₁ with real KEM key]`,
+`A' := Pr[adv true | encrypt m₁ with uniform key]`,
+`B := Pr[adv true | encrypt m₂ with real KEM key]`,
+`B' := Pr[adv true | encrypt m₂ with uniform key]`.
+
+Then under NeverFail hypotheses:
+- composed bias = `|A − B|`
+- KEM left advantage = `|A − A'|`
+- KEM right advantage = `|B − B'|`
+- DEM advantage = `|B' − A'|`
+
+The triangle inequality
+`|A − B| ≤ |A − A'| + |A' − B'| + |B' − B|`
+gives the result.
+
+The detailed game-equivalence chain (showing each Exp game's `Pr[= true]` equals the
+corresponding F-value) is the bulk of the remaining work, supported by the
+`IND_CPA_Game_eq_branch` connectors for `KEMScheme` and `DEMScheme`. -/
 theorem ind_cpa_one_time_bias_advantage_compose_with_dem_le
     (kem : KEMScheme (OracleComp spec) K PK SK CKEM)
     (dem : DEMScheme (OracleComp spec) K M CDEM)
     (runtime : ProbCompRuntime (OracleComp spec))
-    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem)) :
+    (h : LawfulProbCompRuntime runtime)
+    (adversary : AsymmEncAlg.IND_CPA_Adv (kem.composeWithDEM dem))
+    -- NeverFail for the four KEM/DEM Exp games that the connectors will reduce to.
+    [NeverFail (kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMLeftReduction dem adversary) true)]
+    [NeverFail (kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMLeftReduction dem adversary) false)]
+    [NeverFail (kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMRightReduction dem adversary) true)]
+    [NeverFail (kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMRightReduction dem adversary) false)]
+    [NeverFail (dem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toDEMReduction dem adversary) true)]
+    [NeverFail (dem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toDEMReduction dem adversary) false)]
+    -- NeverFail for the composed one-time IND-CPA game.
+    [NeverFail (AsymmEncAlg.IND_CPA_OneTime_Game (encAlg := kem.composeWithDEM dem)
+      adversary runtime)]
+    -- NeverFail for the two composed inner experiments (used by the composed-game
+    -- decomposition lemma `probOutput_composed_eq_half_left_plus_half_right`).
+    [NeverFail (runtime.evalDist (composedInner kem dem adversary true))]
+    [NeverFail (runtime.evalDist (composedInner kem dem adversary false))] :
     AsymmEncAlg.IND_CPA_OneTime_biasAdvantage (kem.composeWithDEM dem) runtime adversary ≤
       kem.IND_CPA_Advantage runtime (kem.composeWithDEM_toKEMLeftReduction dem adversary) +
       kem.IND_CPA_Advantage runtime (kem.composeWithDEM_toKEMRightReduction dem adversary) +
       dem.IND_CPA_Advantage runtime
         (kem.composeWithDEM_toDEMReduction dem adversary) := by
-  sorry
+  -- Abbreviations: A/B are real-key probabilities, A'/B' are random-key probabilities;
+  -- A/A' use the **left** reduction (first message), B/B' use the **right** (second message).
+  set A := (Pr[= true | kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMLeftReduction dem adversary) true]).toReal with hA
+  set B := (Pr[= true | kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMRightReduction dem adversary) true]).toReal with hB
+  set A' := (Pr[= true | kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMLeftReduction dem adversary) false]).toReal with hA'
+  set B' := (Pr[= true | kem.IND_CPA_Exp runtime
+      (kem.composeWithDEM_toKEMRightReduction dem adversary) false]).toReal with hB'
+  -- Convert KEM advantages to |A - A'| and |B - B'| via the connector.
+  have h_kem_left_adv : kem.IND_CPA_Advantage runtime
+      (kem.composeWithDEM_toKEMLeftReduction dem adversary) = |A - A'| := by
+    unfold KEMScheme.IND_CPA_Advantage
+    rw [KEMScheme.IND_CPA_Game_eq_branch _ h _]
+    rw [SPMF.boolBiasAdvantage_uniformBool_pi_eq_boolDistAdvantage]
+    rfl
+  have h_kem_right_adv : kem.IND_CPA_Advantage runtime
+      (kem.composeWithDEM_toKEMRightReduction dem adversary) = |B - B'| := by
+    unfold KEMScheme.IND_CPA_Advantage
+    rw [KEMScheme.IND_CPA_Game_eq_branch _ h _]
+    rw [SPMF.boolBiasAdvantage_uniformBool_pi_eq_boolDistAdvantage]
+    rfl
+  -- Convert DEM advantage to |B' - A'| using the connector + the two proven equivalence
+  -- lemmas `probOutput_dem_exp_{true,false}_eq_kem_{right,left}_exp_false`.
+  have h_dem_adv : dem.IND_CPA_Advantage runtime
+      (kem.composeWithDEM_toDEMReduction dem adversary) = |B' - A'| := by
+    unfold DEMScheme.IND_CPA_Advantage
+    rw [DEMScheme.IND_CPA_Game_eq_branch _ h _]
+    rw [SPMF.boolBiasAdvantage_uniformBool_pi_eq_boolDistAdvantage]
+    change |(Pr[= true | dem.IND_CPA_Exp runtime
+            (kem.composeWithDEM_toDEMReduction dem adversary) true]).toReal -
+          (Pr[= true | dem.IND_CPA_Exp runtime
+            (kem.composeWithDEM_toDEMReduction dem adversary) false]).toReal| = |B' - A'|
+    rw [probOutput_dem_exp_true_eq_kem_right_exp_false kem dem runtime h adversary,
+        probOutput_dem_exp_false_eq_kem_left_exp_false kem dem runtime h adversary]
+  -- Convert composed bias to |A - B| via the composed-game decomposition lemma.
+  have h_composed_bias : AsymmEncAlg.IND_CPA_OneTime_biasAdvantage
+      (kem.composeWithDEM dem) runtime adversary = |A - B| := by
+    unfold AsymmEncAlg.IND_CPA_OneTime_biasAdvantage
+    rw [SPMF.boolBiasAdvantage_eq_two_mul_abs_sub_half,
+      probOutput_composed_eq_half_left_plus_half_right kem dem runtime h adversary]
+    rw [show 1 / 2 * A + 1 / 2 * (1 - B) - 1 / 2 = (A - B) / 2 from by ring,
+      abs_div, show |(2 : ℝ)| = 2 from abs_of_pos (by norm_num)]
+    ring
+  -- Apply triangle.
+  rw [h_composed_bias, h_kem_left_adv, h_kem_right_adv, h_dem_adv]
+  have triangle : |A - B| ≤ |A - A'| + |A' - B'| + |B' - B| := by
+    calc |A - B|
+        = |(A - A') + ((A' - B') + (B' - B))| := by ring_nf
+      _ ≤ |A - A'| + |(A' - B') + (B' - B)| := abs_add_le _ _
+      _ ≤ |A - A'| + (|A' - B'| + |B' - B|) := by linarith [abs_add_le (A' - B') (B' - B)]
+      _ = |A - A'| + |A' - B'| + |B' - B| := by ring
+  have hDEM : |A' - B'| = |B' - A'| := abs_sub_comm _ _
+  have hBB' : |B' - B| = |B - B'| := abs_sub_comm _ _
+  linarith
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/KeyEncapMech.lean
+++ b/VCVio/CryptoFoundations/KeyEncapMech.lean
@@ -11,6 +11,7 @@ import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.SimSemantics.Append
+import VCVio.OracleComp.Constructions.SampleableType
 
 /-!
 # Key Encapsulation Mechanisms
@@ -104,6 +105,56 @@ theorem IND_CPA_Advantage_eq_game_bias {kem : KEMScheme (OracleComp spec) K PK S
     (adversary : kem.IND_CPA_Adversary) :
     kem.IND_CPA_Advantage runtime adversary =
       (kem.IND_CPA_Game runtime adversary).boolBiasAdvantage := rfl
+
+/-! ### Game ↔ Exp connector
+
+Under a `LawfulProbCompRuntime` hypothesis, the KEM single-game SPMF factors as a hidden-bit
+guessing game over the two fixed-branch experiments. This is the bridge from the canonical
+advantage definition to the hybrid-friendly form used in composition proofs. -/
+
+/-- The KEM single-game SPMF factors as `bool >>= fun b => Exp b >>= fun b' => pure (b == b')`
+under a `LawfulProbCompRuntime`. -/
+lemma IND_CPA_Game_eq_branch {kem : KEMScheme (OracleComp spec) K PK SK C}
+    (runtime : ProbCompRuntime (OracleComp spec))
+    (h : LawfulProbCompRuntime runtime)
+    (adversary : kem.IND_CPA_Adversary) :
+    kem.IND_CPA_Game runtime adversary =
+      (liftM (PMF.uniformOfFintype Bool) : SPMF Bool) >>= fun b =>
+        kem.IND_CPA_Exp runtime adversary b >>= fun b' =>
+          pure (b == b') := by
+  -- Factor the game body so that the prefix (keygen, preChallenge) and the bool sample are
+  -- explicit. Then apply the runtime swap helper to pull the bool sample to the top.
+  set pref : OracleComp spec (PK × adversary.State) :=
+    (do let (pk, _sk) ← kem.keygen
+        let st ← adversary.preChallenge pk
+        pure (pk, st)) with hpref
+  set rest : PK × adversary.State → Bool → OracleComp spec Bool :=
+    fun pkst b => do
+      let (cStar, kReal) ← kem.encaps pkst.1
+      let kRand ← runtime.liftProbComp ($ᵗ K)
+      let b' ← adversary.postChallenge pkst.2 cStar (if b then kReal else kRand)
+      pure (b == b') with hrest
+  -- The IND_CPA_Game body equals `pref >>= fun g => liftProbComp bool >>= fun b => rest g b`.
+  have hgame : kem.IND_CPA_Game runtime adversary =
+      runtime.evalDist
+        (pref >>= fun g => runtime.liftProbComp ($ᵗ Bool) >>= fun b => rest g b) := by
+    unfold IND_CPA_Game pref rest
+    congr 1
+    simp [bind_assoc]
+  -- Apply the bool-swap helper.
+  rw [hgame, h.evalDist_bind_bind_liftProbComp_swap pref ($ᵗ Bool) rest]
+  -- Now compute 𝒟[$ᵗ Bool] = liftM (PMF.uniformOfFintype Bool).
+  rw [evalDist_uniformSample]
+  -- Both sides bind on `liftM (PMF.uniformOfFintype Bool)`. Show continuations match.
+  refine bind_congr fun b => ?_
+  -- Goal: runtime.evalDist (pref >>= fun g => rest g b)
+  --     = IND_CPA_Exp runtime adversary b >>= fun b' => pure (b == b')
+  show runtime.evalDist (pref >>= fun g => rest g b) =
+    kem.IND_CPA_Exp runtime adversary b >>= fun b' => pure (b == b')
+  unfold IND_CPA_Exp
+  rw [hpref, hrest]
+  -- Expand both sides via evalDist_bind.
+  simp only [h.evalDist_bind, h.evalDist_pure, pure_bind, bind_assoc]
 
 end IND_CPA
 

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.OracleComp.ProbComp
+import VCVio.OracleComp.ProbCompLift
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.EvalDist.TVDist
 import VCVio.EvalDist.Defs.Semantics
@@ -46,11 +47,206 @@ been observed under bundled subprobabilistic semantics. Any remaining mass corre
 and therefore contributes to neither Boolean branch. -/
 noncomputable def SPMF.boolBiasAdvantage (p : SPMF Bool) : ℝ :=
   |(Pr[= true | p]).toReal - (Pr[= false | p]).toReal|
+
+/-- Distinguishing advantage between two Boolean-valued subdistributions, measured on the `true`
+branch. SPMF analogue of `ProbComp.boolDistAdvantage`. -/
+noncomputable def SPMF.boolDistAdvantage (p q : SPMF Bool) : ℝ :=
+  |(Pr[= true | p]).toReal - (Pr[= true | q]).toReal|
+
 /-- Triangle inequality for Boolean distinguishing advantage. -/
 lemma ProbComp.boolDistAdvantage_triangle (p q r : ProbComp Bool) :
     p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by
   unfold ProbComp.boolDistAdvantage
   exact abs_sub_le _ _ _
+
+/-- Triangle inequality for `SPMF.boolDistAdvantage`. -/
+lemma SPMF.boolDistAdvantage_triangle (p q r : SPMF Bool) :
+    p.boolDistAdvantage r ≤ p.boolDistAdvantage q + q.boolDistAdvantage r := by
+  unfold SPMF.boolDistAdvantage
+  exact abs_sub_le _ _ _
+
+@[simp] lemma SPMF.boolDistAdvantage_self (p : SPMF Bool) :
+    p.boolDistAdvantage p = 0 := by simp [SPMF.boolDistAdvantage]
+
+lemma SPMF.boolDistAdvantage_comm (p q : SPMF Bool) :
+    p.boolDistAdvantage q = q.boolDistAdvantage p := by
+  unfold SPMF.boolDistAdvantage; exact abs_sub_comm _ _
+
+lemma SPMF.boolDistAdvantage_nonneg (p q : SPMF Bool) :
+    0 ≤ p.boolDistAdvantage q := abs_nonneg _
+
+/-- For an `SPMF Bool` game that never fails, the bias advantage equals twice the absolute gap
+between `Pr[true]` and `1/2`. SPMF analogue of
+`ProbComp.boolBiasAdvantage_eq_two_mul_abs_sub_half`. -/
+lemma SPMF.boolBiasAdvantage_eq_two_mul_abs_sub_half (p : SPMF Bool) [NeverFail p] :
+    p.boolBiasAdvantage = 2 * |(Pr[= true | p]).toReal - 1 / 2| := by
+  have hfalse : Pr[= false | p] = 1 - Pr[= true | p] := by
+    have hsum : Pr[= true | p] + Pr[= false | p] = 1 :=
+      probOutput_true_add_false_of_neverFail
+    rw [← hsum, ENNReal.add_sub_cancel_left probOutput_ne_top]
+  unfold SPMF.boolBiasAdvantage
+  rw [hfalse, ENNReal.toReal_sub_of_le probOutput_le_one ENNReal.one_ne_top]
+  rw [ENNReal.toReal_one]
+  rw [show (Pr[= true | p]).toReal - (1 - (Pr[= true | p]).toReal) =
+      2 * ((Pr[= true | p]).toReal - 1 / 2) by ring]
+  rw [abs_mul, abs_of_pos (by positivity : (0 : ℝ) < 2)]
+
+/-- Lifting a `PMF` into `SPMF` never fails: the failure mass comes entirely from `OptionT`
+embedding and is zero on a `liftM`. -/
+instance instNeverFail_liftM_PMF {α : Type _} (p : PMF α) : NeverFail ((liftM p : SPMF α)) :=
+  NeverFail.of_probFailure_eq_zero _ (by simp)
+
+/-- Dropping an unused never-failing SPMF prefix preserves the SPMF as a value. -/
+lemma SPMF.bind_const_of_neverFail {α β : Type _} (p : SPMF α) [NeverFail p] (q : SPMF β) :
+    (p >>= fun _ => q) = q := by
+  refine SPMF.ext fun y => ?_
+  have := probOutput_bind_const (m := SPMF) p q y
+  simp only [probFailure_eq_zero, tsub_zero, one_mul] at this
+  simpa [probOutput_def] using this
+
+namespace LawfulProbCompRuntime
+
+variable {m : Type → Type v} [Monad m] {runtime : ProbCompRuntime m}
+
+/-- A lifted `ProbComp` sample commutes past any earlier `m`-side prefix when the prefix does
+not depend on the sample. The hypothesis `LawfulProbCompRuntime` is essential: it lets us push
+`runtime.evalDist` through binds, and the final SPMF swap is then a pure SPMF identity. -/
+lemma evalDist_bind_bind_liftProbComp_swap [LawfulMonad m]
+    (h : LawfulProbCompRuntime runtime)
+    {γ δ ε : Type} (pref : m γ) (px : ProbComp δ) (rest : γ → δ → m ε) :
+    runtime.evalDist (pref >>= fun g => runtime.liftProbComp px >>= fun d => rest g d) =
+      (𝒟[px] : SPMF δ) >>= fun d =>
+        runtime.evalDist (pref >>= fun g => rest g d) := by
+  have step1 : runtime.evalDist
+        (pref >>= fun g => runtime.liftProbComp px >>= fun d => rest g d) =
+      (runtime.evalDist pref >>= fun g =>
+        ((𝒟[px] : SPMF δ) >>= fun d => runtime.evalDist (rest g d))) := by
+    rw [h.evalDist_bind]
+    congr 1
+    funext g
+    rw [h.evalDist_bind, h.evalDist_liftProbComp]
+  have step2 : (runtime.evalDist pref >>= fun g =>
+        ((𝒟[px] : SPMF δ) >>= fun d => runtime.evalDist (rest g d))) =
+      ((𝒟[px] : SPMF δ) >>= fun d =>
+        runtime.evalDist pref >>= fun g => runtime.evalDist (rest g d)) :=
+    SPMF.bind_bind_swap _ _ _
+  have step3 : ((𝒟[px] : SPMF δ) >>= fun d =>
+        runtime.evalDist pref >>= fun g => runtime.evalDist (rest g d)) =
+      ((𝒟[px] : SPMF δ) >>= fun d =>
+        runtime.evalDist (pref >>= fun g => rest g d)) := by
+    congr 1
+    funext d
+    rw [h.evalDist_bind]
+  rw [step1, step2, step3]
+
+end LawfulProbCompRuntime
+
+/-- The canonical `ProbCompRuntime.probComp` runtime is lawful: its `evalDist` is the global
+`HasEvalSPMF.toSPMF` (already a monad homomorphism), and its `liftProbComp` is the identity. -/
+theorem ProbCompRuntime.probComp_lawful : LawfulProbCompRuntime ProbCompRuntime.probComp where
+  evalDist_pure x := by
+    change 𝒟[(pure x : ProbComp _)] = pure x
+    exact evalDist_pure x
+  evalDist_bind mx my := by
+    change 𝒟[mx >>= my] = 𝒟[mx] >>= fun a => 𝒟[my a]
+    exact evalDist_bind mx my
+  evalDist_liftProbComp _ := rfl
+
+/-- Compute `Pr[= true]` for the uniform-bit branch game in real arithmetic, given the two
+branches never fail. -/
+private lemma SPMF.probOutput_true_uniformBool_branch_toReal
+    (real rand : SPMF Bool) [NeverFail real] [NeverFail rand] :
+    (Pr[= true | (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← if b then real else rand
+      pure (b == z))]).toReal =
+      1 / 2 * (Pr[= true | real]).toReal + 1 / 2 * (Pr[= false | rand]).toReal := by
+  rw [probOutput_bind_eq_tsum, tsum_fintype, Fintype.sum_bool]
+  simp only [probOutput_liftM, PMF.probOutput_eq_apply, PMF.uniformOfFintype_apply,
+    Fintype.card_bool, Nat.cast_ofNat, ↓reduceIte, Bool.true_beq, bind_pure,
+    Bool.false_eq_true, Bool.false_beq, bind_pure_comp, probOutput_not_map, one_div]
+  have hne1 : (2 : ℝ≥0∞)⁻¹ * Pr[= true | real] ≠ ∞ :=
+    ENNReal.mul_ne_top (by simp) probOutput_ne_top
+  have hne2 : (2 : ℝ≥0∞)⁻¹ * Pr[= false | rand] ≠ ∞ :=
+    ENNReal.mul_ne_top (by simp) probOutput_ne_top
+  rw [ENNReal.toReal_add hne1 hne2, ENNReal.toReal_mul, ENNReal.toReal_mul]
+  norm_num
+
+/-- The hidden-bit guessing-game form: for never-failing branches, the bias of the uniform-bit
+branch game equals the distinguishing advantage between the two branches. SPMF analogue of
+`ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch`. -/
+lemma SPMF.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch
+    (real rand : SPMF Bool) [NeverFail real] [NeverFail rand] :
+    (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← if b then real else rand
+      pure (b == z)).boolBiasAdvantage =
+    real.boolDistAdvantage rand := by
+  haveI hbranch : NeverFail (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← if b then real else rand
+      pure (b == z)) :=
+    NeverFail.bind_of_forall (hy := fun b => by
+      cases b <;> exact NeverFail.bind_of_forall (hy := fun _ => inferInstance))
+  rw [SPMF.boolBiasAdvantage_eq_two_mul_abs_sub_half]
+  rw [SPMF.probOutput_true_uniformBool_branch_toReal]
+  -- Pr[= false | rand].toReal = 1 - Pr[= true | rand].toReal
+  have hpf : (Pr[= false | rand]).toReal = 1 - (Pr[= true | rand]).toReal := by
+    have hsum : Pr[= true | rand] + Pr[= false | rand] = 1 :=
+      probOutput_true_add_false_of_neverFail
+    have : (Pr[= true | rand]).toReal + (Pr[= false | rand]).toReal = 1 := by
+      rw [← ENNReal.toReal_add probOutput_ne_top probOutput_ne_top, hsum,
+        ENNReal.toReal_one]
+    linarith
+  rw [hpf, SPMF.boolDistAdvantage]
+  set a := (Pr[= true | real]).toReal
+  set b := (Pr[= true | rand]).toReal
+  rw [show (1 / 2 * a + 1 / 2 * (1 - b) - 1 / 2 : ℝ) = (a - b) / 2 from by ring,
+    abs_div, show |(2 : ℝ)| = 2 from abs_of_pos (by norm_num)]
+  ring
+
+/-- `Pr[= true]` for the function-form uniform-bit branch game. -/
+lemma SPMF.probOutput_true_uniformBool_pi_branch_toReal
+    (E : Bool → SPMF Bool) [NeverFail (E true)] [NeverFail (E false)] :
+    (Pr[= true | (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← E b
+      pure (b == z))]).toReal =
+      1 / 2 * (Pr[= true | E true]).toReal + 1 / 2 * (Pr[= false | E false]).toReal := by
+  have heq : (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← E b
+      pure (b == z)) =
+    (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← if b then E true else E false
+      pure (b == z)) := by
+    refine bind_congr fun b => ?_
+    cases b <;> rfl
+  rw [heq]
+  exact SPMF.probOutput_true_uniformBool_branch_toReal (E true) (E false)
+
+/-- Function-form variant: the bias of `bool >>= fun b => E b >>= fun z => pure (b == z)` for a
+`Bool`-indexed family `E` equals the distinguishing advantage between `E true` and `E false`. -/
+lemma SPMF.boolBiasAdvantage_uniformBool_pi_eq_boolDistAdvantage
+    (E : Bool → SPMF Bool) [NeverFail (E true)] [NeverFail (E false)] :
+    (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← E b
+      pure (b == z)).boolBiasAdvantage =
+    (E true).boolDistAdvantage (E false) := by
+  have heq : (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← E b
+      pure (b == z)) =
+    (do
+      let b ← (liftM (PMF.uniformOfFintype Bool) : SPMF Bool)
+      let z ← if b then E true else E false
+      pure (b == z)) := by
+    refine bind_congr fun b => ?_
+    cases b <;> rfl
+  rw [heq]
+  exact SPMF.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch (E true) (E false)
 
 /-- The `true`-branch probability of one Boolean-valued game is bounded above by the
 `true`-branch probability of another game plus their distinguishing advantage.

--- a/VCVio/EvalDist/Defs/Instances.lean
+++ b/VCVio/EvalDist/Defs/Instances.lean
@@ -45,6 +45,16 @@ lemma probOutput_eq_apply (p : SPMF α) (x : α) : Pr[= x | p] = p x := rfl
 lemma evalDist_eq_iff {m} [Monad m] [HasEvalSPMF m] (mx : m α) (p : SPMF α) :
     𝒟[mx] = p ↔ ∀ x, Pr[= x | mx] = p x := by aesop
 
+/-- Independent SPMF binds commute as SPMF values. The pointwise probability swap
+`probOutput_bind_bind_swap` lifts to SPMF equality via `SPMF.ext`. -/
+lemma bind_bind_swap {α β γ : Type u}
+    (mx : SPMF α) (my : SPMF β) (f : α → β → SPMF γ) :
+    (mx >>= fun a => my >>= fun b => f a b) =
+      (my >>= fun b => mx >>= fun a => f a b) :=
+  SPMF.ext fun x => by
+    simpa [probOutput_def] using
+      probOutput_bind_bind_swap (m := SPMF) mx my f x
+
 end SPMF
 
 namespace PMF

--- a/VCVio/OracleComp/ProbCompLift.lean
+++ b/VCVio/OracleComp/ProbCompLift.lean
@@ -84,3 +84,22 @@ noncomputable def probComp : ProbCompRuntime ProbComp where
   toProbCompLift := ProbCompLift.id
 
 end ProbCompRuntime
+
+/-- Lawfulness predicate: the runtime's `evalDist` commutes with bind and pure, and the lift of
+a plain `ProbComp` reduces to its canonical SPMF denotation.
+
+This is the bundle of monad-homomorphism properties that hybrid arguments need in order to
+move pure / bind / uniform-sampling operations across the surface monad's denotation. Concrete
+runtimes built from `SPMFSemantics.ofHasEvalSPMF` and `ProbCompLift.ofMonadLift` satisfy this. -/
+structure LawfulProbCompRuntime
+    {m : Type → Type v} [Monad m] (runtime : ProbCompRuntime m) : Prop where
+  /-- The runtime's `evalDist` sends `pure` to `pure`. -/
+  evalDist_pure {α : Type} (x : α) : runtime.evalDist (pure x) = pure x
+  /-- The runtime's `evalDist` commutes with bind. -/
+  evalDist_bind {α β : Type} (mx : m α) (my : α → m β) :
+    runtime.evalDist (mx >>= my) =
+      runtime.evalDist mx >>= fun a => runtime.evalDist (my a)
+  /-- The runtime's `evalDist` of a lifted `ProbComp` equals its canonical SPMF denotation. -/
+  evalDist_liftProbComp {α : Type} (px : ProbComp α) :
+    runtime.evalDist (runtime.liftProbComp px) = 𝒟[px]
+


### PR DESCRIPTION
## Summary
- Proves `ind_cpa_one_time_bias_advantage_compose_with_dem_le` (textbook KEM+DEM hybrid argument), removing the `sorry` from issue #197.
- Adds `LawfulProbCompRuntime` — a bundle of monad-homomorphism properties on `evalDist` — with a concrete witness for `ProbCompRuntime.probComp`.
- Adds reusable SPMF advantage-distance infrastructure (`boolDistAdvantage`, triangle, the uniform-bool branch connectors).

## Theorem
For any KEM+DEM composed-scheme adversary `A`:

```
Adv^IND-CPA-1(KEM+DEM, A) ≤ Adv^IND-CPA(KEM, A_KEM-left)
                          + Adv^IND-CPA(KEM, A_KEM-right)
                          + Adv^IND-CPA-1(DEM, A_DEM)
```

where the three reductions (`composeWithDEM_toKEMLeftReduction`, `composeWithDEM_toKEMRightReduction`, `composeWithDEM_toDEMReduction`) are defined in the same file.

The proof factors into three private game-equivalence lemmas plus a triangle inequality. The composed bias `|A − B|` is bounded by `|A − A'| + |A' − B'| + |B' − B|`, where A/A' are the KEM-left experiments at `b = true/false`, B/B' are the KEM-right experiments at `b = true/false`, and the cross gap `|A' − B'|` equals the DEM advantage.

## New assumptions
- `LawfulProbCompRuntime runtime` — satisfied by the canonical `ProbCompRuntime.probComp` (witness `probComp_lawful` included in `SecExp.lean`). Excludes stateful random-oracle runtimes (`withStateOracle`-based, used by `FujisakiOkamoto`, `FiatShamir`, `Fischlin`); none of those modules currently reference `composeWithDEM` or `IND_CPA_OneTime`, so the restriction is theoretical rather than practical.
- 9 `NeverFail` instances on the experiments involved. Mechanical for any adversary built from `pure` / sampling / oracle queries without explicit `failure`. Reducing this count via derived instances is tracked as a follow-up.

## Layering
- `LawfulProbCompRuntime` structure lives in `OracleComp/ProbCompLift.lean` (core layer).
- Its helper lemmas (`evalDist_bind_bind_liftProbComp_swap`) and the `probComp` witness live in `CryptoFoundations/SecExp.lean` (bridge layer).

This split keeps `ProbCompLift.lean` from depending on `EvalDist/Monad/Basic`.

## Commits
1. `feat(SPMF): add boolDistAdvantage and LawfulProbCompRuntime infrastructure` — `SecExp.lean`, `ProbCompLift.lean`, `EvalDist/Defs/Instances.lean`.
2. `feat(KEM,DEM): add IND_CPA_Game_eq_branch connectors` — `KeyEncapMech.lean`, `DataEncapMech.lean`.
3. `feat(KEMDEM): prove IND-CPA composition theorem (closes #197)` — `KEMDEM.lean`.

The split lets reviewers sign off on the infrastructure (Commit 1) independently of the KEM/DEM math.

## Test plan
- [x] `lake build VCVio` — green, 3622 jobs.
- [x] Per-file `lake env lean <touched file>` for all 6 changed files — green.
- [x] Zero sorries in any touched file.
- [x] Zero new axioms introduced.
- [x] Independent adversarial review found no P0/P1 issues. One real bug was caught and fixed during review: the original theorem docstring had `KEM-left = |B − B'|` and `KEM-right = |A − A'|` swapped relative to what the proof body actually establishes — now corrected.
- [x] Naming aligned with `IND_CPA_OneTime_Game`'s `(m₁, m₂)` convention across the three reductions, the private equivalence lemmas, and the docstring.

## Follow-ups (not in this PR)
- Derived `NeverFail` instances for `KEMScheme.IND_CPA_Exp` and `DEMScheme.IND_CPA_Exp` to collapse the 9-instance pile to ~2 at call sites.
- `LawfulProbCompRuntime` witness for `ofMonadLift`-derived runtimes (currently only `probComp` has one).
- Promote `IND_CPA_Game_eq_branch` to a generic typeclass-driven combinator usable across schemes.
- Possible `Commutative SPMF` instance subsuming `SPMF.bind_bind_swap`.
