### PR TITLE
feat(QueryBound): add IsTotalQueryBound.of_bind_left

### DIFF
--- a/VCVio/OracleComp/QueryTracking/QueryBound.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryBound.lean
@@ -712,6 +712,19 @@ lemma isTotalQueryBound_bind {oa : OracleComp spec α} {ob : α → OracleComp s
   · intros _ _ _ _ hcan; exact ⟨by simp; omega, by simp; omega⟩
   · intros _ _ _ _ hcan; exact ⟨by simp; omega, by simp; omega⟩
 
+/-- If `oa >>= ob` has a total query bound `n`, then `oa` alone has total query bound `n`
+(the continuation can only add queries, not remove them). -/
+lemma IsTotalQueryBound.of_bind_left
+    {oa : OracleComp spec α} {ob : α → OracleComp spec β} {n : ℕ}
+    (h : IsTotalQueryBound (oa >>= ob) n) :
+    IsTotalQueryBound oa n := by
+  induction oa using OracleComp.inductionOn generalizing n with
+  | pure _ => trivial
+  | query_bind t mx ih =>
+      rw [bind_assoc, isTotalQueryBound_query_bind_iff] at h
+      rw [isTotalQueryBound_query_bind_iff]
+      exact ⟨h.1, fun u => ih u (h.2 u)⟩
+
 /-- Forward-direction `seq` analogue of `isTotalQueryBound_bind`. Reduces to the bind case
 via `seq_eq_bind_map` plus the `IsTotalQueryBound`-flavoured `isQueryBound_map_iff` to
 discharge the constant continuation. -/


### PR DESCRIPTION
Adds `IsTotalQueryBound.of_bind_left`: if `oa >>= ob` has a total query bound `n`, then `oa` alone has total query bound `n`.

This lemma was made in the course of the extractability PR but after refactoring was not needed. Still, seems useful, so I am PRing it separately.

## Test plan
- [x] `lake build VCVio.OracleComp.QueryTracking.QueryBound`

🤖 Generated with [Claude Code](https://claude.com/claude-code)