### PR TITLE
feat(SampleableType): expand instance coverage (closes #117)

### DIFF
--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -32,13 +32,6 @@ variable [Inhabited K] [Fintype K] [SampleableType K]
 variable [Inhabited S] [Fintype S] [DecidableEq S] [SampleableType S]
 variable [Inhabited O] [Fintype O] [DecidableEq O] [SampleableType O]
 
-instance instSampleableTypeListVector (n : ℕ) : SampleableType (List.Vector O n) :=
-  SampleableType.ofEquiv
-    { toFun := List.Vector.ofFn
-      invFun := fun xs i => xs.get i
-      left_inv := fun f => funext fun i => by simp
-      right_inv := fun xs => List.Vector.ext fun i => by simp }
-
 /-- Deterministically unroll `n` rounds of a state transition/output function. -/
 def streamOutputs (step : S → S × O) : (n : ℕ) → S → List.Vector O n
   | 0, _ => .nil

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -387,7 +387,8 @@ instance instFintypeVector (α : Type u) (n : ℕ) [Fintype α] : Fintype (Vecto
       left_inv := fun f => funext fun i => by simp [Vector.get, Vector.ofFn]
       right_inv := fun v => Vector.ext fun i hi => by simp [Vector.ofFn, Vector.get] }
 
-/-- A function from `Fin n` to a `SampleableType` is also `SampleableType`. -/
+/-- A function from `Fin n` to a `SampleableType` is also `SampleableType`. This is the base
+case used by the general `FinEnum`-indexed `instSampleableTypeFunc` below. -/
 instance instSampleableTypeFinFunc {n : ℕ} {α : Type} [SampleableType α] :
     SampleableType (Fin n → α) :=
   SampleableType.ofEquiv
@@ -396,9 +397,37 @@ instance instSampleableTypeFinFunc {n : ℕ} {α : Type} [SampleableType α] :
       left_inv := fun v => Vector.ext fun i hi => by simp [Vector.ofFn, Vector.get]
       right_inv := fun f => funext fun i => by simp [Vector.get, Vector.ofFn] }
 
-/-- Select a uniform element from `Matrix α n` by selecting each row independently. -/
-instance (α : Type) (n m : ℕ) [SampleableType α] : SampleableType (Matrix (Fin n) (Fin m) α) :=
-  inferInstanceAs (SampleableType (Fin n → Fin m → α))
+/-- A function `β → α` for `β` finitely enumerable and `α` sampleable is itself sampleable.
+This generalizes the `Fin n → α` instance above: the `FinEnum.fin` instance recovers it. -/
+instance instSampleableTypeFunc {β α : Type} [FinEnum β] [SampleableType α] :
+    SampleableType (β → α) :=
+  SampleableType.ofEquiv (α := Fin (FinEnum.card β) → α)
+    (Equiv.arrowCongr FinEnum.equiv.symm (Equiv.refl α))
+
+/-- Select a uniform element from `List.Vector α n` by independently selecting `α` at each
+index. The construction goes through the equivalence with `Fin n → α`. -/
+instance instSampleableTypeListVector {α : Type} {n : ℕ} [SampleableType α] :
+    SampleableType (List.Vector α n) :=
+  SampleableType.ofEquiv
+    { toFun := List.Vector.ofFn
+      invFun := fun xs i => xs.get i
+      left_inv := fun f => funext fun i => by simp
+      right_inv := fun xs => List.Vector.ext fun i => by simp }
+
+/-- Select a uniform element from `Matrix ι κ α` by independently selecting an entry for each
+`(i, j)`. Both index types only need to be `FinEnum`; the previous `Fin n × Fin m`-indexed
+instance is recovered through `FinEnum.fin`. -/
+instance instSampleableTypeMatrix {α ι κ : Type} [FinEnum ι] [FinEnum κ] [SampleableType α] :
+    SampleableType (Matrix ι κ α) :=
+  inferInstanceAs (SampleableType (ι → κ → α))
+
+/-- Discoverability wrapper: `SampleableType (α ⊕ β)` follows from `FinEnum` on each side
+plus nonemptiness of the sum, via Mathlib's `FinEnum.sum` instance and
+`FinEnum.SampleableType`. Listed explicitly so users can see it in the instance set rather
+than relying on a multi-step search. -/
+instance instSampleableTypeSum {α β : Type} [FinEnum α] [FinEnum β]
+    [Nonempty (α ⊕ β)] : SampleableType (α ⊕ β) :=
+  inferInstance
 
 end instances
 

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -10,6 +10,9 @@ import VCVio.EvalDist.Bool
 import VCVio.EvalDist.Prod
 import Init.Data.UInt.Lemmas
 import Mathlib.Data.FinEnum
+import Mathlib.Data.Fintype.Perm
+import Mathlib.Data.Fintype.Pi
+import Mathlib.Data.Fintype.Vector
 
 /-!
 # Uniform Selection Over a Type
@@ -304,6 +307,15 @@ instance FinEnum.SampleableType (α : Type)
   have : NeZero (FinEnum.card α) := NeZero.mk FinEnum.card_ne_zero
   exact SampleableType.ofEquiv h.equiv.symm
 
+/-- Noncomputable bridge from a nonempty `Fintype` with decidable equality to `SampleableType`,
+via `Fintype.equivFin`. Used by downstream instances (e.g. `Sym α n`, `Equiv.Perm α`, `β ↪ α`)
+whose Mathlib `Fintype` instances are not paired with a `FinEnum`. Provided as a `def` rather
+than an `instance` to avoid overlap with `FinEnum.SampleableType`. -/
+@[reducible] noncomputable def SampleableType.ofFintype (α : Type)
+    [Fintype α] [DecidableEq α] [Nonempty α] : SampleableType α :=
+  haveI : NeZero (Fintype.card α) := ⟨Fintype.card_ne_zero⟩
+  SampleableType.ofEquiv (Fintype.equivFin α).symm
+
 instance (n : ℕ) [NeZero n] : FinEnum (ZMod n) where
   card := n
   equiv := (ZMod.finEquiv n).symm.toEquiv
@@ -428,6 +440,39 @@ than relying on a multi-step search. -/
 instance instSampleableTypeSum {α β : Type} [FinEnum α] [FinEnum β]
     [Nonempty (α ⊕ β)] : SampleableType (α ⊕ β) :=
   inferInstance
+
+/-- Discoverability wrapper: `SampleableType (Finset α)` for `FinEnum α`. Uniform sampling
+draws every subset of `α` with the same probability (`2^|α|` outcomes). `Finset α` is always
+inhabited by `∅`, so no `Nonempty` hypothesis is needed. -/
+instance instSampleableTypeFinset {α : Type} [FinEnum α] : SampleableType (Finset α) :=
+  inferInstance
+
+/-- Uniform sampling of size-`n` multisets over `α`. `Sym α n` is the correct finite analogue
+of `Multiset α`: a plain `Multiset α` is unbounded in multiplicity and thus not `Fintype`,
+while `Sym α n` is a `Fintype` whenever `α` is. The `Mathlib` instance lives in
+`Mathlib.Data.Fintype.Vector`; we lift it through `SampleableType.ofFintype`. -/
+noncomputable instance instSampleableTypeSym {α : Type} {n : ℕ}
+    [Fintype α] [DecidableEq α] [Nonempty α] : SampleableType (Sym α n) :=
+  haveI : Nonempty (Sym α n) := ⟨.replicate n (Classical.arbitrary α)⟩
+  SampleableType.ofFintype _
+
+/-- Uniform sampling of permutations of a finite type. `Equiv.Perm α` has `n!` elements when
+`Fintype.card α = n`. Mathlib provides `Fintype (Equiv.Perm α)` via
+`Mathlib.Data.Fintype.Perm`; we lift through `SampleableType.ofFintype`. Useful for
+shuffle-based protocols and oblivious-permutation games. -/
+noncomputable instance instSampleableTypePerm {α : Type} [Fintype α] [DecidableEq α] :
+    SampleableType (Equiv.Perm α) :=
+  haveI : Nonempty (Equiv.Perm α) := ⟨Equiv.refl α⟩
+  SampleableType.ofFintype _
+
+/-- Uniform sampling of injections `β ↪ α` for finite types. The number of such embeddings is
+`α.card! / (α.card - β.card)!` when `β.card ≤ α.card`, else `0`; the `Nonempty (β ↪ α)`
+hypothesis rules out the latter case. Mathlib provides `Fintype (β ↪ α)` via
+`Mathlib.Data.Fintype.Pi`; we lift through `SampleableType.ofFintype`. -/
+noncomputable instance instSampleableTypeEmbedding {β α : Type}
+    [Fintype β] [Fintype α] [DecidableEq β] [DecidableEq α] [Nonempty (β ↪ α)] :
+    SampleableType (β ↪ α) :=
+  SampleableType.ofFintype _
 
 end instances
 

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -431,14 +431,136 @@ end uniformSelectFinset
 
 section uniformSelectArray
 
-instance {α : Type _} : HasUniformSelect (Array α) α where
+instance hasUniformSelectArray (α : Type _) : HasUniformSelect (Array α) α where
   uniformSelect xs := if h : xs.size = 0 then failure else do
     let u ← $[0..xs.size-1]
     return xs[u] -- Note the in-index bound here relies on `h`.
 
--- TODO: full API for this
+variable {α : Type} (xs : Array α)
+
+lemma uniformSelectArray_def :
+    ($ xs : OptionT ProbComp α) =
+      if h : xs.size = 0 then failure else do
+        let u ← $[0..xs.size-1]
+        return xs[u] := rfl
+
+@[simp, grind =]
+lemma uniformSelectArray_empty : ($ (#[] : Array α) : OptionT ProbComp α) = failure := rfl
+
+@[simp, grind =]
+lemma support_uniformSelectArray : support ($ xs) = {x | x ∈ xs} := by
+  by_cases h : xs.size = 0
+  · have hxs : xs = #[] := Array.size_eq_zero_iff.mp h
+    subst hxs; ext x; simp
+  · have hsucc : xs.size - 1 + 1 = xs.size := Nat.succ_pred_eq_of_pos (Nat.pos_of_ne_zero h)
+    rw [uniformSelectArray_def, dif_neg h]
+    ext x
+    simp only [support_bind, OptionT.support_liftM, support_uniformFin,
+      Set.mem_iUnion, Set.mem_setOf_eq, support_pure, Set.mem_singleton_iff]
+    constructor
+    · rintro ⟨i, _, hx⟩
+      have hi : i.val < xs.size := Nat.lt_of_lt_of_eq i.isLt hsucc
+      rw [hx]
+      exact Array.getElem_mem hi
+    · intro hmem
+      obtain ⟨i, hi, hxs⟩ := Array.mem_iff_getElem.mp hmem
+      exact ⟨⟨i, Nat.lt_of_lt_of_eq hi hsucc.symm⟩, Set.mem_univ _, hxs.symm⟩
+
+@[simp, grind =]
+lemma finSupport_uniformSelectArray [DecidableEq α] :
+    finSupport ($ xs) = xs.toList.toFinset := by
+  apply finSupport_eq_of_support_eq_coe
+  rw [support_uniformSelectArray]
+  ext x
+  simp only [List.coe_toFinset, Set.mem_setOf_eq]
+  constructor
+  · intro hmem
+    obtain ⟨i, hi, hxs⟩ := Array.mem_iff_getElem.mp hmem
+    rw [List.mem_iff_getElem]
+    refine ⟨i, by rwa [Array.length_toList], ?_⟩
+    rw [Array.getElem_toList]; exact hxs
+  · intro hmem
+    rw [List.mem_iff_getElem] at hmem
+    obtain ⟨i, hi, hxs⟩ := hmem
+    rw [Array.length_toList] at hi
+    rw [Array.mem_iff_getElem]
+    exact ⟨i, hi, by rw [← Array.getElem_toList (h := hi)]; exact hxs⟩
+
+@[simp, grind =]
+lemma probFailure_uniformSelectArray : Pr[⊥ | $ xs] = if xs.size = 0 then 1 else 0 := by
+  by_cases h : xs.size = 0
+  · have hxs : xs = #[] := Array.size_eq_zero_iff.mp h
+    subst hxs; simp
+  · rw [uniformSelectArray_def, dif_neg h]
+    simp [h]
+
+-- TODO: `probOutput_uniformSelectArray` and `probEvent_uniformSelectArray` analogous to the
+-- `List` API. These need a careful `Fin (xs.size - 1 + 1) ≃ Fin xs.size` reindexing that
+-- the present helpers don't cleanly factor. Bridging through `xs.toList` once a clean
+-- `($ xs : OptionT ProbComp α) = $ xs.toList` lemma lands is probably the right path.
 
 end uniformSelectArray
+
+section uniformSelectMultiset
+
+/-- Choose a random element from a multiset, by converting to a list and choosing from that.
+This is noncomputable as the underlying list is only canonical up to permutation; for any
+fixed `Multiset.toList` representative each element is sampled with weight equal to its
+multiplicity. -/
+noncomputable instance hasUniformSelectMultiset (α : Type) :
+    HasUniformSelect (Multiset α) α where
+  uniformSelect s := $ s.toList
+
+variable {α : Type} (s : Multiset α)
+
+lemma uniformSelectMultiset_def : ($ s : OptionT ProbComp α) = $ s.toList := rfl
+
+@[simp, grind =]
+lemma support_uniformSelectMultiset :
+    support ($ s) = {x | x ∈ s} := by
+  ext x; simp [uniformSelectMultiset_def, Multiset.mem_toList]
+
+@[simp, grind =]
+lemma finSupport_uniformSelectMultiset [DecidableEq α] :
+    finSupport ($ s) = s.toFinset := by
+  apply finSupport_eq_of_support_eq_coe
+  ext x
+  simp [Multiset.mem_toFinset]
+
+@[simp, grind =]
+lemma probOutput_uniformSelectMultiset [DecidableEq α] (x : α) :
+    Pr[= x | $ s] = (s.count x : ℝ≥0∞) / Multiset.card s := by
+  simp only [uniformSelectMultiset_def, probOutput_uniformSelectList,
+    Multiset.length_toList]
+  congr 2
+  exact (Multiset.coe_count x s.toList).symm.trans (by rw [Multiset.coe_toList])
+
+@[simp, grind =]
+lemma probEvent_uniformSelectMultiset (p : α → Prop) [DecidablePred p] :
+    Pr[ p | $ s] = (Multiset.countP p s : ℝ≥0∞) / Multiset.card s := by
+  classical
+  simp only [uniformSelectMultiset_def, probEvent_uniformSelectList,
+    Multiset.length_toList]
+  congr 2
+  exact (Multiset.coe_countP p s.toList).symm.trans (by rw [Multiset.coe_toList])
+
+@[simp, grind =]
+lemma probFailure_uniformSelectMultiset :
+    Pr[⊥ | $ s] = if 0 < Multiset.card s then 0 else 1 := by
+  rw [uniformSelectMultiset_def, probFailure_uniformSelectList]
+  by_cases h : Multiset.card s = 0
+  · have hs : s = 0 := Multiset.card_eq_zero.mp h
+    subst hs
+    simp
+  · have hne : s ≠ 0 := fun hs => h (by rw [hs]; rfl)
+    have hempty_false : s.toList.isEmpty = false := by
+      rw [Bool.eq_false_iff, ne_eq, List.isEmpty_iff, Multiset.toList_eq_nil]
+      exact hne
+    have hpos : 0 < Multiset.card s := Nat.pos_of_ne_zero h
+    rw [hempty_false, if_pos hpos]
+    rfl
+
+end uniformSelectMultiset
 
 end ProbComp
 

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,1 +1,2 @@
+import VCVioTest.SampleableType
 import VCVioTest.Smoke

--- a/VCVioTest/SampleableType.lean
+++ b/VCVioTest/SampleableType.lean
@@ -39,6 +39,28 @@ example : SampleableType (Matrix (Fin 2) (Fin 3) Bool) := inferInstance
 /-- `Sum`-typed sampling works via `FinEnum.sum` + `FinEnum.SampleableType`. -/
 example : SampleableType (Fin 2 ⊕ Fin 3) := inferInstance
 
+/-- `Finset α` for a `FinEnum` element type: drawn uniformly from the `2^|α|` subsets. -/
+example : SampleableType (Finset (Fin 3)) := inferInstance
+example : SampleableType (Finset (Fin 4 ⊕ Fin 2)) := inferInstance
+
+/-- Size-`n` multisets over a nonempty `Fintype`. -/
+noncomputable example : SampleableType (Sym Bool 3) := inferInstance
+noncomputable example : SampleableType (Sym (Fin 3) 2) := inferInstance
+
+/-- Permutations of a finite type: `n!` outcomes. -/
+noncomputable example : SampleableType (Equiv.Perm (Fin 3)) := inferInstance
+noncomputable example : SampleableType (Equiv.Perm Bool) := inferInstance
+
+/-- Function embeddings (injections) between finite types. The `Nonempty (β ↪ α)`
+hypothesis amounts to `card β ≤ card α`, which is supplied at use-site. -/
+noncomputable example : SampleableType (Fin 2 ↪ Fin 3) :=
+  haveI : Nonempty (Fin 2 ↪ Fin 3) :=
+    ⟨⟨Fin.castLE (by omega), Fin.castLE_injective _⟩⟩
+  inferInstance
+noncomputable example : SampleableType (Fin 3 ↪ Fin 3) :=
+  haveI : Nonempty (Fin 3 ↪ Fin 3) := ⟨.refl _⟩
+  inferInstance
+
 end SampleableType
 
 section HasUniformSelect

--- a/VCVioTest/SampleableType.lean
+++ b/VCVioTest/SampleableType.lean
@@ -1,0 +1,61 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio
+
+/-!
+# Regression tests for `SampleableType` and `HasUniformSelect` instance coverage
+
+Inferable smoke tests for the instances added under issue #117. If any of these
+`inferInstance` calls regress (e.g. an instance is renamed, removed, or its priority
+changes so that it no longer fires), the build fails and the regression surfaces
+without needing a runtime check.
+-/
+
+open OracleComp ProbComp ENNReal
+
+section SampleableType
+
+example : SampleableType Bool := inferInstance
+example : SampleableType (Fin 3) := inferInstance
+example : SampleableType (List.Vector Bool 3) := inferInstance
+example : SampleableType (Vector Bool 3) := inferInstance
+
+/-- The `Fin n → α` base instance is still present after the generalization. -/
+example : SampleableType (Fin 3 → Bool) := inferInstance
+
+/-- The general `FinEnum`-indexed function instance: any `FinEnum`-indexed function space
+into a `SampleableType` is `SampleableType`. -/
+example : SampleableType (Fin 4 → Fin 2) := inferInstance
+
+/-- The original `Fin n × Fin m`-indexed Matrix instance. -/
+example : SampleableType (Matrix (Fin 2) (Fin 2) Bool) := inferInstance
+
+/-- The generalized `Matrix` instance: both row and column indices may be any `FinEnum`. -/
+example : SampleableType (Matrix (Fin 2) (Fin 3) Bool) := inferInstance
+
+/-- `Sum`-typed sampling works via `FinEnum.sum` + `FinEnum.SampleableType`. -/
+example : SampleableType (Fin 2 ⊕ Fin 3) := inferInstance
+
+end SampleableType
+
+section HasUniformSelect
+
+example : HasUniformSelect (List Bool) Bool := inferInstance
+example : HasUniformSelect! (Vector Bool 3) Bool := inferInstance
+example : HasUniformSelect! (List.Vector Bool 3) Bool := inferInstance
+noncomputable example : HasUniformSelect (Finset Bool) Bool := inferInstance
+example : HasUniformSelect (Array Bool) Bool := inferInstance
+noncomputable example : HasUniformSelect (Multiset Bool) Bool := inferInstance
+
+end HasUniformSelect
+
+section MultisetProbabilities
+
+/-- For a singleton multiset, sampling always returns the unique element with probability 1. -/
+example : Pr[= true | ($ ({true} : Multiset Bool))] = 1 := by
+  simp
+
+end MultisetProbabilities


### PR DESCRIPTION
## Summary

Closes #117. Expands `SampleableType` and `HasUniformSelect` instance coverage.

**`SampleableType` instances** added in `VCVio/OracleComp/Constructions/SampleableType.lean`:

- `List.Vector α n` — hoisted and generalized out of `Examples/PRGfromPRF.lean`.
- `β → α` for `[FinEnum β] [SampleableType α]` — generalizes the previous `Fin n → α` instance (which is kept as a base case; the generalization recovers it via `FinEnum.fin`).
- `Matrix ι κ α` for `[FinEnum ι] [FinEnum κ]` — generalizes the previous `Fin n × Fin m`-indexed instance.
- `α ⊕ β` (discoverability wrapper) — already automatic via `FinEnum.sum` + `FinEnum.SampleableType`; listed explicitly so users can find it.

**`HasUniformSelect` / `!` instances** added in `VCVio/OracleComp/ProbComp.lean`:

- `Multiset α` (noncomputable, multiplicity-weighted) with the full lemma API: `support`, `finSupport`, `probOutput`, `probEvent`, `probFailure`.
- Fleshes out the `Array α` API (previously `-- TODO: full API for this`): `support`, `finSupport`, and `probFailure` lemmas. `probOutput` / `probEvent` are deferred with a TODO — they need a `Fin (xs.size - 1 + 1) ≃ Fin xs.size` reindexing that the present helpers don't cleanly factor; bridging through `xs.toList` once a clean `($ xs) = $ xs.toList` lemma lands is probably the right path.

**Regression tests** in new `VCVioTest/SampleableType.lean`: `inferInstance` smoke tests for each new instance so future regressions in the instance set surface as build failures.

## Test plan

- [x] `lake build` succeeds with no new `sorry`.
- [x] `lake build VCVioTest.SampleableType` succeeds — all `inferInstance` checks resolve.
- [x] `Examples/PRGfromPRF.lean` still typechecks after the local `instSampleableTypeListVector` is removed (the hoisted general instance subsumes it).
- [x] `LatticeCrypto` and `Examples` libraries still build cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)