### PR TITLE
refactor(Birthday): remove redundant argument in gauss_sum_inv_le usage

### DIFF
--- a/ToMathlib/Data/ENNReal/Gauss.lean
+++ b/ToMathlib/Data/ENNReal/Gauss.lean
@@ -66,33 +66,6 @@ lemma toReal_sub_le_abs_toReal_sub (a b : ℝ≥0∞) :
       exact abs_nonneg _
 
 open Finset in
-/-- The Gauss sum `∑_{k=0}^{n-1} k/N ≤ n²/(2N)`, the arithmetic core of the birthday bound. -/
-lemma gauss_sum_inv_le (n : ℕ) (N : ℝ≥0∞) (_hN : 0 < N) :
-    ∑ k ∈ range n, ((k : ℕ) : ℝ≥0∞) * N⁻¹ ≤
-      (n ^ 2 : ℝ≥0∞) / (2 * N) := by
-  rw [← Finset.sum_mul]
-  have hnat : 2 * (∑ k ∈ range n, k) ≤ n ^ 2 := by
-    have := Finset.sum_range_id_mul_two n; nlinarith [Nat.sub_le n 1]
-  have henn : 2 * (∑ k ∈ range n, (k : ℝ≥0∞)) ≤ (n : ℝ≥0∞) ^ 2 := by
-    have hcast : (∑ k ∈ range n, (k : ℝ≥0∞)) = ((∑ k ∈ range n, k : ℕ) : ℝ≥0∞) := by
-      simp [Nat.cast_sum]
-    rw [hcast, show (2 : ℝ≥0∞) = ((2 : ℕ) : ℝ≥0∞) from by norm_num,
-      show (n : ℝ≥0∞) ^ 2 = ((n ^ 2 : ℕ) : ℝ≥0∞) from by push_cast; ring,
-      ← Nat.cast_mul]
-    exact_mod_cast hnat
-  have hle : (∑ k ∈ range n, (k : ℝ≥0∞)) ≤ (n : ℝ≥0∞) ^ 2 / 2 := by
-    rw [ENNReal.le_div_iff_mul_le (Or.inl (by norm_num : (2 : ℝ≥0∞) ≠ 0))
-      (Or.inl (by norm_num : (2 : ℝ≥0∞) ≠ ⊤))]
-    rwa [mul_comm]
-  calc (∑ k ∈ range n, (k : ℝ≥0∞)) * N⁻¹
-      ≤ ((n : ℝ≥0∞) ^ 2 / 2) * N⁻¹ := mul_le_mul_left hle N⁻¹
-    _ = (n : ℝ≥0∞) ^ 2 / (2 * N) := by
-        rw [ENNReal.div_eq_inv_mul, ENNReal.div_eq_inv_mul,
-          ENNReal.mul_inv (Or.inl (by norm_num : (2 : ℝ≥0∞) ≠ 0))
-            (Or.inl (by norm_num : (2 : ℝ≥0∞) ≠ ⊤))]
-        ring
-
-open Finset in
 /-- Tight Gauss sum: `∑_{k=0}^{n-1} k/N = n*(n-1)/(2N)`. -/
 lemma gauss_sum_inv_eq (n : ℕ) (N : ℝ≥0∞) :
     ∑ k ∈ range n, ((k : ℕ) : ℝ≥0∞) * N⁻¹ =
@@ -116,6 +89,17 @@ lemma gauss_sum_inv_eq (n : ℕ) (N : ℝ≥0∞) :
           ENNReal.mul_inv (Or.inl (by norm_num : (2 : ℝ≥0∞) ≠ 0))
             (Or.inl (by norm_num : (2 : ℝ≥0∞) ≠ ⊤))]
         ring
+
+open Finset in
+/-- The Gauss sum `∑_{k=0}^{n-1} k/N ≤ n²/(2N)`, the arithmetic core of the birthday bound. -/
+lemma gauss_sum_inv_le (n : ℕ) (N : ℝ≥0∞) :
+    ∑ k ∈ range n, ((k : ℕ) : ℝ≥0∞) * N⁻¹ ≤
+      (n ^ 2 : ℝ≥0∞) / (2 * N) := by
+  rw [gauss_sum_inv_eq]
+  gcongr
+  have h : n * (n - 1) ≤ n ^ 2 := by
+    rw [sq]; exact Nat.mul_le_mul_left _ (Nat.sub_le _ _)
+  exact_mod_cast h
 
 /-- `a/(2N) + b/N = (a + 2b)/(2N)` for natural-number casts to `ℝ≥0∞`. -/
 lemma add_div_two_mul_nat (a b N : ℕ) :

--- a/VCVio/OracleComp/QueryTracking/Birthday.lean
+++ b/VCVio/OracleComp/QueryTracking/Birthday.lean
@@ -401,7 +401,6 @@ theorem probEvent_logCollision_le_birthday_total {α : Type}
     (oa : OracleComp spec α)
     (n : ℕ)
     (hbound : IsTotalQueryBound oa n)
-    (hC : 0 < Fintype.card (spec.Range default))
     (hrange : ∀ t, Fintype.card (spec.Range default) ≤ Fintype.card (spec.Range t)) :
     Pr[fun z => LogHasCollision z.2 |
       (simulateQ loggingOracle oa).run] ≤
@@ -547,7 +546,7 @@ theorem probEvent_logCollision_le_birthday_total {α : Type}
               omega
           have := hcard_nat n; push_cast [this]; rfl
         rw [hcard_eq, Finset.sum_mul]
-        exact ENNReal.gauss_sum_inv_le n C (by exact_mod_cast hC)
+        exact ENNReal.gauss_sum_inv_le n C
 
 /-- **Tight birthday bound for `cachingOracle`** (total query bound):
 The probability of a collision in the cache is ≤ n*(n-1)/(2|C|). -/


### PR DESCRIPTION
This PR refactors this proof to be based directly on the adjacent tighter proof, thereby removing an unnecessary argument.