### PR TITLE
feat(NegacyclicRing/MLDSA/Rounding): add coeff access API and simplify MLDSA/Rounding proofs

### DIFF
--- a/LatticeCrypto/MLDSA/Arithmetic.lean
+++ b/LatticeCrypto/MLDSA/Arithmetic.lean
@@ -65,6 +65,8 @@ abbrev Quotient := LatticeCrypto.NegacyclicRingSemantics.Quotient coeffSemantics
 /-- Coefficient-domain polynomials in `R_q = Z_q[X] / (X^256 + 1)`. -/
 abbrev Rq := coeffRing.Poly
 
+instance : AddCommGroup Rq := inferInstance
+
 /-- Transform-domain polynomials for the ML-DSA bundled ring. -/
 abbrev Tq := LatticeCrypto.TransformPoly coeffRing
 

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -142,80 +142,47 @@ def useHint (p : Params) (h : Hint) (r : Rq) : High :=
 def hintWeight (h : Hint) : ℕ :=
   h.toList.foldl (fun acc b => acc + cond b 1 0) 0
 
-private def rqNSMul (n : ℕ) (x : Rq) : Rq :=
-  Vector.ofFn fun i => n • x.get i
-
-private def rqZSMul (n : ℤ) (x : Rq) : Rq :=
-  Vector.ofFn fun i => n • x.get i
-
-local instance : Add Rq := Vector.instAdd
-local instance : Zero Rq := Vector.instZero
-local instance : Sub Rq := Vector.instSub
-local instance : Neg Rq := Vector.instNeg
-
 @[simp] theorem Rq.get_zero (i : Fin ringDegree) : (0 : Rq).get i = 0 :=
   Vector.getElem_zero i.1 i.2
 
 @[simp] theorem Rq.get_add (a b : Rq) (i : Fin ringDegree) :
     (a + b).get i = a.get i + b.get i :=
-  Vector.getElem_add a b i.1 i.2
+  NegacyclicRing.coeff_add coeffRing a b i
 
 @[simp] theorem Rq.get_neg (a : Rq) (i : Fin ringDegree) :
     (-a).get i = -a.get i :=
-  Vector.getElem_neg a i.1 i.2
+  NegacyclicRing.coeff_neg coeffRing a i
 
 @[simp] theorem Rq.get_sub (a b : Rq) (i : Fin ringDegree) :
     (a - b).get i = a.get i - b.get i :=
-  Vector.getElem_sub a b i.1 i.2
+  NegacyclicRing.coeff_sub coeffRing a b i
 
 @[simp] theorem coeffRing_sub_eq (r s : Rq) : coeffRing.sub r s = r - s := by
-  apply Poly.ext_get_eq; intro i
-  simp [vectorRing_sub_get, Rq.get_sub]
+  ext i; simp only [NegacyclicRing.coeff_sub, coeffRing.sub_coeff]
 
 @[simp] theorem coeffRing_add_eq (r s : Rq) : coeffRing.add r s = r + s := by
-  apply Poly.ext_get_eq; intro i
-  simp [vectorRing_add_get, Rq.get_add]
+  ext i; simp only [NegacyclicRing.coeff_add, coeffRing.add_coeff]
 
-local instance instRqAddCommGroup : AddCommGroup Rq where
-  add := (· + ·)
-  add_assoc a b c := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add (a + b) c j, Rq.get_add a b j, Rq.get_add a (b + c) j, Rq.get_add b c j]
-    exact add_assoc _ _ _
-  zero := 0
-  zero_add a := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add 0 a j, Rq.get_zero j]; exact zero_add _
-  add_zero a := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add a 0 j, Rq.get_zero j]; exact add_zero _
-  nsmul := rqNSMul
-  nsmul_zero x := Poly.ext_get_eq fun j => by
-    rw [Rq.get_zero j]; simp [rqNSMul]
-  nsmul_succ n x := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add (rqNSMul n x) x j]
-    simpa [rqNSMul] using AddMonoid.nsmul_succ n (x.get j)
-  neg := Neg.neg
-  sub := Sub.sub
-  sub_eq_add_neg a b := Poly.ext_get_eq fun j => by
-    rw [Rq.get_sub a b j, Rq.get_add a (-b) j, Rq.get_neg b j]
-    exact sub_eq_add_neg _ _
-  zsmul := rqZSMul
-  zsmul_zero' a := Poly.ext_get_eq fun j => by
-    rw [Rq.get_zero j]; simp [rqZSMul]
-  zsmul_succ' n a := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add (rqZSMul (↑n) a) a j]
-    simpa [rqZSMul] using SubNegMonoid.zsmul_succ' n (a.get j)
-  zsmul_neg' n a := Poly.ext_get_eq fun j => by
-    rw [Rq.get_neg (rqZSMul (↑n.succ) a) j]
-    simpa [rqZSMul] using SubNegMonoid.zsmul_neg' n (a.get j)
-  neg_add_cancel a := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add (-a) a j, Rq.get_neg a j, Rq.get_zero j]
-    exact neg_add_cancel _
-  add_comm a b := Poly.ext_get_eq fun j => by
-    rw [Rq.get_add a b j, Rq.get_add b a j]
-    exact add_comm _ _
+private structure BalancedDecomp (alpha m : ℕ) : Prop where
+  hα   : 0 < alpha
+  hm   : 0 < m
+  hqm1 : alpha * m = modulus - 1
+  hq   : alpha < modulus
+  hdvd : alpha ∣ modulus - 1
+  hsmall : 2 * (alpha + 1) < modulus
+
+private def BalancedDecomp.ofApproved {p : Params} (hp : p.isApproved) :
+    BalancedDecomp (2 * p.gamma2) ((modulus - 1) / (2 * p.gamma2)) where
+  hα     := by rcases hp with rfl | rfl | rfl <;> decide
+  hm     := by rcases hp with rfl | rfl | rfl <;> decide
+  hqm1   := Nat.mul_div_cancel' (by rcases hp with rfl | rfl | rfl <;> decide)
+  hq     := by rcases hp with rfl | rfl | rfl <;> decide
+  hdvd   := by rcases hp with rfl | rfl | rfl <;> decide
+  hsmall := by rcases hp with rfl | rfl | rfl <;> decide
 
 private theorem power2RoundCoeff_eq (r : Coeff) :
     let (r1, r0) := power2RoundCoeff r
-    ((power2Scale : Coeff) * (r1 : Coeff)) + (intToCoeff r0) = r := by
+    ((power2Scale : Coeff) * (r1 : Coeff)) + r0 = r := by
   unfold power2RoundCoeff
   set t : ℕ := r.val % power2Scale
   have hdiv : t + power2Scale * (r.val / power2Scale) = r.val := by
@@ -224,23 +191,13 @@ private theorem power2RoundCoeff_eq (r : Coeff) :
   have hdiv' : ((t + power2Scale * (r.val / power2Scale) : ℕ) : Coeff) = r := by
     simpa [ZMod.natCast_zmod_val] using congrArg (fun n : ℕ => (n : Coeff)) hdiv
   by_cases h : t ≤ power2Scale / 2
-  · simp only [h, ↓reduceDIte, intToCoeff, Int.cast_natCast]
-    calc
-      ((power2Scale : Coeff) * ((r.val / power2Scale : ℕ) : Coeff)) + (t : Coeff)
-          = ((power2Scale * (r.val / power2Scale) + t : ℕ) : Coeff) := by
-              rw [← Nat.cast_mul, ← Nat.cast_add]
-      _ = r := by
-            simpa [Nat.add_comm] using hdiv'
-  · simp only [h, ↓reduceDIte, Nat.cast_add, Nat.cast_one, intToCoeff, Int.cast_sub,
-      Int.cast_natCast]
-    calc
-      (↑power2Scale : Coeff) * (↑(r.val / power2Scale) + 1) + ((t : Coeff) - power2Scale)
-          = ((power2Scale : Coeff) * ((r.val / power2Scale : ℕ) : Coeff)) + (t : Coeff) := by
-              ring
-      _ = ((power2Scale * (r.val / power2Scale) + t : ℕ) : Coeff) := by
-            rw [← Nat.cast_mul, ← Nat.cast_add]
-      _ = r := by
-            simpa [Nat.add_comm] using hdiv'
+  · simp only [h, ↓reduceDIte, Int.cast_natCast]
+    rw [← Nat.cast_mul, ← Nat.cast_add]
+    simp [Nat.add_comm, hdiv']
+  · simp only [h, ↓reduceDIte, Nat.cast_add, Nat.cast_one, Int.cast_sub, Int.cast_natCast]
+    ring_nf
+    rw [← Nat.cast_mul, ← Nat.cast_add]
+    simp [Nat.add_comm, hdiv']
 
 private theorem power2RoundCoeff_bound (r : Coeff) :
     (power2RoundCoeff r).2.natAbs ≤ power2Scale / 2 := by
@@ -258,136 +215,60 @@ private theorem power2RoundCoeff_bound (r : Coeff) :
 
 theorem centeredRepr_eq_of_natAbs_le (z : ℤ) {b : ℕ}
     (hbound : z.natAbs ≤ b) (hbq : 2 * b < modulus) :
-    LatticeCrypto.centeredRepr (intToCoeff z) = z :=
-  LatticeCrypto.centeredRepr_intCast_eq_of_natAbs_le z hbound hbq
+    centeredRepr (intToCoeff z) = z :=
+  centeredRepr_intCast_eq_of_natAbs_le z hbound hbq
 
 private theorem power2RoundLow_centeredRepr (r : Coeff) :
-    LatticeCrypto.centeredRepr (intToCoeff ((power2RoundCoeff r).2)) = (power2RoundCoeff r).2 := by
+    centeredRepr (intToCoeff ((power2RoundCoeff r).2)) = (power2RoundCoeff r).2 := by
   apply centeredRepr_eq_of_natAbs_le
   · exact power2RoundCoeff_bound r
   · norm_num [power2Scale, droppedBits, modulus]
 
-private theorem modulus_sub_one_eq_neg_one : ((modulus - 1 : ℕ) : Coeff) = (-1 : Coeff) := by
-  rw [Nat.cast_sub (show 1 ≤ modulus by norm_num [modulus])]
-  rw [ZMod.natCast_self]
-  simp
-
-private theorem decomposeCoeff_eq (r : Coeff) {gamma2 : ℕ} (hγ : 0 < gamma2) :
-    let (r1, r0) := decomposeCoeff r gamma2
-    (((2 * gamma2 : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 = r := by
-  unfold decomposeCoeff
+private theorem decomposeCoeff_eq (r : Coeff) {r1 gamma2 : ℕ} {r0 : ℤ}
+    (hdecomp : (r1, r0) = decomposeCoeff r gamma2) :
+    (((2 * gamma2 : ℕ) : Coeff) * (r1 : Coeff)) + r0 = r := by
+  simp only [decomposeCoeff] at hdecomp
   set alpha : ℕ := 2 * gamma2
   set t : ℕ := r.val % alpha
-  have hα : 0 < alpha := by
-    dsimp [alpha]
-    omega
-  have hdiv : t + alpha * (r.val / alpha) = r.val := by
-    subst t
-    exact Nat.mod_add_div _ _
-  have hdiv' : ((t + alpha * (r.val / alpha) : ℕ) : Coeff) = r := by
-    calc
-      ((t + alpha * (r.val / alpha) : ℕ) : Coeff) = (r.val : Coeff) :=
-        congrArg (fun n : ℕ => (n : Coeff)) hdiv
-      _ = r := ZMod.natCast_zmod_val r
-  by_cases h : t ≤ alpha / 2
-  · have base : ((alpha : Coeff) * ((r.val / alpha : ℕ) : Coeff)) + intToCoeff (t : ℤ) = r := by
-      calc
-        ((alpha : Coeff) * ((r.val / alpha : ℕ) : Coeff)) + intToCoeff (t : ℤ)
-            = ((alpha * (r.val / alpha) + t : ℕ) : Coeff) := by
-                rw [intToCoeff, Int.cast_natCast, ← Nat.cast_mul, ← Nat.cast_add]
-        _ = r := by
-              simpa [Nat.add_comm] using hdiv'
-    by_cases hs : alpha * (r.val / alpha) = modulus - 1
-    · have hsCoeff : ((alpha : Coeff) * ((r.val / alpha : ℕ) : Coeff)) = (-1 : Coeff) := by
-        rw [← Nat.cast_mul, hs]
-        exact modulus_sub_one_eq_neg_one
-      rw [hsCoeff] at base
-      simpa [t, h, hs, intToCoeff, sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using
-        base
-    · simpa [t, h, hs, intToCoeff] using base
-  · have base :
-        ((alpha : Coeff) * (((r.val / alpha) + 1 : ℕ) : Coeff)) +
-          intToCoeff ((t : ℤ) - alpha) = r := by
-      calc
-        ((alpha : Coeff) * (((r.val / alpha) + 1 : ℕ) : Coeff)) + intToCoeff ((t : ℤ) - alpha)
-            = ((alpha : Coeff) * ((r.val / alpha : ℕ) : Coeff)) + (t : Coeff) := by
-                simp [intToCoeff]
-                ring
-        _ = ((alpha * (r.val / alpha) + t : ℕ) : Coeff) := by
-              rw [← Nat.cast_mul, ← Nat.cast_add]
-        _ = r := by
-              simpa [Nat.add_comm] using hdiv'
-    by_cases hs : alpha * (1 + r.val / alpha) = modulus - 1
-    · have hsCoeff : ((alpha : Coeff) * ((1 + r.val / alpha : ℕ) : Coeff)) = (-1 : Coeff) := by
-        rw [← Nat.cast_mul, hs]
-        exact modulus_sub_one_eq_neg_one
-      rw [show ((alpha : Coeff) * (((r.val / alpha) + 1 : ℕ) : Coeff)) =
-            ((alpha : Coeff) * ((1 + r.val / alpha : ℕ) : Coeff)) by simp [Nat.add_comm]] at base
-      rw [hsCoeff] at base
-      simpa [t, h, hs, intToCoeff, sub_eq_add_neg, add_assoc, add_left_comm, add_comm,
-        Nat.add_comm] using base
-    · have hs' : alpha * ((r.val / alpha) + 1) ≠ modulus - 1 := by
-        simpa [Nat.add_comm] using hs
-      simpa [t, h, hs', intToCoeff] using base
+  set q := r.val / alpha
+  have hbase : ((alpha : ℕ) : Coeff) * (q : Coeff) + (t : Coeff) = r := by
+    have : alpha * q + t = r.val := by rw [Nat.div_add_mod]
+    apply congrArg (↑· : ℕ → Coeff) at this
+    rw [ZMod.natCast_zmod_val r ] at this
+    push_cast at this
+    exact this
+  have hwrap : ∀ (k : ℕ), alpha * k = modulus - 1 →
+      ((alpha : ℕ) : Coeff) * (k : Coeff) = -1 := fun k hk => by
+    rw [← Nat.cast_mul, hk, Nat.cast_sub (by norm_num [modulus]),
+      ZMod.natCast_self, zero_sub, Nat.cast_one]
+  split_ifs at hdecomp with h hs hs <;>
+    simp only [Prod.mk.injEq] at hdecomp <;>
+    obtain ⟨rfl, rfl⟩ := hdecomp
+  · rw [hwrap q hs] at hbase
+    simp only [Nat.cast_zero, mul_zero, Int.cast_sub, Int.cast_natCast, Int.cast_one, zero_add]
+    exact hbase
+  · exact hbase
+  · have h1 : (alpha:Coeff) * (q:Coeff) = (alpha:Coeff) * (((q + 1):ℕ):Coeff) - alpha := by
+      simp [mul_add]
+    rw [← hbase, h1, hwrap (q+1) hs]
+    simp [mul_zero]
+    ring
+  · simp [← hbase, mul_add]
 
 private theorem lowBitsCoeff_bound (r : Coeff) {gamma2 : ℕ} (hγ : 0 < gamma2) :
     (lowBitsCoeff r gamma2).natAbs ≤ gamma2 := by
-  unfold lowBitsCoeff decomposeCoeff
+  simp only [lowBitsCoeff, decomposeCoeff]
   set alpha : ℕ := 2 * gamma2
   set t : ℕ := r.val % alpha
-  have hα : 0 < alpha := by
-    dsimp [alpha]
-    omega
-  have htlt : t < alpha := by
-    subst t
-    exact Nat.mod_lt _ hα
-  have hhalf : alpha / 2 = gamma2 := by
-    dsimp [alpha]
-    omega
-  by_cases h : t ≤ alpha / 2
-  · have htγ : t ≤ gamma2 := by simpa [hhalf] using h
-    have hcond : r.val % (2 * gamma2) ≤ gamma2 := by
-      simpa [alpha, t] using htγ
-    by_cases hs : alpha * (r.val / alpha) = modulus - 1
-    · have hbound : Int.natAbs ((t : ℤ) - 1) ≤ gamma2 := by
-        simpa using Int.natAbs_coe_sub_coe_le_of_le htγ (show 1 ≤ gamma2 by omega)
-      simpa [lowBitsCoeff, decomposeCoeff, alpha, t, hcond, hs] using hbound
-    · have hbound : Int.natAbs (t : ℤ) ≤ gamma2 := by
-        simpa using htγ
-      simpa [lowBitsCoeff, decomposeCoeff, alpha, t, hcond, hs] using hbound
-  · have htgt : alpha / 2 < t := Nat.lt_of_not_ge h
-    have htgeγ : gamma2 + 1 ≤ t := by
-      have : gamma2 < t := by simpa [hhalf] using htgt
-      omega
-    have hnotcond : ¬r.val % (2 * gamma2) ≤ gamma2 := by
-      intro hcond
-      apply h
-      simpa [alpha, t, hhalf] using hcond
-    by_cases hs : alpha * (1 + r.val / alpha) = modulus - 1
-    · have hs' : (2 * gamma2) * (1 + r.val / (2 * gamma2)) = modulus - 1 := by
-        simpa [alpha] using hs
-      have hbound : Int.natAbs ((t : ℤ) - ((alpha + 1 : ℕ) : ℤ)) ≤ gamma2 := by
-        rw [Int.natAbs_natCast_sub_natCast_of_le (show t ≤ alpha + 1 by omega)]
-        rw [show alpha = 2 * gamma2 by rfl]
-        omega
-      have hbound' : Int.natAbs ((t : ℤ) - alpha - 1) ≤ gamma2 := by
-        simpa [sub_eq_add_neg, add_assoc, add_left_comm, add_comm] using hbound
-      simpa [lowBitsCoeff, decomposeCoeff, alpha, t, hnotcond, hs', Nat.add_comm] using hbound'
-    · have hs' : (2 * gamma2) * (1 + r.val / (2 * gamma2)) ≠ modulus - 1 := by
-        simpa [alpha] using hs
-      have hbound : Int.natAbs ((t : ℤ) - alpha) ≤ gamma2 := by
-        rw [Int.natAbs_natCast_sub_natCast_of_le htlt.le]
-        rw [show alpha = 2 * gamma2 by rfl]
-        omega
-      simpa [lowBitsCoeff, decomposeCoeff, alpha, t, hnotcond, hs', Nat.add_comm] using hbound
+  have htlt : t < alpha := Nat.mod_lt _ (by omega)
+  split_ifs with h hs hs <;> omega
 
 private theorem lowBits_centeredRepr (r : Coeff) {gamma2 : ℕ}
     (hγ : 0 < gamma2) (hq : 2 * gamma2 < modulus) :
-    LatticeCrypto.centeredRepr (intToCoeff (lowBitsCoeff r gamma2)) = lowBitsCoeff r gamma2 := by
+    centeredRepr (intToCoeff (lowBitsCoeff r gamma2)) = lowBitsCoeff r gamma2 := by
   apply centeredRepr_eq_of_natAbs_le
   · exact lowBitsCoeff_bound r hγ
   · linarith
-
 
 private theorem power2RoundShift_high_get (r : Rq) (i : Fin ringDegree) :
     (power2RoundShift (power2RoundHigh r)).get i =
@@ -411,9 +292,9 @@ theorem concretePower2Round_remainder_eq_low (r : Rq) :
     exact sub_eq_iff_eq_add'.2 (power2RoundCoeff_eq (r.get j)).symm
 
 theorem concretePower2Round_bound (r : Rq) :
-    LatticeCrypto.cInfNorm (r - power2RoundShift (power2RoundHigh r)) ≤ 2 ^ (droppedBits - 1) := by
+    cInfNorm (r - power2RoundShift (power2RoundHigh r)) ≤ 2 ^ (droppedBits - 1) := by
   rw [concretePower2Round_remainder_eq_low]
-  refine LatticeCrypto.cInfNorm_le_of_coeff_le ?_
+  refine cInfNorm_le_of_coeff_le ?_
   intro i
   rw [power2RoundLow_get]
   rw [power2RoundLow_centeredRepr (r.get i)]
@@ -428,16 +309,16 @@ private theorem lowBits_get (p : Params) (r : Rq) (i : Fin ringDegree) :
     (lowBits p r).get i = intToCoeff (lowBitsCoeff (r.get i) p.gamma2) := by
   simp [lowBits]
 
-theorem concreteRounding_high_low_decomp (p : Params) (hγ : 0 < p.gamma2) (r : Rq) :
+theorem concreteRounding_high_low_decomp (p : Params) (r : Rq) :
     highBitsShift p (highBits p r) + lowBits p r = r :=
   Poly.ext_get_eq fun j => by
     rw [Rq.get_add, highBitsShift_high_get, lowBits_get]
-    simpa [highBitsCoeff, lowBitsCoeff] using decomposeCoeff_eq (r.get j) hγ
+    exact decomposeCoeff_eq (r.get j) (Prod.eta _)
 
 theorem concreteRounding_lowBits_bound (p : Params)
     (hγ : 0 < p.gamma2) (hq : 2 * p.gamma2 < modulus) (r : Rq) :
-    LatticeCrypto.cInfNorm (lowBits p r) ≤ p.gamma2 := by
-  refine LatticeCrypto.cInfNorm_le_of_coeff_le ?_
+    cInfNorm (lowBits p r) ≤ p.gamma2 := by
+  refine cInfNorm_le_of_coeff_le ?_
   intro i
   rw [lowBits_get]
   rw [lowBits_centeredRepr (r := r.get i) hγ hq]
@@ -453,1135 +334,563 @@ private theorem gamma2_double_lt_modulus_of_isApproved {p : Params} (hp : p.isAp
 
 private theorem gamma2_half (p : Params) : (2 * p.gamma2) / 2 = p.gamma2 := by omega
 
-private theorem useHintModulus_pos_of_isApproved {p : Params} (hp : p.isApproved) :
-    0 < (modulus - 1) / (2 * p.gamma2) := by
-  rcases hp with rfl | rfl | rfl <;> decide
-
-private theorem twoGamma_dvd_modulus_sub_one_of_isApproved {p : Params} (hp : p.isApproved) :
-    2 * p.gamma2 ∣ modulus - 1 := by
-  rcases hp with rfl | rfl | rfl <;> decide
-
-private theorem alphaPlusOne_double_lt_modulus_of_isApproved {p : Params} (hp : p.isApproved) :
-    2 * (2 * p.gamma2 + 1) < modulus := by
-  rcases hp with rfl | rfl | rfl <;> decide
-
 private theorem highBitsCoeff_lt_useHintModulus_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Coeff) :
     highBitsCoeff r p.gamma2 < (modulus - 1) / (2 * p.gamma2) := by
+  let ctx := BalancedDecomp.ofApproved hp
   unfold highBitsCoeff decomposeCoeff
   set alpha : ℕ := 2 * p.gamma2
   set m : ℕ := (modulus - 1) / alpha
   set t : ℕ := r.val % alpha
-  have hα : 0 < alpha := by
-    have hγ := gamma2_pos_of_isApproved hp
-    dsimp [alpha]
-    omega
-  have hm : 0 < m := by
-    simpa [m, alpha] using useHintModulus_pos_of_isApproved hp
-  have hqm : alpha * m = modulus - 1 := by
-    have hdvd : alpha ∣ modulus - 1 := by
-      simpa [alpha] using twoGamma_dvd_modulus_sub_one_of_isApproved hp
-    simpa [m] using (Nat.mul_div_cancel' hdvd)
-  have htlt : t < alpha := by
-    subst t
-    exact Nat.mod_lt _ hα
-  have hdiv : t + alpha * (r.val / alpha) = r.val := by
-    subst t
-    exact Nat.mod_add_div _ _
   by_cases h : t ≤ alpha / 2
-  · have hcond : r.val % (2 * p.gamma2) ≤ p.gamma2 := by
-      simpa [alpha, t] using h
-    by_cases hs : alpha * (r.val / alpha) = modulus - 1
-    · simpa [t, h, hs] using hm
+  · by_cases hs : alpha * (r.val / alpha) = modulus - 1
+    · simp [h, t, hs, ctx.hm]
     · have hlt : r.val / alpha < m := by
+        have hle : r.val ≤ alpha * m := by
+          have := ZMod.val_lt r; rw [ctx.hqm1]; omega
+        have hdiv_le : r.val / alpha ≤ m := by
+          rw [← Nat.mul_div_cancel_left m ctx.hα]
+          exact Nat.div_le_div_right hle
+        exact lt_of_le_of_ne hdiv_le fun h => hs (by rw [h]; exact ctx.hqm1)
+      simp [h, t, hs, hlt]
+  · by_cases hs : alpha * (r.val / alpha + 1) = modulus - 1
+    · simp [h, t, hs, ctx.hm]
+    · have hqdiv_lt : r.val / alpha < m := by
         by_contra hge
-        have hmle : m ≤ r.val / alpha := Nat.not_lt.mp hge
-        have hmul : modulus - 1 ≤ alpha * (r.val / alpha) := by
-          simpa [hqm] using Nat.mul_le_mul_left alpha hmle
-        have hupper : alpha * (r.val / alpha) ≤ r.val := by
-          have hhdiv := hdiv
-          omega
-        have hval : r.val = modulus - 1 := by
-          have hltq : r.val < modulus := ZMod.val_lt r
-          omega
-        have heq : alpha * (r.val / alpha) = modulus - 1 := by
-          have hhdiv := hdiv
-          omega
-        exact hs heq
-      simpa [t, h, hs] using hlt
-  · have hnotcond : ¬r.val % (2 * p.gamma2) ≤ p.gamma2 := by
-      intro hcond
-      apply h
-      simpa [alpha, t] using hcond
-    by_cases hs : alpha * (1 + r.val / alpha) = modulus - 1
-    · simpa [t, h, hs, Nat.add_comm] using hm
-    · have hlt : r.val / alpha + 1 < m := by
-        have hqdiv_lt_m : r.val / alpha < m := by
-          by_contra hge
-          have hmle : m ≤ r.val / alpha := Nat.not_lt.mp hge
-          have hmul : modulus - 1 ≤ alpha * (r.val / alpha) := by
-            simpa [hqm] using Nat.mul_le_mul_left alpha hmle
-          have htpos : 0 < t := by
-            have htgt : alpha / 2 < t := Nat.lt_of_not_ge h
-            omega
-          have hval : modulus ≤ r.val := by
-            have hhdiv := hdiv
-            omega
-          exact (Nat.not_lt.mpr hval) (ZMod.val_lt r)
-        have hle : r.val / alpha + 1 ≤ m := Nat.succ_le_of_lt hqdiv_lt_m
-        have hne : r.val / alpha + 1 ≠ m := by
-          intro heq
-          have heq' : alpha * (1 + r.val / alpha) = modulus - 1 := by
-            rw [Nat.add_comm, heq, hqm]
-          exact hs heq'
-        exact lt_of_le_of_ne hle hne
-      simpa [t, h, hs, Nat.add_comm] using hlt
+        have hmle : alpha * m ≤ alpha * (r.val / alpha) :=
+          Nat.mul_le_mul_left alpha (Nat.not_lt.mp hge)
+        have hdadd : alpha * (r.val / alpha) + t = r.val := Nat.div_add_mod r.val alpha
+        have htpos : 0 < t := by have := Nat.lt_of_not_le h; omega
+        have hmod : alpha * m + 1 = modulus := by rw[ctx.hqm1]; norm_cast
+        linarith [ZMod.val_lt r]
+      have hlt : r.val / alpha + 1 < m :=
+        lt_of_le_of_ne (Nat.succ_le_of_lt hqdiv_lt)
+          (fun heq => hs (by rw [heq]; exact ctx.hqm1))
+      simp [h, t, hs, hlt]
 
-private theorem alphaMulUseHintModulus_eq_neg_one_of_isApproved (p : Params)
-    (hp : p.isApproved) :
-    let alpha := 2 * p.gamma2
-    let m := (modulus - 1) / alpha
-    (((alpha : ℕ) : Coeff) * (m : Coeff)) = (-1 : Coeff) := by
-  dsimp
-  have hdvd : 2 * p.gamma2 ∣ modulus - 1 := twoGamma_dvd_modulus_sub_one_of_isApproved hp
-  rw [← Nat.cast_mul, Nat.mul_div_cancel' hdvd]
-  exact modulus_sub_one_eq_neg_one
+private theorem alphaMul_pred_m_eq_coeff {alpha m : ℕ} (ctx : BalancedDecomp alpha m) :
+    ((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff) = (-1 : Coeff) - ((alpha : ℕ) : Coeff) := by
+  have hmulm: (((alpha : ℕ) : Coeff) * (m : Coeff)) = (-1 : Coeff) := by
+    rw [← Nat.cast_mul, ctx.hqm1,
+      Nat.cast_sub (show 1 ≤ modulus by norm_num [modulus]),
+      ZMod.natCast_self, zero_sub]
+    push_cast; rfl
+  have hcast : ((m - 1 : ℕ) : Coeff) = (m : Coeff) - 1 := by
+    push_cast [show 1 ≤ m from ctx.hm]; rfl
+  rw [hcast, mul_sub, mul_one, hmulm]
 
-private theorem alphaMulUseHintModulus_eq_modulus_sub_one_of_isApproved (p : Params)
-    (hp : p.isApproved) :
-    let alpha := 2 * p.gamma2
-    let m := (modulus - 1) / alpha
-    alpha * m = modulus - 1 := by
-  dsimp
-  exact Nat.mul_div_cancel' (twoGamma_dvd_modulus_sub_one_of_isApproved hp)
+private theorem highBitsCoeff_of_nonneg_val {r : Coeff} {gamma2 r1 t : ℕ}
+    (hα : 0 < 2 * gamma2)
+    (hval : r.val = 2 * gamma2 * r1 + t)
+    (ht : t ≤ gamma2)
+    (hwrap : 2 * gamma2 * r1 ≠ modulus - 1) :
+    highBitsCoeff r gamma2 = r1 := by
+  simp only [highBitsCoeff, decomposeCoeff]
+  have hmod : r.val % (2 * gamma2) = t := by
+    rw [hval, Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt (by omega)]
+  have hdiv : r.val / (2 * gamma2) = r1 := by
+    rw [hval, Nat.add_comm, Nat.add_mul_div_left _ _ hα, Nat.div_eq_of_lt (by omega), zero_add]
+  rw [hmod, hdiv]
+  simp [mul_div_cancel_left₀, ht, hwrap]
 
-private theorem centeredRepr_alpha_mul_natAbs_ge_of_isApproved (p : Params)
-    (hp : p.isApproved) {delta : ℕ}
-    (hdelta0 : 0 < delta)
-    (hdeltalt : delta < (modulus - 1) / (2 * p.gamma2)) :
-    2 * p.gamma2 ≤
-      (LatticeCrypto.centeredRepr
-        ((((2 * p.gamma2 : ℕ) * delta : ℕ) : Coeff))).natAbs := by
-  rcases hp with rfl | rfl | rfl
-  · have hdeltalt' : delta < 44 := by
-      simpa [mldsa44, modulus] using hdeltalt
-    interval_cases delta <;> decide
-  · have hdeltalt' : delta < 16 := by
-      simpa [mldsa65, modulus] using hdeltalt
-    interval_cases delta <;> decide
-  · have hdeltalt' : delta < 16 := by
-      simpa [mldsa87, modulus] using hdeltalt
-    interval_cases delta <;> decide
+private theorem highBitsCoeff_of_neg_val {r : Coeff} {gamma2 r1 t : ℕ}
+    (hα : 0 < 2 * gamma2)
+    (hval : r.val = 2 * gamma2 * (r1 - 1) + t)
+    (htγ : gamma2 < t)
+    (ht_lt : t < 2 * gamma2)
+    (hr1 : 0 < r1)
+    (hwrap : 2 * gamma2 * r1 ≠ modulus - 1) :
+    highBitsCoeff r gamma2 = r1 := by
+  simp only [highBitsCoeff, decomposeCoeff]
+  have hmod : r.val % (2 * gamma2) = t := by
+    rw [hval, Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt ht_lt]
+  have hdiv : r.val / (2 * gamma2) = r1 - 1 := by
+    rw [hval, Nat.add_comm, Nat.add_mul_div_left _ _ hα, Nat.div_eq_of_lt ht_lt, zero_add]
+  have hnowrap : 2 * gamma2 * (r1 - 1 + 1) ≠ modulus - 1 := by rwa [Nat.sub_add_cancel hr1]
+  rw [hmod, hdiv, if_neg hnowrap, Nat.sub_add_cancel hr1]
+  simp [htγ.not_ge]
+
+private theorem highBitsCoeff_of_repr (p : Params) (hp : p.isApproved)
+    {r : Coeff} (r1 : ℕ) (r0 : ℤ)
+    (hr1 : r1 < (modulus - 1) / (2 * p.gamma2))
+    (hr0 : r0.natAbs ≤ p.gamma2)
+    (hr0_neg : r0 < 0 → r1 = 0 ∨ r0.natAbs < p.gamma2)
+    (hdecomp : ((2 * p.gamma2 : ℕ) : Coeff) * (r1 : Coeff) + r0 = r) :
+    highBitsCoeff r p.gamma2 = r1 := by
+  let ctx := BalancedDecomp.ofApproved hp
+  let alpha : ℕ := 2 * p.gamma2
+  let n := r0.natAbs
+  let m : ℕ := (modulus - 1) / alpha
+  have hqm1 : alpha * m = modulus - 1 := ctx.hqm1
+  have hr1m : r1 < m := hr1
+  have hn_lt : n < alpha := by
+    change r0.natAbs < 2 * p.gamma2
+    have hγ : 0 < p.gamma2 := gamma2_pos_of_isApproved hp
+    linarith [hr0]
+  have hmul : alpha * (m - 1) + alpha = alpha * m := by
+    rw [Nat.mul_sub_one, Nat.sub_add_cancel]
+    exact Nat.le_mul_of_pos_right alpha ctx.hm
+  have hltq : alpha * r1 + n < modulus := by
+    have hle : alpha * r1 + n ≤ alpha * (m - 1) + p.gamma2 :=
+      Nat.add_le_add (Nat.mul_le_mul_left alpha (by omega)) hr0
+    have htop : alpha * (m - 1) + p.gamma2 < modulus := by
+      rw[Nat.mul_sub_one, ctx.hqm1]
+      omega
+    linarith
+  by_cases hr0nn: 0 ≤ r0
+  · have hval : r.val = alpha * r1 + r0.natAbs := by
+      have hrcast : r = ((alpha * r1 + n : ℕ) : Coeff) := by
+        rw [← hdecomp]
+        simp [alpha, n]
+        congr 1
+        simp [abs_eq_self.mpr hr0nn]
+      rw [hrcast, ZMod.val_natCast_of_lt hltq]
+    exact highBitsCoeff_of_nonneg_val ctx.hα hval hr0
+      (ne_of_lt (by rw [← ctx.hqm1]; exact Nat.mul_lt_mul_of_pos_left hr1 ctx.hα))
+  · by_cases hr1z : r1 = 0
+    · push Not at hr0nn
+      have hn0 : 0 < n := Int.natAbs_pos.mpr (by omega)
+      have hrn : r =  (-(n : ℤ)) := by
+        simp [hr1z, ← hdecomp, n, abs_eq_neg_self.mpr (Int.le_of_lt hr0nn)]
+      have hnltq : n < modulus := lt_of_le_of_lt hr0
+          (by linarith [gamma2_double_lt_modulus_of_isApproved hp])
+      have hneq : ((n : ℕ) : Coeff) ≠ 0 := by
+        intro h
+        exact absurd (Nat.le_of_dvd hn0 ((ZMod.natCast_eq_zero_iff n modulus).mp h)) (by omega)
+      have hval : r.val = modulus - n := by
+        haveI : NeZero ((n : ℕ) : Coeff) := ⟨hneq⟩
+        simp [hrn, ZMod.val_neg_of_ne_zero ((n : ℕ) : Coeff),
+            ZMod.val_natCast_of_lt hnltq]
+      by_cases hn1 : n = 1
+      · simp_rw [hn1] at *
+        have hmod : r.val % alpha = 0 := by
+          rw [hval, show modulus - 1 = alpha * m by omega, Nat.mul_mod_right]
+        have hdiv : r.val / alpha = m := by
+          rw [hval, show modulus - 1 = alpha * m by omega, Nat.mul_div_cancel_left _ ctx.hα]
+        have hcond1 : r.val % alpha ≤ alpha / 2 := by rw [hmod]; omega
+        have hcond2 : alpha * (r.val / alpha) = modulus - 1 := by rw [hdiv]; omega
+        simp [highBitsCoeff, decomposeCoeff, hr1z, hval]
+        rw [hval] at hcond1 hcond2
+        unfold alpha at hcond1 hcond2
+        simp [mul_div_cancel_left₀] at hcond1
+        simp [hcond1, hcond2]
+      · have hn2 : 2 ≤ n := by omega
+        have hrepr : modulus - n = (alpha + 1 - n) + (m - 1) * alpha := by
+          zify [show n ≤ alpha + 1 by omega,
+                show n ≤ modulus by linarith [ctx.hqm1],
+                show alpha ≤ m * alpha from Nat.le_mul_of_pos_left alpha ctx.hm]
+          have : (alpha : ℤ) * m = modulus - 1 := by omega
+          linarith
+        have hltα : alpha + 1 - n < alpha := by omega
+        have hmod : r.val % alpha = alpha + 1 - n := by
+          rw [hval, hrepr, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hltα]
+        have hdiv : r.val / alpha = m - 1 := by
+          rw [hval, hrepr, Nat.add_mul_div_right _ _ ctx.hα, Nat.div_eq_of_lt hltα, zero_add]
+        have hcond1 : ¬(r.val % alpha ≤ alpha / 2) := by rw [hmod]; omega
+        have hcond2 : alpha * (r.val / alpha + 1) = modulus - 1 := by
+          rw [hdiv, show m - 1 + 1 = m by omega]; omega
+        simp only [hval, alpha] at hcond1 hcond2
+        simp only [ne_eq, OfNat.ofNat_ne_zero, not_false_eq_true, mul_div_cancel_left₀] at hcond1
+        simp [highBitsCoeff, decomposeCoeff, hr1z, hval, hcond1, hcond2]
+    · have hr0neg : r0 < 0 := lt_of_not_ge hr0nn
+      have hr1pos : 0 < r1 := Nat.pos_of_ne_zero hr1z
+      have hn_lt : r0.natAbs < p.gamma2 := by
+        rcases hr0_neg hr0neg with h | h
+        · exact absurd h hr1z
+        · exact h
+      have hr1qm1 : alpha * r1 < modulus - 1 := by
+        rw[← ctx.hqm1]
+        exact Nat.mul_lt_mul_of_pos_left hr1 ctx.hα
+      have hn0   : 0 < n := Int.natAbs_pos.mpr (by omega)
+      have hn_lt_alpha : n < alpha := by change r0.natAbs < 2 * p.gamma2; omega
+      have hnle  : n ≤ alpha * r1 :=
+        le_trans hn_lt_alpha.le (Nat.le_mul_of_pos_right alpha hr1pos)
+      have hltq  : alpha * r1 - n < modulus :=
+        lt_of_le_of_lt (Nat.sub_le _ _) (by omega)
+      have hval  : r.val = alpha * r1 - n := by
+        have hrcast : r = ((alpha * r1 - n : ℕ) : Coeff) := by
+          rw [← hdecomp]
+          rw [show (r0 : Coeff) = -((n : ℕ) : Coeff) from by
+            simp only [Nat.cast_natAbs, n]; rw [abs_eq_neg_self.mpr (Int.le_of_lt hr0neg)]; simp]
+          push_cast [Nat.cast_sub hnle]
+          simp [alpha]
+          ring_nf
+        rw [hrcast, ZMod.val_natCast_of_lt hltq]
+      have hval_repr : r.val = alpha * (r1 - 1) + (alpha - n) := by
+        have h1 : alpha ≤ alpha * r1 := Nat.le_mul_of_pos_right alpha hr1pos
+        rw [mul_tsub, mul_one, hval]
+        omega
+      exact highBitsCoeff_of_neg_val ctx.hα hval_repr
+        (by omega)
+        (by omega)
+        hr1pos
+        (ne_of_lt (by rw [← ctx.hqm1]; exact Nat.mul_lt_mul_of_pos_left hr1 ctx.hα))
+
+private theorem centeredRepr_alpha_mul_natAbs_ge
+    {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
+    {delta : ℕ} (hd0 : 0 < delta) (hdm : delta < m) :
+    alpha ≤ (centeredRepr ((alpha * delta : ℕ) : Coeff)).natAbs := by
+  have hqm1 := ctx.hqm1
+  have hq : modulus = alpha * m + 1 := by
+    have := ctx.hsmall; omega
+  have hlt : alpha * delta < modulus :=
+    calc alpha * delta < alpha * m := Nat.mul_lt_mul_of_pos_left hdm ctx.hα
+      _ = modulus - 1 := ctx.hqm1
+      _ < modulus := Nat.sub_lt (by omega) one_pos
+  have hval : ((alpha * delta : ℕ) : Coeff).val = alpha * delta := ZMod.val_natCast_of_lt hlt
+  have hval' : (((alpha * delta : ℕ) : Coeff).val : ℤ) = (alpha * delta : ℕ) := by
+    exact_mod_cast hval
+  by_cases hle : (((alpha * delta : ℕ) : Coeff).val : ℤ) ≤ (modulus : ℤ) / 2
+  · rw [centeredRepr_of_le hle, hval', Int.natAbs_natCast]
+    nlinarith [ctx.hα]
+  · push Not at hle
+    rw [centeredRepr_of_gt hle, hval']
+    have hnat : (((alpha * delta : ℕ) : ℤ) - modulus).natAbs = modulus - alpha * delta := by
+      omega
+    rw [hnat]
+    have hdelt_le : alpha * delta ≤ alpha * (m - 1) := Nat.mul_le_mul_left alpha (by omega)
+    have hmul : alpha * (m - 1) + alpha = alpha * m := by
+      cases m with
+      | zero => exact absurd ctx.hm (by omega)
+      | succ k => ring_nf; simp only [add_tsub_cancel_left]
+    omega
+
+private theorem decomposeCoeff_unique (p : Params) (hp : p.isApproved)
+    {r : Coeff} (r1 : ℕ) (r0 : ℤ)
+    (hr1 : r1 < (modulus - 1) / (2 * p.gamma2))
+    (hr0 : r0.natAbs ≤ p.gamma2)
+    (hr0_neg : r0 < 0 → r1 = 0 ∨ r0.natAbs < p.gamma2)
+    (hdecomp : ((2 * p.gamma2 : ℕ) : Coeff) * (r1 : Coeff) + r0 = r) :
+    decomposeCoeff r p.gamma2 = (r1, r0) := by
+  let ctx := BalancedDecomp.ofApproved hp
+  have hγ := gamma2_pos_of_isApproved hp
+  have h1 : highBitsCoeff r p.gamma2 = r1 :=
+    highBitsCoeff_of_repr p hp r1 r0 hr1 hr0 hr0_neg hdecomp
+  have hdecomp' : ((2 * p.gamma2 : ℕ) : Coeff) * (r1 : Coeff) +
+      (lowBitsCoeff r p.gamma2) = r := by
+    have h : ((2 * p.gamma2 : ℕ) : Coeff) * ((decomposeCoeff r p.gamma2).1 : Coeff) +
+        (decomposeCoeff r p.gamma2).2 = r := decomposeCoeff_eq r (Prod.eta _)
+    have h1' : (decomposeCoeff r p.gamma2).1 = r1 := h1
+    rw [h1'] at h; exact h
+  have hlow_eq : intToCoeff (lowBitsCoeff r p.gamma2) = intToCoeff r0 :=
+    add_left_cancel (hdecomp'.trans hdecomp.symm)
+  have h2 : lowBitsCoeff r p.gamma2 = r0 := by
+    have cr_eq := congrArg centeredRepr hlow_eq
+    rw [centeredRepr_eq_of_natAbs_le _ (lowBitsCoeff_bound r hγ) ctx.hq,
+        centeredRepr_eq_of_natAbs_le _ hr0 ctx.hq] at cr_eq
+    exact cr_eq
+  exact Prod.ext h1 h2
 
 private theorem highBitsCoeff_add_eq_of_small_of_isApproved (p : Params)
     (hp : p.isApproved) (r s : Coeff) {b : ℕ}
-    (hs : (LatticeCrypto.centeredRepr s).natAbs ≤ b)
+    (hs : (centeredRepr s).natAbs ≤ b)
     (hr : (lowBitsCoeff r p.gamma2).natAbs < p.gamma2 - b) :
     highBitsCoeff (r + s) p.gamma2 = highBitsCoeff r p.gamma2 := by
+  let ctx := BalancedDecomp.ofApproved hp
+  rcases hdecomp_r : decomposeCoeff r p.gamma2 with ⟨r1, r0⟩
+  rcases hdecomp_rs : decomposeCoeff (r + s) p.gamma2 with ⟨u, w⟩
   let alpha : ℕ := 2 * p.gamma2
   let m : ℕ := (modulus - 1) / alpha
-  let decr := decomposeCoeff r p.gamma2
-  let r1 : ℕ := decr.1
-  let r0 : ℤ := decr.2
-  let decrs := decomposeCoeff (r + s) p.gamma2
-  let u : ℕ := decrs.1
-  let w : ℤ := decrs.2
-  let z : ℤ := LatticeCrypto.centeredRepr s
+  let z : ℤ := centeredRepr s
   let v : ℤ := r0 + z
-  have hγ := gamma2_pos_of_isApproved hp
-  have hm : 0 < m := by
-    simpa [alpha, m] using useHintModulus_pos_of_isApproved hp
-  have hr1lt : r1 < m := by
-    simpa [alpha, m, decr, r1] using highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
-  have hult : u < m := by
-    simpa [alpha, m, decrs, u] using highBitsCoeff_lt_useHintModulus_of_isApproved p hp (r + s)
-  have hdecomp_r : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 = r := by
-    simpa [alpha, decr, r1, r0] using decomposeCoeff_eq (r := r) (gamma2 := p.gamma2) hγ
-  have hdecomp_rs : (((alpha : ℕ) : Coeff) * (u : Coeff)) + intToCoeff w = r + s := by
-    simpa [alpha, decrs, u, w] using decomposeCoeff_eq (r := r + s) (gamma2 := p.gamma2) hγ
-  have hwbound : w.natAbs ≤ p.gamma2 := by
-    simpa [decrs, w] using lowBitsCoeff_bound (r := r + s) (gamma2 := p.gamma2) hγ
-  have hrpred : r0.natAbs ≤ p.gamma2 - b - 1 := Nat.le_pred_of_lt hr
-  have hr0bounds := neg_le_and_le_of_natAbs_le hrpred
-  have hzbounds := neg_le_and_le_of_natAbs_le hs
-  have hvupper : v ≤ ((p.gamma2 - 1 : ℕ) : ℤ) := by
-    dsimp [v]
-    omega
-  have hvlower : -((p.gamma2 - 1 : ℕ) : ℤ) ≤ v := by
-    dsimp [v]
-    omega
-  have hvbound : v.natAbs ≤ p.gamma2 - 1 :=
-    natAbs_le_of_neg_le_and_le hvlower hvupper
-  have hzcast : s = intToCoeff z := by
-    simpa [z] using LatticeCrypto.centeredRepr_intCast s
-  have hcandidate : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v = r + s := by
-    calc
-      (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v
-          = ((((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0) + intToCoeff z := by
-              dsimp [v]
-              simp [intToCoeff]
-              ring
-      _ = r + s := by
-            simpa [intToCoeff, hdecomp_r, hzcast]
-  by_contra hneq
-  have hsmallq : 2 * (alpha - 1) < modulus := by
-    have hbase : 2 * (alpha + 1) < modulus := by
-      simpa [alpha, Nat.mul_add, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc, two_mul] using
-        alphaPlusOne_double_lt_modulus_of_isApproved hp
-    omega
-  have hvbounds := neg_le_and_le_of_natAbs_le hvbound
-  have hwbounds := neg_le_and_le_of_natAbs_le hwbound
-  have hdiffupper : v - w ≤ ((alpha - 1 : ℕ) : ℤ) := by
-    omega
-  have hdifflower : -((alpha - 1 : ℕ) : ℤ) ≤ v - w := by
-    omega
-  have hdiffbound : (v - w).natAbs ≤ alpha - 1 :=
-    natAbs_le_of_neg_le_and_le hdifflower hdiffupper
-  have hrepr_diff : LatticeCrypto.centeredRepr (intToCoeff (v - w)) = v - w :=
-    centeredRepr_eq_of_natAbs_le (z := v - w) hdiffbound hsmallq
+  by_contra hneq; push Not at hneq
+  have hdiffbound : (v - w).natAbs ≤ alpha - 1 := by
+    have hwbound : w.natAbs ≤ p.gamma2 := by
+      have h := lowBitsCoeff_bound (r := r + s) (gamma2_pos_of_isApproved hp)
+      rwa [lowBitsCoeff, hdecomp_rs] at h
+    have hvbound : v.natAbs ≤ p.gamma2 - 1 := by
+      rw [lowBitsCoeff, hdecomp_r] at hr
+      have h1 : r0.natAbs ≤ p.gamma2 - b - 1 := Nat.le_pred_of_lt hr
+      have h2 := Int.natAbs_add_le r0 z
+      omega
+    exact (Int.natAbs_sub_le v w).trans
+      (Nat.add_le_add hvbound hwbound |>.trans_eq (by omega))
   have heq :
-      (((alpha : ℕ) : Coeff) * (u : Coeff)) + intToCoeff w =
-        (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v :=
-    hdecomp_rs.trans hcandidate.symm
-  have hneq' : u ≠ r1 := by
-    simpa [u, r1, decrs, decr, highBitsCoeff] using hneq
-  have hlt_or_gt : r1 < u ∨ u < r1 := lt_or_gt_of_ne hneq'.symm
+      (((alpha : ℕ) : Coeff) * (u : Coeff)) + w =
+        (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + v := by
+    have hcandidate : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + v = r + s := by
+      rw[centeredRepr_intCast s]
+      simp only [Int.cast_add, ← add_assoc, v]
+      rw[decomposeCoeff_eq r hdecomp_r.symm]
+    exact (decomposeCoeff_eq (r + s) hdecomp_rs.symm).trans hcandidate.symm
+  have contra : ∀ (lo hi : ℕ) (e1 e2 : ℤ),
+      lo < hi → hi < m →
+      (e1 - e2).natAbs ≤ alpha - 1 →
+      (((alpha : ℕ) : Coeff) * (lo : Coeff)) + e1 =
+      (((alpha : ℕ) : Coeff) * (hi : Coeff)) + e2 →
+      False := fun lo hi e1 e2 hlt hhi hbound heq' => by
+    have hdelta0 : 0 < hi - lo := Nat.sub_pos_of_lt hlt
+    have hdeltaeq : (((alpha : ℕ) : Coeff) * ((hi - lo : ℕ) : Coeff)) = intToCoeff (e1 - e2) := by
+      rw [Nat.cast_sub (le_of_lt hlt), mul_sub]
+      simp only [intToCoeff, Int.cast_sub] at ⊢ heq'
+      apply sub_eq_sub_iff_add_eq_add.mpr
+      ring_nf
+      exact heq'.symm
+    have hbig := centeredRepr_alpha_mul_natAbs_ge ctx hdelta0 (by simp [alpha, m] at hhi; omega)
+    have hsmallq : 2 * (alpha - 1) < modulus := by
+      have hbase : 2 * (alpha + 1) < modulus := ctx.hsmall; omega
+    have hrepr := congrArg centeredRepr hdeltaeq
+    rw [centeredRepr_eq_of_natAbs_le _ hbound hsmallq] at hrepr
+    apply congrArg Int.natAbs at hrepr
+    simp only [alpha, ← Nat.cast_mul] at hrepr
+    omega
+  have hlt_or_gt : r1 < u ∨ u < r1 := by
+    simp only [highBitsCoeff, hdecomp_rs, hdecomp_r] at hneq
+    exact lt_or_gt_of_ne hneq.symm
   cases hlt_or_gt with
   | inl hr1ltu =>
-      let delta : ℕ := u - r1
-      have hdelta0 : 0 < delta := by
-        dsimp [delta]
-        omega
-      have hdeltalt : delta < m := by
-        dsimp [delta]
-        omega
-      have hudelta : u = r1 + delta := by
-        dsimp [delta]
-        omega
-      have hsub :
-          (((alpha : ℕ) : Coeff) * (u : Coeff)) -
-              (((alpha : ℕ) : Coeff) * (r1 : Coeff)) = intToCoeff (v - w) := by
-        have htmp := congrArg
-          (fun x : Coeff => x - ((((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff w)) heq
-        simpa [intToCoeff] using htmp
-      have hdeltaeq :
-          (((alpha : ℕ) : Coeff) * (delta : Coeff)) = intToCoeff (v - w) := by
-        have hdelta_cast : (u : Coeff) = (r1 : Coeff) + (delta : Coeff) := by
-          rw [hudelta]
-          simp
-        calc
-          (((alpha : ℕ) : Coeff) * (delta : Coeff))
-              = (((alpha : ℕ) : Coeff) * (u : Coeff)) -
-                  (((alpha : ℕ) : Coeff) * (r1 : Coeff)) := by
-                    rw [hdelta_cast]
-                    ring
-          _ = intToCoeff (v - w) := hsub
-      have hbig :
-          alpha ≤ (LatticeCrypto.centeredRepr
-            ((((alpha : ℕ) * delta : ℕ) : Coeff))).natAbs := by
-        have hbig0 := centeredRepr_alpha_mul_natAbs_ge_of_isApproved (p := p) hp hdelta0
-          (delta := delta) (by simpa [alpha, m] using hdeltalt)
-        simpa [alpha] using hbig0
-      have hrepr_eq := congrArg LatticeCrypto.centeredRepr hdeltaeq
-      rw [hrepr_diff] at hrepr_eq
-      have hbig' : alpha ≤ (v - w).natAbs := by
-        rw [← hrepr_eq]
-        simpa [Nat.cast_mul] using hbig
-      omega
-  | inr hurt1 =>
-      let delta : ℕ := r1 - u
-      have hdelta0 : 0 < delta := by
-        dsimp [delta]
-        omega
-      have hdeltalt : delta < m := by
-        dsimp [delta]
-        omega
-      have hr1delta : r1 = u + delta := by
-        dsimp [delta]
-        omega
-      have hsub :
-          (((alpha : ℕ) : Coeff) * (r1 : Coeff)) -
-              (((alpha : ℕ) : Coeff) * (u : Coeff)) = intToCoeff (w - v) := by
-        have htmp := congrArg
-          (fun x : Coeff => x - ((((alpha : ℕ) : Coeff) * (u : Coeff)) + intToCoeff v)) heq.symm
-        simpa [intToCoeff] using htmp
-      have hdeltaeq :
-          (((alpha : ℕ) : Coeff) * (delta : Coeff)) = intToCoeff (w - v) := by
-        have hdelta_cast : (r1 : Coeff) = (u : Coeff) + (delta : Coeff) := by
-          rw [hr1delta]
-          simp
-        calc
-          (((alpha : ℕ) : Coeff) * (delta : Coeff))
-              = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) -
-                  (((alpha : ℕ) : Coeff) * (u : Coeff)) := by
-                    rw [hdelta_cast]
-                    ring
-          _ = intToCoeff (w - v) := hsub
-      have hbig :
-          alpha ≤ (LatticeCrypto.centeredRepr
-            ((((alpha : ℕ) * delta : ℕ) : Coeff))).natAbs := by
-        have hbig0 := centeredRepr_alpha_mul_natAbs_ge_of_isApproved (p := p) hp hdelta0
-          (delta := delta) (by simpa [alpha, m] using hdeltalt)
-        simpa [alpha] using hbig0
-      have hdiffbound' : (w - v).natAbs ≤ alpha - 1 := by
-        have hwvupper : w - v ≤ ((alpha - 1 : ℕ) : ℤ) := by omega
-        have hwvlower : -((alpha - 1 : ℕ) : ℤ) ≤ w - v := by omega
-        exact natAbs_le_of_neg_le_and_le hwvlower hwvupper
-      have hrepr_diff' : LatticeCrypto.centeredRepr (intToCoeff (w - v)) = w - v :=
-        centeredRepr_eq_of_natAbs_le (z := w - v) hdiffbound' hsmallq
-      have hrepr_eq := congrArg LatticeCrypto.centeredRepr hdeltaeq
-      rw [hrepr_diff'] at hrepr_eq
-      have hbig' : alpha ≤ (w - v).natAbs := by
-        rw [← hrepr_eq]
-        simpa [Nat.cast_mul] using hbig
-      omega
-
-private theorem highBitsCoeff_nonneg_repr_of_isApproved (p : Params)
-    (hp : p.isApproved) (u n : ℕ)
-    (hu : u < (modulus - 1) / (2 * p.gamma2))
-    (hn : n ≤ p.gamma2) :
-    highBitsCoeff
-        (intToCoeff (((((2 * p.gamma2 : ℕ) * u) + n : ℕ) : ℤ))) p.gamma2 = u := by
-  let alpha : ℕ := 2 * p.gamma2
-  let m : ℕ := (modulus - 1) / alpha
-  have hα : 0 < alpha := by
-    have hγ : 0 < p.gamma2 := gamma2_pos_of_isApproved hp
-    dsimp [alpha]
-    omega
-  have hm : 0 < m := by
-    simpa [alpha, m] using useHintModulus_pos_of_isApproved hp
-  have hqm1 : alpha * m = modulus - 1 := by
-    simpa [alpha, m] using alphaMulUseHintModulus_eq_modulus_sub_one_of_isApproved p hp
-  have hu_lt_m : u < m := by
-    simpa [alpha, m] using hu
-  have huqm1 : alpha * u < modulus - 1 :=
-    lt_of_lt_of_eq (Nat.mul_lt_mul_of_pos_left hu_lt_m hα) hqm1
-  have hltα : n < alpha := by
-    dsimp [alpha]
-    omega
-  have hltq : alpha * u + n < modulus := by
-    have hu_le : u ≤ m - 1 := by omega
-    have hbound : alpha * u + n ≤ alpha * (m - 1) + p.gamma2 := by
-      gcongr
-    have htop : alpha * (m - 1) + p.gamma2 < modulus := by
-      have hγ : 0 < p.gamma2 := gamma2_pos_of_isApproved hp
-      have hlt_am : alpha * (m - 1) + p.gamma2 < alpha * m := by
-        calc
-          alpha * (m - 1) + p.gamma2
-              < alpha * (m - 1) + p.gamma2 + p.gamma2 := Nat.lt_add_of_pos_right hγ
-          _ = alpha * m := by
-                calc
-                  alpha * (m - 1) + p.gamma2 + p.gamma2 = alpha * (m - 1) + alpha := by
-                    dsimp [alpha]
-                    ring
-                  _ = alpha * m := by
-                    calc
-                      alpha * (m - 1) + alpha = alpha * ((m - 1) + 1) := by ring
-                      _ = alpha * m := by congr; omega
-      have hαm_lt_mod : alpha * m < modulus := by
-        rw [hqm1]
-        omega
-      exact lt_trans hlt_am hαm_lt_mod
-    exact lt_of_le_of_lt hbound htop
-  have hval :
-      (intToCoeff (((alpha * u + n : ℕ) : ℤ))).val = alpha * u + n := by
-    simpa [intToCoeff] using (ZMod.val_natCast_of_lt (n := modulus) (a := alpha * u + n) hltq)
-  unfold highBitsCoeff decomposeCoeff
-  rw [hval]
-  have hmod : (alpha * u + n) % alpha = n := by
-    rw [Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt hltα]
-  have hdiv : (alpha * u + n) / alpha = u := by
-    rw [Nat.add_comm, Nat.add_mul_div_left _ _ hα, Nat.div_eq_of_lt hltα, zero_add]
-  have hle : (alpha * u + n) % alpha ≤ alpha / 2 := by
-    rw [hmod]
-    dsimp [alpha]
-    omega
-  have hspe : alpha * ((alpha * u + n) / alpha) ≠ modulus - 1 := by
-    rw [hdiv]
-    exact ne_of_lt huqm1
-  simp [hmod, hdiv, hn, huqm1.ne, alpha]
-
-private theorem highBitsCoeff_neg_repr_of_isApproved (p : Params)
-    (hp : p.isApproved) (u n : ℕ)
-    (hu : u < (modulus - 1) / (2 * p.gamma2))
-    (hu0 : 0 < u) (hn0 : 0 < n) (hn : n < p.gamma2) :
-    highBitsCoeff
-        (intToCoeff ((((2 * p.gamma2 : ℕ) * u - n : ℕ) : ℤ))) p.gamma2 = u := by
-  let alpha : ℕ := 2 * p.gamma2
-  let m : ℕ := (modulus - 1) / alpha
-  have hα : 0 < alpha := by
-    have hγ : 0 < p.gamma2 := gamma2_pos_of_isApproved hp
-    dsimp [alpha]
-    omega
-  have hqm1 : alpha * m = modulus - 1 := by
-    simpa [alpha, m] using alphaMulUseHintModulus_eq_modulus_sub_one_of_isApproved p hp
-  have hu_lt_m : u < m := by
-    simpa [alpha, m] using hu
-  have huqm1 : alpha * u < modulus - 1 :=
-    lt_of_lt_of_eq (Nat.mul_lt_mul_of_pos_left hu_lt_m hα) hqm1
-  have hltαn : n < alpha := by
-    dsimp [alpha]
-    omega
-  have hnle : n ≤ alpha * u := by
-    have hα_le : alpha ≤ alpha * u := by
-      calc
-        alpha = alpha * 1 := by ring
-        _ ≤ alpha * u := Nat.mul_le_mul_left alpha (show 1 ≤ u by omega)
-    exact le_trans hltαn.le hα_le
-  have hαu : alpha ≤ alpha * u := by
-    calc
-      alpha = alpha * 1 := by ring
-      _ ≤ alpha * u := Nat.mul_le_mul_left alpha (show 1 ≤ u by omega)
-  have hltq : alpha * u - n < modulus :=
-    lt_of_le_of_lt (Nat.sub_le _ _) (lt_trans huqm1 (by omega))
-  have hval :
-      (intToCoeff (((alpha * u - n : ℕ) : ℤ))).val = alpha * u - n := by
-    simpa [intToCoeff] using (ZMod.val_natCast_of_lt (n := modulus) (a := alpha * u - n) hltq)
-  have hrepr : alpha * u - n = (alpha - n) + (u - 1) * alpha := by
-    have hnα : n ≤ alpha := hltαn.le
-    calc
-      alpha * u - n = alpha * u - alpha + (alpha - n) := by omega
-      _ = (u - 1) * alpha + (alpha - n) := by
-            rw [show alpha * u - alpha = alpha * (u - 1) by
-              have hpred' : u - 1 + 1 = u := by omega
-              calc
-                alpha * u - alpha = alpha * (u - 1 + 1) - alpha := by
-                  rw [hpred']
-                _ = alpha * (u - 1) + alpha - alpha := by rw [Nat.mul_add, mul_one]
-                _ = alpha * (u - 1) := by rw [Nat.add_sub_cancel]]
-            rw [Nat.mul_comm]
-      _ = (alpha - n) + (u - 1) * alpha := by rw [add_comm]
-  have hltα : alpha - n < alpha :=
-    Nat.sub_lt hα hn0
-  have hmod : (alpha * u - n) % alpha = alpha - n := by
-    rw [hrepr, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hltα]
-  have hdiv : (alpha * u - n) / alpha = u - 1 := by
-    rw [hrepr, Nat.add_mul_div_right _ _ hα, Nat.div_eq_of_lt hltα, zero_add]
-  have hprev_lt : alpha * (u - 1) < modulus - 1 := by
-    have hltu : u - 1 < u := Nat.sub_lt hu0 (by omega)
-    exact lt_trans (Nat.mul_lt_mul_of_pos_left hltu hα) huqm1
-  have hcross : ¬2 * p.gamma2 ≤ p.gamma2 + n := by
-    omega
-  have hpred : u - 1 + 1 = u := by
-    omega
-  simp [highBitsCoeff, decomposeCoeff, hval, hmod, hdiv, hcross, hpred, huqm1.ne, alpha]
-
-private theorem highBitsCoeff_wrap_neg_repr_of_isApproved (p : Params)
-    (hp : p.isApproved) (n : ℕ)
-    (hn0 : 0 < n) (hn : n ≤ p.gamma2) :
-    highBitsCoeff (intToCoeff (-(n : ℤ))) p.gamma2 = 0 := by
-  let alpha : ℕ := 2 * p.gamma2
-  let m : ℕ := (modulus - 1) / alpha
-  have hα : 0 < alpha := by
-    have hγ : 0 < p.gamma2 := gamma2_pos_of_isApproved hp
-    dsimp [alpha]
-    omega
-  have hm : 0 < m := by
-    simpa [alpha, m] using useHintModulus_pos_of_isApproved hp
-  have hqm1 : alpha * m = modulus - 1 := by
-    simpa [alpha, m] using alphaMulUseHintModulus_eq_modulus_sub_one_of_isApproved p hp
-  have hnltq : n < modulus := by
-    have hγlt : p.gamma2 < modulus := by
-      have hq := gamma2_double_lt_modulus_of_isApproved hp
-      omega
-    exact lt_of_le_of_lt hn hγlt
-  have hneq : ((n : ℕ) : Coeff) ≠ 0 := by
-    intro hzero
-    have hdvd : modulus ∣ n := (ZMod.natCast_eq_zero_iff n modulus).mp hzero
-    have hle : modulus ≤ n := Nat.le_of_dvd hn0 hdvd
-    omega
-  haveI : NeZero (((n : ℕ) : Coeff)) := ⟨hneq⟩
-  have hvaln : (((n : ℕ) : Coeff)).val = n := by
-    simpa using (ZMod.val_natCast_of_lt hnltq : (((n : ℕ) : Coeff)).val = n)
-  have hval : (intToCoeff (-(n : ℤ))).val = modulus - n := by
-    simpa [intToCoeff, hvaln] using (ZMod.val_neg_of_ne_zero (a := ((n : ℕ) : Coeff)))
-  by_cases hn1 : n = 1
-  · subst hn1
-    unfold highBitsCoeff decomposeCoeff
-    rw [hval]
-    have hmod : (modulus - 1) % alpha = 0 := by
-      rw [← hqm1]
-      simp
-    have hdiv : (modulus - 1) / alpha = m := by
-      rw [← hqm1]
-      simp [Nat.mul_div_right _ hα]
-    simp [hmod, hdiv, hqm1, alpha, m]
-  · have hn2 : 2 ≤ n := by omega
-    have hreprNat : modulus - n = (alpha + 1 - n) + (m - 1) * alpha := by
-      have hq : modulus = alpha * m + 1 := by
-        omega
-      have hm1 : m - 1 + 1 = m := by omega
-      calc
-        modulus - n = alpha * m + 1 - n := by rw [hq]
-        _ = alpha * (m - 1 + 1) + 1 - n := by rw [hm1]
-        _ = alpha * (m - 1) + alpha + 1 - n := by rw [Nat.mul_add, Nat.mul_one]
-        _ = (alpha + 1 - n) + (m - 1) * alpha := by
-              rw [Nat.mul_comm (m - 1) alpha]
-              omega
-    have hltα : alpha + 1 - n < alpha := by
-      dsimp [alpha]
-      omega
-    have hmod : (modulus - n) % alpha = alpha + 1 - n := by
-      rw [hreprNat, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hltα]
-    have hdiv : (modulus - n) / alpha = m - 1 := by
-      rw [hreprNat, Nat.add_mul_div_right _ _ hα, Nat.div_eq_of_lt hltα, zero_add]
-    unfold highBitsCoeff decomposeCoeff
-    rw [hval]
-    have hcross : ¬(alpha + 1 - n ≤ alpha / 2) := by
-      dsimp [alpha]
-      omega
-    have houter : ¬2 * p.gamma2 < p.gamma2 + n := by
-      omega
-    have hspecial : alpha * (m - 1 + 1) = modulus - 1 := by
-      have hpred : m - 1 + 1 = m := by omega
-      simpa [hpred] using hqm1
-    simp [hmod, hdiv, houter, hspecial, alpha, m]
+      have hult : u < m := by
+        have := highBitsCoeff_lt_useHintModulus_of_isApproved p hp (r + s)
+        rwa [highBitsCoeff, hdecomp_rs] at this
+      exact contra r1 u v w hr1ltu hult hdiffbound heq.symm
+  | inr hultr1 =>
+      have hdiffbound2: (w - v).natAbs ≤ alpha - 1 := by
+        rw [show w - v = -(v - w) from by ring, Int.natAbs_neg]
+        exact hdiffbound
+      have hr1lt : r1 < m := by
+        have := highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
+        rwa [highBitsCoeff, hdecomp_r] at this
+      exact contra u r1 w v hultr1 hr1lt hdiffbound2 heq
 
 private theorem useHintCoeff_shift_sub_bound_of_isApproved (p : Params)
     (hp : p.isApproved) (h : Bool) (r : Coeff) :
-    (LatticeCrypto.centeredRepr
+    (centeredRepr
       (r - (((2 * p.gamma2 : ℕ) : Coeff) * (useHintCoeff h r p.gamma2 : Coeff)))).natAbs ≤
         2 * p.gamma2 + 1 := by
+  let ctx := BalancedDecomp.ofApproved hp
   let alpha : ℕ := 2 * p.gamma2
   let m : ℕ := (modulus - 1) / alpha
-  let dec := decomposeCoeff r p.gamma2
-  let r1 : ℕ := dec.1
-  let r0 : ℤ := dec.2
-  have hγ := gamma2_pos_of_isApproved hp
-  have hm : 0 < m := by
-    simpa [m, alpha] using useHintModulus_pos_of_isApproved hp
-  have hsmall : 2 * (alpha + 1) < modulus := by
-    simpa [alpha, Nat.mul_add, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc, two_mul] using
-      alphaPlusOne_double_lt_modulus_of_isApproved hp
-  have hdec : decomposeCoeff r p.gamma2 = (r1, r0) := by
-    simp [dec, r1, r0]
-  have hdecomp : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 = r := by
-    simpa [alpha, dec, r1, r0] using decomposeCoeff_eq (r := r) (gamma2 := p.gamma2) hγ
+  rcases hdec : decomposeCoeff r p.gamma2 with ⟨r1, r0⟩
+  have hdecomp : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 = r :=
+    decomposeCoeff_eq r hdec.symm
   have hr1lt : r1 < m := by
-    simpa [alpha, m, dec, r1] using highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
+    have := highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
+    rwa [highBitsCoeff, hdec] at this
   have hr0bound : r0.natAbs ≤ p.gamma2 := by
-    simpa [dec, r0] using lowBitsCoeff_bound (r := r) (gamma2 := p.gamma2) hγ
-  obtain ⟨hr0low, hr0up⟩ := neg_le_and_le_of_natAbs_le hr0bound
+    have := lowBitsCoeff_bound r (gamma2 := p.gamma2) (gamma2_pos_of_isApproved hp)
+    rwa [lowBitsCoeff, hdec] at this
   cases h with
   | false =>
-      have huse : useHintCoeff false r p.gamma2 = r1 := by
-        simp [useHintCoeff, hdec]
       have hcoeff :
           r - (((alpha : ℕ) : Coeff) * (useHintCoeff false r p.gamma2 : Coeff)) =
             intToCoeff r0 := by
-        rw [huse]
-        exact sub_eq_iff_eq_add'.2 hdecomp.symm
-      have hbound : r0.natAbs ≤ alpha + 1 := by
-        dsimp [alpha]
-        omega
-      rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0) hbound hsmall]
+        simp [useHintCoeff, hdec, sub_eq_iff_eq_add'.2 hdecomp.symm]
+      have hbound : r0.natAbs ≤ alpha + 1 := by omega
+      rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0) hbound ctx.hsmall]
       exact hbound
   | true =>
       by_cases hr0pos : 0 < r0
       · by_cases hwrap : r1 + 1 < m
-        · have huse : useHintCoeff true r p.gamma2 = r1 + 1 := by
-            simpa [m, alpha, useHintCoeff, hdec, hr0pos] using (Nat.mod_eq_of_lt hwrap)
-          have hcoeff :
+        · have hcoeff :
               r - (((alpha : ℕ) : Coeff) * (useHintCoeff true r p.gamma2 : Coeff)) =
                 intToCoeff (r0 - alpha) := by
-            rw [huse]
-            exact sub_eq_iff_eq_add'.2 <| by
-              calc
-                r = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 := hdecomp.symm
-                _ = (((alpha : ℕ) : Coeff) * ((r1 + 1 : ℕ) : Coeff)) + intToCoeff (r0 - alpha) := by
-                      simp [intToCoeff]
-                      ring
-          have hr0ge1 : 1 ≤ r0 := by omega
-          have hbound : (r0 - alpha).natAbs ≤ alpha + 1 := by
-            dsimp [alpha]
-            omega
-          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 - alpha) hbound hsmall]
+            simp only [useHintCoeff, ↓reduceIte, hdec, gt_iff_lt, hr0pos]
+            rw [Nat.mod_eq_of_lt hwrap, ← hdecomp]
+            simp [intToCoeff]
+            ring
+          have hbound : (r0 - alpha).natAbs ≤ alpha + 1 := by omega
+          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 - alpha) hbound ctx.hsmall]
           exact hbound
-        · have heq : r1 + 1 = m := by omega
-          have hr1eq : r1 = m - 1 := by omega
-          have huse : useHintCoeff true r p.gamma2 = 0 := by
-            simp [useHintCoeff, hdec, hr0pos, heq, m, alpha]
-          have hmulm : (((alpha : ℕ) : Coeff) * (m : Coeff)) = (-1 : Coeff) := by
-            simpa [alpha, m] using alphaMulUseHintModulus_eq_neg_one_of_isApproved p hp
-          have hm_succ_cast : (m : Coeff) = (((m - 1 : ℕ) : Coeff) + 1) := by
-            rw [show m = (m - 1) + 1 by omega]
-            norm_num
-          have hcastm1 : (((m - 1 : ℕ) : Coeff)) = (m : Coeff) - 1 := by
-            calc
-              (((m - 1 : ℕ) : Coeff)) = ((((m - 1 : ℕ) : Coeff) + 1) - 1) := by ring
-              _ = (m : Coeff) - 1 := by rw [← hm_succ_cast]
-          have hmcoeff : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) = (-1 : Coeff) - alpha := by
-            calc
-              (((alpha : ℕ) : Coeff) * (r1 : Coeff))
-                  = (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) := by rw [hr1eq]
-              _ = (((alpha : ℕ) : Coeff) * ((m : Coeff) - 1)) := by rw [hcastm1]
-              _ = (((alpha : ℕ) : Coeff) * (m : Coeff)) - alpha := by
-                    ring
-              _ = (-1 : Coeff) - alpha := by rw [hmulm]
-          have hcoeff :
+        · have hcoeff :
               r - (((alpha : ℕ) : Coeff) * (useHintCoeff true r p.gamma2 : Coeff)) =
                 intToCoeff (r0 - alpha - 1) := by
+            have heq : r1 + 1 = m := by omega
+            have hr1eq : r1 = m - 1 := by omega
+            have huse : useHintCoeff true r p.gamma2 = 0 := by
+              simp [useHintCoeff, hdec, hr0pos, heq, m, alpha]
+            have hmcoeff : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) = (-1 : Coeff) - alpha := by
+              rw[hr1eq]
+              exact alphaMul_pred_m_eq_coeff ctx
             rw [huse]
-            simp only [Nat.cast_zero, mul_zero, sub_zero]
-            calc
-              r = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 := hdecomp.symm
-              _ = intToCoeff (r0 - alpha - 1) := by
-                    rw [hmcoeff]
-                    simp [intToCoeff]
-                    ring
-          have hr0ge1 : 1 ≤ r0 := by omega
+            simp only [Nat.cast_zero, mul_zero, sub_zero, ← hdecomp, hmcoeff]
+            rw[intToCoeff, intToCoeff, Int.cast_sub, Int.cast_sub]
+            zify
+            ring_nf
           have hbound : (r0 - alpha - 1).natAbs ≤ alpha + 1 := by
             dsimp [alpha]
             omega
-          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 - alpha - 1) hbound hsmall]
+          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 - alpha - 1) hbound ctx.hsmall]
           exact hbound
-      · have hr0nonpos : r0 ≤ 0 := le_of_not_gt hr0pos
-        by_cases hr1zero : r1 = 0
-        · have huse : useHintCoeff true r p.gamma2 = m - 1 := by
-            have hpred : (m - 1) % m = m - 1 := Nat.mod_eq_of_lt (Nat.pred_lt hm.ne')
-            simp [useHintCoeff, hdec, alpha, m, hr0pos, hr1zero, hpred]
-          have hmulm : (((alpha : ℕ) : Coeff) * (m : Coeff)) = (-1 : Coeff) := by
-            simpa [alpha, m] using alphaMulUseHintModulus_eq_neg_one_of_isApproved p hp
-          have hm_succ_cast : (m : Coeff) = (((m - 1 : ℕ) : Coeff) + 1) := by
-            rw [show m = (m - 1) + 1 by omega]
-            norm_num
-          have hcastm1 : (((m - 1 : ℕ) : Coeff)) = (m : Coeff) - 1 := by
-            calc
-              (((m - 1 : ℕ) : Coeff)) = ((((m - 1 : ℕ) : Coeff) + 1) - 1) := by ring
-              _ = (m : Coeff) - 1 := by rw [← hm_succ_cast]
-          have hmcoeff :
-              (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) = (-1 : Coeff) - alpha := by
-            calc
-              (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff))
-                  = (((alpha : ℕ) : Coeff) * ((m : Coeff) - 1)) := by rw [hcastm1]
-              _ = (((alpha : ℕ) : Coeff) * (m : Coeff)) - alpha := by
-                      ring
-              _ = (-1 : Coeff) - alpha := by rw [hmulm]
-          have hcoeff :
+      · by_cases hr1zero : r1 = 0
+        · have hcoeff :
               r - (((alpha : ℕ) : Coeff) * (useHintCoeff true r p.gamma2 : Coeff)) =
                 intToCoeff (r0 + alpha + 1) := by
-            rw [huse]
-            exact sub_eq_iff_eq_add'.2 <| by
-              calc
-                r = intToCoeff r0 := by simpa [hr1zero] using hdecomp.symm
-                _ =
-                    (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) +
-                      intToCoeff (r0 + alpha + 1) := by
-                      rw [hmcoeff]
-                      simp [intToCoeff]
-                      ring
-          have hbound : (r0 + alpha + 1).natAbs ≤ alpha + 1 := by
-            dsimp [alpha]
-            omega
-          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 + alpha + 1) hbound hsmall]
+            have huse : useHintCoeff true r p.gamma2 = m - 1 := by
+              have hpred : (m - 1) % m = m - 1 := Nat.mod_eq_of_lt (Nat.pred_lt ctx.hm.ne')
+              simp [useHintCoeff, hdec, alpha, m, hr0pos, hr1zero, hpred]
+            have hmcoeff :
+                (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) = (-1 : Coeff) - alpha := by
+              exact alphaMul_pred_m_eq_coeff ctx
+            rw [huse, hmcoeff, ← hdecomp, hr1zero]
+            simp [mul_zero, intToCoeff, Int.cast_add, sub_sub_eq_add_sub]
+          have hbound : (r0 + alpha + 1).natAbs ≤ alpha + 1 := by omega
+          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 + alpha + 1) hbound ctx.hsmall]
           exact hbound
-        · have hr1pos : 0 < r1 := Nat.pos_of_ne_zero hr1zero
-          have hmle : m ≤ r1 + (m - 1) := by omega
-          have hadd : (r1 + (m - 1)) % m + m = r1 + (m - 1) := by
-            have hc : m ≤ r1 % m + (m - 1) % m := by
-              simpa [Nat.mod_eq_of_lt hr1lt, Nat.mod_eq_of_lt (Nat.pred_lt hm.ne')] using hmle
-            simpa [Nat.mod_eq_of_lt hr1lt, Nat.mod_eq_of_lt (Nat.pred_lt hm.ne')] using
-              (Nat.add_mod_add_of_le_add_mod (a := r1) (b := m - 1) (c := m) hc)
-          have hmod : (r1 + (m - 1)) % m = r1 - 1 := by
-            omega
-          have hmod' : (r1 + m - 1) % m = r1 - 1 := by
-            have hsum : r1 + m - 1 = r1 + (m - 1) := by omega
-            rw [hsum]
-            exact hmod
-          have huse : useHintCoeff true r p.gamma2 = r1 - 1 := by
-            simpa [useHintCoeff, hdec, hr0pos, m, alpha] using hmod'
-          have hr1_succ_cast : (r1 : Coeff) = (((r1 - 1 : ℕ) : Coeff) + 1) := by
-            rw [show r1 = (r1 - 1) + 1 by omega]
-            norm_num
-          have hcastr1 : (((r1 - 1 : ℕ) : Coeff)) = (r1 : Coeff) - 1 := by
-            calc
-              (((r1 - 1 : ℕ) : Coeff)) = ((((r1 - 1 : ℕ) : Coeff) + 1) - 1) := by ring
-              _ = (r1 : Coeff) - 1 := by rw [← hr1_succ_cast]
+        · have huse : useHintCoeff true r p.gamma2 = r1 - 1 := by
+            have hmod' : (r1 + m - 1) % m = r1 - 1 := by
+              rw [show r1 + m - 1 = r1 - 1 + m by omega, Nat.add_mod_right,
+                  Nat.mod_eq_of_lt (by omega)]
+            simp [useHintCoeff, hdec, hr0pos, ← hmod', m, alpha]
           have hcoeff :
-              r - (((alpha : ℕ) : Coeff) * (useHintCoeff true r p.gamma2 : Coeff)) =
+              r - ((alpha : ℕ) : Coeff) * (useHintCoeff true r p.gamma2 : Coeff) =
                 intToCoeff (r0 + alpha) := by
-            rw [huse]
-            exact sub_eq_iff_eq_add'.2 <| by
-              calc
-                r = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 := hdecomp.symm
-                _ = (((alpha : ℕ) : Coeff) * ((r1 - 1 : ℕ) : Coeff)) + intToCoeff (r0 + alpha) := by
-                      rw [hcastr1]
-                      simp [intToCoeff]
-                      ring
-          have hbound : (r0 + alpha).natAbs ≤ alpha + 1 := by
-            dsimp [alpha]
-            omega
-          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 + alpha) hbound hsmall]
+            rw [huse, ← hdecomp, Nat.cast_sub (Nat.pos_of_ne_zero hr1zero)]
+            simp [intToCoeff]
+            ring_nf
+          have hbound : (r0 + alpha).natAbs ≤ alpha + 1 := by omega
+          rw [hcoeff, centeredRepr_eq_of_natAbs_le (z := r0 + alpha) hbound ctx.hsmall]
           exact hbound
 
-private theorem highBitsCoeff_eq_of_mid_of_isApproved (p : Params)
-    (hp : p.isApproved) (r : Coeff) (z0 : ℤ)
-    (hvlow : let r0 : ℤ := (decomposeCoeff r p.gamma2).2; -(p.gamma2 : ℤ) < r0 + z0)
-    (hvup : let r0 : ℤ := (decomposeCoeff r p.gamma2).2; r0 + z0 ≤ p.gamma2) :
-    highBitsCoeff (r + intToCoeff z0) p.gamma2 = highBitsCoeff r p.gamma2 := by
+private theorem decomposeCoeff_mid_of_isApproved (p : Params)
+    (hp : p.isApproved) (r : Coeff) (z0 r0 : ℤ) (r1 : ℕ)
+    (hdec : (r1, r0) = decomposeCoeff r p.gamma2)
+    (hvlow : -(p.gamma2 : ℤ) < r0 + z0)
+    (hvup : r0 + z0 ≤ p.gamma2) :
+    decomposeCoeff (r + intToCoeff z0) p.gamma2 =
+      (highBitsCoeff r p.gamma2, lowBitsCoeff r p.gamma2 + z0) := by
   let alpha : ℕ := 2 * p.gamma2
   let m : ℕ := (modulus - 1) / alpha
-  rcases hdec : decomposeCoeff r p.gamma2 with ⟨r1, r0⟩
   let v : ℤ := r0 + z0
-  have hvlow' : -(p.gamma2 : ℤ) < v := by simpa [v, hdec] using hvlow
-  have hvup' : v ≤ p.gamma2 := by simpa [v, hdec] using hvup
-  have hγ := gamma2_pos_of_isApproved hp
   have hr1lt : r1 < m := by
-    simpa [alpha, m, highBitsCoeff, hdec] using
-      highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
-  have hr1eq : highBitsCoeff r p.gamma2 = r1 := by simp [highBitsCoeff, hdec]
-  have hcore : r + z0 = ((alpha * r1 : ℕ) : Coeff) + (v : Coeff) := by
-    have hd : ((alpha * r1 : ℕ) : Coeff) + (r0 : Coeff) = r :=
-      by simpa [alpha, intToCoeff, hdec] using decomposeCoeff_eq (r := r) (gamma2 := p.gamma2) hγ
-    simp only [v, Int.cast_add, ← hd]; ring_nf
-  rw [hr1eq]
-  change highBitsCoeff (r + z0) p.gamma2 = r1
-  by_cases hvnonneg : 0 ≤ v
-  · have hvnat_le : v.natAbs ≤ p.gamma2 := by
-      have : (v.natAbs : ℤ) ≤ p.gamma2 :=
-        (Int.natAbs_of_nonneg hvnonneg).symm ▸ hvup'
-      exact_mod_cast this
-    rw [hcore, show (v : Coeff) = ((v.natAbs : ℕ) : Coeff) from
-        (congrArg (Int.cast : ℤ → Coeff) (Int.natAbs_of_nonneg hvnonneg)).symm,
-      ← Nat.cast_add]
-    exact highBitsCoeff_nonneg_repr_of_isApproved p hp r1 v.natAbs hr1lt hvnat_le
-  · have hvneg : v < 0 := lt_of_not_ge hvnonneg
-    have hnatv0 : 0 < v.natAbs := Int.natAbs_pos.mpr (by omega)
-    have hnatv_lt : v.natAbs < p.gamma2 := by
-      have h1 : (v.natAbs : ℤ) = -v := Int.ofNat_natAbs_of_nonpos hvneg.le
-      have h2 : -v < (p.gamma2 : ℤ) := by linarith [hvlow']
-      exact_mod_cast h1.symm ▸ h2
-    have hvcast : (v : Coeff) = -((v.natAbs : ℕ) : Coeff) := by
-      have h : ((v.natAbs : ℕ) : Coeff) = -(v : Coeff) := by
-        simpa using congrArg (Int.cast : ℤ → Coeff) (Int.ofNat_natAbs_of_nonpos hvneg.le)
-      simp [h]
-    by_cases hr1zero : r1 = 0
-    · rw [hr1zero, show r + z0 = -((v.natAbs : ℕ) : Coeff) from by
-          rw [hcore, hr1zero]; simp [hvcast]]
-      simpa only [Nat.cast_natAbs, intToCoeff, Int.cast_abs, Int.cast_eq, Int.cast_neg] using
-        highBitsCoeff_wrap_neg_repr_of_isApproved p hp v.natAbs hnatv0 hnatv_lt.le
-    · have hr1pos : 0 < r1 := Nat.pos_of_ne_zero hr1zero
-      have hnatv_le : v.natAbs ≤ alpha * r1 := by
-        have hlt : v.natAbs < alpha := by
-          have h1 : (v.natAbs : ℤ) = -v := Int.ofNat_natAbs_of_nonpos hvneg.le
-          exact_mod_cast h1.symm ▸ (show -v < (alpha : ℤ) by dsimp [alpha]; omega)
-        have : alpha ≤ alpha * r1 := Nat.le_mul_of_pos_right alpha hr1pos
-        omega
-      rw [hcore, hvcast, show ((alpha * r1 : ℕ) : Coeff) + -((v.natAbs : ℕ) : Coeff) =
-          ((alpha * r1 - v.natAbs : ℕ) : Coeff) from by rw [Nat.cast_sub hnatv_le]; ring]
-      exact highBitsCoeff_neg_repr_of_isApproved p hp r1 v.natAbs hr1lt hr1pos hnatv0 hnatv_lt
+    have := highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
+    simp only [highBitsCoeff, ← hdec] at this
+    exact this
+  have hcore : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v = r + intToCoeff z0 := by
+    have hd : (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 = r := decomposeCoeff_eq r hdec
+    simp only [v, intToCoeff, Int.cast_add, ← hd]; ring
+  have hv_bound : v.natAbs ≤ p.gamma2 := natAbs_le_of_neg_le_and_le (le_of_lt hvlow) hvup
+  have hv_neg_cond : v < 0 → r1 = 0 ∨ v.natAbs < p.gamma2 := fun hvneg =>
+    Or.inr (by
+      have h : (v.natAbs : ℤ) = -v := Int.ofNat_natAbs_of_nonpos hvneg.le
+      exact_mod_cast h ▸ (show -v < (p.gamma2 : ℤ) by linarith))
+  have huniq := decomposeCoeff_unique p hp r1 v hr1lt hv_bound hv_neg_cond hcore
+  rw [huniq]
+  simp [highBitsCoeff, lowBitsCoeff, v, ← hdec]
+
+private theorem highBitsCoeff_of_pos_overflow (p : Params) (hp : p.isApproved)
+    {s : Coeff} (r1 : ℕ) (v : ℤ)
+    (hr1 : r1 < (modulus - 1) / (2 * p.gamma2))
+    (hv_lo : (p.gamma2 : ℤ) < v)
+    (hv_hi : v ≤ (2 * p.gamma2 : ℤ))
+    (hsum : ((2 * p.gamma2 : ℕ) : Coeff) * (r1 : Coeff) + intToCoeff v = s) :
+    highBitsCoeff s p.gamma2 = (r1 + 1) % ((modulus - 1) / (2 * p.gamma2)) := by
+  let ctx := BalancedDecomp.ofApproved hp
+  let alpha : ℕ := 2 * p.gamma2
+  let m : ℕ := (modulus - 1) / alpha
+  by_cases hwrap : r1 + 1 < m
+  · have hmod : (r1 + 1) % m = r1 + 1 := Nat.mod_eq_of_lt hwrap
+    rw [hmod]
+    refine highBitsCoeff_of_repr p hp (r1+1) (v - alpha) hwrap (by omega) (by omega) ?_
+    · dsimp only [alpha]
+      rw [← hsum]
+      simp only [intToCoeff, Nat.cast_add, Nat.cast_one]
+      push_cast; ring
+  · have hmr1 : r1 < m := hr1
+    push Not at hwrap
+    have hwrap' : r1 + 1 = m := by omega
+    have hmod : (r1 + 1) % m = 0 := by rw [hwrap', Nat.mod_self]
+    rw [hmod]
+    refine highBitsCoeff_of_repr p hp 0 (v - alpha - 1) ctx.hm (by omega) (by omega) ?_
+    · have hmcoeff : ((alpha : ℕ) : Coeff) * (r1 : Coeff) =
+            (-1 : Coeff) - ((alpha : ℕ) : Coeff) := by
+        rw [show r1 = m - 1 from by omega]
+        exact alphaMul_pred_m_eq_coeff ctx
+      simp only [Nat.cast_zero, mul_zero, zero_add]
+      rw [← hsum, hmcoeff]
+      simp only [intToCoeff]; dsimp only [alpha]; push_cast; ring
+
+private theorem highBitsCoeff_of_neg_overflow (p : Params) (hp : p.isApproved)
+    {s : Coeff} (r1 : ℕ) (v : ℤ)
+    (hr1 : r1 < (modulus - 1) / (2 * p.gamma2))
+    (hv_lo : -(2 * p.gamma2 : ℤ) ≤ v)
+    (hv_hi : v ≤ -(p.gamma2 : ℤ))
+    (hbdry : v = -(p.gamma2 : ℤ) → 0 < r1)
+    (hsum : ((2 * p.gamma2 : ℕ) : Coeff) * (r1 : Coeff) + v = s) :
+    highBitsCoeff s p.gamma2 =
+      (r1 + (modulus - 1) / (2 * p.gamma2) - 1) % ((modulus - 1) / (2 * p.gamma2)) := by
+  let ctx := BalancedDecomp.ofApproved hp
+  let alpha : ℕ := 2 * p.gamma2
+  let m : ℕ := (modulus - 1) / alpha
+  rcases Nat.eq_zero_or_pos r1 with hr1z | hr1pos
+  · have hvlt : v < -(p.gamma2 : ℤ) :=
+      lt_of_le_of_ne hv_hi (fun h => absurd (hbdry h) (by omega))
+    have hmod : (r1 + m - 1) % m = m - 1 := by
+      subst hr1z; simp only [zero_add]
+      exact Nat.mod_eq_of_lt (Nat.sub_lt ctx.hm (by norm_num))
+    rw [hmod]
+    refine highBitsCoeff_of_repr p hp
+      (m - 1) (v + alpha + 1) (Nat.pred_lt ctx.hm.ne') (by omega) (by omega) ?_
+    · rw [alphaMul_pred_m_eq_coeff ctx, ← hsum, hr1z]
+      dsimp only [alpha]; push_cast; ring
+  · have hmr1 : r1 < m := hr1
+    have hmod : (r1 + m - 1) % m = r1 - 1 := by
+      rw [show r1 + m - 1 = (r1 - 1) + m from by omega, Nat.add_mod_right,
+          Nat.mod_eq_of_lt (by omega)]
+    rw [hmod]
+    refine highBitsCoeff_of_repr p hp (r1 - 1) (v + alpha) (by omega) (by omega) (by omega) ?_
+    · rw[Nat.cast_sub hr1pos, ← hsum]; dsimp[alpha]; push_cast; ring
 
 private theorem useHintCoeff_correct_of_small_of_isApproved (p : Params)
     (hp : p.isApproved) (z r : Coeff)
-    (hz : (LatticeCrypto.centeredRepr z).natAbs ≤ p.gamma2) :
+    (hz : (centeredRepr z).natAbs ≤ p.gamma2) :
     useHintCoeff (makeHintCoeff z r p.gamma2) r p.gamma2 =
       highBitsCoeff (r + z) p.gamma2 := by
+  let ctx := BalancedDecomp.ofApproved hp
   let alpha : ℕ := 2 * p.gamma2
   let m : ℕ := (modulus - 1) / alpha
-  let decr := decomposeCoeff r p.gamma2
-  let r1 : ℕ := decr.1
-  let r0 : ℤ := decr.2
-  let z0 : ℤ := LatticeCrypto.centeredRepr z
+  rcases hdec : decomposeCoeff r p.gamma2 with ⟨r1, r0⟩
+  let z0 : ℤ := centeredRepr z
   let v : ℤ := r0 + z0
-  have hγ := gamma2_pos_of_isApproved hp
-  have hm : 0 < m := by
-    simpa [alpha, m] using useHintModulus_pos_of_isApproved hp
-  have hdec : decomposeCoeff r p.gamma2 = (r1, r0) := by
-    simp [decr, r1, r0]
-  have hr1eq : highBitsCoeff r p.gamma2 = r1 := by
-    simp [highBitsCoeff, decr, r1]
+  have hr1eq : highBitsCoeff r p.gamma2 = r1 := by simp [highBitsCoeff, hdec]
   have hr1lt : r1 < m := by
-    simpa [alpha, m, decr, r1] using highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
+    have h := highBitsCoeff_lt_useHintModulus_of_isApproved p hp r
+    rwa [highBitsCoeff, hdec] at h
   have hr0bound : r0.natAbs ≤ p.gamma2 := by
-    simpa [decr, r0] using lowBitsCoeff_bound (r := r) (gamma2 := p.gamma2) hγ
-  obtain ⟨hr0low, hr0up⟩ := neg_le_and_le_of_natAbs_le hr0bound
-  obtain ⟨hzlow, hzup⟩ := neg_le_and_le_of_natAbs_le hz
-  have hzcast : z = intToCoeff z0 := by
-    simpa [z0] using LatticeCrypto.centeredRepr_intCast z
-  have hdecomp :
-      (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 = r := by
-    simpa [alpha, decr, r1, r0] using decomposeCoeff_eq (r := r) (gamma2 := p.gamma2) hγ
-  have hsum :
-      (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v = r + z := by
-    calc
-      (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v
-          = ((((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0) + intToCoeff z0 := by
-              dsimp [v]
-              simp [intToCoeff]
-              ring
-      _ = r + z := by rw [hdecomp]; simp [hzcast]
-  by_cases hneq : highBitsCoeff r p.gamma2 ≠ highBitsCoeff (r + z) p.gamma2
-  · have hhint : makeHintCoeff z r p.gamma2 = true := by
-      simp [makeHintCoeff, hneq]
-    by_cases hr0pos : 0 < r0
-    · have hvlow : -(p.gamma2 : ℤ) < v := by
-        dsimp [v]
-        omega
-      have hvupα : v ≤ alpha := by
-        dsimp [v, alpha]
-        omega
-      have hvnotmid : ¬ v ≤ p.gamma2 := by
-        intro hvmid
-        have hsame := highBitsCoeff_eq_of_mid_of_isApproved p hp r z0
-          (hvlow := by simpa [decr, r0, z0, v] using hvlow)
-          (hvup := by simpa [decr, r0, z0, v] using hvmid)
-        exact hneq (by simpa [hzcast] using hsame.symm)
-      have hvgt : p.gamma2 < v := by
-        omega
-      have hvnonneg : 0 ≤ v := by omega
-      have hvnat : (((v.natAbs : ℕ) : ℤ)) = v := by
-        simpa using (Int.natAbs_of_nonneg hvnonneg)
-      have hvcast : intToCoeff v = ((v.natAbs : ℕ) : Coeff) := by
-        simpa [intToCoeff] using (congrArg (fun z : ℤ => (z : Coeff)) hvnat).symm
-      by_cases hwrap : r1 + 1 < m
-      · have huse : useHintCoeff true r p.gamma2 = r1 + 1 := by
-          simpa [m, alpha, useHintCoeff, hdec, hr0pos] using (Nat.mod_eq_of_lt hwrap)
-        by_cases hvEqAlpha : v.natAbs = alpha
-        · have hgoal : highBitsCoeff (r + z) p.gamma2 = r1 + 1 := by
-            have hcoeff :
-                r + z = ((alpha * (r1 + 1) : ℕ) : Coeff) := by
-              calc
-                r + z = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v := by
-                  simpa [add_comm] using hsum.symm
-                _ = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + ((v.natAbs : ℕ) : Coeff) := by
-                  rw [hvcast]
-                _ = ((alpha * (r1 + 1) : ℕ) : Coeff) := by
-                  rw [show alpha * (r1 + 1) = alpha + alpha * r1 by ring]
-                  rw [hvEqAlpha]
-                  simp [Nat.cast_mul, Nat.cast_add, add_comm]
-            rw [hcoeff]
-            simpa [intToCoeff, alpha] using
-              (highBitsCoeff_nonneg_repr_of_isApproved p hp (r1 + 1) 0
-                (by simpa [alpha, m] using hwrap) (show 0 ≤ p.gamma2 by omega))
-          simpa [hhint, huse] using hgoal.symm
-        · let n : ℕ := alpha - v.natAbs
-          have hnatabs_le_alpha : v.natAbs ≤ alpha := by
-            have : (((v.natAbs : ℕ) : ℤ)) ≤ alpha := by
-              rw [hvnat]
-              exact_mod_cast hvupα
-            exact_mod_cast this
-          have hnatabs_lt_alpha : v.natAbs < alpha :=
-            lt_of_le_of_ne hnatabs_le_alpha (by simpa using hvEqAlpha)
-          have hnatabs_gt_gamma : p.gamma2 < v.natAbs := by
-            have : (p.gamma2 : ℤ) < ((v.natAbs : ℕ) : ℤ) := by
-              rw [hvnat]
-              exact_mod_cast hvgt
-            exact_mod_cast this
-          have hn0 : 0 < n := by
-            dsimp [n]
-            omega
-          have hnlt : n < p.gamma2 := by
-            dsimp [n]
-            omega
-          have hgoal : highBitsCoeff (r + z) p.gamma2 = r1 + 1 := by
-            have hcoeff :
-                r + z = ((alpha * (r1 + 1) - n : ℕ) : Coeff) := by
-              calc
-                r + z = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v := by
-                  simpa [add_comm] using hsum.symm
-                _ = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + ((v.natAbs : ℕ) : Coeff) := by
-                  rw [hvcast]
-                _ = ((alpha * r1 + v.natAbs : ℕ) : Coeff) := by
-                  simp [Nat.cast_add, Nat.cast_mul]
-                _ = ((alpha * (r1 + 1) - n : ℕ) : Coeff) := by
-                  have hrepr : alpha * (r1 + 1) - n = alpha * r1 + v.natAbs := by
-                    dsimp [n]
-                    have hle : v.natAbs ≤ alpha := hnatabs_le_alpha
-                    calc
-                      alpha * (r1 + 1) - (alpha - v.natAbs)
-                          = alpha * r1 + alpha - (alpha - v.natAbs) := by
-                              rw [Nat.mul_add, Nat.mul_one]
-                      _ = alpha * r1 + (alpha - (alpha - v.natAbs)) := by
-                            omega
-                      _ = alpha * r1 + v.natAbs := by
-                            rw [Nat.sub_sub_self hle]
-                  rw [hrepr]
-            rw [hcoeff]
-            simpa [intToCoeff, alpha, n] using
-              (highBitsCoeff_neg_repr_of_isApproved p hp (r1 + 1) n
-                (by simpa [alpha, m] using hwrap) (show 0 < r1 + 1 by omega) hn0 hnlt)
-          simpa [hhint, huse] using hgoal.symm
-      · have heq : r1 + 1 = m := by
-          omega
-        have hr1eqm1 : r1 = m - 1 := by
-          omega
-        have huse : useHintCoeff true r p.gamma2 = 0 := by
-          simp [useHintCoeff, hdec, hr0pos, heq, m, alpha]
-        have hmulm : (((alpha : ℕ) : Coeff) * (m : Coeff)) = (-1 : Coeff) := by
-          simpa [alpha, m] using alphaMulUseHintModulus_eq_neg_one_of_isApproved p hp
-        have hm_succ_cast : (m : Coeff) = (((m - 1 : ℕ) : Coeff) + 1) := by
-          rw [show m = (m - 1) + 1 by omega]
-          norm_num
-        have hcastm1 : (((m - 1 : ℕ) : Coeff)) = (m : Coeff) - 1 := by
-          calc
-            (((m - 1 : ℕ) : Coeff)) = ((((m - 1 : ℕ) : Coeff) + 1) - 1) := by ring
-            _ = (m : Coeff) - 1 := by rw [← hm_succ_cast]
-        have hmcoeff :
-            (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) = (-1 : Coeff) - alpha := by
-          calc
-            (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff))
-                = (((alpha : ℕ) : Coeff) * ((m : Coeff) - 1)) := by rw [hcastm1]
-            _ = (((alpha : ℕ) : Coeff) * (m : Coeff)) - alpha := by ring
-            _ = (-1 : Coeff) - alpha := by rw [hmulm]
-        let n : ℕ := alpha + 1 - v.natAbs
-        have hnatabs_le_alpha : v.natAbs ≤ alpha := by
-          have : (((v.natAbs : ℕ) : ℤ)) ≤ alpha := by
-            rw [hvnat]
-            exact_mod_cast hvupα
-          exact_mod_cast this
-        have hnatabs_gt_gamma : p.gamma2 < v.natAbs := by
-          have : (p.gamma2 : ℤ) < ((v.natAbs : ℕ) : ℤ) := by
-            rw [hvnat]
-            exact_mod_cast hvgt
-          exact_mod_cast this
-        have hn0 : 0 < n := by
-          dsimp [n]
-          omega
-        have hnle : n ≤ p.gamma2 := by
-          dsimp [n]
-          omega
-        have hgoal : highBitsCoeff (r + z) p.gamma2 = 0 := by
-          have hcoeff : r + z = intToCoeff (-(n : ℤ)) := by
-            calc
-              r + z = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v := by
-                simpa [add_comm] using hsum.symm
-              _ = (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) + intToCoeff v := by
-                rw [hr1eqm1]
-              _ = (-1 : Coeff) - alpha + intToCoeff v := by
-                rw [hmcoeff]
-              _ = intToCoeff (-(n : ℤ)) := by
-                rw [hvcast]
-                have hrepr : (-(n : ℤ)) = ((v.natAbs : ℕ) : ℤ) - alpha - 1 := by
-                  dsimp [n]
-                  omega
-                rw [hrepr]
-                simp [intToCoeff]
-                ring
-          rw [hcoeff]
-          simpa [intToCoeff, alpha, n] using
-            (highBitsCoeff_wrap_neg_repr_of_isApproved p hp n hn0 hnle)
-        simpa [hhint, huse] using hgoal.symm
-    · have hr0nonpos : r0 ≤ 0 := le_of_not_gt hr0pos
-      have hvup : v ≤ p.gamma2 := by
-        dsimp [v]
-        omega
-      by_cases hr1zero : r1 = 0
-      · have hvnotmid : ¬ -(p.gamma2 : ℤ) < v := by
-          intro hvlow
-          have hsame := highBitsCoeff_eq_of_mid_of_isApproved p hp r z0
-            (hvlow := by simpa [decr, r0, z0, v] using hvlow)
-            (hvup := by simpa [decr, r0, z0, v] using hvup)
-          exact hneq (by simpa [hzcast] using hsame.symm)
-        have hveq_not : v ≠ -(p.gamma2 : ℤ) := by
-          intro hveq
-          have hcoeff : r + z = -((p.gamma2 : ℕ) : Coeff) := by
-            calc
-              r + z = intToCoeff v := by
-                simpa [hr1zero, add_comm] using hsum.symm
-              _ = -((p.gamma2 : ℕ) : Coeff) := by
-                rw [hveq]
-                simp [intToCoeff]
-          have hsame0 : highBitsCoeff (r + z) p.gamma2 = 0 := by
-            rw [hcoeff]
-            simpa [intToCoeff, alpha] using
-              (highBitsCoeff_wrap_neg_repr_of_isApproved p hp p.gamma2 hγ le_rfl)
-          exact hneq (by simpa [hr1eq, hr1zero] using hsame0.symm)
-        have hvlt : v < -(p.gamma2 : ℤ) := by
-          omega
-        have huse : useHintCoeff true r p.gamma2 = m - 1 := by
-          have hpred : (m - 1) % m = m - 1 := Nat.mod_eq_of_lt (Nat.pred_lt hm.ne')
-          simp [useHintCoeff, hdec, alpha, m, hr0pos, hr1zero, hpred]
-        have hmulm : (((alpha : ℕ) : Coeff) * (m : Coeff)) = (-1 : Coeff) := by
-          simpa [alpha, m] using alphaMulUseHintModulus_eq_neg_one_of_isApproved p hp
-        have hm_succ_cast : (m : Coeff) = (((m - 1 : ℕ) : Coeff) + 1) := by
-          rw [show m = (m - 1) + 1 by omega]
-          norm_num
-        have hcastm1 : (((m - 1 : ℕ) : Coeff)) = (m : Coeff) - 1 := by
-          calc
-            (((m - 1 : ℕ) : Coeff)) = ((((m - 1 : ℕ) : Coeff) + 1) - 1) := by ring
-            _ = (m : Coeff) - 1 := by rw [← hm_succ_cast]
-        have hmcoeff :
-            (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) = (-1 : Coeff) - alpha := by
-          calc
-            (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff))
-                = (((alpha : ℕ) : Coeff) * ((m : Coeff) - 1)) := by rw [hcastm1]
-            _ = (((alpha : ℕ) : Coeff) * (m : Coeff)) - alpha := by ring
-            _ = (-1 : Coeff) - alpha := by rw [hmulm]
-        have hvneg : v < 0 := by omega
-        have hnatv : (((v.natAbs : ℕ) : ℤ)) = -v := by
-          simpa using (Int.ofNat_natAbs_of_nonpos hvneg.le)
-        let n : ℕ := alpha + 1 - v.natAbs
-        have hnatabs_gt_gamma : p.gamma2 < v.natAbs := by
-          have : (p.gamma2 : ℤ) < ((v.natAbs : ℕ) : ℤ) := by
-            rw [hnatv]
-            omega
-          exact_mod_cast this
-        have hn0 : 0 < n := by
-          dsimp [n]
-          omega
-        have hnle : n ≤ p.gamma2 := by
-          dsimp [n]
-          omega
-        have hgoal : highBitsCoeff (r + z) p.gamma2 = m - 1 := by
-          have hcoeff : r + z = ((alpha * (m - 1) + n : ℕ) : Coeff) := by
-            calc
-              r + z = intToCoeff v := by
-                simpa [hr1zero, add_comm] using hsum.symm
-              _ = intToCoeff (-((v.natAbs : ℕ) : ℤ)) := by
-                have hvrepr : v = -((v.natAbs : ℕ) : ℤ) := by
-                  rw [hnatv]
-                  ring
-                rw [hvrepr]
-                have hnonpos : -((v.natAbs : ℕ) : ℤ) ≤ 0 := by omega
-                simp [intToCoeff]
-              _ = (((alpha : ℕ) : Coeff) * ((m - 1 : ℕ) : Coeff)) + (n : Coeff) := by
-                rw [hmcoeff]
-                have hrepr : (-((v.natAbs : ℕ) : ℤ)) = (n : ℤ) - alpha - 1 := by
-                  dsimp [n]
-                  omega
-                rw [hrepr]
-                simp [intToCoeff]
-                ring
-              _ = ((alpha * (m - 1) + n : ℕ) : Coeff) := by
-                simp [Nat.cast_add, Nat.cast_mul]
-          rw [hcoeff]
-          simpa [intToCoeff, alpha, n] using
-            (highBitsCoeff_nonneg_repr_of_isApproved p hp (m - 1) n
-              (Nat.pred_lt hm.ne') hnle)
-        simpa [hhint, huse] using hgoal.symm
-      · have hvnotmid : ¬ -(p.gamma2 : ℤ) < v := by
-          intro hvlow
-          have hsame := highBitsCoeff_eq_of_mid_of_isApproved p hp r z0
-            (hvlow := by simpa [decr, r0, z0, v] using hvlow)
-            (hvup := by simpa [decr, r0, z0, v] using hvup)
-          exact hneq (by simpa [hzcast] using hsame.symm)
-        have hvle : v ≤ -(p.gamma2 : ℤ) := by
-          omega
-        have hr1pos : 0 < r1 := Nat.pos_of_ne_zero hr1zero
-        have hmle : m ≤ r1 + (m - 1) := by omega
-        have hadd : (r1 + (m - 1)) % m + m = r1 + (m - 1) := by
-          have hc : m ≤ r1 % m + (m - 1) % m := by
-            simpa [Nat.mod_eq_of_lt hr1lt, Nat.mod_eq_of_lt (Nat.pred_lt hm.ne')] using hmle
-          simpa [Nat.mod_eq_of_lt hr1lt, Nat.mod_eq_of_lt (Nat.pred_lt hm.ne')] using
-            (Nat.add_mod_add_of_le_add_mod (a := r1) (b := m - 1) (c := m) hc)
-        have hmod : (r1 + (m - 1)) % m = r1 - 1 := by
-          omega
-        have hmod' : (r1 + m - 1) % m = r1 - 1 := by
-          have hsum' : r1 + m - 1 = r1 + (m - 1) := by omega
-          rw [hsum']
-          exact hmod
-        have huse : useHintCoeff true r p.gamma2 = r1 - 1 := by
-          simpa [useHintCoeff, hdec, hr0pos, m, alpha] using hmod'
-        have hvneg : v < 0 := by omega
-        have hnatv : (((v.natAbs : ℕ) : ℤ)) = -v := by
-          simpa using (Int.ofNat_natAbs_of_nonpos hvneg.le)
-        have hr1pred_lt : r1 - 1 < m := by
-          omega
-        have hr0gt : -(p.gamma2 : ℤ) < r0 := by
-          by_contra hr0le
-          have hr0eq : r0 = -(p.gamma2 : ℤ) := by
-            omega
-          have hγle : p.gamma2 ≤ alpha * r1 := by
-            have hαu : alpha ≤ alpha * r1 := by
-              calc
-                alpha = alpha * 1 := by ring
-                _ ≤ alpha * r1 := Nat.mul_le_mul_left alpha (show 1 ≤ r1 by omega)
-            exact le_trans (by dsimp [alpha]; omega) hαu
-          have hcoeff0 : r = ((alpha * (r1 - 1) + p.gamma2 : ℕ) : Coeff) := by
-            calc
-              r = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff r0 := hdecomp.symm
-              _ = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff (-(p.gamma2 : ℤ)) := by
-                    rw [hr0eq]
-              _ = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) - ((p.gamma2 : ℕ) : Coeff) := by
-                    simp [intToCoeff]
-                    ring
-              _ = ((alpha * r1 - p.gamma2 : ℕ) : Coeff) := by
-                    rw [← Nat.cast_mul, ← Nat.cast_sub hγle]
-              _ = ((alpha * (r1 - 1) + p.gamma2 : ℕ) : Coeff) := by
-                    have hrepr : alpha * r1 - p.gamma2 = alpha * (r1 - 1) + p.gamma2 := by
-                      have hr1succ : r1 = (r1 - 1) + 1 := by omega
-                      rw [hr1succ, Nat.mul_add, Nat.mul_one]
-                      dsimp [alpha]
-                      omega
-                    rw [hrepr]
-          have hsame0 : highBitsCoeff r p.gamma2 = r1 - 1 := by
-            rw [hcoeff0]
-            simpa [intToCoeff, alpha] using
-              (highBitsCoeff_nonneg_repr_of_isApproved p hp (r1 - 1) p.gamma2 hr1pred_lt le_rfl)
-          have : r1 = r1 - 1 := by
-            simpa [hr1eq] using hsame0
-          omega
-        have hvgt_neg_alpha : -(alpha : ℤ) < v := by
-          dsimp [v, alpha]
-          omega
-        have hnatv_ltα : v.natAbs < alpha := by
-          have : (((v.natAbs : ℕ) : ℤ)) < alpha := by
-            rw [hnatv]
-            simpa using (neg_lt_neg hvgt_neg_alpha)
-          exact_mod_cast this
-        have hnatv_le : v.natAbs ≤ alpha * r1 := by
-          have hαu : alpha ≤ alpha * r1 := by
-            calc
-              alpha = alpha * 1 := by ring
-              _ ≤ alpha * r1 := Nat.mul_le_mul_left alpha (show 1 ≤ r1 by omega)
-          exact le_trans hnatv_ltα.le hαu
-        let n : ℕ := alpha - v.natAbs
-        have hnle : n ≤ p.gamma2 := by
-          dsimp [n]
-          omega
-        have hgoal : highBitsCoeff (r + z) p.gamma2 = r1 - 1 := by
-          have hvcast : intToCoeff v = -((v.natAbs : ℕ) : Coeff) := by
-            calc
-              intToCoeff v = -intToCoeff (-v) := by simp [intToCoeff]
-              _ = -((v.natAbs : ℕ) : Coeff) := by
-                congr 1
-                simpa [intToCoeff] using
-                  (congrArg (fun z : ℤ => (z : Coeff)) hnatv).symm
-          have hcoeff : r + z = ((alpha * (r1 - 1) + n : ℕ) : Coeff) := by
-            calc
-              r + z = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + intToCoeff v := by
-                simpa [add_comm] using hsum.symm
-              _ = (((alpha : ℕ) : Coeff) * (r1 : Coeff)) - ((v.natAbs : ℕ) : Coeff) := by
-                rw [hvcast]
-                ring
-              _ = ((alpha * r1 - v.natAbs : ℕ) : Coeff) := by
-                rw [← Nat.cast_mul, ← Nat.cast_sub hnatv_le]
-              _ = ((alpha * (r1 - 1) + n : ℕ) : Coeff) := by
-                have hrepr : alpha * (r1 - 1) + n = alpha * r1 - v.natAbs := by
-                  dsimp [n]
-                  have hle : v.natAbs ≤ alpha := hnatv_ltα.le
-                  calc
-                    alpha * (r1 - 1) + (alpha - v.natAbs)
-                        = alpha * (r1 - 1) + alpha - v.natAbs := by
-                            rw [Nat.add_sub_assoc hle]
-                    _ = alpha * r1 - v.natAbs := by
-                          have hr1repr : alpha * r1 = alpha * (r1 - 1) + alpha := by
-                            have hr1succ : r1 - 1 + 1 = r1 := by omega
-                            have hpred : r1 - 1 + 1 - 1 = r1 - 1 := by omega
-                            rw [← hr1succ, Nat.mul_add, Nat.mul_one, hpred]
-                          rw [hr1repr]
-                rw [hrepr]
-          rw [hcoeff]
-          simpa [intToCoeff, alpha, n] using
-            (highBitsCoeff_nonneg_repr_of_isApproved p hp (r1 - 1) n
-              hr1pred_lt hnle)
-        simpa [hhint, huse] using hgoal.symm
-  · have hsame : highBitsCoeff r p.gamma2 = highBitsCoeff (r + z) p.gamma2 := by
-      exact not_ne_iff.mp hneq
-    calc
-      useHintCoeff (makeHintCoeff z r p.gamma2) r p.gamma2 = r1 := by
-        simp [makeHintCoeff, hneq, useHintCoeff, hdec]
-      _ = highBitsCoeff (r + z) p.gamma2 := by
-        simpa [hr1eq] using hsame
-
-theorem concreteRounding_high_low_decomp_of_isApproved (p : Params)
-    (hp : p.isApproved) (r : Rq) :
-    highBitsShift p (highBits p r) + lowBits p r = r :=
-  concreteRounding_high_low_decomp p (gamma2_pos_of_isApproved hp) r
+    have h := lowBitsCoeff_bound r (gamma2 := p.gamma2) (gamma2_pos_of_isApproved hp)
+    rwa [lowBitsCoeff, hdec] at h
+  have hzcast : z = intToCoeff z0 := centeredRepr_intCast z
+  have hsum : ((alpha : ℕ) : Coeff) * (r1 : Coeff) + v = r + z := by
+    have hdecomp :
+      (((alpha : ℕ) : Coeff) * (r1 : Coeff)) + r0 = r :=
+      decomposeCoeff_eq r hdec.symm
+    simp only [Int.cast_add, hzcast, v]
+    rw [← hdecomp, intToCoeff]; ring_nf
+  by_cases heq : highBitsCoeff r p.gamma2 = highBitsCoeff (r + z) p.gamma2
+  · simp [useHintCoeff, makeHintCoeff, heq, hdec, ← hr1eq]
+  · push Not at heq; rename' heq => hneq
+    have hhint : makeHintCoeff z r p.gamma2 = true := by simp [makeHintCoeff, hneq]
+    have hvnotmid : ¬ (-(p.gamma2 : ℤ) < v ∧ v ≤ p.gamma2) := by
+      by_contra ⟨hlo, hhi⟩
+      have : highBitsCoeff (r + z) p.gamma2 = highBitsCoeff r p.gamma2 := by
+        simp [highBitsCoeff,
+          decomposeCoeff_mid_of_isApproved p hp r z0 r0 r1  hdec.symm hlo hhi, hzcast]
+      exact absurd this.symm hneq
+    rcases show (p.gamma2 : ℤ) < v ∨ v ≤ -(p.gamma2 : ℤ) by omega with hvpos | hvneg
+    · have hr0pos : 0 < r0 := by omega
+      have huse : useHintCoeff true r p.gamma2 = (r1 + 1) % m := by
+        simp [useHintCoeff, hdec, hr0pos, m, alpha]
+      have hgoal : highBitsCoeff (r + z) p.gamma2 = (r1 + 1) % m :=
+        highBitsCoeff_of_pos_overflow p hp r1 v hr1lt hvpos (by omega) hsum
+      rw [hhint, huse, hgoal]
+    · have hr0nonpos : ¬ 0 < r0 := by omega
+      have huse : useHintCoeff true r p.gamma2 = (r1 + m - 1) % m := by
+        simp [useHintCoeff, hdec, hr0nonpos, m, alpha]
+      have hbdry : v = -(p.gamma2 : ℤ) → 0 < r1 := fun hveq => by
+        by_contra hr1z
+        have hr1z' : r1 = 0 := by omega
+        have hcoeff : (-(p.gamma2 : ℤ)) = r + z := by
+          simpa [hr1z', hveq] using hsum
+        have hzero : highBitsCoeff (r + z) p.gamma2 = 0 :=
+          hcoeff ▸ highBitsCoeff_of_repr p hp 0 (-(p.gamma2 : ℤ)) ctx.hm
+            (by simp) (by omega) (by simp)
+        exact hneq (by simpa [hr1eq, hr1z'] using hzero.symm)
+      have hgoal : highBitsCoeff (r + z) p.gamma2 = (r1 + m - 1) % m :=
+        highBitsCoeff_of_neg_overflow p hp r1 v hr1lt (by omega) hvneg hbdry hsum
+      rw [hhint, huse, hgoal]
 
 theorem concreteRounding_lowBits_bound_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) :
-    LatticeCrypto.cInfNorm (lowBits p r) ≤ p.gamma2 :=
+    cInfNorm (lowBits p r) ≤ p.gamma2 :=
   concreteRounding_lowBits_bound p (gamma2_pos_of_isApproved hp)
     (gamma2_double_lt_modulus_of_isApproved hp) r
 
@@ -1592,14 +901,10 @@ private theorem coeff_mul_left_injective_of_isUnit {c : Coeff} (hc : IsUnit c) :
   have hxy' := congrArg (fun z : Coeff => ↑u⁻¹ * z) hxy
   simpa [mul_assoc] using hxy'
 
-private theorem twoGamma_coprime_modulus_of_isApproved {p : Params} (hp : p.isApproved) :
-    Nat.Coprime (2 * p.gamma2) modulus := by
-  rcases hp with rfl | rfl | rfl <;> decide
-
 private theorem twoGamma_isUnit_of_isApproved {p : Params} (hp : p.isApproved) :
     IsUnit (((2 * p.gamma2 : ℕ) : Coeff)) := by
-  simpa using (ZMod.isUnit_iff_coprime (2 * p.gamma2) modulus).2
-    (twoGamma_coprime_modulus_of_isApproved hp)
+  have : Nat.Coprime (2 * p.gamma2) modulus := by rcases hp with rfl | rfl | rfl <;> decide
+  exact (ZMod.isUnit_iff_coprime (2 * p.gamma2) modulus).mpr this
 
 theorem highBitsShift_injective_of_isApproved (p : Params)
     (hp : p.isApproved) :
@@ -1619,7 +924,7 @@ def concretePower2RoundOps : MLDSA.Power2RoundOps where
   shift2 := power2RoundShift
 
 theorem concretePower2Round_bound_field (r : Rq) :
-    LatticeCrypto.cInfNorm
+    cInfNorm
       (r - concretePower2RoundOps.shift2 (concretePower2RoundOps.power2Round r)) ≤
         2 ^ (droppedBits - 1) := by
   simpa [concretePower2RoundOps] using concretePower2Round_bound r
@@ -1634,17 +939,10 @@ def concreteRoundingOps (p : Params) : MLDSA.RoundingOps (2 * p.gamma2) where
   makeHint := makeHint p
   useHint := useHint p
 
-theorem concreteRounding_high_low_decomp_field_of_isApproved (p : Params)
-    (hp : p.isApproved) (r : Rq) :
-    (concreteRoundingOps p).shift ((concreteRoundingOps p).highBits r) +
-      (concreteRoundingOps p).lowBits r = r := by
-  change highBitsShift p (highBits p r) + lowBits p r = r
-  exact concreteRounding_high_low_decomp_of_isApproved p hp r
-
 theorem concreteRounding_lowBits_bound_field_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) :
-    LatticeCrypto.cInfNorm ((concreteRoundingOps p).lowBits r) ≤ (2 * p.gamma2) / 2 := by
-  change LatticeCrypto.cInfNorm (lowBits p r) ≤ (2 * p.gamma2) / 2
+    cInfNorm ((concreteRoundingOps p).lowBits r) ≤ (2 * p.gamma2) / 2 := by
+  change cInfNorm (lowBits p r) ≤ (2 * p.gamma2) / 2
   simp only [gamma2_half]
   exact concreteRounding_lowBits_bound_of_isApproved p hp r
 
@@ -1656,20 +954,19 @@ theorem concreteRounding_shift_injective_field_of_isApproved (p : Params)
 
 theorem concreteRounding_useHint_correct_of_isApproved (p : Params)
     (hp : p.isApproved) (z r : Rq) :
-    LatticeCrypto.cInfNorm z ≤ p.gamma2 →
+    cInfNorm z ≤ p.gamma2 →
     useHint p (makeHint p z r) r = highBits p (r + z) := by
   intro hz
   refine Poly.ext_get_eq fun j => ?_
-  have hzj : (LatticeCrypto.centeredRepr (z.get j)).natAbs ≤ p.gamma2 :=
-    (LatticeCrypto.cInfNorm_le_iff.mp hz) j
+  have hzj : (centeredRepr (z.get j)).natAbs ≤ p.gamma2 := cInfNorm_le_iff.mp hz j
   simp only [useHint, makeHint, highBits, Vector.get_ofFn, Rq.get_add]
-  apply congrArg (fun n : ℕ => (n : Coeff))
+  apply congrArg fun n : ℕ => (n : Coeff)
   exact useHintCoeff_correct_of_small_of_isApproved p hp (z := z.get j) (r := r.get j) hzj
 
 theorem concreteRounding_useHint_bound_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) (h : Hint) :
-    LatticeCrypto.cInfNorm (r - highBitsShift p (useHint p h r)) ≤ 2 * p.gamma2 + 1 := by
-  apply LatticeCrypto.cInfNorm_le_iff.mpr
+    cInfNorm (r - highBitsShift p (useHint p h r)) ≤ 2 * p.gamma2 + 1 := by
+  apply cInfNorm_le_iff.mpr
   intro j
   have hcoeff : (r - highBitsShift p (useHint p h r)).get j =
       r.get j -
@@ -1682,16 +979,16 @@ theorem concreteRounding_useHint_bound_of_isApproved (p : Params)
 
 theorem concreteRounding_hide_low_of_isApproved (p : Params)
     (hp : p.isApproved) (r s : Rq) (b : ℕ) :
-    LatticeCrypto.cInfNorm s ≤ b →
-    LatticeCrypto.cInfNorm (lowBits p r) + b < p.gamma2 →
+    cInfNorm s ≤ b →
+    cInfNorm (lowBits p r) + b < p.gamma2 →
     highBits p (r + s) = highBits p r := by
   intro hs hlow
   refine Poly.ext_get_eq fun j => ?_
   simp only [highBits, Vector.get_ofFn, Rq.get_add]
-  apply congrArg (fun n : ℕ => (n : Coeff))
-  apply highBitsCoeff_add_eq_of_small_of_isApproved p hp (b:=b)
-  · exact (LatticeCrypto.cInfNorm_le_iff.mp hs) j
-  · have hcoeff := LatticeCrypto.coeff_le_cInfNorm (lowBits p r) j
+  apply congrArg fun n : ℕ => (n : Coeff)
+  apply highBitsCoeff_add_eq_of_small_of_isApproved p hp
+  · exact cInfNorm_le_iff.mp hs j
+  · have hcoeff := coeff_le_cInfNorm (lowBits p r) j
     rw [lowBits_get, lowBits_centeredRepr (r := r.get j)
       (hγ := gamma2_pos_of_isApproved hp)
       (hq := gamma2_double_lt_modulus_of_isApproved hp)] at hcoeff
@@ -1699,15 +996,15 @@ theorem concreteRounding_hide_low_of_isApproved (p : Params)
 
 theorem concreteRounding_useHint_bound_field_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) (h : Hint) :
-    LatticeCrypto.cInfNorm
+    cInfNorm
       (r - (concreteRoundingOps p).shift ((concreteRoundingOps p).useHint h r)) ≤
         2 * p.gamma2 + 1 := by
-  change LatticeCrypto.cInfNorm (r - highBitsShift p (useHint p h r)) ≤ 2 * p.gamma2 + 1
+  change cInfNorm (r - highBitsShift p (useHint p h r)) ≤ 2 * p.gamma2 + 1
   exact concreteRounding_useHint_bound_of_isApproved p hp r h
 
 theorem concreteRounding_useHint_correct_field_of_isApproved (p : Params)
     (hp : p.isApproved) (z r : Rq) :
-    LatticeCrypto.cInfNorm z ≤ (2 * p.gamma2) / 2 →
+    cInfNorm z ≤ (2 * p.gamma2) / 2 →
     (concreteRoundingOps p).useHint ((concreteRoundingOps p).makeHint z r) r =
       (concreteRoundingOps p).highBits (r + z) := by
   intro hz
@@ -1716,16 +1013,15 @@ theorem concreteRounding_useHint_correct_field_of_isApproved (p : Params)
 
 theorem concreteRounding_hide_low_field_of_isApproved (p : Params)
     (hp : p.isApproved) (r s : Rq) (b : ℕ) :
-    LatticeCrypto.cInfNorm s ≤ b →
-    LatticeCrypto.cInfNorm ((concreteRoundingOps p).lowBits r) + b < (2 * p.gamma2) / 2 →
+    cInfNorm s ≤ b →
+    cInfNorm ((concreteRoundingOps p).lowBits r) + b < (2 * p.gamma2) / 2 →
     (concreteRoundingOps p).highBits (r + s) = (concreteRoundingOps p).highBits r := by
   intro hs hlow
   change highBits p (r + s) = highBits p r
   exact concreteRounding_hide_low_of_isApproved p hp r s b hs (by simpa [gamma2_half] using hlow)
 
 theorem concretePower2RoundLaws :
-    LatticeCrypto.Power2RoundOps.Laws (ring := coeffRing)
-      concretePower2RoundOps LatticeCrypto.cInfNorm := by
+    Power2RoundOps.Laws (ring := coeffRing) concretePower2RoundOps cInfNorm := by
   refine { power2Round_bound := ?_ }
   intro r
   change cInfNorm (coeffRing.sub _ _) ≤ _
@@ -1733,37 +1029,28 @@ theorem concretePower2RoundLaws :
   exact concretePower2Round_bound_field r
 
 theorem concreteRoundingLaws_of_isApproved (p : Params) (hp : p.isApproved) :
-    LatticeCrypto.RoundingOps.Laws (ring := coeffRing)
-      (concreteRoundingOps p) LatticeCrypto.cInfNorm := by
+    RoundingOps.Laws (ring := coeffRing) (concreteRoundingOps p) cInfNorm := by
   let cp := concreteRoundingOps p
   refine {
-    high_low_decomp := by
-      intro x
+    high_low_decomp x := by
       change coeffRing.add (cp.shift (cp.highBits x)) (cp.lowBits x) = x
       simp only [coeffRing_add_eq]
-      exact concreteRounding_high_low_decomp_field_of_isApproved p hp x
+      exact concreteRounding_high_low_decomp p x
     lowBits_bound := concreteRounding_lowBits_bound_field_of_isApproved p hp
-    hide_low := by
-      intro r s b h1 h2
+    hide_low r s b h1 h2 := by
       change cp.highBits (coeffRing.add r s) = cp.highBits r
       change cInfNorm (lowBits p r) + b < 2 * p.gamma2 / 2 at h2
       simp only [coeffRing_add_eq, gamma2_half] at ⊢ h2
       exact concreteRounding_hide_low_of_isApproved p hp r s b h1 h2
     shift_injective := concreteRounding_shift_injective_field_of_isApproved p hp
-    useHint_correct := by
-      intro z r h
+    useHint_correct z r h := by
       change cp.useHint (cp.makeHint z r) r = cp.highBits (coeffRing.add r z)
       simp only [coeffRing_add_eq]
       exact concreteRounding_useHint_correct_field_of_isApproved p hp z r h
-    useHint_bound := by
-      intro r h
+    useHint_bound r h := by
       change cInfNorm (coeffRing.sub _ _) ≤ _
       simp only [coeffRing_sub_eq]
       exact concreteRounding_useHint_bound_of_isApproved p hp r h
   }
-
-/-
-The concrete `Power2Round` and approved-parameter `RoundingOps` wrappers now compile.
--/
 
 end MLDSA.Concrete

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -143,7 +143,7 @@ def hintWeight (h : Hint) : ℕ :=
   h.toList.foldl (fun acc b => acc + cond b 1 0) 0
 
 @[simp] theorem Rq.get_zero (i : Fin ringDegree) : (0 : Rq).get i = 0 :=
-  Vector.getElem_zero i.1 i.2
+  NegacyclicRing.coeff_zero coeffRing i
 
 @[simp] theorem Rq.get_add (a b : Rq) (i : Fin ringDegree) :
     (a + b).get i = a.get i + b.get i :=

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -888,6 +888,11 @@ private theorem useHintCoeff_correct_of_small_of_isApproved (p : Params)
         highBitsCoeff_of_neg_overflow p hp r1 v hr1lt (by omega) hvneg hbdry hsum
       rw [hhint, huse, hgoal]
 
+theorem concreteRounding_high_low_decomp_of_isApproved (p : Params)
+    (_hp : p.isApproved) (r : Rq) :
+    highBitsShift p (highBits p r) + lowBits p r = r :=
+  concreteRounding_high_low_decomp p r
+
 theorem concreteRounding_lowBits_bound_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) :
     cInfNorm (lowBits p r) ≤ p.gamma2 :=

--- a/LatticeCrypto/Ring/Core.lean
+++ b/LatticeCrypto/Ring/Core.lean
@@ -134,6 +134,10 @@ def mapCoeffs {Coeff' : Type v}
     f (src.coeff p ⟨i.val, by
       exact Nat.lt_of_lt_of_eq i.isLt hdeg.symm⟩)
 
+@[ext] theorem ext_coeff {backend : PolyBackend Coeff} {p q : backend.Poly}
+    (h : ∀ i, backend.coeff p i = backend.coeff q i) : p = q :=
+  backend.build_coeff p ▸ backend.build_coeff q ▸ congr_arg backend.build (funext h)
+
 end PolyBackend
 
 

--- a/LatticeCrypto/Ring/Core.lean
+++ b/LatticeCrypto/Ring/Core.lean
@@ -134,6 +134,7 @@ def mapCoeffs {Coeff' : Type v}
     f (src.coeff p ⟨i.val, by
       exact Nat.lt_of_lt_of_eq i.isLt hdeg.symm⟩)
 
+/-- Two `backend.Poly` values are equal iff they agree on every coefficient. -/
 @[ext] theorem ext_coeff {backend : PolyBackend Coeff} {p q : backend.Poly}
     (h : ∀ i, backend.coeff p i = backend.coeff q i) : p = q :=
   backend.build_coeff p ▸ backend.build_coeff q ▸ congr_arg backend.build (funext h)

--- a/LatticeCrypto/Ring/Kernel.lean
+++ b/LatticeCrypto/Ring/Kernel.lean
@@ -20,6 +20,10 @@ Executable layer for the generic lattice ring architecture. Defines:
   `R[X] / (X^n + 1)` via a homomorphism `quotientOf`.
 - `schoolbookNegacyclicMul`: a backend-generic `O(n²)` reference multiplier
   implementing negacyclic convolution.
+- `coeff_add/sub/zero/neg`: `@[simp]` API projecting the four kernel axioms to
+  the `backend.coeff` accessor, used for coefficient-wise proof automation.
+- `AddCommGroup ring.Poly`: global instance derived from the coefficient axioms
+  via `ext_coeff`, so downstream code never needs local arithmetic instances.
 
 The executable / proof boundary is enforced structurally: `NegacyclicRing` is
 computable and carries no quotient types, while `NegacyclicRingSemantics` is
@@ -129,22 +133,27 @@ instance (ring : NegacyclicRing Coeff) : Sub ring.Poly :=
 instance (ring : NegacyclicRing Coeff) : Neg ring.Poly :=
   ⟨ring.neg⟩
 
+/-- Two `ring.Poly` values are equal iff they agree on every coefficient. -/
 theorem poly_ext {ring : NegacyclicRing Coeff} {p q : ring.Poly}
     (h : ∀ i, ring.backend.coeff p i = ring.backend.coeff q i) : p = q :=
   PolyBackend.ext_coeff h
 
+/-- The `i`-th coefficient of `f + g` equals the sum of the individual coefficients. -/
 @[simp] theorem coeff_add (ring : NegacyclicRing Coeff) (f g : ring.Poly) (i : Fin ring.degree) :
     ring.backend.coeff (f + g) i = ring.backend.coeff f i + ring.backend.coeff g i :=
   ring.add_coeff f g i
 
+/-- The `i`-th coefficient of `f - g` equals the difference of the individual coefficients. -/
 @[simp] theorem coeff_sub (ring : NegacyclicRing Coeff) (f g : ring.Poly) (i : Fin ring.degree) :
     ring.backend.coeff (f - g) i = ring.backend.coeff f i - ring.backend.coeff g i :=
   ring.sub_coeff f g i
 
+/-- Every coefficient of the zero polynomial is zero. -/
 @[simp] theorem coeff_zero (ring : NegacyclicRing Coeff) (i : Fin ring.degree) :
     ring.backend.coeff (0 : ring.Poly) i = 0 :=
   ring.zero_coeff i
 
+/-- The `i`-th coefficient of `-f` is the negation of the `i`-th coefficient of `f`. -/
 @[simp] theorem coeff_neg (ring : NegacyclicRing Coeff) (f : ring.Poly) (i : Fin ring.degree) :
     ring.backend.coeff (-f) i = -ring.backend.coeff f i :=
   ring.neg_coeff f i

--- a/LatticeCrypto/Ring/Kernel.lean
+++ b/LatticeCrypto/Ring/Kernel.lean
@@ -75,6 +75,10 @@ structure NegacyclicRing (Coeff : Type u) [CommRing Coeff] where
   sub : backend.Poly → backend.Poly → backend.Poly
   neg : backend.Poly → backend.Poly
   mul : backend.Poly → backend.Poly → backend.Poly
+  add_coeff : ∀ f g i, backend.coeff (add f g) i = backend.coeff f i + backend.coeff g i
+  sub_coeff : ∀ f g i, backend.coeff (sub f g) i = backend.coeff f i - backend.coeff g i
+  zero_coeff : ∀ i, backend.coeff zero i = 0
+  neg_coeff : ∀ f i, backend.coeff (neg f) i = -backend.coeff f i
 
 /-- Proof-facing soundness certificate for a `NegacyclicRing`.
 
@@ -124,6 +128,36 @@ instance (ring : NegacyclicRing Coeff) : Sub ring.Poly :=
 
 instance (ring : NegacyclicRing Coeff) : Neg ring.Poly :=
   ⟨ring.neg⟩
+
+theorem poly_ext {ring : NegacyclicRing Coeff} {p q : ring.Poly}
+    (h : ∀ i, ring.backend.coeff p i = ring.backend.coeff q i) : p = q :=
+  PolyBackend.ext_coeff h
+
+@[simp] theorem coeff_add (ring : NegacyclicRing Coeff) (f g : ring.Poly) (i : Fin ring.degree) :
+    ring.backend.coeff (f + g) i = ring.backend.coeff f i + ring.backend.coeff g i :=
+  ring.add_coeff f g i
+
+@[simp] theorem coeff_sub (ring : NegacyclicRing Coeff) (f g : ring.Poly) (i : Fin ring.degree) :
+    ring.backend.coeff (f - g) i = ring.backend.coeff f i - ring.backend.coeff g i :=
+  ring.sub_coeff f g i
+
+@[simp] theorem coeff_zero (ring : NegacyclicRing Coeff) (i : Fin ring.degree) :
+    ring.backend.coeff (0 : ring.Poly) i = 0 :=
+  ring.zero_coeff i
+
+@[simp] theorem coeff_neg (ring : NegacyclicRing Coeff) (f : ring.Poly) (i : Fin ring.degree) :
+    ring.backend.coeff (-f) i = -ring.backend.coeff f i :=
+  ring.neg_coeff f i
+
+instance (ring : NegacyclicRing Coeff) : AddCommGroup ring.Poly where
+  add_assoc a b c     := by ext i; simp only [coeff_add, add_assoc]
+  zero_add a          := by ext i; simp only [coeff_add, coeff_zero, zero_add]
+  add_zero a          := by ext i; simp only [coeff_add, coeff_zero, add_zero]
+  neg_add_cancel a    := by ext i; simp only [coeff_add, coeff_neg, neg_add_cancel, coeff_zero]
+  add_comm a b        := by ext i; simp only [coeff_add, add_comm]
+  sub_eq_add_neg a b  := by ext i; simp only [coeff_sub, coeff_add, coeff_neg, sub_eq_add_neg]
+  nsmul               := nsmulRec
+  zsmul               := zsmulRec
 
 /-- Indexed access into a polynomial carrier by coefficient position. -/
 instance (ring : NegacyclicRing Coeff) :

--- a/LatticeCrypto/Ring/Smoke.lean
+++ b/LatticeCrypto/Ring/Smoke.lean
@@ -68,6 +68,10 @@ def piRing (Coeff : Type*) [CommRing Coeff] (n : Nat) :
   sub := fun f g i => f i - g i
   neg := fun f i => -f i
   mul := negacyclicMulPure (piKernel Coeff n)
+  add_coeff  _ _ _ := rfl
+  sub_coeff  _ _ _ := rfl
+  zero_coeff _     := rfl
+  neg_coeff  _ _   := rfl
 
 /-- Quotient semantics for the function-backed negacyclic ring. -/
 noncomputable def piSemantics (Coeff : Type*) [CommRing Coeff] (n : Nat) :

--- a/LatticeCrypto/Ring/VectorBackend.lean
+++ b/LatticeCrypto/Ring/VectorBackend.lean
@@ -101,6 +101,10 @@ def vectorNegacyclicRing (Coeff : Type u) [CommRing Coeff] (n : Nat) :
   sub := fun f g => Vector.ofFn fun i => f.get i - g.get i
   neg := fun f => Vector.ofFn fun i => -f.get i
   mul := negacyclicMulPure (vectorKernel Coeff n)
+  add_coeff f g i := by simp [vectorBackend, Vector.ofFn, Vector.get]
+  sub_coeff f g i := by simp [vectorBackend, Vector.ofFn, Vector.get]
+  neg_coeff f i   := by simp [vectorBackend, Vector.ofFn, Vector.get]
+  zero_coeff i    := by simp [vectorBackend, Vector.get]
 
 section VectorRingSimp
 


### PR DESCRIPTION
## Summary

- **`Ring/Core.lean`**: Tag `PolyBackend.ext_coeff` with `@[ext]`, enabling
  `ext i` in downstream ring proofs.
- **`Ring/Kernel.lean`**: Add four coefficient-axiom fields to `NegacyclicRingKernel`
  (`add_coeff`, `sub_coeff`, `zero_coeff`, `neg_coeff`); expose them as `@[simp]`
  lemmas `coeff_add/sub/zero/neg`; derive a global `AddCommGroup ring.Poly` instance
  from these axioms via `ext`-based proofs.
- **`Ring/VectorBackend.lean`**: Fill the four new fields for `vectorNegacyclicRing`.
- **`MLDSA/Arithmetic.lean`**: Re-export `instance : AddCommGroup Rq := inferInstance`
  so downstream files resolve the instance through the `abbrev` chain.
- **`MLDSA/Concrete/Rounding.lean`**: Replace local `Add`/`Sub`/`Neg`/`Zero`/`nsmul`/
  `zsmul` definitions and `instRqAddCommGroup` with the global `AddCommGroup ring.Poly`
  instance. Rewrite `get_add/sub/neg` lemmas via the new `coeff_*` API. Simplify
  multiple proofs using `split_ifs <;> omega` and the bundled `BalancedDecomp`
  structure. Net: −1296 / +627 lines, no `sorry` introduced.

## Theorem statement changes

- `concreteRounding_high_low_decomp`: dropped the `hγ : 0 < p.gamma2` argument
  (now derivable from the decomposition structure directly).

