### PR TITLE
refactor(MLDSA/Concrete/Rounding): rename private lemmas, simplify proofs via suffices

### DIFF
--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -467,25 +467,6 @@ private theorem alpha_le_natAbs_centeredRepr_mul
       _ ≤ alpha * m             := Nat.mul_le_mul_left alpha (Nat.succ_le_of_lt hzm)
       _ ≤ alpha * m + 1         := Nat.le_succ _
 
-private theorem decomposeCoeff_unique {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
-    {r : Coeff} (r1 : ℕ) (r0 : ℤ)
-    (hr1 : r1 < m)
-    (hr0 : r0.natAbs ≤ alpha / 2)
-    (hr0_neg : r0 < 0 → r1 = 0 ∨ r0.natAbs < alpha / 2)
-    (hdecomp : (alpha : Coeff) * (r1 : Coeff) + r0 = r) :
-    decomposeCoeff r (alpha / 2) = (r1, r0) := by
-  have h1 := highBitsCoeff_eq_of_repr ctx r1 r0 hr1 hr0 hr0_neg hdecomp
-  have hdecomp' : (alpha : Coeff) * r1 + lowBitsCoeff r (alpha / 2) = r := by
-    have h := decomposeCoeff_eq r ctx.h2α (Prod.eta _)
-    simp only [highBitsCoeff, lowBitsCoeff, ← h1] at h ⊢; exact h
-  have hlow_eq := add_left_cancel (hdecomp'.trans hdecomp.symm)
-  have h2 : lowBitsCoeff r (alpha / 2) = r0 := by
-    have cr_eq := congrArg centeredRepr hlow_eq
-    have hγ2 := by have := ctx.hq; rwa [← ctx.h2α] at this
-    rwa [centeredRepr_intCast_lowBitsCoeff r ctx.hγ hγ2,
-        centeredRepr_intCast_eq_of_natAbs_le r0 hr0 hγ2] at cr_eq
-  exact Prod.ext h1 h2
-
 private theorem highBitsCoeff_add_eq_of_centeredRepr_lt
     {alpha m b : ℕ} (ctx : BalancedDecomp alpha m) (r s : Coeff)
     (hs : (centeredRepr s).natAbs ≤ b)
@@ -496,54 +477,40 @@ private theorem highBitsCoeff_add_eq_of_centeredRepr_lt
   let z : ℤ := centeredRepr s
   let v : ℤ := r0 + z
   by_contra hneq; push Not at hneq
+  suffices h : ∃ (lo hi : ℕ) (e1 e2 : ℤ), lo < hi ∧ hi < m ∧ (e1 - e2).natAbs ≤ alpha - 1 ∧
+      alpha * (lo : Coeff) + e1 = alpha * (hi : Coeff) + e2 by
+    obtain ⟨lo, hi, e1, e2, hlt, hhi, hbound, heq'⟩ := h
+    let delta := (hi : ℤ) - (lo : ℤ)
+    have hbig := alpha_le_natAbs_centeredRepr_mul (z := delta) ctx (by omega) (by omega)
+    have hsmallq : 2 * (alpha - 1) < modulus := by have := ctx.hsmall; omega
+    have hdeltaeq : alpha * (delta : Coeff) = e1 - e2 := by
+      zify [delta, mul_sub]
+      apply sub_eq_sub_iff_add_eq_add.mpr
+      ring_nf; exact heq'.symm
+    rw [hdeltaeq, ← Int.cast_sub, centeredRepr_intCast_eq_of_natAbs_le _ hbound hsmallq] at hbig
+    exact absurd (hbig.trans hbound) (Nat.not_le.mpr (Nat.sub_lt ctx.hα one_pos))
   have hdiffbound : (v - w).natAbs ≤ alpha - 1 := by
     have hwbound := lowBitsCoeff_bound (r := r + s) ctx.hγ hdecomp_rs
     have hvbound : v.natAbs ≤ alpha / 2 - 1 := by
       rw [lowBitsCoeff, hdecomp_r] at hr
-      have h1 : r0.natAbs ≤ alpha / 2 - b - 1 := Nat.le_pred_of_lt hr
-      have h2 := Int.natAbs_add_le r0 z
+      have := Int.natAbs_add_le r0 z
       omega
-    have : alpha / 2 - 1 + alpha / 2 = alpha - 1 := by
-      nth_rewrite 3 [← ctx.h2α]
-      rw [two_mul, add_comm, Nat.add_sub_assoc]
-      omega
-    exact (Int.natAbs_sub_le v w).trans (Nat.add_le_add hvbound hwbound |>.trans_eq this)
+    have := Int.natAbs_sub_le v w
+    have := ctx.h2α
+    omega
   have heq : alpha * (u : Coeff) + w = alpha * (r1 : Coeff) + v := by
     have hcandidate : (alpha * (r1 : Coeff)) + v = r + s := by
       rw [centeredRepr_intCast s, Int.cast_add, ← add_assoc, decomposeCoeff_eq r ctx.h2α hdecomp_r]
     exact (decomposeCoeff_eq (r + s) ctx.h2α hdecomp_rs).trans hcandidate.symm
-  have contra : ∀ (lo hi : ℕ) (e1 e2 : ℤ),
-      lo < hi → hi < m →
-      (e1 - e2).natAbs ≤ alpha - 1 →
-      alpha * (lo : Coeff) + e1 = alpha * (hi : Coeff) + e2 →
-      False := fun lo hi e1 e2 hlt hhi hbound heq' => by
-    let delta := (hi : ℤ) - (lo : ℤ)
-    have hbig := alpha_le_natAbs_centeredRepr_mul (z:= delta) ctx (by omega) (by omega)
-    have hsmallq : 2 * (alpha - 1) < modulus := by have := ctx.hsmall; omega
-    have hdeltaeq : alpha * (delta : Coeff) = e1 - e2 := by
-      zify[delta, mul_sub]
-      apply sub_eq_sub_iff_add_eq_add.mpr
-      ring_nf
-      exact heq'.symm
-    rw [hdeltaeq, ← Int.cast_sub, centeredRepr_intCast_eq_of_natAbs_le _ hbound hsmallq] at hbig
-    exact absurd (hbig.trans hbound) (Nat.not_le.mpr (Nat.sub_lt ctx.hα one_pos))
-  have hlt_or_gt : r1 < u ∨ u < r1 := by
-    simp only [highBitsCoeff, hdecomp_rs, hdecomp_r] at hneq
-    exact lt_or_gt_of_ne hneq.symm
-  cases hlt_or_gt with
+  simp only [highBitsCoeff, hdecomp_rs, hdecomp_r] at hneq
+  cases show r1 < u ∨ u < r1 from lt_or_gt_of_ne hneq.symm with
   | inl hr1ltu =>
-      have hult : u < m := by
-        have := highBitsCoeff_lt_m ctx (r + s)
-        rwa [highBitsCoeff, hdecomp_rs] at this
-      exact contra r1 u v w hr1ltu hult hdiffbound heq.symm
+    use r1, u, v, w; refine ⟨hr1ltu, ?_, hdiffbound, heq.symm⟩
+    · simpa [highBitsCoeff, hdecomp_rs] using highBitsCoeff_lt_m ctx (r + s)
   | inr hultr1 =>
-      have hdiffbound2: (w - v).natAbs ≤ alpha - 1 := by
-        rw [show w - v = -(v - w) from by ring, Int.natAbs_neg]
-        exact hdiffbound
-      have hr1lt : r1 < m := by
-        have := highBitsCoeff_lt_m ctx r
-        rwa [highBitsCoeff, hdecomp_r] at this
-      exact contra u r1 w v hultr1 hr1lt hdiffbound2 heq
+    use u, r1, w, v; refine ⟨hultr1, ?_, ?_, heq⟩
+    · simpa [highBitsCoeff, hdecomp_r] using highBitsCoeff_lt_m ctx r
+    · rw [show w - v = -(v - w) from by ring, Int.natAbs_neg]; exact hdiffbound
 
 private theorem useHintCoeff_shift_sub_le
     {alpha m : ℕ} (ctx : BalancedDecomp alpha m) (hbit : Bool) (r : Coeff) :
@@ -552,9 +519,7 @@ private theorem useHintCoeff_shift_sub_le
         alpha + 1 := by
   rcases hdec : decomposeCoeff r (alpha / 2) with ⟨r1, r0⟩
   have hdecomp : alpha * (r1 : Coeff) + r0 = r := decomposeCoeff_eq r ctx.h2α hdec
-  have hr1lt : r1 < m := by
-    have := highBitsCoeff_lt_m ctx r
-    rwa [highBitsCoeff, hdec] at this
+  have hr1lt : r1 < m := by simpa [highBitsCoeff, hdec] using highBitsCoeff_lt_m ctx r
   have hr0bound := lowBitsCoeff_bound r ctx.hγ hdec
   suffices h : ∃ v : ℤ, r - (alpha : Coeff) * (useHintCoeff _ r (alpha / 2) : Coeff) = v
       ∧ v.natAbs ≤ alpha + 1 by
@@ -575,48 +540,25 @@ private theorem useHintCoeff_shift_sub_le
         · use r0 - alpha - 1; constructor
           · rw [show useHintCoeff true r (alpha / 2) = 0 by
                 simp [useHintCoeff, hdec, hr0pos, ctx.h2α, ctx.hmdef, show r1 + 1 = m by omega]]
-            zify [← hdecomp, show r1 = m - 1 by omega, alpha_mul_pred_m_eq ctx]
+            simp [← hdecomp, show r1 = m - 1 by omega, alpha_mul_pred_m_eq ctx]
             ring_nf
           · omega
       · by_cases hr1zero : r1 = 0
         · use r0 + alpha + 1; constructor
-          · have huse : useHintCoeff true r (alpha / 2) = m - 1 := by
-              have hpred : (m - 1) % m = m - 1 := Nat.mod_eq_of_lt (Nat.pred_lt ctx.hm.ne')
-              simp [useHintCoeff, hdec, hr0pos, hr1zero, ctx.h2α, ctx.hmdef, hpred]
-            rw [huse, alpha_mul_pred_m_eq ctx, ← hdecomp, hr1zero]
-            simp [sub_sub_eq_add_sub]
+          · rw [show useHintCoeff true r (alpha / 2) = m - 1 by
+                  simp [useHintCoeff, hdec, hr0pos, hr1zero, ctx.h2α, ctx.hmdef],
+              alpha_mul_pred_m_eq ctx, ← hdecomp, hr1zero]
+            push_cast; ring_nf
           · omega
         · use r0 + alpha; constructor
           · have huse : useHintCoeff true r (alpha / 2) = r1 - 1 := by
-              have hmod' : (r1 + m - 1) % m = r1 - 1 := by
-                rw [show r1 + m - 1 = r1 - 1 + m by omega, Nat.add_mod_right,
+              simp only [useHintCoeff, hdec, hr0pos, ctx.h2α, ctx.hmdef]
+              change (r1 + m - 1) % m = r1 - 1
+              rw [show r1 + m - 1 = r1 - 1 + m by omega, Nat.add_mod_right,
                     Nat.mod_eq_of_lt (by omega)]
-              simp [useHintCoeff, hdec, hr0pos, ctx.h2α, ctx.hmdef, hmod']
-            rw [huse, ← hdecomp, Nat.cast_sub (Nat.pos_of_ne_zero hr1zero),
-              Nat.succ_eq_add_one, zero_add, Nat.cast_one, Int.cast_add, Int.cast_natCast]
-            ring_nf
+            rw [huse, ← hdecomp, Nat.cast_sub (Nat.pos_of_ne_zero hr1zero)]
+            push_cast; ring_nf
           · omega
-
-private theorem decomposeCoeff_mid_of_isApproved
-    {alpha m : ℕ} (ctx : BalancedDecomp alpha m) (r : Coeff) (z0 r0 : ℤ) (r1 : ℕ)
-    (hdec : decomposeCoeff r (alpha / 2) = (r1, r0))
-    (hvlow : -(alpha / 2 : ℤ) < r0 + z0)
-    (hvup : r0 + z0 ≤ alpha / 2) :
-    decomposeCoeff (r + z0) (alpha / 2) =
-      (highBitsCoeff r (alpha / 2), lowBitsCoeff r (alpha / 2) + z0) := by
-  set v : ℤ := r0 + z0
-  have hr1lt : r1 < m := by
-    have := highBitsCoeff_lt_m ctx r
-    rwa [highBitsCoeff, hdec] at this
-  have hcore : alpha * (r1 : Coeff) + v = r + z0 := by
-    dsimp [v]; push_cast; rw [← add_assoc, decomposeCoeff_eq r ctx.h2α hdec]
-  have hv_bound : v.natAbs ≤ alpha / 2 := natAbs_le_of_neg_le_and_le (le_of_lt hvlow) hvup
-  have hv_neg_cond : v < 0 → r1 = 0 ∨ v.natAbs < alpha / 2 := fun hvneg =>
-    Or.inr (by
-      have h : (v.natAbs : ℤ) = -v := Int.ofNat_natAbs_of_nonpos hvneg.le
-      exact_mod_cast h ▸ (show -v < alpha / 2 by omega))
-  rw [decomposeCoeff_unique ctx r1 v hr1lt hv_bound hv_neg_cond hcore]
-  simp [highBitsCoeff, lowBitsCoeff, v, hdec]
 
 private theorem highBitsCoeff_eq_of_pos_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {s : Coeff} (r1 : ℕ) (v : ℤ)
@@ -625,19 +567,20 @@ private theorem highBitsCoeff_eq_of_pos_overflow {alpha m : ℕ} (ctx : Balanced
     (hv_hi : v ≤ (alpha : ℤ))
     (hsum : alpha * (r1 : Coeff) + v = s) :
     highBitsCoeff s (alpha/2) = (r1 + 1) % m := by
-  have : v - (alpha :ℤ ) ≤ 0 := by omega
   have h2α := ctx.h2α
+  suffices h : ∃ (r1' : ℕ) (r0' : ℤ), (r1 + 1) % m = r1' ∧ r1' < m ∧ r0'.natAbs ≤ alpha / 2 ∧
+      (r0' < 0 → r1' = 0 ∨ r0'.natAbs < alpha / 2) ∧ alpha * r1' + r0' = s by
+    obtain ⟨r1', r0', hr1eq, hr1', hr0', hr0_neg', hdecomp⟩ := h
+    rw [hr1eq]; exact highBitsCoeff_eq_of_repr ctx r1' r0' hr1' hr0' hr0_neg' hdecomp
   by_cases hwrap : r1 + 1 < m
-  · rw [Nat.mod_eq_of_lt hwrap]
-    exact highBitsCoeff_eq_of_repr ctx (r1+1) (v - alpha) hwrap (by omega) (by omega)
-      (by rw [← hsum, Nat.cast_add, Nat.cast_one]; push_cast; ring)
-  · push Not at hwrap
-    rw [show r1 + 1 = m  by omega, Nat.mod_self]
-    exact highBitsCoeff_eq_of_repr ctx 0 (v - alpha - 1) ctx.hm (by omega) (by omega)
-      (by
-        rw [Nat.cast_zero, mul_zero, zero_add, ← hsum,
-        show r1 = m - 1 from by omega, alpha_mul_pred_m_eq ctx]
-        push_cast; ring)
+  · use r1 + 1, v - alpha
+    refine ⟨Nat.mod_eq_of_lt hwrap, hwrap, by omega, by omega, ?_⟩
+    rw [← hsum, Nat.cast_add, Nat.cast_one]; push_cast; ring
+  · use 0, v - alpha - 1
+    refine ⟨by rw [show r1 + 1 = m by omega, Nat.mod_self], ctx.hm, by omega, by omega, ?_⟩
+    rw [Nat.cast_zero, mul_zero, zero_add, ← hsum,
+      show r1 = m - 1 from by omega, alpha_mul_pred_m_eq ctx]
+    push_cast; ring
 
 private theorem highBitsCoeff_eq_of_neg_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {s : Coeff} (r1 : ℕ) (v : ℤ)
@@ -647,16 +590,20 @@ private theorem highBitsCoeff_eq_of_neg_overflow {alpha m : ℕ} (ctx : Balanced
     (hsum : alpha * (r1 : Coeff) + v = s) :
     highBitsCoeff s (alpha / 2) = (r1 + m - 1) % m := by
   have h2α := ctx.h2α
+  suffices h : ∃ (r1' : ℕ) (r0' : ℤ), (r1 + m - 1) % m = r1' ∧ r1' < m ∧ r0'.natAbs ≤ alpha / 2 ∧
+      (r0' < 0 → r1' = 0 ∨ r0'.natAbs < alpha / 2) ∧ alpha * r1' + r0' = s by
+    obtain ⟨r1', r0', hr1eq, hr1', hr0', hr0_neg', hdecomp⟩ := h
+    rw [hr1eq]; exact highBitsCoeff_eq_of_repr ctx r1' r0' hr1' hr0' hr0_neg' hdecomp
   rcases Nat.eq_zero_or_pos r1 with hr1z | hr1pos
-  · rw [hr1z, zero_add, Nat.mod_eq_of_lt (Nat.sub_lt ctx.hm (by decide))]
-    exact highBitsCoeff_eq_of_repr ctx
-      (m - 1) (v + alpha + 1) (Nat.pred_lt ctx.hm.ne') (by omega) (by omega)
-      (by rw [alpha_mul_pred_m_eq ctx, ← hsum, hr1z]; push_cast; ring)
-  · rw [show r1 + m - 1 = (r1 - 1) + m from by omega,
+  · use m - 1, v + alpha + 1
+    refine ⟨?_, Nat.pred_lt ctx.hm.ne', by omega, by omega, ?_⟩
+    · rw [hr1z, zero_add, Nat.mod_eq_of_lt (Nat.sub_lt ctx.hm (by decide))]
+    · rw [alpha_mul_pred_m_eq ctx, ← hsum, hr1z]; push_cast; ring
+  · use r1 - 1, v + alpha
+    refine ⟨?_, show r1 - 1 < m by omega, by omega, by omega, ?_⟩
+    · rw [show r1 + m - 1 = (r1 - 1) + m from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt (by omega)]
-    exact highBitsCoeff_eq_of_repr ctx (r1 - 1) (v + alpha)
-      (show r1 - 1 < m by omega) (by omega) (by omega)
-      (by rw [Nat.cast_sub hr1pos, ← hsum]; push_cast; ring)
+    · rw [Nat.cast_sub hr1pos, ← hsum]; push_cast; ring
 
 private theorem useHintCoeff_makeHintCoeff_eq_of_small
     {alpha m : ℕ} (ctx : BalancedDecomp alpha m) (z r : Coeff)
@@ -686,9 +633,14 @@ private theorem useHintCoeff_makeHintCoeff_eq_of_small
         simp [useHintCoeff, hdec, show 0 < r0 by omega, ctx.h2α, ctx.hmdef]
       simp only [makeHintCoeff, ne_eq, hneq, not_false_eq_true, decide_true, huse]
       exact (highBitsCoeff_eq_of_pos_overflow ctx r1 v hr1lt (by omega) (by omega) hsum).symm
-    · have : highBitsCoeff (r + z) (alpha / 2) = highBitsCoeff r (alpha / 2) := by
-        rw [highBitsCoeff, hzcast, decomposeCoeff_mid_of_isApproved ctx r z0 r0 r1 hdec hlo hhi]
-      exact absurd this.symm hneq
+    · by_contra; apply hneq.symm
+      suffices h : highBitsCoeff (r + ↑z0) (alpha / 2) = r1 by
+        rw [hzcast, h]; simp [highBitsCoeff, hdec]
+      refine highBitsCoeff_eq_of_repr ctx (r := r + z0) r1 (r0 + z0) ?_ ?_ ?_ ?_
+      · simpa [highBitsCoeff, hdec] using highBitsCoeff_lt_m ctx r
+      · exact natAbs_le_of_neg_le_and_le (le_of_lt hlo) hhi
+      · intros; right; omega
+      · push_cast; rw [← add_assoc, decomposeCoeff_eq r ctx.h2α hdec]
     · have huse : useHintCoeff true r (alpha / 2) = (r1 + m - 1) % m := by
         simp [useHintCoeff, hdec, show ¬0 < r0 by omega, ctx.h2α, ctx.hmdef]
       have hv_hi : v < -(alpha / 2 : ℤ) ∨ (v = -(alpha / 2 : ℤ) ∧ 0 < r1) := by

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -503,12 +503,10 @@ private theorem highBitsCoeff_add_eq_of_centeredRepr_lt
       rw [centeredRepr_intCast s, Int.cast_add, ← add_assoc, decomposeCoeff_eq r ctx.h2α hdecomp_r]
     exact (decomposeCoeff_eq (r + s) ctx.h2α hdecomp_rs).trans hcandidate.symm
   simp only [highBitsCoeff, hdecomp_rs, hdecomp_r] at hneq
-  cases show r1 < u ∨ u < r1 from lt_or_gt_of_ne hneq.symm with
-  | inl hr1ltu =>
-    use r1, u, v, w; refine ⟨hr1ltu, ?_, hdiffbound, heq.symm⟩
+  rcases lt_or_gt_of_ne hneq.symm with hr1ltu | hultr1
+  · use r1, u, v, w; refine ⟨hr1ltu, ?_, hdiffbound, heq.symm⟩
     · simpa [highBitsCoeff, hdecomp_rs] using highBitsCoeff_lt_m ctx (r + s)
-  | inr hultr1 =>
-    use u, r1, w, v; refine ⟨hultr1, ?_, ?_, heq⟩
+  · use u, r1, w, v; refine ⟨hultr1, ?_, ?_, heq⟩
     · simpa [highBitsCoeff, hdecomp_r] using highBitsCoeff_lt_m ctx r
     · rw [show w - v = -(v - w) from by ring, Int.natAbs_neg]; exact hdiffbound
 
@@ -534,21 +532,20 @@ private theorem useHintCoeff_shift_sub_le
         · use r0 - alpha; constructor
           · simp only [useHintCoeff, if_true, hdec, hr0pos, ctx.h2α, ctx.hmdef]
             rw [Nat.mod_eq_of_lt hwrap, ←hdecomp]
-            push_cast
-            ring_nf
+            push_cast; ring
           · omega
         · use r0 - alpha - 1; constructor
           · rw [show useHintCoeff true r (alpha / 2) = 0 by
                 simp [useHintCoeff, hdec, hr0pos, ctx.h2α, ctx.hmdef, show r1 + 1 = m by omega]]
             simp [← hdecomp, show r1 = m - 1 by omega, alpha_mul_pred_m_eq ctx]
-            ring_nf
+            ring
           · omega
       · by_cases hr1zero : r1 = 0
         · use r0 + alpha + 1; constructor
           · rw [show useHintCoeff true r (alpha / 2) = m - 1 by
                   simp [useHintCoeff, hdec, hr0pos, hr1zero, ctx.h2α, ctx.hmdef],
               alpha_mul_pred_m_eq ctx, ← hdecomp, hr1zero]
-            push_cast; ring_nf
+            push_cast; ring
           · omega
         · use r0 + alpha; constructor
           · have huse : useHintCoeff true r (alpha / 2) = r1 - 1 := by
@@ -557,7 +554,7 @@ private theorem useHintCoeff_shift_sub_le
               rw [show r1 + m - 1 = r1 - 1 + m by omega, Nat.add_mod_right,
                     Nat.mod_eq_of_lt (by omega)]
             rw [huse, ← hdecomp, Nat.cast_sub (Nat.pos_of_ne_zero hr1zero)]
-            push_cast; ring_nf
+            push_cast; ring
           · omega
 
 private theorem highBitsCoeff_eq_of_pos_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
@@ -657,13 +654,6 @@ private theorem useHintCoeff_makeHintCoeff_eq_of_small
       simp only [makeHintCoeff, ne_eq, hneq, not_false_eq_true, decide_true, huse]
       rw [highBitsCoeff_eq_of_neg_overflow ctx r1 v hr1lt (by omega) hv_hi hsum]
 
-private theorem mul_left_injective_of_isUnit {c : Coeff} (hc : IsUnit c) :
-    Function.Injective fun x : Coeff => c * x := by
-  intro x y hxy
-  rcases hc with ⟨u, rfl⟩
-  have hxy' := congrArg (fun z : Coeff => ↑u⁻¹ * z) hxy
-  simpa [mul_assoc] using hxy'
-
 theorem highBitsShift_injective_of_isApproved (p : Params)
     (hp : p.isApproved) :
     Function.Injective (highBitsShift p) := by
@@ -671,7 +661,7 @@ theorem highBitsShift_injective_of_isApproved (p : Params)
   refine Poly.ext_get_eq fun j => ?_
   have hcoeff : (2 * p.gamma2 : ℕ) * x.get j = (2 * p.gamma2 : ℕ) * y.get j := by
     simpa [highBitsShift] using congrArg (fun v : Rq => v.get j) hxy
-  exact mul_left_injective_of_isUnit (BalancedDecomp.ofApproved hp).hunit hcoeff
+  exact IsUnit.mul_right_injective (BalancedDecomp.ofApproved hp).hunit hcoeff
 
 /-- Concrete `Power2RoundOps` with `Power2High = Rq`. -/
 def concretePower2RoundOps : MLDSA.Power2RoundOps where

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -355,19 +355,6 @@ private theorem alpha_mul_pred_m_eq {alpha m : ℕ} (ctx : BalancedDecomp alpha 
     ctx.hqm1, Nat.cast_sub (show 1 ≤ modulus by decide), ZMod.natCast_self]
   ring_nf
 
-private theorem highBitsCoeff_of_euclid {r : Coeff} {alpha q t r1 : ℕ}
-    (hα : 0 < alpha) (h2α : 2 * (alpha / 2) = alpha)
-    (hval : r.val = alpha * q + t) (ht : t < alpha)
-    (hside : (t ≤ alpha / 2 ∧ r1 = q) ∨ (alpha / 2 < t ∧ r1 = q + 1))
-    (hwrap : alpha * r1 ≠ modulus - 1) :
-    highBitsCoeff r (alpha / 2) = r1 := by
-  have hmod : r.val % alpha = t := by
-    rw [hval, Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt ht]
-  have hdiv : r.val / alpha = q := by
-    rw [hval, Nat.add_comm, Nat.add_mul_div_left _ _ hα, Nat.div_eq_of_lt ht, zero_add]
-  simp only [highBitsCoeff, decomposeCoeff, h2α, hmod, hdiv]
-  rcases hside with ⟨hle, rfl⟩ | ⟨hgt, rfl⟩ <;> simp_all; simp [not_le.mpr hgt]
-
 private theorem highBitsCoeff_eq_of_repr {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {r : Coeff} (r1 : ℕ) (r0 : ℤ)
     (hr1 : r1 < m)
@@ -375,87 +362,84 @@ private theorem highBitsCoeff_eq_of_repr {alpha m : ℕ} (ctx : BalancedDecomp a
     (hr0_neg : r0 < 0 → r1 = 0 ∨ r0.natAbs < alpha / 2)
     (hdecomp : (alpha : Coeff) * (r1 : Coeff) + r0 = r) :
     highBitsCoeff r (alpha / 2) = r1 := by
-  simp only [highBitsCoeff, decomposeCoeff]
   set n := r0.natAbs
   have hn_lt : n < alpha := by have := ctx.hα; omega
-  have hmul : alpha * (m - 1) + alpha = alpha * m := by
-    rw [Nat.mul_sub_one, Nat.sub_add_cancel]
-    exact Nat.le_mul_of_pos_right alpha ctx.hm
   have hltq : alpha * r1 + n < modulus := by
     have hle : alpha * r1 + n ≤ alpha * (m - 1) + alpha/2 :=
       Nat.add_le_add (Nat.mul_le_mul_left alpha (by omega)) (by simp [hr0])
     have htop : alpha * (m - 1) + alpha/2 < modulus := by
       rw [Nat.mul_sub_one, ctx.hqm1]
-      have := ctx.hqm1
+      have hle : alpha ≤ modulus - 1 := ctx.hqm1 ▸ Nat.le_mul_of_pos_right alpha ctx.hm
       omega
     linarith
-  by_cases hr0nn: 0 ≤ r0
-  · have hval : r.val = alpha * r1 + r0.natAbs := by
-      have hrcast : r = ((alpha * r1 + n : ℕ) : Coeff) := by
-        simp [← hdecomp, n]
-        congr 1
-        simp [abs_eq_self.mpr hr0nn]
+  suffices hRecoverPath : ∃ (q t : ℕ), r.val = alpha * q + t ∧ t < alpha ∧
+      ((  t ≤ alpha / 2 ∧ ((alpha * q       = modulus - 1 ∧ r1 = 0) ∨ r1 = q )) ∨
+      (   alpha / 2 < t ∧ ((alpha * (q + 1) = modulus - 1 ∧ r1 = 0) ∨ r1 = q + 1))) by
+    obtain ⟨q, t, hrepr, ht, hside⟩ := hRecoverPath
+    have hmod : r.val % alpha = t := by
+      rw [hrepr, Nat.add_comm, Nat.add_mul_mod_self_left, Nat.mod_eq_of_lt ht]
+    have hdiv : r.val / alpha = q := by
+      rw [hrepr, Nat.add_comm, Nat.add_mul_div_left _ _ ctx.hα, Nat.div_eq_of_lt ht, zero_add]
+    simp only [highBitsCoeff, decomposeCoeff, ctx.h2α, hmod, hdiv]
+    have hwrap : alpha * r1 ≠ modulus - 1 :=
+      ne_of_lt (by rw [← ctx.hqm1]; exact Nat.mul_lt_mul_of_pos_left hr1 ctx.hα)
+    rcases hside with ⟨hle, hcond2⟩ | ⟨hgt, hcond2⟩
+    · rcases hcond2 with ⟨heq, hr1z⟩ | ⟨hr1q⟩
+      · simp [hle, heq, hr1z]
+      · simp [hle, ← hr1q, hwrap]
+    · rcases hcond2 with ⟨heq, hr1z⟩ | ⟨hr1q⟩
+      · simp [not_le.mpr hgt, heq, hr1z]
+      · simp [not_le.mpr hgt, ← hr1q, hwrap]
+  cases le_or_gt 0 r0 with
+  | inl hr0nn =>
+    refine ⟨r1, r0.natAbs, ?_, by omega, ?_⟩
+    · have hrcast : r = ((alpha * r1 + n : ℕ) : Coeff) := by
+        simp [← hdecomp, n]; congr 1; simp [abs_eq_self.mpr hr0nn]
       rw [hrcast, ZMod.val_natCast_of_lt hltq]
-    have hwrap : alpha * r1 ≠ modulus - 1 := ne_of_lt
-      (by rw [← ctx.hqm1]; exact Nat.mul_lt_mul_of_pos_left hr1 ctx.hα)
-    exact highBitsCoeff_of_euclid ctx.hα ctx.h2α hval
-      (by omega) (Or.inl ⟨(show n ≤ alpha/2 by omega), rfl⟩) hwrap
-  · by_cases hr1z : r1 = 0
-    · push Not at hr0nn
-      have hrn : r = -(n : ℤ) := by
-        simp [hr1z, ← hdecomp, n, abs_eq_neg_self.mpr (Int.le_of_lt hr0nn)]
-      have hnltq : n < modulus := lt_of_le_of_lt hr0 (by have := ctx.hq; omega)
+    · left; exact ⟨show n ≤ alpha/2 by omega, by right; rfl⟩
+  | inr hr0neg =>
+    cases Nat.eq_zero_or_pos r1 with
+    | inl hr1z =>
+      have hrn : r = -(n : ℤ) := by simp [hr1z, ← hdecomp, n, abs_eq_neg_self.mpr hr0neg.le]
+      have hnltq : n < modulus := by simp only [hr1z, mul_zero, zero_add] at hltq; exact hltq
       have hneq : ((n : ℕ) : Coeff) ≠ 0 := by
-        intro h
-        exact absurd
-          (Nat.le_of_dvd (Int.natAbs_pos.mpr hr0nn.ne) ((ZMod.natCast_eq_zero_iff n modulus).mp h))
-          hnltq.not_ge
+        by_contra h; exact hnltq.not_ge
+          (Nat.le_of_dvd (Int.natAbs_pos.mpr hr0neg.ne) ((ZMod.natCast_eq_zero_iff n modulus).mp h))
       have hval : r.val = modulus - n := by
         haveI : NeZero ((n : ℕ) : Coeff) := ⟨hneq⟩
         simp [hrn, ZMod.val_neg_of_ne_zero n, ZMod.val_natCast_of_lt hnltq]
       by_cases hn1 : n = 1
-      · simp_rw [hn1] at *
-        have hcond1 : r.val % alpha ≤ alpha / 2 := by
-          simp only [hval, ← ctx.hqm1, Nat.mul_mod_right, zero_le]
-        have hcond2 : alpha * (r.val / alpha) = modulus - 1 := by
-          rw [hval, ← ctx.hqm1, Nat.mul_div_cancel_left _ ctx.hα, ctx.hqm1]
-        simp [hr1z, ctx.h2α, hcond1, hcond2]
-      · have hrepr : modulus - n = (alpha + 1 - n) + (m - 1) * alpha := by
-          rw [Nat.sub_mul, mul_comm, ctx.hqm1, one_mul]
+      · refine ⟨m, 0, ?_, ctx.hα, ?_⟩
+        · simp [hn1, hval, ctx.hqm1]
+        · left; exact ⟨by omega, by left; exact ⟨ctx.hqm1, hr1z⟩⟩
+      · refine ⟨m - 1, alpha + 1 - n, ?_, by omega, ?_⟩
+        · change r.val = alpha * (m - 1) + (alpha + 1 - n)
+          rw [hval, Nat.mul_sub, mul_one, ctx.hqm1]
           zify [show n ≤ alpha + 1 by omega,
-                show alpha ≤ modulus - 1 by haveI := ctx.hqm1; omega,
+                ctx.hqm1 ▸ Nat.le_mul_of_pos_right alpha ctx.hm,
                 show 1 ≤ modulus by omega, hnltq.le]
-          ring_nf
-        have hltα : alpha + 1 - n < alpha := by omega
-        have hcond1 : ¬(r.val % alpha ≤ alpha / 2) := by
-          rw [hval, hrepr, Nat.add_mul_mod_self_right, Nat.mod_eq_of_lt hltα]; omega
-        have hcond2 : alpha * (r.val / alpha + 1) = modulus - 1 := by
-          rw [hval, hrepr, Nat.add_mul_div_right _ _ ctx.hα, Nat.div_eq_of_lt hltα, zero_add,
-            Nat.sub_add_cancel (ctx.hm), ctx.hqm1]
-        simp [hr1z, ctx.h2α, hcond1, hcond2]
-    · have hr0neg : r0 < 0 := lt_of_not_ge hr0nn
-      have hr1pos : 0 < r1 := Nat.pos_of_ne_zero hr1z
-      have hnle  : n ≤ alpha * r1 := by
-        have hn_lt_alpha : n < alpha := by omega
-        exact le_trans hn_lt_alpha.le (Nat.le_mul_of_pos_right alpha hr1pos)
-      have hval  : r.val = alpha * r1 - n := by
-        have hrcast : r = ((alpha * r1 - n : ℕ) : Coeff) := by
-          zify [← hdecomp, Nat.cast_sub hnle,
-            show (r0 : Coeff) = -((n : ℕ) : Coeff) by
-              simp [Nat.cast_natAbs, n, abs_eq_neg_self.mpr (Int.le_of_lt hr0neg)]]
-          ring_nf
-        have hltq  : alpha * r1 - n < modulus :=
-          lt_of_le_of_lt (Nat.sub_le _ _) (by omega)
-        rw [hrcast, ZMod.val_natCast_of_lt hltq]
-      have hval_repr : r.val = alpha * (r1 - 1) + (alpha - n) := by
+          ring
+        · right; constructor
+          · omega
+          · rw [Nat.sub_add_cancel (by omega)]; left; exact ⟨ctx.hqm1, hr1z⟩
+    | inr hr1pos =>
+      refine ⟨r1 - 1, alpha - n, ?_, by omega, ?_⟩
+      · change r.val = alpha * (r1 - 1) + (alpha - n)
+        have hnle : n ≤ alpha * r1 :=
+          le_trans hn_lt.le (Nat.le_mul_of_pos_right alpha hr1pos)
+        have hval : r.val = alpha * r1 - n := by
+          have hrcast : r = ((alpha * r1 - n : ℕ) : Coeff) := by
+            zify [← hdecomp, Nat.cast_sub hnle,
+              show (r0 : Coeff) = -((n : ℕ) : Coeff) by
+                simp [Nat.cast_natAbs, n, abs_eq_neg_self.mpr (Int.le_of_lt hr0neg)]]
+            ring_nf
+          have hltq : alpha * r1 - n < modulus := lt_of_le_of_lt (Nat.sub_le _ _) (by omega)
+          rw [hrcast, ZMod.val_natCast_of_lt hltq]
         zify [hval, hn_lt, hnle,
-          show 1 ≤ r1 from Nat.one_le_cast_iff_ne_zero.mpr hr1z,
+          show 1 ≤ r1 from Nat.add_one_le_of_lt hr1pos,
           show alpha ≤ alpha * r1 from Nat.le_mul_of_pos_right alpha hr1pos]
         ring_nf
-      have hwrap : alpha * r1 ≠ modulus - 1 := ne_of_lt
-        (by rw [← ctx.hqm1]; exact Nat.mul_lt_mul_of_pos_left hr1 ctx.hα)
-      exact highBitsCoeff_of_euclid ctx.hα ctx.h2α hval_repr (by omega)
-        (Or.inr ⟨(by omega), (Nat.sub_add_cancel hr1pos).symm⟩) hwrap
+      · right; omega
 
 private theorem alpha_le_natAbs_centeredRepr_mul
     {alpha m : ℕ} (ctx : BalancedDecomp alpha m)

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -194,7 +194,7 @@ private lemma hunit {ctx : BalancedDecomp alpha m} : IsUnit (alpha : Coeff) :=
 
 end BalancedDecomp
 
-private theorem coeff_cast_div_add_mod (r : Coeff) (s : ℕ) :
+private theorem natCast_div_add_mod (r : Coeff) (s : ℕ) :
     s * ((r.val / s):Coeff) + ((r.val % s): Coeff) = r := by
   rw [← Nat.cast_mul, ← Nat.cast_add]
   nth_rewrite 3 [← ZMod.natCast_zmod_val r]
@@ -204,7 +204,7 @@ private theorem power2RoundCoeff_eq (r : Coeff) {r1 : ℕ} {r0 : ℤ}
   (hdecomp : power2RoundCoeff r = (r1, r0)) :
     ((power2Scale : Coeff) * (r1 : Coeff)) + r0 = r := by
   simp only [power2RoundCoeff] at hdecomp
-  have hdam := coeff_cast_div_add_mod r power2Scale
+  have hdam := natCast_div_add_mod r power2Scale
   split_ifs at hdecomp <;> rcases hdecomp with ⟨rfl, rfl⟩ <;> push_cast
   · exact hdam
   · ring_nf; exact hdam
@@ -226,7 +226,7 @@ private theorem decomposeCoeff_eq
   simp only [decomposeCoeff, h2α] at hdecomp
   set t : ℕ := r.val % alpha
   set q := r.val / alpha
-  have hdam : (alpha: Coeff) * q  + t = r := coeff_cast_div_add_mod r alpha
+  have hdam : (alpha: Coeff) * q  + t = r := natCast_div_add_mod r alpha
   have hwrap : ∀ (k : ℕ), alpha * k = modulus - 1 → (alpha : Coeff) * k = -1 := fun k hk => by
     rw [← Nat.cast_mul, hk, Nat.cast_sub (by norm_num [modulus]),
       ZMod.natCast_self, zero_sub, Nat.cast_one]
@@ -248,7 +248,7 @@ private theorem lowBitsCoeff_bound (r : Coeff) {r1 gamma2 : ℕ} {r0 : ℤ} (hγ
   have htlt : t < alpha := Nat.mod_lt _ (by omega)
   split_ifs at hdec with h hs hs <;> simp_all <;> omega
 
-private theorem lowBits_centeredRepr (r : Coeff) {gamma2 : ℕ}
+private theorem centeredRepr_intCast_lowBitsCoeff (r : Coeff) {gamma2 : ℕ}
     (hγ : 0 < gamma2) (hq : 2 * gamma2 < modulus) :
     centeredRepr ((lowBitsCoeff r gamma2):Coeff) = lowBitsCoeff r gamma2 := by
   have : (lowBitsCoeff r gamma2).natAbs ≤ gamma2 := by
@@ -311,20 +311,20 @@ theorem concreteRounding_lowBits_bound (p : Params)
   refine cInfNorm_le_of_coeff_le ?_
   intro i
   rw [lowBits_get]
-  rw [lowBits_centeredRepr (r := r.get i) hγ hq]
+  rw [centeredRepr_intCast_lowBitsCoeff (r := r.get i) hγ hq]
   simp only [lowBitsCoeff]
   rcases hdec : decomposeCoeff (r.get i) p.gamma2 with ⟨r1, r0⟩
   exact lowBitsCoeff_bound (r := r.get i) hγ hdec
 
-private theorem gamma2_pos_of_isApproved {p : Params} (hp : p.isApproved) :
+private theorem gamma2_pos {p : Params} (hp : p.isApproved) :
     0 < p.gamma2 := by
   rcases hp with rfl | rfl | rfl <;> decide
 
-private theorem gamma2_double_lt_modulus_of_isApproved {p : Params} (hp : p.isApproved) :
+private theorem two_gamma2_lt_modulus {p : Params} (hp : p.isApproved) :
     2 * p.gamma2 < modulus := by
   rcases hp with rfl | rfl | rfl <;> decide
 
-private theorem highBitsCoeff_lt_useHintModulus_of_isApproved {alpha m : ℕ}
+private theorem highBitsCoeff_lt_m {alpha m : ℕ}
     (ctx : BalancedDecomp alpha m) (r : Coeff) :
     highBitsCoeff r (alpha / 2) < m := by
   simp only [highBitsCoeff, decomposeCoeff, ctx.h2α]
@@ -349,7 +349,7 @@ private theorem highBitsCoeff_lt_useHintModulus_of_isApproved {alpha m : ℕ}
     have hdiv_le := Nat.add_one_le_of_lt hlt
     exact lt_of_le_of_ne hdiv_le fun hm => hs (by rw [hm, ctx.hqm1])
 
-private theorem alphaMul_pred_m_eq_coeff {alpha m : ℕ} (ctx : BalancedDecomp alpha m) :
+private theorem alpha_mul_pred_m_eq {alpha m : ℕ} (ctx : BalancedDecomp alpha m) :
     (alpha: Coeff) * ((m - 1 : ℕ) : Coeff) = (-1 : Coeff) - (alpha : Coeff) := by
   rw [Nat.cast_sub (show 1 ≤ m from ctx.hm), mul_sub, ← Nat.cast_mul,
     ctx.hqm1, Nat.cast_sub (show 1 ≤ modulus by decide), ZMod.natCast_self]
@@ -368,7 +368,7 @@ private theorem highBitsCoeff_of_euclid {r : Coeff} {alpha q t r1 : ℕ}
   simp only [highBitsCoeff, decomposeCoeff, h2α, hmod, hdiv]
   rcases hside with ⟨hle, rfl⟩ | ⟨hgt, rfl⟩ <;> simp_all; simp [not_le.mpr hgt]
 
-private theorem highBitsCoeff_of_repr {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
+private theorem highBitsCoeff_eq_of_repr {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {r : Coeff} (r1 : ℕ) (r0 : ℤ)
     (hr1 : r1 < m)
     (hr0 : r0.natAbs ≤ alpha / 2)
@@ -457,7 +457,7 @@ private theorem highBitsCoeff_of_repr {alpha m : ℕ} (ctx : BalancedDecomp alph
       exact highBitsCoeff_of_euclid ctx.hα ctx.h2α hval_repr (by omega)
         (Or.inr ⟨(by omega), (Nat.sub_add_cancel hr1pos).symm⟩) hwrap
 
-private theorem centeredRepr_alpha_mul_natAbs_ge
+private theorem alpha_le_natAbs_centeredRepr_mul
     {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {z : ℤ} (hz0 : 0 < z) (hzm : z.toNat < m) :
     alpha ≤ (centeredRepr ((alpha : Coeff) * (z : Coeff))).natAbs := by
@@ -490,7 +490,7 @@ private theorem decomposeCoeff_unique {alpha m : ℕ} (ctx : BalancedDecomp alph
     (hr0_neg : r0 < 0 → r1 = 0 ∨ r0.natAbs < alpha / 2)
     (hdecomp : (alpha : Coeff) * (r1 : Coeff) + r0 = r) :
     decomposeCoeff r (alpha / 2) = (r1, r0) := by
-  have h1 := highBitsCoeff_of_repr ctx r1 r0 hr1 hr0 hr0_neg hdecomp
+  have h1 := highBitsCoeff_eq_of_repr ctx r1 r0 hr1 hr0 hr0_neg hdecomp
   have hdecomp' : (alpha : Coeff) * r1 + lowBitsCoeff r (alpha / 2) = r := by
     have h := decomposeCoeff_eq r ctx.h2α (Prod.eta _)
     simp only [highBitsCoeff, lowBitsCoeff, ← h1] at h ⊢; exact h
@@ -498,11 +498,11 @@ private theorem decomposeCoeff_unique {alpha m : ℕ} (ctx : BalancedDecomp alph
   have h2 : lowBitsCoeff r (alpha / 2) = r0 := by
     have cr_eq := congrArg centeredRepr hlow_eq
     have hγ2 := by have := ctx.hq; rwa [← ctx.h2α] at this
-    rwa [lowBits_centeredRepr r ctx.hγ hγ2,
+    rwa [centeredRepr_intCast_lowBitsCoeff r ctx.hγ hγ2,
         centeredRepr_intCast_eq_of_natAbs_le r0 hr0 hγ2] at cr_eq
   exact Prod.ext h1 h2
 
-private theorem highBitsCoeff_add_eq_of_small_of_isApproved
+private theorem highBitsCoeff_add_eq_of_centeredRepr_lt
     {alpha m b : ℕ} (ctx : BalancedDecomp alpha m) (r s : Coeff)
     (hs : (centeredRepr s).natAbs ≤ b)
     (hr : (lowBitsCoeff r (alpha / 2)).natAbs < (alpha / 2) - b) :
@@ -534,7 +534,7 @@ private theorem highBitsCoeff_add_eq_of_small_of_isApproved
       alpha * (lo : Coeff) + e1 = alpha * (hi : Coeff) + e2 →
       False := fun lo hi e1 e2 hlt hhi hbound heq' => by
     let delta := (hi : ℤ) - (lo : ℤ)
-    have hbig := centeredRepr_alpha_mul_natAbs_ge (z:= delta) ctx (by omega) (by omega)
+    have hbig := alpha_le_natAbs_centeredRepr_mul (z:= delta) ctx (by omega) (by omega)
     have hsmallq : 2 * (alpha - 1) < modulus := by have := ctx.hsmall; omega
     have hdeltaeq : alpha * (delta : Coeff) = e1 - e2 := by
       zify[delta, mul_sub]
@@ -549,7 +549,7 @@ private theorem highBitsCoeff_add_eq_of_small_of_isApproved
   cases hlt_or_gt with
   | inl hr1ltu =>
       have hult : u < m := by
-        have := highBitsCoeff_lt_useHintModulus_of_isApproved ctx (r + s)
+        have := highBitsCoeff_lt_m ctx (r + s)
         rwa [highBitsCoeff, hdecomp_rs] at this
       exact contra r1 u v w hr1ltu hult hdiffbound heq.symm
   | inr hultr1 =>
@@ -557,26 +557,26 @@ private theorem highBitsCoeff_add_eq_of_small_of_isApproved
         rw [show w - v = -(v - w) from by ring, Int.natAbs_neg]
         exact hdiffbound
       have hr1lt : r1 < m := by
-        have := highBitsCoeff_lt_useHintModulus_of_isApproved ctx r
+        have := highBitsCoeff_lt_m ctx r
         rwa [highBitsCoeff, hdecomp_r] at this
       exact contra u r1 w v hultr1 hr1lt hdiffbound2 heq
 
-private theorem useHintCoeff_shift_sub_bound_of_isApproved
-    {alpha m : ℕ} (ctx : BalancedDecomp alpha m) (h : Bool) (r : Coeff) :
+private theorem useHintCoeff_shift_sub_le
+    {alpha m : ℕ} (ctx : BalancedDecomp alpha m) (hbit : Bool) (r : Coeff) :
     (centeredRepr
-      (r - (alpha : Coeff) * (useHintCoeff h r (alpha / 2) : Coeff))).natAbs ≤
+      (r - (alpha : Coeff) * (useHintCoeff hbit r (alpha / 2) : Coeff))).natAbs ≤
         alpha + 1 := by
   rcases hdec : decomposeCoeff r (alpha / 2) with ⟨r1, r0⟩
   have hdecomp : alpha * (r1 : Coeff) + r0 = r := decomposeCoeff_eq r ctx.h2α hdec
   have hr1lt : r1 < m := by
-    have := highBitsCoeff_lt_useHintModulus_of_isApproved ctx r
+    have := highBitsCoeff_lt_m ctx r
     rwa [highBitsCoeff, hdec] at this
   have hr0bound := lowBitsCoeff_bound r ctx.hγ hdec
   suffices h : ∃ v : ℤ, r - (alpha : Coeff) * (useHintCoeff _ r (alpha / 2) : Coeff) = v
       ∧ v.natAbs ≤ alpha + 1 by
     obtain ⟨v, hveq, hvb⟩ := h
     rw [hveq, centeredRepr_intCast_eq_of_natAbs_le v hvb ctx.hsmall]; exact hvb
-  cases h with
+  cases hbit with
   | false =>
       use r0; exact ⟨by simp [useHintCoeff, hdec, sub_eq_iff_eq_add'.2 hdecomp.symm], by omega⟩
   | true =>
@@ -591,7 +591,7 @@ private theorem useHintCoeff_shift_sub_bound_of_isApproved
         · use r0 - alpha - 1; constructor
           · rw [show useHintCoeff true r (alpha / 2) = 0 by
                 simp [useHintCoeff, hdec, hr0pos, ctx.h2α, ctx.hmdef, show r1 + 1 = m by omega]]
-            zify [← hdecomp, show r1 = m - 1 by omega, alphaMul_pred_m_eq_coeff ctx]
+            zify [← hdecomp, show r1 = m - 1 by omega, alpha_mul_pred_m_eq ctx]
             ring_nf
           · omega
       · by_cases hr1zero : r1 = 0
@@ -599,7 +599,7 @@ private theorem useHintCoeff_shift_sub_bound_of_isApproved
           · have huse : useHintCoeff true r (alpha / 2) = m - 1 := by
               have hpred : (m - 1) % m = m - 1 := Nat.mod_eq_of_lt (Nat.pred_lt ctx.hm.ne')
               simp [useHintCoeff, hdec, hr0pos, hr1zero, ctx.h2α, ctx.hmdef, hpred]
-            rw [huse, alphaMul_pred_m_eq_coeff ctx, ← hdecomp, hr1zero]
+            rw [huse, alpha_mul_pred_m_eq ctx, ← hdecomp, hr1zero]
             simp [sub_sub_eq_add_sub]
           · omega
         · use r0 + alpha; constructor
@@ -622,7 +622,7 @@ private theorem decomposeCoeff_mid_of_isApproved
       (highBitsCoeff r (alpha / 2), lowBitsCoeff r (alpha / 2) + z0) := by
   set v : ℤ := r0 + z0
   have hr1lt : r1 < m := by
-    have := highBitsCoeff_lt_useHintModulus_of_isApproved ctx r
+    have := highBitsCoeff_lt_m ctx r
     rwa [highBitsCoeff, hdec] at this
   have hcore : alpha * (r1 : Coeff) + v = r + z0 := by
     dsimp [v]; push_cast; rw [← add_assoc, decomposeCoeff_eq r ctx.h2α hdec]
@@ -634,7 +634,7 @@ private theorem decomposeCoeff_mid_of_isApproved
   rw [decomposeCoeff_unique ctx r1 v hr1lt hv_bound hv_neg_cond hcore]
   simp [highBitsCoeff, lowBitsCoeff, v, hdec]
 
-private theorem highBitsCoeff_of_pos_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
+private theorem highBitsCoeff_eq_of_pos_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {s : Coeff} (r1 : ℕ) (v : ℤ)
     (hr1 : r1 < m)
     (hv_lo : (alpha / 2 : ℤ) < v)
@@ -645,17 +645,17 @@ private theorem highBitsCoeff_of_pos_overflow {alpha m : ℕ} (ctx : BalancedDec
   have h2α := ctx.h2α
   by_cases hwrap : r1 + 1 < m
   · rw [Nat.mod_eq_of_lt hwrap]
-    exact highBitsCoeff_of_repr ctx (r1+1) (v - alpha) hwrap (by omega) (by omega)
+    exact highBitsCoeff_eq_of_repr ctx (r1+1) (v - alpha) hwrap (by omega) (by omega)
       (by rw [← hsum, Nat.cast_add, Nat.cast_one]; push_cast; ring)
   · push Not at hwrap
     rw [show r1 + 1 = m  by omega, Nat.mod_self]
-    exact highBitsCoeff_of_repr ctx 0 (v - alpha - 1) ctx.hm (by omega) (by omega)
+    exact highBitsCoeff_eq_of_repr ctx 0 (v - alpha - 1) ctx.hm (by omega) (by omega)
       (by
         rw [Nat.cast_zero, mul_zero, zero_add, ← hsum,
-        show r1 = m - 1 from by omega, alphaMul_pred_m_eq_coeff ctx]
+        show r1 = m - 1 from by omega, alpha_mul_pred_m_eq ctx]
         push_cast; ring)
 
-private theorem highBitsCoeff_of_neg_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
+private theorem highBitsCoeff_eq_of_neg_overflow {alpha m : ℕ} (ctx : BalancedDecomp alpha m)
     {s : Coeff} (r1 : ℕ) (v : ℤ)
     (hr1 : r1 < m)
     (hv_lo : -(alpha : ℤ) ≤ v)
@@ -665,16 +665,16 @@ private theorem highBitsCoeff_of_neg_overflow {alpha m : ℕ} (ctx : BalancedDec
   have h2α := ctx.h2α
   rcases Nat.eq_zero_or_pos r1 with hr1z | hr1pos
   · rw [hr1z, zero_add, Nat.mod_eq_of_lt (Nat.sub_lt ctx.hm (by decide))]
-    exact highBitsCoeff_of_repr ctx
+    exact highBitsCoeff_eq_of_repr ctx
       (m - 1) (v + alpha + 1) (Nat.pred_lt ctx.hm.ne') (by omega) (by omega)
-      (by rw [alphaMul_pred_m_eq_coeff ctx, ← hsum, hr1z]; push_cast; ring)
+      (by rw [alpha_mul_pred_m_eq ctx, ← hsum, hr1z]; push_cast; ring)
   · rw [show r1 + m - 1 = (r1 - 1) + m from by omega,
         Nat.add_mod_right, Nat.mod_eq_of_lt (by omega)]
-    exact highBitsCoeff_of_repr ctx (r1 - 1) (v + alpha)
+    exact highBitsCoeff_eq_of_repr ctx (r1 - 1) (v + alpha)
       (show r1 - 1 < m by omega) (by omega) (by omega)
       (by rw [Nat.cast_sub hr1pos, ← hsum]; push_cast; ring)
 
-private theorem useHintCoeff_correct_of_small_of_isApproved
+private theorem useHintCoeff_makeHintCoeff_eq_of_small
     {alpha m : ℕ} (ctx : BalancedDecomp alpha m) (z r : Coeff)
     (hz : (centeredRepr z).natAbs ≤ alpha / 2) :
     useHintCoeff (makeHintCoeff z r (alpha / 2)) r (alpha / 2) =
@@ -684,7 +684,7 @@ private theorem useHintCoeff_correct_of_small_of_isApproved
   set v : ℤ := r0 + z0
   have hr1eq : highBitsCoeff r (alpha / 2) = r1 := by simp [highBitsCoeff, hdec]
   have hr1lt : r1 < m := by
-    have h := highBitsCoeff_lt_useHintModulus_of_isApproved ctx r
+    have h := highBitsCoeff_lt_m ctx r
     rwa [highBitsCoeff, hdec] at h
   have hr0bound := lowBitsCoeff_bound r ctx.hγ hdec
   have hzcast : z = z0 := centeredRepr_intCast z
@@ -701,7 +701,7 @@ private theorem useHintCoeff_correct_of_small_of_isApproved
     · have huse : useHintCoeff true r (alpha / 2) = (r1 + 1) % m := by
         simp [useHintCoeff, hdec, show 0 < r0 by omega, ctx.h2α, ctx.hmdef]
       simp only [makeHintCoeff, ne_eq, hneq, not_false_eq_true, decide_true, huse]
-      exact (highBitsCoeff_of_pos_overflow ctx r1 v hr1lt (by omega) (by omega) hsum).symm
+      exact (highBitsCoeff_eq_of_pos_overflow ctx r1 v hr1lt (by omega) (by omega) hsum).symm
     · have : highBitsCoeff (r + z) (alpha / 2) = highBitsCoeff r (alpha / 2) := by
         rw [highBitsCoeff, hzcast, decomposeCoeff_mid_of_isApproved ctx r z0 r0 r1 hdec hlo hhi]
       exact absurd this.symm hneq
@@ -715,13 +715,13 @@ private theorem useHintCoeff_correct_of_small_of_isApproved
             have hr1z' : r1 = 0 := by omega
             have hrz : r + z = (-(alpha / 2 : ℤ) : Coeff) := by simpa [hv, hr1z'] using hsum.symm
             have hrepr: highBitsCoeff (-(alpha / 2 : ℤ) : Coeff) (alpha / 2) = 0 :=
-              highBitsCoeff_of_repr ctx 0 (-(alpha / 2 : ℤ)) ctx.hm
+              highBitsCoeff_eq_of_repr ctx 0 (-(alpha / 2 : ℤ)) ctx.hm
                 (by omega) (fun _ => Or.inl rfl) (by simp)
             exact hneq (by rw [hr1eq, hr1z', hrz, hrepr])⟩
       simp only [makeHintCoeff, ne_eq, hneq, not_false_eq_true, decide_true, huse]
-      rw [highBitsCoeff_of_neg_overflow ctx r1 v hr1lt (by omega) hv_hi hsum]
+      rw [highBitsCoeff_eq_of_neg_overflow ctx r1 v hr1lt (by omega) hv_hi hsum]
 
-private theorem coeff_mul_left_injective_of_isUnit {c : Coeff} (hc : IsUnit c) :
+private theorem mul_left_injective_of_isUnit {c : Coeff} (hc : IsUnit c) :
     Function.Injective fun x : Coeff => c * x := by
   intro x y hxy
   rcases hc with ⟨u, rfl⟩
@@ -735,7 +735,7 @@ theorem highBitsShift_injective_of_isApproved (p : Params)
   refine Poly.ext_get_eq fun j => ?_
   have hcoeff : (2 * p.gamma2 : ℕ) * x.get j = (2 * p.gamma2 : ℕ) * y.get j := by
     simpa [highBitsShift] using congrArg (fun v : Rq => v.get j) hxy
-  exact coeff_mul_left_injective_of_isUnit (BalancedDecomp.ofApproved hp).hunit hcoeff
+  exact mul_left_injective_of_isUnit (BalancedDecomp.ofApproved hp).hunit hcoeff
 
 /-- Concrete `Power2RoundOps` with `Power2High = Rq`. -/
 def concretePower2RoundOps : MLDSA.Power2RoundOps where
@@ -761,7 +761,7 @@ theorem concreteRounding_useHint_correct_of_isApproved (p : Params)
   refine Poly.ext_get_eq fun j => ?_
   simp only [useHint, makeHint, highBits, Vector.get_ofFn, Rq.get_add]
   apply congrArg fun n : ℕ => (n : Coeff)
-  simpa using useHintCoeff_correct_of_small_of_isApproved (BalancedDecomp.ofApproved hp)
+  simpa using useHintCoeff_makeHintCoeff_eq_of_small (BalancedDecomp.ofApproved hp)
     (z := z.get j) (r := r.get j) (by simpa using cInfNorm_le_iff.mp hz j)
 
 theorem concreteRounding_useHint_bound_of_isApproved (p : Params)
@@ -770,7 +770,7 @@ theorem concreteRounding_useHint_bound_of_isApproved (p : Params)
   refine cInfNorm_le_iff.mpr fun j => ?_
   simp only [Rq.get_sub, highBitsShift, Nat.cast_mul, Nat.cast_ofNat, useHint, Vector.map_ofFn,
       Vector.get_ofFn, Function.comp_apply]
-  simpa using useHintCoeff_shift_sub_bound_of_isApproved
+  simpa using useHintCoeff_shift_sub_le
     (BalancedDecomp.ofApproved hp) (h.get j) (r.get j)
 
 theorem concreteRounding_hide_low_of_isApproved (p : Params)
@@ -785,14 +785,14 @@ theorem concreteRounding_hide_low_of_isApproved (p : Params)
   have hr : (lowBitsCoeff (r.get j) p.gamma2).natAbs < p.gamma2 - b := by
     have hcoeff : (lowBitsCoeff (r.get j) p.gamma2).natAbs ≤ cInfNorm (lowBits p r) := by
       have := coeff_le_cInfNorm (lowBits p r) j
-      rwa [lowBits_get, lowBits_centeredRepr (r := r.get j)
-        (hγ := gamma2_pos_of_isApproved hp)
-        (hq := gamma2_double_lt_modulus_of_isApproved hp)] at this
+      rwa [lowBits_get, centeredRepr_intCast_lowBitsCoeff (r := r.get j)
+        (hγ := gamma2_pos hp)
+        (hq := two_gamma2_lt_modulus hp)] at this
     exact hcoeff.trans_lt (Nat.lt_sub_of_add_lt hlow)
   set alpha : ℕ := 2 * p.gamma2
   have : p.gamma2 = alpha /2 := by omega
   rw [this] at hr ⊢
-  exact highBitsCoeff_add_eq_of_small_of_isApproved
+  exact highBitsCoeff_add_eq_of_centeredRepr_lt
     (BalancedDecomp.ofApproved hp) (r.get j) (s.get j) (cInfNorm_le_iff.mp hs j) hr
 
 theorem concretePower2RoundLaws :
@@ -803,8 +803,8 @@ theorem concreteRoundingLaws_of_isApproved (p : Params) (hp : p.isApproved) :
     RoundingOps.Laws (ring := coeffRing) (concreteRoundingOps p) cInfNorm where
   high_low_decomp := concreteRounding_high_low_decomp p
   lowBits_bound r := by
-    simpa using concreteRounding_lowBits_bound p (gamma2_pos_of_isApproved hp)
-      (gamma2_double_lt_modulus_of_isApproved hp) r
+    simpa using concreteRounding_lowBits_bound p (gamma2_pos hp)
+      (two_gamma2_lt_modulus hp) r
   hide_low r s b hs hlow :=
     concreteRounding_hide_low_of_isApproved p hp r s b hs (by simpa using hlow)
   shift_injective := highBitsShift_injective_of_isApproved p hp

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -316,14 +316,6 @@ theorem concreteRounding_lowBits_bound (p : Params)
   rcases hdec : decomposeCoeff (r.get i) p.gamma2 with ⟨r1, r0⟩
   exact lowBitsCoeff_bound (r := r.get i) hγ hdec
 
-private theorem gamma2_pos {p : Params} (hp : p.isApproved) :
-    0 < p.gamma2 := by
-  rcases hp with rfl | rfl | rfl <;> decide
-
-private theorem two_gamma2_lt_modulus {p : Params} (hp : p.isApproved) :
-    2 * p.gamma2 < modulus := by
-  rcases hp with rfl | rfl | rfl <;> decide
-
 private theorem highBitsCoeff_lt_m {alpha m : ℕ}
     (ctx : BalancedDecomp alpha m) (r : Coeff) :
     highBitsCoeff r (alpha / 2) < m := by
@@ -708,18 +700,19 @@ theorem concreteRounding_hide_low_of_isApproved (p : Params)
   refine Poly.ext_get_eq fun j => ?_
   simp only [highBits, Vector.get_ofFn, Rq.get_add]
   apply congrArg fun n : ℕ => (n : Coeff)
-  have hr : (lowBitsCoeff (r.get j) p.gamma2).natAbs < p.gamma2 - b := by
-    have hcoeff : (lowBitsCoeff (r.get j) p.gamma2).natAbs ≤ cInfNorm (lowBits p r) := by
+  let ctx := BalancedDecomp.ofApproved hp
+  have hr : (lowBitsCoeff (r.get j) (p.gamma2)).natAbs < (p.gamma2) - b := by
+    have hcoeff : (lowBitsCoeff (r.get j) (p.gamma2)).natAbs ≤ cInfNorm (lowBits p r) := by
       have := coeff_le_cInfNorm (lowBits p r) j
-      rwa [lowBits_get, centeredRepr_intCast_lowBitsCoeff (r := r.get j)
-        (hγ := gamma2_pos hp)
-        (hq := two_gamma2_lt_modulus hp)] at this
+      rwa [lowBits_get, centeredRepr_intCast_lowBitsCoeff (gamma2 := p.gamma2) (r := r.get j)
+        (hγ := by haveI := ctx.hα; omega)
+        (hq := ctx.hq)] at this
     exact hcoeff.trans_lt (Nat.lt_sub_of_add_lt hlow)
   set alpha : ℕ := 2 * p.gamma2
   have : p.gamma2 = alpha /2 := by omega
   rw [this] at hr ⊢
   exact highBitsCoeff_add_eq_of_centeredRepr_lt
-    (BalancedDecomp.ofApproved hp) (r.get j) (s.get j) (cInfNorm_le_iff.mp hs j) hr
+    ctx (r.get j) (s.get j) (cInfNorm_le_iff.mp hs j) hr
 
 theorem concretePower2RoundLaws :
     Power2RoundOps.Laws (ring := coeffRing) concretePower2RoundOps cInfNorm where
@@ -729,8 +722,9 @@ theorem concreteRoundingLaws_of_isApproved (p : Params) (hp : p.isApproved) :
     RoundingOps.Laws (ring := coeffRing) (concreteRoundingOps p) cInfNorm where
   high_low_decomp := concreteRounding_high_low_decomp p
   lowBits_bound r := by
-    simpa using concreteRounding_lowBits_bound p (gamma2_pos hp)
-      (two_gamma2_lt_modulus hp) r
+    let ctx := BalancedDecomp.ofApproved hp
+    have hγ : 0 <  p.gamma2 := by haveI := ctx.hα; omega
+    simpa using concreteRounding_lowBits_bound p hγ ctx.hq r
   hide_low r s b hs hlow :=
     concreteRounding_hide_low_of_isApproved p hp r s b hs (by simpa using hlow)
   shift_injective := highBitsShift_injective_of_isApproved p hp


### PR DESCRIPTION
Follow-up to #405. This pull request should be merged after #405. Apologies in sending multiple pull requests for just shortening proofs — I got a bit OCD trying to shorten everything after the first PR.

### What changed

**Rename private lemmas** (`_of_isApproved` suffix dropped, head-symbol-first names)

The old names were verbose and didn't follow Mathlib convention. Examples:

- `highBitsCoeff_lt_useHintModulus_of_isApproved` → `highBitsCoeff_lt_m`
- `centeredRepr_alpha_mul_natAbs_ge` → `alpha_le_natAbs_centeredRepr_mul`
No logic changes.

#### Refactor `highBitsCoeff_eq_of_repr` using `suffices`; remove `highBitsCoeff_of_euclid`

The old proof split on the sign of `r0`, then called an auxiliary `highBitsCoeff_of_euclid` (which handled the Euclidean-representation case) in each branch. The insight is that all three branches are really doing the same thing: supplying a `(q, t)` witness to a fixed suffices goal. Once the proof is stated that way, `highBitsCoeff_of_euclid` becomes dead code.

#### Remove `decomposeCoeff_unique` and `decomposeCoeff_mid_of_isApproved`; simplify overflow lemmas

With `highBitsCoeff_eq_of_repr` as the canonical way to establish a `highBitsCoeff` value, `decomposeCoeff_unique` (which went via `decomposeCoeff` to recover the same result) is no longer needed. This lets `decomposeCoeff_mid_of_isApproved` go too — its only call site in `useHintCoeff_makeHintCoeff_eq_of_small` can be replaced by a direct refine `highBitsCoeff_eq_of_repr` with the obvious witness.

`highBitsCoeff_eq_of_pos/neg_overflow` get the same `suffices`-then-`highBitsCoeff_eq_of_repr` treatment, and `highBitsCoeff_add_eq_of_centeredRepr_lt` likewise replaces its internal `contra` closure with a `suffices` block.

Line changes from 1769 to 736 since #403