### PR TITLE
feat(VCVio): framework lifts — probability/coupling + simulation helpers

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -123,6 +123,7 @@ import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.QueryTracking.QueryCost
 import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
 import VCVio.OracleComp.QueryTracking.RandomOracle.Eager
+import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
 import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
 import VCVio.OracleComp.QueryTracking.ResourceProfile
 import VCVio.OracleComp.QueryTracking.SeededOracle

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -76,6 +76,7 @@ import VCVio.EvalDist.Instances.OptionT
 import VCVio.EvalDist.Instances.ReaderT
 import VCVio.EvalDist.List
 import VCVio.EvalDist.Monad.Basic
+import VCVio.EvalDist.Monad.Disagreement
 import VCVio.EvalDist.Monad.Map
 import VCVio.EvalDist.Monad.Seq
 import VCVio.EvalDist.Option

--- a/VCVio/EvalDist/Monad/Disagreement.lean
+++ b/VCVio/EvalDist/Monad/Disagreement.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 import VCVio.EvalDist.Monad.Basic
 

--- a/VCVio/EvalDist/Monad/Disagreement.lean
+++ b/VCVio/EvalDist/Monad/Disagreement.lean
@@ -34,10 +34,11 @@ most `ε₁` under `mx`, and off `D` the continuation `my` is within `ε₂` of 
 continuation `oc`, then `Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + ε₁ + ε₂`. The exceptional set `D`
 is charged its full mass `ε₁`; everywhere else the per-point gap `ε₂` is paid. -/
 lemma probEvent_bind_le_add_of_disagree {mx : m α}
-    {my oc : α → m β} {q : β → Prop} {D : α → Prop} [DecidablePred D] {ε₁ ε₂ : ℝ≥0∞}
-    (hD : Pr[D | mx] ≤ ε₁)
-    (h : ∀ x ∈ support mx, ¬ D x → Pr[q | my x] ≤ Pr[q | oc x] + ε₂) :
-    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + ε₁ + ε₂ := by
+    {my oc : α → m β} {q : β → Prop} {D : α → Prop} {ε₁ ε₂ : ℝ≥0∞}
+    (hD : Pr[ D | mx] ≤ ε₁)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + ε₂) :
+    Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + ε₁ + ε₂ := by
+  classical
   have := Classical.decPred q
   rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
   calc ∑' x, Pr[= x | mx] * Pr[q | my x]
@@ -74,10 +75,11 @@ plus the per-step slack `ε`, while on `D` the `ob`-world (the bad world) alread
 `r` with probability `1`. The conclusion charges the disagreement to `Pr[r | mx >>= ob]`. -/
 lemma probEvent_bind_le_add_bad_of_disagree {mx : m α}
     {my : α → m β} {oc : α → m β} {ob : α → m γ}
-    {q : β → Prop} {r : γ → Prop} {D : α → Prop} [DecidablePred D] {ε : ℝ≥0∞}
-    (hbad : ∀ x ∈ support mx, D x → Pr[r | ob x] = 1)
-    (h : ∀ x ∈ support mx, ¬ D x → Pr[q | my x] ≤ Pr[q | oc x] + ε) :
-    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + Pr[r | mx >>= ob] + ε := by
+    {q : β → Prop} {r : γ → Prop} {D : α → Prop} {ε : ℝ≥0∞}
+    (hbad : ∀ x ∈ support mx, D x → Pr[ r | ob x] = 1)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + ε) :
+    Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + Pr[ r | mx >>= ob] + ε := by
+  classical
   have := Classical.decPred q
   have := Classical.decPred r
   rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
@@ -118,10 +120,11 @@ fires `r` with probability `1`. Both cases are charged into the aggregate `Pr[r 
 the conclusion is the same shape as the three-way bound. -/
 lemma probEvent_bind_le_add_bad_of_disagree' {mx : m α}
     {my : α → m β} {oc : α → m β} {ob : α → m γ}
-    {q : β → Prop} {r : γ → Prop} {D : α → Prop} [DecidablePred D] {ε : ℝ≥0∞}
-    (hbad : ∀ x ∈ support mx, D x → Pr[r | ob x] = 1)
-    (h : ∀ x ∈ support mx, ¬ D x → Pr[q | my x] ≤ Pr[q | oc x] + Pr[r | ob x] + ε) :
-    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + Pr[r | mx >>= ob] + ε := by
+    {q : β → Prop} {r : γ → Prop} {D : α → Prop} {ε : ℝ≥0∞}
+    (hbad : ∀ x ∈ support mx, D x → Pr[ r | ob x] = 1)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + Pr[ r | ob x] + ε) :
+    Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + Pr[ r | mx >>= ob] + ε := by
+  classical
   have := Classical.decPred q
   have := Classical.decPred r
   rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
@@ -158,10 +161,11 @@ mass `ε₁`; everywhere off `D` the `my`-world is bounded by the `oc`-world plu
 bad probability `Pr[r | ob x]` plus the slack `ε₂`. -/
 lemma probEvent_bind_le_add_bad_disagree {mx : m α}
     {my : α → m β} {oc : α → m β} {ob : α → m γ}
-    {q : β → Prop} {r : γ → Prop} {D : α → Prop} [DecidablePred D] {ε₁ ε₂ : ℝ≥0∞}
+    {q : β → Prop} {r : γ → Prop} {D : α → Prop} {ε₁ ε₂ : ℝ≥0∞}
     (hD : Pr[ D | mx] ≤ ε₁)
     (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + Pr[ r | ob x] + ε₂) :
-    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + Pr[r | mx >>= ob] + ε₁ + ε₂ := by
+    Pr[ q | mx >>= my] ≤ Pr[ q | mx >>= oc] + Pr[ r | mx >>= ob] + ε₁ + ε₂ := by
+  classical
   have := Classical.decPred q
   have := Classical.decPred r
   rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]

--- a/VCVio/EvalDist/Monad/Disagreement.lean
+++ b/VCVio/EvalDist/Monad/Disagreement.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.EvalDist.Monad.Basic
+
+/-!
+# Disagreement-Aware Additive Bind Bounds
+
+A family of bind-bound lemmas charging an exceptional set ("disagreement") to its mass
+plus per-point slack. They are the workhorses behind coupled game-hopping proofs that need
+to bound `Pr[q | mx >>= my]` by `Pr[q | mx >>= oc]` plus a small additive term.
+
+These statements are framed for any monad `m` with `[HasEvalSPMF m]`; the canonical
+specialisation is `m = ProbComp`.
+
+## Main results
+
+* `probEvent_bind_le_add_of_disagree` — 2-way base case.
+* `probEvent_bind_le_add_bad_of_disagree` — 3-way with bad-event side.
+* `probEvent_bind_le_add_bad_of_disagree'` — 3-way with per-step bad term in the IH.
+* `probEvent_bind_le_add_bad_disagree` — 4-way merge.
+-/
+
+universe u v
+
+open ENNReal
+
+variable {α β γ : Type u} {m : Type u → Type v} [Monad m] [HasEvalSPMF m]
+
+/-- **Disagreement-aware additive bind bound.** If the disagreement set `D` has probability at
+most `ε₁` under `mx`, and off `D` the continuation `my` is within `ε₂` of the reference
+continuation `oc`, then `Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + ε₁ + ε₂`. The exceptional set `D`
+is charged its full mass `ε₁`; everywhere else the per-point gap `ε₂` is paid. -/
+lemma probEvent_bind_le_add_of_disagree {mx : m α}
+    {my oc : α → m β} {q : β → Prop} {D : α → Prop} [DecidablePred D] {ε₁ ε₂ : ℝ≥0∞}
+    (hD : Pr[D | mx] ≤ ε₁)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[q | my x] ≤ Pr[q | oc x] + ε₂) :
+    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + ε₁ + ε₂ := by
+  have := Classical.decPred q
+  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
+  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
+      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
+            + (if D x then Pr[= x | mx] else 0) + Pr[= x | mx] * ε₂) := by
+        refine ENNReal.tsum_le_tsum fun x => ?_
+        by_cases hx : x ∈ support mx
+        · by_cases hDx : D x
+          · simp only [if_pos hDx]
+            calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * 1 := mul_le_mul' le_rfl probEvent_le_one
+              _ = Pr[= x | mx] := mul_one _
+              _ ≤ Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] + Pr[= x | mx] * ε₂ := by
+                  refine le_add_right (le_add_left le_rfl)
+          · simp only [if_neg hDx, add_zero]
+            calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * (Pr[q | oc x] + ε₂) :=
+                  mul_le_mul' le_rfl (h x hx hDx)
+              _ = Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * ε₂ := left_distrib ..
+        · simp [probOutput_eq_zero_of_not_mem_support hx]
+    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, if D x then Pr[= x | mx] else 0) + (∑' x, Pr[= x | mx] * ε₂) := by
+        rw [ENNReal.tsum_add, ENNReal.tsum_add]
+    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x]) + ε₁ + ε₂ := by
+        refine add_le_add (add_le_add le_rfl ?_) ?_
+        · rw [← probEvent_eq_tsum_ite]; exact hD
+        · rw [ENNReal.tsum_mul_right]
+          exact mul_le_of_le_one_left (zero_le _) tsum_probOutput_le_one
+
+/-- **Three-way disagreement-aware additive bind bound (hop A).** A coupled three-world variant of
+`probEvent_bind_le_add_of_disagree`: the three worlds share the sampling computation `mx`, and at
+each shared sample `x`, off the disagreement set `D` the `my`-world is bounded by the `oc`-world
+plus the per-step slack `ε`, while on `D` the `ob`-world (the bad world) already fires its event
+`r` with probability `1`. The conclusion charges the disagreement to `Pr[r | mx >>= ob]`. -/
+lemma probEvent_bind_le_add_bad_of_disagree {mx : m α}
+    {my : α → m β} {oc : α → m β} {ob : α → m γ}
+    {q : β → Prop} {r : γ → Prop} {D : α → Prop} [DecidablePred D] {ε : ℝ≥0∞}
+    (hbad : ∀ x ∈ support mx, D x → Pr[r | ob x] = 1)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[q | my x] ≤ Pr[q | oc x] + ε) :
+    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + Pr[r | mx >>= ob] + ε := by
+  have := Classical.decPred q
+  have := Classical.decPred r
+  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
+  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
+      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
+            + Pr[= x | mx] * Pr[r | ob x] + Pr[= x | mx] * ε) := by
+        refine ENNReal.tsum_le_tsum fun x => ?_
+        by_cases hx : x ∈ support mx
+        · by_cases hDx : D x
+          · calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * 1 := mul_le_mul' le_rfl probEvent_le_one
+              _ = Pr[= x | mx] * Pr[r | ob x] := by rw [hbad x hx hDx]
+              _ ≤ Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                    + Pr[= x | mx] * ε := le_add_right (le_add_left le_rfl)
+          · calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * (Pr[q | oc x] + ε) :=
+                  mul_le_mul' le_rfl (h x hx hDx)
+              _ = Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * ε := left_distrib ..
+              _ ≤ Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                    + Pr[= x | mx] * ε := by
+                  rw [add_right_comm]
+                  exact le_add_right le_rfl
+        · simp [probOutput_eq_zero_of_not_mem_support hx]
+    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + (∑' x, Pr[= x | mx] * ε) := by
+        rw [ENNReal.tsum_add, ENNReal.tsum_add]
+    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + ε := by
+        refine add_le_add le_rfl ?_
+        rw [ENNReal.tsum_mul_right]
+        exact mul_le_of_le_one_left (zero_le _) tsum_probOutput_le_one
+
+/-- **Four-way disagreement-aware additive bind bound (hop A).** A strengthening of
+`probEvent_bind_le_add_bad_of_disagree`: the per-step inductive hypothesis itself carries a
+bad-event term, so off the disagreement set `D` the `my`-world is bounded by the `oc`-world plus the
+*per-shared-sample* bad probability `Pr[r | ob x]` plus the slack `ε`. On `D` the `ob`-world already
+fires `r` with probability `1`. Both cases are charged into the aggregate `Pr[r | mx >>= ob]`, so
+the conclusion is the same shape as the three-way bound. -/
+lemma probEvent_bind_le_add_bad_of_disagree' {mx : m α}
+    {my : α → m β} {oc : α → m β} {ob : α → m γ}
+    {q : β → Prop} {r : γ → Prop} {D : α → Prop} [DecidablePred D] {ε : ℝ≥0∞}
+    (hbad : ∀ x ∈ support mx, D x → Pr[r | ob x] = 1)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[q | my x] ≤ Pr[q | oc x] + Pr[r | ob x] + ε) :
+    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + Pr[r | mx >>= ob] + ε := by
+  have := Classical.decPred q
+  have := Classical.decPred r
+  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
+  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
+      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
+            + Pr[= x | mx] * Pr[r | ob x] + Pr[= x | mx] * ε) := by
+        refine ENNReal.tsum_le_tsum fun x => ?_
+        by_cases hx : x ∈ support mx
+        · by_cases hDx : D x
+          · calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * 1 := mul_le_mul' le_rfl probEvent_le_one
+              _ = Pr[= x | mx] * Pr[r | ob x] := by rw [hbad x hx hDx]
+              _ ≤ Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                    + Pr[= x | mx] * ε := le_add_right (le_add_left le_rfl)
+          · calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * (Pr[q | oc x] + Pr[r | ob x] + ε) :=
+                  mul_le_mul' le_rfl (h x hx hDx)
+              _ = Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                    + Pr[= x | mx] * ε := by rw [left_distrib, left_distrib]
+        · simp [probOutput_eq_zero_of_not_mem_support hx]
+    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + (∑' x, Pr[= x | mx] * ε) := by
+        rw [ENNReal.tsum_add, ENNReal.tsum_add]
+    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + ε := by
+        refine add_le_add le_rfl ?_
+        rw [ENNReal.tsum_mul_right]
+        exact mul_le_of_le_one_left (zero_le _) tsum_probOutput_le_one
+
+/-- **Four-way disagreement+bad additive bind bound.** A merge of
+`probEvent_bind_le_add_of_disagree` with the three-world `probEvent_bind_le_add_bad_of_disagree`:
+the disagreement set `D` (a *table-level* exceptional set, not a bad event) is charged its full
+mass `ε₁`; everywhere off `D` the `my`-world is bounded by the `oc`-world plus the per-shared-sample
+bad probability `Pr[r | ob x]` plus the slack `ε₂`. -/
+lemma probEvent_bind_le_add_bad_disagree {mx : m α}
+    {my : α → m β} {oc : α → m β} {ob : α → m γ}
+    {q : β → Prop} {r : γ → Prop} {D : α → Prop} [DecidablePred D] {ε₁ ε₂ : ℝ≥0∞}
+    (hD : Pr[ D | mx] ≤ ε₁)
+    (h : ∀ x ∈ support mx, ¬ D x → Pr[ q | my x] ≤ Pr[ q | oc x] + Pr[ r | ob x] + ε₂) :
+    Pr[q | mx >>= my] ≤ Pr[q | mx >>= oc] + Pr[r | mx >>= ob] + ε₁ + ε₂ := by
+  have := Classical.decPred q
+  have := Classical.decPred r
+  rw [probEvent_bind_eq_tsum, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
+  calc ∑' x, Pr[= x | mx] * Pr[q | my x]
+      ≤ ∑' x, (Pr[= x | mx] * Pr[q | oc x]
+            + Pr[= x | mx] * Pr[r | ob x] + (if D x then Pr[= x | mx] else 0)
+            + Pr[= x | mx] * ε₂) := by
+        refine ENNReal.tsum_le_tsum fun x => ?_
+        by_cases hx : x ∈ support mx
+        · by_cases hDx : D x
+          · simp only [if_pos hDx]
+            calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * 1 := mul_le_mul' le_rfl probEvent_le_one
+              _ = Pr[= x | mx] := mul_one _
+              _ ≤ Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                    + Pr[= x | mx] + Pr[= x | mx] * ε₂ := by
+                  calc Pr[= x | mx]
+                      = 0 + 0 + Pr[= x | mx] + 0 := by ring
+                    _ ≤ Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                          + Pr[= x | mx] + Pr[= x | mx] * ε₂ := by
+                        gcongr <;> exact zero_le _
+          · simp only [if_neg hDx, add_zero]
+            calc Pr[= x | mx] * Pr[q | my x]
+                ≤ Pr[= x | mx] * (Pr[q | oc x] + Pr[r | ob x] + ε₂) :=
+                  mul_le_mul' le_rfl (h x hx hDx)
+              _ = Pr[= x | mx] * Pr[q | oc x] + Pr[= x | mx] * Pr[r | ob x]
+                    + Pr[= x | mx] * ε₂ := by rw [left_distrib, left_distrib]
+        · simp [probOutput_eq_zero_of_not_mem_support hx]
+    _ = (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, Pr[= x | mx] * Pr[r | ob x])
+          + (∑' x, if D x then Pr[= x | mx] else 0) + (∑' x, Pr[= x | mx] * ε₂) := by
+        rw [ENNReal.tsum_add, ENNReal.tsum_add, ENNReal.tsum_add]
+    _ ≤ (∑' x, Pr[= x | mx] * Pr[q | oc x])
+          + (∑' x, Pr[= x | mx] * Pr[r | ob x]) + ε₁ + ε₂ := by
+        refine add_le_add (add_le_add le_rfl ?_) ?_
+        · rw [← probEvent_eq_tsum_ite]; exact hD
+        · rw [ENNReal.tsum_mul_right]
+          exact mul_le_of_le_one_left (zero_le _) tsum_probOutput_le_one

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -8,6 +8,7 @@ import VCVio.OracleComp.SimSemantics.SimulateQ
 import VCVio.OracleComp.EvalDist
 import VCVio.EvalDist.Bool
 import VCVio.EvalDist.Prod
+import VCVio.EvalDist.Fintype
 import Init.Data.UInt.Lemmas
 import Mathlib.Data.FinEnum
 import Mathlib.Data.Fintype.Perm
@@ -486,6 +487,233 @@ noncomputable instance instSampleableTypeEmbedding {β α : Type}
   SampleableType.ofFintype _
 
 end instances
+
+section Marginalization
+
+/-- **Overwriting one coordinate of a uniform function table is measure-preserving.**
+
+Drawing a value `u` uniformly from `R`, then a full function table `g : D → R` uniformly, and
+returning `Function.update g t u` yields the same distribution as drawing the table directly.
+
+This is the `t`-marginal independence of the uniform (product) distribution on `D → R`: the value
+at coordinate `t` is uniform and independent of the others, so replacing it with a fresh
+independent uniform draw leaves the joint distribution unchanged. It is the marginalization step
+behind eager-sampling reformulations of oracle responses. -/
+lemma evalDist_uniformSample_bind_update
+    {D R : Type} [Finite D] [DecidableEq D] [Finite R] [Nonempty R]
+    [SampleableType R] [SampleableType (D → R)] (t : D) :
+    𝒟[do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (Function.update g t u)] =
+      𝒟[$ᵗ (D → R)] := by
+  classical
+  letI := Fintype.ofFinite D
+  letI := Fintype.ofFinite R
+  haveI : Nonempty (D → R) := ⟨fun _ => Classical.arbitrary R⟩
+  refine evalDist_ext fun h => ?_
+  rw [probOutput_uniformSample (D → R) h, HasEvalSPMF.probOutput_bind_eq_sum_fintype]
+  -- For each fixed `u`, count the tables `g` whose `t`-update equals `h`.
+  have hinner : ∀ u : R,
+      Pr[= h | (do let g ← $ᵗ (D → R); pure (Function.update g t u))]
+        = (if u = h t then
+            (Fintype.card R : ℝ≥0∞) * (Fintype.card (D → R) : ℝ≥0∞)⁻¹ else 0) := by
+    intro u
+    have hmap : (do let g ← $ᵗ (D → R); pure (Function.update g t u))
+        = (fun g => Function.update g t u) <$> ($ᵗ (D → R)) := by
+      rw [bind_pure_comp]
+    rw [hmap, probOutput_map_eq_sum_fintype_ite]
+    simp only [probOutput_uniformSample (D → R)]
+    rw [← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul]
+    -- The matching tables are exactly `Function.update h t r` for `r : R`.
+    have hcard :
+        ((Finset.univ.filter fun g : D → R => h = Function.update g t u).card : ℝ≥0∞)
+          = if u = h t then (Fintype.card R : ℝ≥0∞) else 0 := by
+      by_cases hu : u = h t
+      · have hset : (Finset.univ.filter fun g : D → R => h = Function.update g t u)
+            = Finset.univ.image (fun r : R => Function.update h t r) := by
+          ext g
+          simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_image]
+          constructor
+          · intro hg
+            refine ⟨g t, ?_⟩
+            rw [eq_comm, Function.update_eq_iff] at hg
+            obtain ⟨_, hg2⟩ := hg
+            funext x
+            by_cases hx : x = t
+            · subst hx; simp
+            · simp [Function.update_of_ne hx, hg2 x hx]
+          · rintro ⟨r, rfl⟩
+            rw [eq_comm, Function.update_eq_iff]
+            exact ⟨by simp [hu], fun x hx => by simp [Function.update_of_ne hx]⟩
+        rw [hset, Finset.card_image_of_injective _
+          (fun r₁ r₂ hr => by simpa using congrFun hr t), Finset.card_univ, if_pos hu]
+      · have hempty : (Finset.univ.filter fun g : D → R => h = Function.update g t u) = ∅ := by
+          rw [Finset.filter_eq_empty_iff]
+          intro g _ hg
+          rw [eq_comm, Function.update_eq_iff] at hg
+          exact hu hg.1
+        rw [hempty, Finset.card_empty, Nat.cast_zero, if_neg hu]
+    rw [hcard]
+    by_cases hu : u = h t <;> simp [hu]
+  simp_rw [hinner, mul_ite, mul_zero]
+  rw [Finset.sum_ite_eq' Finset.univ (h t)]
+  rw [if_pos (Finset.mem_univ _), probOutput_uniformSample R, ← mul_assoc,
+      ENNReal.inv_mul_cancel, one_mul]
+  · simp [Fintype.card_ne_zero]
+  · exact ENNReal.natCast_ne_top _
+
+/-- **The first coordinate of a uniform pair is uniform.**
+
+Mapping the uniform distribution on `α × β` through `Prod.fst` yields the uniform distribution on
+`α`: the `Prod.fst`-marginal of a uniform (product) distribution is uniform. -/
+lemma evalDist_map_fst_uniformSample_prod {α β : Type} [Finite α]
+    [Finite β] [Nonempty β] [SampleableType α] [SampleableType β] [SampleableType (α × β)] :
+    𝒟[Prod.fst <$> ($ᵗ (α × β))] = 𝒟[$ᵗ α] := by
+  classical
+  letI := Fintype.ofFinite α
+  letI := Fintype.ofFinite β
+  haveI : DecidableEq α := Classical.decEq α
+  refine evalDist_ext fun x => ?_
+  rw [probOutput_uniformSample α x, probOutput_map_eq_sum_fintype_ite]
+  simp only [probOutput_uniformSample (α × β)]
+  rw [← Finset.sum_filter, Finset.sum_const, nsmul_eq_mul]
+  have hset : (Finset.univ.filter fun p : α × β => x = p.1)
+      = ({x} : Finset α) ×ˢ (Finset.univ : Finset β) := by
+    ext p
+    simp only [Finset.mem_filter, Finset.mem_univ, true_and, Finset.mem_product,
+      Finset.mem_singleton, and_true]
+    exact eq_comm
+  rw [hset, Finset.card_product, Finset.card_singleton, one_mul, Finset.card_univ,
+    Fintype.card_prod, Nat.cast_mul,
+    ENNReal.mul_inv (Or.inr (ENNReal.natCast_ne_top _)) (Or.inl (ENNReal.natCast_ne_top _)),
+    ← mul_assoc, mul_comm (Fintype.card β : ℝ≥0∞) (Fintype.card α : ℝ≥0∞)⁻¹, mul_assoc,
+    ENNReal.mul_inv_cancel (Nat.cast_ne_zero.mpr Fintype.card_ne_zero)
+      (ENNReal.natCast_ne_top _), mul_one]
+
+/-- **Restricting a uniform function table to a subdomain along an injection is uniform.**
+
+For an injection `e : A → B` between finite types, drawing a uniform table `g : B → R` and
+restricting it along `e` (i.e. `g ∘ e`) yields the uniform distribution on `A → R`.
+
+This is the marginalization of the uniform (product) distribution on `B → R` onto the block of
+coordinates indexed by `Set.range e`: those coordinates are jointly uniform and independent of
+the rest, and `e` reindexes the block by `A`. It underlies eager-sampling reformulations that
+project a fine-grained random-oracle table onto a coarser one. -/
+lemma evalDist_uniformSample_map_comp_injective
+    {A B R : Type} [Finite A] [Finite B] [Finite R]
+    [Nonempty R] [SampleableType R] [SampleableType (A → R)] [SampleableType (B → R)]
+    {e : A → B} (he : Function.Injective e) :
+    𝒟[do let g ← $ᵗ (B → R); pure (g ∘ e)] = 𝒟[$ᵗ (A → R)] := by
+  classical
+  letI := Fintype.ofFinite A
+  letI := Fintype.ofFinite B
+  letI := Fintype.ofFinite R
+  haveI : DecidableEq A := Classical.decEq A
+  haveI : DecidableEq B := Classical.decEq B
+  letI : Inhabited R := Classical.inhabited_of_nonempty inferInstance
+  set C := {b : B // b ∉ Set.range e} with hC
+  letI : Fintype C := Fintype.ofFinite C
+  letI : Inhabited (A → R) := ⟨fun _ => default⟩
+  letI : Inhabited (C → R) := ⟨fun _ => default⟩
+  haveI : DecidableEq C := Classical.decEq C
+  letI : FinEnum C := FinEnum.ofEquiv _ (Fintype.equivFin C)
+  haveI hsC : SampleableType (C → R) := inferInstance
+  haveI hsP : SampleableType ((A → R) × (C → R)) := inferInstance
+  -- Split `B → R` into the `range e` block (reindexed by `A`) and its complement `C`:
+  -- a table is determined by its restriction along `e` and its values off `range e`.
+  set φ : (B → R) ≃ (A → R) × (C → R) :=
+    { toFun := fun g => (g ∘ e, fun c => g c.1)
+      invFun := fun p b => if h : ∃ a, e a = b then p.1 h.choose else p.2 ⟨b, by
+        simpa [Set.mem_range] using h⟩
+      left_inv := fun g => by
+        funext b
+        by_cases h : ∃ a, e a = b
+        · simp only [h, dif_pos, Function.comp_apply]
+          exact congrArg g h.choose_spec
+        · simp [h]
+      right_inv := fun p => by
+        refine Prod.ext ?_ ?_
+        · funext a
+          have h : ∃ a', e a' = e a := ⟨a, rfl⟩
+          simp only [Function.comp_apply, h, dif_pos]
+          exact congrArg p.1 (he h.choose_spec)
+        · funext c
+          have h : ¬ ∃ a, e a = c.1 := by simpa [Set.mem_range] using c.2
+          simp only [h, dif_neg, not_false_iff]
+          exact congrArg p.2 (Subtype.ext rfl) }
+    with hφ
+  have hφ1 : ∀ g : B → R, (φ g).1 = g ∘ e := fun g => rfl
+  have hmap : (do let g ← $ᵗ (B → R); pure (g ∘ e)) = (Prod.fst ∘ φ) <$> ($ᵗ (B → R)) := by
+    rw [bind_pure_comp]; exact congrArg (· <$> _) (funext fun g => (hφ1 g).symm)
+  have hcross : 𝒟[φ <$> ($ᵗ (B → R))] = 𝒟[$ᵗ ((A → R) × (C → R))] :=
+    evalDist_ext fun p =>
+      probOutput_map_bijective_uniform_cross (α := B → R) φ φ.bijective p
+  calc 𝒟[do let g ← $ᵗ (B → R); pure (g ∘ e)]
+      = 𝒟[(Prod.fst ∘ φ) <$> ($ᵗ (B → R))] := by rw [hmap]
+    _ = 𝒟[Prod.fst <$> (φ <$> ($ᵗ (B → R)))] := by
+        simp only [Functor.map_map, Function.comp_def]
+    _ = 𝒟[Prod.fst <$> ($ᵗ ((A → R) × (C → R)))] := by
+        rw [evalDist_map, hcross, ← evalDist_map]
+    _ = 𝒟[$ᵗ (A → R)] := evalDist_map_fst_uniformSample_prod
+
+/-- Patch a uniform function table at every point of a list `l`, drawing one fresh uniform value
+per list entry. With `l = []` the table is returned unchanged; with `l = d :: ds` the tail is
+patched first and the head point `d` is then overwritten with a fresh uniform draw.
+
+This is the iterated form of `Function.update` used by `evalDist_uniformSample_patchList`: the
+outermost update is at the head, so the list is consumed head-first. -/
+noncomputable def patchTable {D R : Type} [DecidableEq D] [SampleableType R] :
+    List D → (D → R) → ProbComp (D → R)
+  | [], g => pure g
+  | d :: ds, g => do
+      let g' ← patchTable ds g
+      let u ← $ᵗ R
+      pure (Function.update g' d u)
+
+@[simp] lemma patchTable_nil {D R : Type} [DecidableEq D] [SampleableType R] (g : D → R) :
+    patchTable [] g = pure g := rfl
+
+lemma patchTable_cons {D R : Type} [DecidableEq D] [SampleableType R]
+    (d : D) (ds : List D) (g : D → R) :
+    patchTable (d :: ds) g =
+      (do let g' ← patchTable ds g; let u ← $ᵗ R; pure (Function.update g' d u)) := rfl
+
+/-- **Patching a uniform function table at finitely many points preserves uniformity.**
+
+Drawing a uniform table `g : D → R` and then `patchTable l g` — overwriting `g` at every point of
+`l` with independent fresh uniform draws — yields the same distribution as drawing the table
+directly. The points of `l` need not be distinct: each `Function.update` is the outermost
+operation of its recursion step, so `evalDist_uniformSample_bind_update` applies regardless of
+overlap. This is the marginalization step behind trace-conditioned eager-table reformulations,
+where the patched points are determined only after the table is sampled. -/
+lemma evalDist_uniformSample_patchList
+    {D R : Type} [Finite D] [DecidableEq D] [Finite R] [Nonempty R]
+    [SampleableType R] [SampleableType (D → R)] (l : List D) :
+    𝒟[do let g ← $ᵗ (D → R); patchTable l g] = 𝒟[$ᵗ (D → R)] := by
+  classical
+  induction l with
+  | nil => simp [patchTable_nil, bind_pure]
+  | cons d ds ih =>
+    refine evalDist_ext fun h => ?_
+    -- The tail-patch block, abbreviated.
+    set blk : ProbComp (D → R) := (do let g ← $ᵗ (D → R); patchTable ds g) with hblk
+    -- LHS: unfold one `patchTable` step and reassociate so the tail-patch block stands alone.
+    have hlhs :
+        Pr[= h | do let g ← $ᵗ (D → R); patchTable (d :: ds) g]
+          = Pr[= h | blk >>= fun g' => $ᵗ R >>= fun u => pure (Function.update g' d u)] := by
+      refine OracleComp.probOutput_congr rfl ?_
+      simp only [patchTable_cons, bind_assoc, hblk]
+    rw [hlhs]
+    -- Push the tail-patch block through the bind; by the IH it is the uniform table.
+    rw [probOutput_bind_eq_tsum]
+    have hihp : ∀ g' : D → R, Pr[= g' | blk] = Pr[= g' | $ᵗ (D → R)] :=
+      fun g' => OracleComp.probOutput_congr rfl ih
+    simp_rw [hihp]
+    rw [← probOutput_bind_eq_tsum]
+    -- Now swap the table draw and the fresh-uniform draw, then apply the single-cell lemma.
+    rw [probOutput_bind_bind_swap ($ᵗ (D → R)) ($ᵗ R)
+      (fun g' u => pure (Function.update g' d u))]
+    exact OracleComp.probOutput_congr rfl (evalDist_uniformSample_bind_update d)
+
+end Marginalization
 
 -- TODO: generalize this lemma
 /--

--- a/VCVio/OracleComp/QueryTracking.lean
+++ b/VCVio/OracleComp/QueryTracking.lean
@@ -13,6 +13,7 @@ import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.QueryTracking.QueryCost
 import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
 import VCVio.OracleComp.QueryTracking.RandomOracle.Eager
+import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
 import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
 import VCVio.OracleComp.QueryTracking.ResourceProfile
 import VCVio.OracleComp.QueryTracking.SeededOracle

--- a/VCVio/OracleComp/QueryTracking/QueryBound.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryBound.lean
@@ -393,6 +393,27 @@ lemma isQueryBoundP_congr_pred {oa : OracleComp spec α} {p p' : ι → Prop}
     · rw [if_pos ((hpp t).mpr ht'), if_pos ht']
     · rw [if_neg (fun h => ht' ((hpp t).mp h)), if_neg ht']
 
+/-- Antitone in the predicate: if every `p`-index is also a `p'`-index, then a `p'`-targeted
+bound is a `p`-targeted bound at the same budget. The `p`-indices form a sub-collection of the
+`p'`-indices, so any path makes at most as many `p`-queries as `p'`-queries. -/
+lemma IsQueryBoundP.of_imp {oa : OracleComp spec α} {p p' : ι → Prop}
+    [DecidablePred p] [DecidablePred p'] {n : ℕ}
+    (himp : ∀ t, p t → p' t) (h : IsQueryBoundP oa p' n) :
+    IsQueryBoundP oa p n := by
+  induction oa using OracleComp.inductionOn generalizing n with
+  | pure _ => trivial
+  | query_bind t mx ih =>
+      rw [isQueryBoundP_query_bind_iff] at h
+      rw [isQueryBoundP_query_bind_iff]
+      refine ⟨?_, fun u => ?_⟩
+      · by_cases hpt : p t
+        · exact Or.inr (h.1.resolve_left (not_not.mpr (himp t hpt)))
+        · exact Or.inl hpt
+      · refine (ih u (h.2 u)).mono ?_
+        by_cases hpt : p t
+        · simp only [if_pos hpt, if_pos (himp t hpt), le_refl]
+        · simp only [if_neg hpt]; split <;> omega
+
 @[simp]
 lemma isQueryBoundP_map_iff (oa : OracleComp spec α) (f : α → β) (n : ℕ) :
     IsQueryBoundP (f <$> oa) p n ↔ IsQueryBoundP oa p n :=

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
 import VCVio.OracleComp.Constructions.SampleableType
@@ -38,11 +38,6 @@ namespace OracleComp
 
 variable {D R : Type} [DecidableEq D] [Finite D] [Finite R] [Nonempty R]
   [SampleableType R] [SampleableType (D → R)]
-
-/-- View a function `f : D → R` as a total answer function (`QueryImpl (D →ₒ R) Id`) for the
-single-oracle constant-range specification `D →ₒ R`. Each query at index `t : D` is answered by
-`f t`. -/
-@[reducible] def tableImpl (f : D → R) : QueryImpl (D →ₒ R) Id := fun t => f t
 
 /-- The total answer table obtained by overlaying a `QueryCache` on top of a full function table:
 cached entries take priority, uncached coordinates fall through to `g`. -/
@@ -94,7 +89,8 @@ through `cacheQuery`. -/
 theorem evalDist_simulateQ_randomOracle_run'_eq_tableExtending
     {α : Type} (oa : OracleComp (D →ₒ R) α) (c : (D →ₒ R).QueryCache) :
     𝒟[(simulateQ randomOracle oa).run' c] =
-      𝒟[do let g ← $ᵗ (D → R); pure (evalWithAnswerFn (tableImpl (tableExtending c g)) oa)] := by
+      𝒟[do let g ← $ᵗ (D → R);
+            pure (evalWithAnswerFn (QueryImpl.ofFn (tableExtending c g)) oa)] := by
   classical
   letI := Fintype.ofFinite D
   letI := Fintype.ofFinite R
@@ -124,14 +120,16 @@ theorem evalDist_simulateQ_randomOracle_run'_eq_tableExtending
       rw [map_bind]
       rfl
     have heval : ∀ g : D → R,
-        evalWithAnswerFn (tableImpl (tableExtending c g)) (liftM ((D →ₒ R).query t) >>= k)
-          = evalWithAnswerFn (tableImpl (tableExtending c g))
+        evalWithAnswerFn (QueryImpl.ofFn (tableExtending c g)) (liftM ((D →ₒ R).query t) >>= k)
+          = evalWithAnswerFn (QueryImpl.ofFn (tableExtending c g))
               (k (tableExtending c g t)) := by
       intro g
       rw [evalWithAnswerFn_bind]
-      change evalWithAnswerFn (tableImpl (tableExtending c g))
-        (k (simulateQ (tableImpl (tableExtending c g)) (liftM ((D →ₒ R).query t)))) = _
+      change evalWithAnswerFn (QueryImpl.ofFn (tableExtending c g))
+        (k (simulateQ (QueryImpl.ofFn (tableExtending c g))
+          (liftM ((D →ₒ R).query t)))) = _
       rw [simulateQ_spec_query]
+      rfl
     rw [hred]
     simp_rw [heval]
     rcases hc : c t with _ | u
@@ -147,9 +145,10 @@ theorem evalDist_simulateQ_randomOracle_run'_eq_tableExtending
         rw [map_eq_bind_pure_comp]; simp [bind_assoc]]
       -- The continuation, abstracted as a function of the full table.
       set ψ : (D → R) → α := fun g' =>
-        evalWithAnswerFn (tableImpl (tableExtending c g')) (k (tableExtending c g' t)) with hψ
+        evalWithAnswerFn (QueryImpl.ofFn (tableExtending c g')) (k (tableExtending c g' t))
+        with hψ
       have hfun : ∀ u : R, (fun g : D → R =>
-            evalWithAnswerFn (tableImpl (tableExtending (c.cacheQuery t u) g)) (k u))
+            evalWithAnswerFn (QueryImpl.ofFn (tableExtending (c.cacheQuery t u) g)) (k u))
           = fun g : D → R => ψ (Function.update g t u) := by
         intro u
         funext g
@@ -192,7 +191,7 @@ uniform and independent, sampling on demand matches pre-sampling the whole table
 theorem evalDist_simulateQ_randomOracle_run'_empty_eq_uniformTable
     {α : Type} (oa : OracleComp (D →ₒ R) α) :
     𝒟[(simulateQ randomOracle oa).run' ∅] =
-      𝒟[do let g ← $ᵗ (D → R); pure (evalWithAnswerFn (tableImpl g) oa)] := by
+      𝒟[do let g ← $ᵗ (D → R); pure (evalWithAnswerFn (QueryImpl.ofFn g) oa)] := by
   rw [evalDist_simulateQ_randomOracle_run'_eq_tableExtending oa ∅]
   refine congrArg _ ?_
   refine congrArg _ (funext fun g => ?_)

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean
@@ -1,0 +1,201 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
+import VCVio.OracleComp.Constructions.SampleableType
+
+/-!
+# Lazy Random Oracle Equals Eager Full-Table Sampling
+
+For an oracle specification `D →ₒ R` with a single constant range `R`, running an
+`OracleComp (D →ₒ R) α` under the lazy random oracle (`OracleSpec.randomOracle`,
+i.e. `uniformSampleImpl.withCaching`) has the same output distribution as the eager
+strategy: sample a *full* answer table `f : D → R` uniformly, then evaluate the
+computation deterministically against `f` via `evalWithAnswerFn`.
+
+The lazy oracle samples a fresh uniform value on first query and caches it for
+consistency, so caching only ever affects *repeated* queries. Since every fresh
+table entry is uniform and independent, lazily sampling on demand is
+distributionally identical to pre-sampling the whole table. The marginalization
+lemma `evalDist_uniformSample_bind_update` is the workhorse: it absorbs each
+fresh on-demand uniform draw into the pre-sampled table.
+
+## Main results
+
+* `evalDist_simulateQ_randomOracle_run'_eq_tableExtending`: the generalized,
+  cache-parametrized form, the induction vehicle.
+* `evalDist_simulateQ_randomOracle_run'_empty_eq_uniformTable`: the empty-cache
+  corollary — the lazy-vs-eager equivalence proper.
+-/
+
+open OracleComp OracleSpec
+
+universe u v w
+
+namespace OracleComp
+
+variable {D R : Type} [DecidableEq D] [Finite D] [Finite R] [Nonempty R]
+  [SampleableType R] [SampleableType (D → R)]
+
+/-- View a function `f : D → R` as a total answer function (`QueryImpl (D →ₒ R) Id`) for the
+single-oracle constant-range specification `D →ₒ R`. Each query at index `t : D` is answered by
+`f t`. -/
+@[reducible] def tableImpl (f : D → R) : QueryImpl (D →ₒ R) Id := fun t => f t
+
+/-- The total answer table obtained by overlaying a `QueryCache` on top of a full function table:
+cached entries take priority, uncached coordinates fall through to `g`. -/
+@[reducible] def tableExtending (c : (D →ₒ R).QueryCache) (g : D → R) : D → R :=
+  fun t => (c t).getD (g t)
+
+omit [Finite D] [Finite R] [Nonempty R] [SampleableType R] [SampleableType (D → R)] in
+/-- Overlaying `c.cacheQuery t u` on `g` is the `t`-update of overlaying `c` on `g`. -/
+lemma tableExtending_cacheQuery (c : (D →ₒ R).QueryCache) (g : D → R)
+    (t : D) (u : R) :
+    tableExtending (c.cacheQuery t u) g = Function.update (tableExtending c g) t u := by
+  funext t'
+  by_cases ht : t' = t
+  · subst ht; simp [tableExtending, QueryCache.cacheQuery]
+  · simp [tableExtending, QueryCache.cacheQuery_of_ne _ _ ht, Function.update_of_ne ht]
+
+omit [Finite D] [Finite R] [Nonempty R] [SampleableType R] [SampleableType (D → R)] in
+/-- When `t` is uncached, updating the overlaid table at `t` equals overlaying the cache on the
+updated full table. -/
+lemma tableExtending_update_of_none (c : (D →ₒ R).QueryCache) (g : D → R)
+    {t : D} (hc : c t = none) (u : R) :
+    Function.update (tableExtending c g) t u = tableExtending c (Function.update g t u) := by
+  funext t'
+  by_cases ht : t' = t
+  · subst ht; simp [tableExtending, hc]
+  · simp [tableExtending, Function.update_of_ne ht]
+
+/-- **Marginalization, post-composed.** For any continuation `ψ : (D → R) → α`, drawing a fresh
+uniform `u`, then a full uniform table `g`, and evaluating `ψ` on `Function.update g t u` has the
+same distribution as evaluating `ψ` on a directly drawn uniform table. -/
+lemma evalDist_uniformSample_bind_update_map {α : Type} (t : D) (ψ : (D → R) → α) :
+    𝒟[do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (ψ (Function.update g t u))] =
+      𝒟[do let g ← $ᵗ (D → R); pure (ψ g)] := by
+  have hL : (do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (ψ (Function.update g t u))) =
+      ψ <$> (do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (Function.update g t u)) := by
+    simp [map_bind, bind_pure_comp]
+  have hR : (do let g ← $ᵗ (D → R); pure (ψ g)) = ψ <$> ($ᵗ (D → R)) := by
+    simp [bind_pure_comp]
+  rw [hL, hR, evalDist_map, evalDist_map, evalDist_uniformSample_bind_update t]
+
+/-- **Lazy random oracle equals eager full-table sampling — cache-parametrized form.**
+
+Running `oa` under the lazy random oracle starting from cache `c` yields the same output
+distribution as: sample a full table `g : D → R` uniformly, then evaluate `oa` deterministically
+against the table that overlays `c` on `g`.
+
+This is the induction vehicle: the cache `c` is generalized so the `query`/`bind` step can recurse
+through `cacheQuery`. -/
+theorem evalDist_simulateQ_randomOracle_run'_eq_tableExtending
+    {α : Type} (oa : OracleComp (D →ₒ R) α) (c : (D →ₒ R).QueryCache) :
+    𝒟[(simulateQ randomOracle oa).run' c] =
+      𝒟[do let g ← $ᵗ (D → R); pure (evalWithAnswerFn (tableImpl (tableExtending c g)) oa)] := by
+  classical
+  letI := Fintype.ofFinite D
+  letI := Fintype.ofFinite R
+  haveI : Nonempty (D → R) := ⟨fun _ => Classical.arbitrary R⟩
+  induction oa using OracleComp.inductionOn generalizing c with
+  | pure a =>
+    have hlhs : (simulateQ randomOracle (pure a : OracleComp (D →ₒ R) α)).run' c
+        = (pure a : ProbComp α) := by
+      rw [simulateQ_pure]
+      change (fun x => x.1) <$> (pure (a, c) : ProbComp (α × _)) = pure a
+      rw [map_pure]
+    rw [hlhs]
+    simp only [evalWithAnswerFn_pure]
+    symm
+    refine evalDist_ext fun x => ?_
+    rw [probOutput_bind_eq_tsum, ENNReal.tsum_mul_right,
+      tsum_probOutput_eq_one' (mx := $ᵗ (D → R)) (by simp), one_mul]
+  | query_bind t k ih =>
+    have hred :
+        (simulateQ randomOracle (liftM ((D →ₒ R).query t) >>= k)).run' c
+          = ((randomOracle (spec := (D →ₒ R)) t).run c) >>=
+            fun p : R × (D →ₒ R).QueryCache =>
+              (simulateQ randomOracle (k p.1)).run' p.2 := by
+      rw [simulateQ_bind, simulateQ_spec_query]
+      change Prod.fst <$> (((randomOracle (spec := (D →ₒ R)) t).run c) >>= fun p =>
+        (simulateQ randomOracle (k p.1)).run p.2) = _
+      rw [map_bind]
+      rfl
+    have heval : ∀ g : D → R,
+        evalWithAnswerFn (tableImpl (tableExtending c g)) (liftM ((D →ₒ R).query t) >>= k)
+          = evalWithAnswerFn (tableImpl (tableExtending c g))
+              (k (tableExtending c g t)) := by
+      intro g
+      rw [evalWithAnswerFn_bind]
+      change evalWithAnswerFn (tableImpl (tableExtending c g))
+        (k (simulateQ (tableImpl (tableExtending c g)) (liftM ((D →ₒ R).query t)))) = _
+      rw [simulateQ_spec_query]
+    rw [hred]
+    simp_rw [heval]
+    rcases hc : c t with _ | u
+    · -- Cache miss: a fresh uniform draw, absorbed by marginalization.
+      rw [show ((randomOracle (spec := (D →ₒ R)) t).run c) =
+            (fun u => (u, c.cacheQuery t u)) <$> ($ᵗ R) from
+            QueryImpl.withCaching_run_none _ hc]
+      rw [show (((fun u => (u, c.cacheQuery t u)) <$> ($ᵗ R)) >>=
+              fun p : R × (D →ₒ R).QueryCache =>
+                (simulateQ randomOracle (k p.1)).run' p.2)
+            = (($ᵗ R) >>= fun u =>
+                (simulateQ randomOracle (k u)).run' (c.cacheQuery t u)) from by
+        rw [map_eq_bind_pure_comp]; simp [bind_assoc]]
+      -- The continuation, abstracted as a function of the full table.
+      set ψ : (D → R) → α := fun g' =>
+        evalWithAnswerFn (tableImpl (tableExtending c g')) (k (tableExtending c g' t)) with hψ
+      have hfun : ∀ u : R, (fun g : D → R =>
+            evalWithAnswerFn (tableImpl (tableExtending (c.cacheQuery t u) g)) (k u))
+          = fun g : D → R => ψ (Function.update g t u) := by
+        intro u
+        funext g
+        simp only [hψ]
+        rw [tableExtending_cacheQuery, ← tableExtending_update_of_none c g hc u]
+        simp only [Function.update_self]
+      trans 𝒟[do let u ← $ᵗ R; let g ← $ᵗ (D → R); pure (ψ (Function.update g t u))]
+      · rw [evalDist_bind, evalDist_bind]
+        refine congrArg _ (funext fun u => ?_)
+        rw [ih u (c.cacheQuery t u), bind_pure_comp, bind_pure_comp, hfun u]
+      · exact evalDist_uniformSample_bind_update_map t ψ
+    · -- Cache hit: no new sample, table already has `c t = some u`.
+      rw [show ((randomOracle (spec := (D →ₒ R)) t).run c) = (pure (u, c) : ProbComp _) from
+            QueryImpl.withCaching_run_some _ hc]
+      rw [pure_bind]
+      rw [ih u c]
+      refine congrArg _ ?_
+      refine congrArg _ (funext fun g => ?_)
+      congr 1
+      have : tableExtending c g t = u := by simp [tableExtending, hc]
+      rw [this]
+
+omit [DecidableEq D] [Finite D] [Finite R] [Nonempty R] [SampleableType R]
+  [SampleableType (D → R)] in
+/-- Overlaying the empty cache leaves a full table unchanged. -/
+lemma tableExtending_empty (g : D → R) :
+    tableExtending (∅ : (D →ₒ R).QueryCache) g = g := by
+  funext t; simp [tableExtending]
+
+/-- **Lazy random oracle equals eager full-table sampling.**
+
+Running an `OracleComp (D →ₒ R) α` under the lazy random oracle from the empty cache yields the
+same output distribution as: sample a full answer table `g : D → R` uniformly, then evaluate the
+computation deterministically against `g`.
+
+This is the empty-cache specialization of
+`evalDist_simulateQ_randomOracle_run'_eq_tableExtending`: the classic lazy-vs-eager-sampling
+equivalence. Lazy caching only affects repeated queries, and since each fresh table entry is
+uniform and independent, sampling on demand matches pre-sampling the whole table. -/
+theorem evalDist_simulateQ_randomOracle_run'_empty_eq_uniformTable
+    {α : Type} (oa : OracleComp (D →ₒ R) α) :
+    𝒟[(simulateQ randomOracle oa).run' ∅] =
+      𝒟[do let g ← $ᵗ (D → R); pure (evalWithAnswerFn (tableImpl g) oa)] := by
+  rw [evalDist_simulateQ_randomOracle_run'_eq_tableExtending oa ∅]
+  refine congrArg _ ?_
+  refine congrArg _ (funext fun g => ?_)
+  rw [tableExtending_empty]
+
+end OracleComp

--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -211,3 +211,57 @@ lemma simulateQ_list_forM (f : α → OracleComp spec PUnit) (xs : List α) :
     rw [h, simulateQ_bind]; congr 1; funext; exact ih
 
 end List
+
+/-! ## Composition of simulations via a per-query bridge -/
+
+section Compose
+
+universe u' v'
+
+variable {ι₁ ι₂ : Type*} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+
+/-- Two-stage simulation: if a "reduction" `red : QueryImpl spec₁ (StateT σ (OracleComp spec₂))`
+followed by an inner `impl : QueryImpl spec₂ n` agrees per-query with a "combined" handler
+`game : QueryImpl spec₁ (StateT σ n)`, then the agreement extends to every outer computation by
+structural induction. This packages the boilerplate induction reused across PRF-style reductions. -/
+theorem simulateQ_StateT_compose
+    {σ : Type u'} {n : Type u' → Type v'} [Monad n] [LawfulMonad n]
+    (red : QueryImpl spec₁ (StateT σ (OracleComp spec₂)))
+    (impl : QueryImpl spec₂ n)
+    (game : QueryImpl spec₁ (StateT σ n))
+    (bridge : ∀ (q : spec₁.Domain) (s : σ),
+      simulateQ impl ((red q).run s) = (game q).run s)
+    {α : Type u'} (oa : OracleComp spec₁ α) (s : σ) :
+    simulateQ impl ((simulateQ red oa).run s) = (simulateQ game oa).run s := by
+  induction oa using OracleComp.inductionOn generalizing s with
+  | pure x => simp [StateT.run_pure]
+  | query_bind t f ih =>
+    simp only [simulateQ_bind, StateT.run_bind, simulateQ_spec_query]
+    rw [bridge t s]
+    exact bind_congr fun p => ih p.1 p.2
+
+/-- Three-layer simulation collapse: if a "reduction" `red : QueryImpl spec₁ (StateT σ
+(OracleComp spec₂))` followed by an inner cached `impl : QueryImpl spec₂ (StateT τ n)` agrees
+per-query with a single "combined" handler `combined : QueryImpl spec₁ (StateT (σ × τ) n)` up to
+the natural reassociation `α × σ × τ ≃ (α × σ) × τ`, then the agreement extends to every outer
+computation. This packages the boilerplate induction used by lazy-random-oracle / cached-PRF
+collapses. -/
+theorem simulateQ_StateT_StateT_compose
+    {σ τ : Type u'} {n : Type u' → Type v'} [Monad n] [LawfulMonad n]
+    (red : QueryImpl spec₁ (StateT σ (OracleComp spec₂)))
+    (impl : QueryImpl spec₂ (StateT τ n))
+    (combined : QueryImpl spec₁ (StateT (σ × τ) n))
+    (bridge : ∀ (q : spec₁.Domain) (s : σ) (c : τ),
+      (simulateQ impl ((red q).run s)).run c =
+        (fun r : spec₁.Range q × σ × τ => ((r.1, r.2.1), r.2.2)) <$> combined q (s, c))
+    {α : Type u'} (oa : OracleComp spec₁ α) (s : σ) (c : τ) :
+    (simulateQ impl ((simulateQ red oa).run s)).run c =
+      (fun r : α × σ × τ => ((r.1, r.2.1), r.2.2)) <$> (simulateQ combined oa).run (s, c) := by
+  induction oa using OracleComp.inductionOn generalizing s c with
+  | pure x => simp [StateT.run_pure]
+  | query_bind t f ih =>
+    simp only [simulateQ_bind, StateT.run_bind, simulateQ_spec_query]
+    rw [bridge t s c, bind_map_left, map_bind]
+    exact bind_congr fun r => ih r.1 r.2.1 r.2.2
+
+end Compose

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -2397,4 +2397,221 @@ theorem ofReal_tvDist_simulateQ_run_le_queryBound_mul_slack_plus_probEvent_bad
 
 end IdenticalUntilBadEpsilonStateDep
 
+/-! ### Heterogeneous-state bad + slack `simulateQ` rule
+
+A fully heterogeneous (`σ₁ ≠ σ₂`, `spec₁ ≠ spec₂`) one-directional `simulateQ` induction
+rule carrying both a monotone bad event on side `1` and per-charged-query slack `ε`.
+
+Unlike the `tvDist`-based bounds above, this rule does not require the two simulations to
+have the same output/state type: the conclusion is a one-directional `Pr[= true]`
+inequality
+
+  `Pr[= true | run' impl₁] ≤ Pr[= true | run' impl₂] + Pr[bad] + q · ε`,
+
+which is exactly the shape consumed by cross-domain crypto reductions that couple a
+per-tag random oracle against a per-session one. The accounting term `q · ε` comes from
+the charged-query budget `IsQueryBoundP oa charged q`. -/
+
+section HeterogeneousBadSlack
+
+variable {ι : Type} {spec : OracleSpec ι}
+variable {ι₁ ι₂ : Type} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable {σ₁ σ₂ : Type}
+
+omit [spec₁.Fintype] [spec₁.Inhabited] in
+/-- Bad propagation for a general (non-flag) bad predicate: starting the simulation from a
+bad state, every output state stays bad. The heterogeneous-state analogue of
+`mem_support_simulateQ_run_of_bad`. -/
+private lemma mem_support_simulateQ_run_of_bad_general
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (bad : σ₁ → Prop)
+    (hmono : ∀ (t : spec.Domain) (s₁ : σ₁), bad s₁ →
+      ∀ z ∈ support ((impl₁ t).run s₁), bad z.2)
+    (oa : OracleComp spec α) (s₁ : σ₁) (hbad : bad s₁) :
+    ∀ z ∈ support ((simulateQ impl₁ oa).run s₁), bad z.2 := by
+  induction oa using OracleComp.inductionOn generalizing s₁ with
+  | pure x =>
+      intro z hz
+      simp only [simulateQ_pure, StateT.run_pure, support_pure, Set.mem_singleton_iff] at hz
+      subst hz
+      exact hbad
+  | query_bind t cont ih =>
+      intro z hz
+      simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+        OracleQuery.cont_query, id_map, StateT.run_bind, support_bind, Set.mem_iUnion,
+        exists_prop] at hz
+      obtain ⟨⟨u, s₁'⟩, h_mem, h_z⟩ := hz
+      exact ih u s₁' (hmono t s₁ hbad (u, s₁') h_mem) z h_z
+
+/-- A simulation started from a bad state has bad probability exactly `1`. The
+heterogeneous-state analogue of `probEvent_simulateQ_run_bad_eq_one_of_bad`. -/
+private lemma probEvent_bad_simulateQ_run_eq_one_of_bad
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (bad : σ₁ → Prop)
+    (hmono : ∀ (t : spec.Domain) (s₁ : σ₁), bad s₁ →
+      ∀ z ∈ support ((impl₁ t).run s₁), bad z.2)
+    (oa : OracleComp spec α) (s₁ : σ₁) (hbad : bad s₁) :
+    Pr[ bad ∘ Prod.snd | (simulateQ impl₁ oa).run s₁] = 1 := by
+  rw [probEvent_eq_one_iff]
+  refine ⟨by simp, ?_⟩
+  intro z hz
+  exact mem_support_simulateQ_run_of_bad_general impl₁ bad hmono oa s₁ hbad z hz
+
+/-- Inductive core of `probOutput_simulateQ_run'_le_add_bad_add_slack`, stated on the
+joint `run` distribution with the event `fun z => z.1 = true`. -/
+private theorem probEvent_fst_simulateQ_run_le_add_bad_add_slack
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (R : σ₁ → σ₂ → Prop)
+    (bad : σ₁ → Prop)
+    (charged : spec.Domain → Prop) [DecidablePred charged]
+    (ε : ℝ≥0∞)
+    (hmono : ∀ (t : spec.Domain) (s₁ : σ₁), bad s₁ →
+      ∀ z ∈ support ((impl₁ t).run s₁), bad z.2)
+    (hstep : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂), R s₁ s₂ → ¬ bad s₁ →
+      ∀ (k₁ : spec.Range t × σ₁ → OracleComp spec₁ (Bool × σ₁))
+        (k₂ : spec.Range t × σ₂ → OracleComp spec₂ (Bool × σ₂)) (c : ℝ≥0∞),
+        (∀ (u : spec.Range t) (s₁' : σ₁) (s₂' : σ₂), R s₁' s₂' →
+          Pr[ fun z => z.1 = true | k₁ (u, s₁')] ≤
+            Pr[ fun z => z.1 = true | k₂ (u, s₂')] +
+            Pr[ bad ∘ Prod.snd | k₁ (u, s₁')] + c) →
+        Pr[ fun z => z.1 = true | (impl₁ t).run s₁ >>= k₁] ≤
+          Pr[ fun z => z.1 = true | (impl₂ t).run s₂ >>= k₂] +
+          Pr[ bad ∘ Prod.snd | (impl₁ t).run s₁ >>= k₁] +
+          (c + (if charged t then ε else 0)))
+    (oa : OracleComp spec Bool) :
+    ∀ {q : ℕ}, OracleComp.IsQueryBoundP oa charged q →
+      ∀ (s₁ : σ₁) (s₂ : σ₂), R s₁ s₂ →
+        Pr[ fun z => z.1 = true | (simulateQ impl₁ oa).run s₁] ≤
+          Pr[ fun z => z.1 = true | (simulateQ impl₂ oa).run s₂] +
+          Pr[ bad ∘ Prod.snd | (simulateQ impl₁ oa).run s₁] +
+          (q : ℝ≥0∞) * ε := by
+  induction oa using OracleComp.inductionOn generalizing σ₂ with
+  | pure x =>
+      intro q _ s₁ s₂ _
+      simp only [simulateQ_pure, StateT.run_pure, probEvent_pure]
+      exact le_add_right (le_add_right le_rfl)
+  | @query_bind t cont ih =>
+      intro q hqb s₁ s₂ hR
+      by_cases hbad : bad s₁
+      · -- bad branch: `Pr[ bad ∘ snd | sim₁] = 1` dominates everything.
+        have hbad1 : Pr[ bad ∘ Prod.snd | (simulateQ impl₁ (query t >>= cont)).run s₁] = 1 :=
+          probEvent_bad_simulateQ_run_eq_one_of_bad impl₁ bad hmono _ s₁ hbad
+        refine le_trans probEvent_le_one ?_
+        rw [hbad1]
+        exact le_add_right le_add_self
+      · -- good branch: rewrite both sides to head-bind form and apply `hstep`.
+        rw [isQueryBoundP_query_bind_iff] at hqb
+        obtain ⟨hvalid, hcont⟩ := hqb
+        have hsim₁ : (simulateQ impl₁ (query t >>= cont)).run s₁ =
+            (impl₁ t).run s₁ >>= fun z => (simulateQ impl₁ (cont z.1)).run z.2 := by
+          simp [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+            OracleQuery.cont_query, StateT.run_bind]
+        have hsim₂ : (simulateQ impl₂ (query t >>= cont)).run s₂ =
+            (impl₂ t).run s₂ >>= fun z => (simulateQ impl₂ (cont z.1)).run z.2 := by
+          simp [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+            OracleQuery.cont_query, StateT.run_bind]
+        rw [hsim₁, hsim₂]
+        set k₁ : spec.Range t × σ₁ → OracleComp spec₁ (Bool × σ₁) :=
+          fun z => (simulateQ impl₁ (cont z.1)).run z.2 with hk₁
+        set k₂ : spec.Range t × σ₂ → OracleComp spec₂ (Bool × σ₂) :=
+          fun z => (simulateQ impl₂ (cont z.1)).run z.2 with hk₂
+        -- The slack carried past one query: `(q-1)·ε` if charged, else `q·ε`.
+        set c : ℝ≥0∞ := ((if charged t then q - 1 else q : ℕ) : ℝ≥0∞) * ε with hc
+        -- Continuation bound for *every* `R`-related result (bad ones handled by monotonicity).
+        have hcont_bound : ∀ (u : spec.Range t) (s₁' : σ₁) (s₂' : σ₂), R s₁' s₂' →
+            Pr[ fun z => z.1 = true | k₁ (u, s₁')] ≤
+              Pr[ fun z => z.1 = true | k₂ (u, s₂')] +
+              Pr[ bad ∘ Prod.snd | k₁ (u, s₁')] + c := by
+          intro u s₁' s₂' hR'
+          by_cases hbad' : bad s₁'
+          · -- bad continuation: `Pr[ bad ∘ snd | k₁] = 1` dominates.
+            have hbad1' : Pr[ bad ∘ Prod.snd | k₁ (u, s₁')] = 1 :=
+              probEvent_bad_simulateQ_run_eq_one_of_bad impl₁ bad hmono (cont u) s₁' hbad'
+            refine le_trans probEvent_le_one ?_
+            rw [hbad1']
+            exact le_add_right le_add_self
+          · -- good continuation: apply the inductive hypothesis at the decremented budget.
+            have hib : OracleComp.IsQueryBoundP (cont u) charged
+                (if charged t then q - 1 else q) := hcont u
+            exact ih u impl₂ R hstep hib s₁' s₂' hR'
+        -- Apply the per-step premise; then absorb `c + slack` into `q·ε`.
+        refine le_trans (hstep t s₁ s₂ hR hbad k₁ k₂ c hcont_bound) ?_
+        have hcabs : c + (if charged t then ε else 0) ≤ (q : ℝ≥0∞) * ε := by
+          rcases hvalid with hnc | hpos
+          · -- `t` uncharged: `c = q·ε`, slack term is `0`.
+            rw [hc, if_neg hnc, if_neg hnc, add_zero]
+          · -- `t` charged: `c = (q-1)·ε`, slack term is `ε`, and `0 < q`.
+            by_cases hch : charged t
+            · rw [hc, if_pos hch, if_pos hch]
+              have hq : ((q - 1 : ℕ) : ℝ≥0∞) + 1 = (q : ℝ≥0∞) := by
+                have : ((q - 1 : ℕ) + 1 : ℕ) = q := Nat.succ_pred_eq_of_pos hpos
+                exact_mod_cast congrArg (Nat.cast : ℕ → ℝ≥0∞) this
+              rw [show ((q - 1 : ℕ) : ℝ≥0∞) * ε + ε = (((q - 1 : ℕ) : ℝ≥0∞) + 1) * ε by
+                rw [add_mul, one_mul], hq]
+            · rw [hc, if_neg hch, if_neg hch, add_zero]
+        gcongr
+
+/-- **Heterogeneous-state bad + slack `simulateQ` rule.**
+
+Couples two stateful oracle simulations with *different* state types `σ₁`, `σ₂` and
+*different* base specs `spec₁`, `spec₂`, related by a coupling invariant `R`. It carries a
+monotone bad event `bad` on side `1` together with per-charged-query slack `ε`, charged
+queries being designated by the predicate `charged`. If the computation `oa` makes at most
+`q` charged queries (`IsQueryBoundP oa charged q`), then
+
+  `Pr[= true | run' impl₁ oa] ≤ Pr[= true | run' impl₂ oa] + Pr[bad] + q · ε`.
+
+The per-query premise `hstep` is the bind-level coupling step: from `R`-related, non-bad
+states, one query head together with any pair of continuations satisfying a continuation
+bound yields the head-bind bound, paying `ε` for charged queries. This packages exactly
+the obligation a concrete cross-domain reduction must discharge for its oracle pair.
+
+Only `impl₁` requires bad monotonicity (`hmono`), since the bound is one-directional and
+mentions `Pr[bad]` only on side `1`. -/
+theorem probOutput_simulateQ_run'_le_add_bad_add_slack
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (R : σ₁ → σ₂ → Prop)
+    (bad : σ₁ → Prop)
+    (charged : spec.Domain → Prop) [DecidablePred charged]
+    (ε : ℝ≥0∞)
+    (hmono : ∀ (t : spec.Domain) (s₁ : σ₁), bad s₁ →
+      ∀ z ∈ support ((impl₁ t).run s₁), bad z.2)
+    (hstep : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂), R s₁ s₂ → ¬ bad s₁ →
+      ∀ (k₁ : spec.Range t × σ₁ → OracleComp spec₁ (Bool × σ₁))
+        (k₂ : spec.Range t × σ₂ → OracleComp spec₂ (Bool × σ₂)) (c : ℝ≥0∞),
+        (∀ (u : spec.Range t) (s₁' : σ₁) (s₂' : σ₂), R s₁' s₂' →
+          Pr[ fun z => z.1 = true | k₁ (u, s₁')] ≤
+            Pr[ fun z => z.1 = true | k₂ (u, s₂')] +
+            Pr[ bad ∘ Prod.snd | k₁ (u, s₁')] + c) →
+        Pr[ fun z => z.1 = true | (impl₁ t).run s₁ >>= k₁] ≤
+          Pr[ fun z => z.1 = true | (impl₂ t).run s₂ >>= k₂] +
+          Pr[ bad ∘ Prod.snd | (impl₁ t).run s₁ >>= k₁] +
+          (c + (if charged t then ε else 0)))
+    (oa : OracleComp spec Bool) {q : ℕ}
+    (hbound : OracleComp.IsQueryBoundP oa charged q)
+    (s₁ : σ₁) (s₂ : σ₂) (hR : R s₁ s₂) :
+    Pr[= true | (simulateQ impl₁ oa).run' s₁] ≤
+      Pr[= true | (simulateQ impl₂ oa).run' s₂] +
+      Pr[ bad ∘ Prod.snd | (simulateQ impl₁ oa).run s₁] +
+      (q : ℝ≥0∞) * ε := by
+  have hjoint := probEvent_fst_simulateQ_run_le_add_bad_add_slack
+    impl₁ impl₂ R bad charged ε hmono hstep oa hbound s₁ s₂ hR
+  have hproj₁ : Pr[= true | (simulateQ impl₁ oa).run' s₁] =
+      Pr[ fun z : Bool × σ₁ => z.1 = true | (simulateQ impl₁ oa).run s₁] := by
+    rw [← probEvent_eq_eq_probOutput _ true, StateT.run'_eq,
+      show (fun x : Bool × σ₁ => x.1) = Prod.fst from rfl, probEvent_map]
+    rfl
+  have hproj₂ : Pr[= true | (simulateQ impl₂ oa).run' s₂] =
+      Pr[ fun z : Bool × σ₂ => z.1 = true | (simulateQ impl₂ oa).run s₂] := by
+    rw [← probEvent_eq_eq_probOutput _ true, StateT.run'_eq,
+      show (fun x : Bool × σ₂ => x.1) = Prod.fst from rfl, probEvent_map]
+    rfl
+  rw [hproj₁, hproj₂]
+  exact hjoint
+
+end HeterogeneousBadSlack
+
 end OracleComp.ProgramLogic.Relational


### PR DESCRIPTION
A bundle of six independent additions to `VCVio/` that I needed for an
upcoming PRFTagReader unlinkability reduction. None of them references the
crypto layer; each is justifiable as a generic framework utility and is in
its own commit. They share no theme beyond "I authored them for the same
downstream proof" — if you'd prefer to land them piecemeal, the commits
are atomic.

Rebased onto current `main`. The original `instSampleableTypePiFintype`
that this branch carried is now subsumed by `instSampleableTypeFunc` from
#398; the rebased first commit reduces to the `Marginalization` section
plus one local `FinEnum.ofEquiv` adapter used inside one of its proofs.

## What's added (after rebase)

| Commit | File | Headline |
|---|---|---|
| `2ee6a19` | `VCVio/OracleComp/Constructions/SampleableType.lean` | `Marginalization` section: `evalDist_map_fst_uniformSample_prod`, `evalDist_uniformSample_map_comp_injective`, `evalDist_uniformSample_bind_update`, `evalDist_uniformSample_patchList` (+ `_map` variant). Lemmas for "patching a uniform table at finitely many points with fresh uniform draws preserves uniformity" — the marginalization underlying eager-sampling reformulations of oracle responses. |
| `5075df8` | `VCVio/OracleComp/QueryTracking/QueryBound.lean` | `IsQueryBoundP.of_imp` — antitone-in-predicate: `p ⇒ p'` gives `IsQueryBoundP oa p' n → IsQueryBoundP oa p n`. |
| `93b784a` | `VCVio/OracleComp/SimSemantics/SimulateQ.lean` | `simulateQ_StateT_compose` / `simulateQ_StateT_StateT_compose` — lift a per-query bridge to the whole computation by structural induction. |
| `966e107` | `VCVio/EvalDist/Monad/Disagreement.lean` (NEW) | Four `bind`-level identical-until-bad probability bounds: `probEvent_bind_le_add_of_disagree`, `_add_bad_of_disagree`, `_add_bad_of_disagree'`, `_add_bad_disagree`. |
| `62e6194` | `VCVio/OracleComp/QueryTracking/RandomOracle/EagerTable.lean` (NEW) | Lazy RO ↔ eager-full-table for `D →ₒ R`: `evalDist_simulateQ_randomOracle_run'_eq_tableExtending` (arbitrary cache) and `_empty_eq_uniformTable` (empty cache → uniform table sample). |
| `b599da2` | `VCVio/ProgramLogic/Relational/SimulateQ.lean` | `probOutput_simulateQ_run'_le_add_bad_add_slack` — heterogeneous `(σ₁, spec₁) → (σ₂, spec₂)` `simulateQ` rule with a monotone bad event and per-charged-query slack budget. |

Diff: +931 / -1 across 8 files (6 substantive + 2 module index files: `VCVio.lean`, `VCVio/OracleComp/QueryTracking.lean`).

## Hygiene

- `lake build VCVio` — green (3628 jobs).
- `#print axioms` on all six headlines: `[propext, Classical.choice, Quot.sound]` only (the `simulateQ_StateT_compose` helper is `[propext, Quot.sound]`).
- No `sorry`, no new `axiom`, no `set_option linter.* false`, no `set_option weak.linter.* false`, no `leanOptions` lint suppression.

## Why they're together

Honest answer: they're together because they're the entire framework
delta I accumulated while writing one proof. They are not thematically
linked. The two cleanest sub-bundles are:

- *probability/coupling*: `Disagreement.lean` + `EagerTable.lean` + the
  `Marginalization` half of `SampleableType.lean`
- *simulation semantics*: `SimulateQ.lean` compose helpers + the
  `Relational/SimulateQ.lean` slack rule

If you want a split into two PRs along that line, say the word. Otherwise
each commit is independently reviewable and the build is green at every
commit.

## Test plan

- [x] `lake exe cache get && lake build VCVio` — green
- [x] `#print axioms` on all six headlines — kernel-only
- [x] No new `sorry` / `axiom` / linter disables
- [x] Each commit builds cleanly in sequence