### PR TITLE
refactor(EvalDist): rebuild probability semantics on MonadLiftT

### DIFF
--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,1 +1,0 @@
-{"sessionId":"aa7a1f00-dd11-4977-bec6-01bad30b6fc7","pid":85428,"procStart":"5883726","acquiredAt":1780172371794}

--- a/.claude/scheduled_tasks.lock
+++ b/.claude/scheduled_tasks.lock
@@ -1,0 +1,1 @@
+{"sessionId":"aa7a1f00-dd11-4977-bec6-01bad30b6fc7","pid":85428,"procStart":"5883726","acquiredAt":1780172371794}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,7 +7,8 @@ Formally verified cryptography proofs in Lean 4, built on Mathlib.
 1. Run `lake exe cache get && lake build`.
 2. Read `Examples/OneTimePad/Basic.lean` for a compact modern proof (correctness and privacy).
 3. Choose the work area by task: use `VCVio/` for oracle/probability/program-logic work, `LatticeCrypto/` for lattice schemes and reductions, and `LatticeCryptoTest/` for vectors or differential tests.
-4. If probability lemmas fail unexpectedly, first check for `[spec.Fintype]` and `[spec.Inhabited]`.
+4. If probability lemmas fail unexpectedly, first check for `[IsProbabilitySpec spec]`
+   or `[IsUniformSpec spec]` as appropriate.
 
 `AGENTS.md` is the canonical guide. `CLAUDE.md` is a symlink to this file.
 
@@ -25,7 +26,7 @@ Follow [`CONTRIBUTING.md`](CONTRIBUTING.md) for the repo's explicit attribution 
 
 ## What This Project Is
 
-VCVio is a framework for formal cryptographic proofs built around `OracleComp spec α`, the free monad on the polynomial functor induced by an oracle signature `OracleSpec ι := ι → Type`. Its universal fold `simulateQ impl : OracleComp spec α → r α` is the unique monad morphism extending any `impl : QueryImpl spec r` to the free monad, and the distribution semantics `evalDist` (with `support`, `probOutput`, `Pr[…]`) are *definitionally* `simulateQ` into `PMF` / `SetM` / … with queries interpreted as uniform sampling. `ProbComp α := OracleComp unifSpec α` specializes to computations whose only oracle is uniform selection.
+VCVio is a framework for formal cryptographic proofs built around `OracleComp spec α`, the free monad on the polynomial functor induced by an oracle signature `OracleSpec ι := ι → Type`. Its universal fold `simulateQ impl : OracleComp spec α → r α` is the unique monad morphism extending any `impl : QueryImpl spec r` to the free monad. For `OracleComp`, `support` is definitionally `simulateQ` into `SetM` with queries interpreted by `Set.univ`; `evalDist` / `probOutput` / `Pr[…]` are definitionally `simulateQ` into `PMF` using the per-query distributions supplied by `[IsProbabilitySpec spec]`. Uniform cardinality lemmas and the `support`/probability bridge use `[IsUniformSpec spec]`, which bundles `[spec.Fintype]`, `[spec.Inhabited]`, and uniform sampling. `ProbComp α := OracleComp unifSpec α` specializes to computations whose only oracle is uniform selection.
 
 The repo also includes a first-class lattice cryptography library under `LatticeCrypto/`, built on top of the `VCVio` framework. That layer contains generic lattice algebra plus ML-DSA, ML-KEM, and Falcon specifications, security statements, concrete implementations, FFI bridges, and tests.
 
@@ -81,9 +82,9 @@ or `VCVioTest/`. This contract is enforced by
 
 ## Critical Gotchas
 
-1. **`[spec.Fintype]` and `[spec.Inhabited]`** are required for probability reasoning (`evalDist`, `Pr[...]`).
+1. **Probability assumptions are explicit.** `support` on `OracleComp spec` works for arbitrary specs. `evalDist` / `Pr[...]` need `[IsProbabilitySpec spec]`; uniform/cardinality lemmas and `support ↔ Pr[= _] ≠ 0` need `[IsUniformSpec spec]`. Use `IsUniformSpec.ofFintypeInhabited` when you have `[spec.Fintype] [spec.Inhabited]` and intend uniform semantics.
 2. **`autoImplicit = false` is set globally in `lakefile.lean`**. Do not add `set_option autoImplicit false` in individual files. Every variable must be explicitly declared.
-3. **`evalDist` IS `simulateQ`** with uniform distributions. This is definitional (`rfl`).
+3. **`evalDist` IS `simulateQ`** with `IsProbabilitySpec.toPMF`; under `[IsUniformSpec spec]` this is uniform. This is definitional (`rfl`).
 4. **`++ₒ` is dead** — use `+` for combining oracle specs.
 5. **Commented-out code is legacy** — follow only uncommented code. Use `Examples/OneTimePad/Basic.lean` as canonical reference.
 6. **Preserve partial proofs** with `stop` instead of deleting large proof blocks.

--- a/Examples.lean
+++ b/Examples.lean
@@ -16,6 +16,7 @@ import Examples.ElGamal.Common
 import Examples.ElGamal.Hash
 import Examples.ElGamal.ReductionCost
 import Examples.ElGamal.SSP
+import Examples.EvalDistCompatible.Basic
 import Examples.FrankingProtocol
 import Examples.OneTimePad.Basic
 import Examples.OneTimePad.HeapBasic

--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -80,8 +80,12 @@ theorem correct (hcorrect : tdp.Correct) :
     obtain ⟨c, hc, hy⟩ := hy
     rw [mem_support_bind_iff] at hc
     obtain ⟨r, _, hc⟩ := hc
-    simp only [support_pure, Set.mem_singleton_iff] at hc hy
-    subst hc; subst hy
+    rw [mem_support_bind_iff] at hy
+    obtain ⟨msg', hmsg', hy⟩ := hy
+    simp only [support_pure, Set.mem_singleton_iff] at hc hmsg' hy
+    obtain rfl := hc
+    obtain rfl := hmsg'
+    obtain rfl := hy
     simp [hcorrect pk sk hpksk r]
   change Pr[= true | mx] = 1
   exact probOutput_eq_one_of_support_subset_singleton

--- a/Examples/CommitmentScheme/Binding.lean
+++ b/Examples/CommitmentScheme/Binding.lean
@@ -58,8 +58,6 @@ open OracleSpec OracleComp ENNReal
 
 variable {M S C : Type}
   [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C]
 
 /-! ## Adversary, game, and inner computation -/
 
@@ -94,13 +92,12 @@ private def bindingInner {t : ℕ} (A : BindingAdversary M S C t) :
   let c₁ ← (CMOracle M S C).query (m₁, s₁)
   return (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
 /-- The binding game equals `simulateQ cachingOracle` on `bindingInner`. -/
 private lemma bindingGame_eq {t : ℕ} (A : BindingAdversary M S C t) :
     bindingGame A = (simulateQ cachingOracle (bindingInner A)).run ∅ := rfl
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
-private lemma binding_win_implies_collision {t : ℕ} (A : BindingAdversary M S C t) :
+private lemma binding_win_implies_collision {t : ℕ} [Finite C] [Inhabited C]
+    (A : BindingAdversary M S C t) :
     ∀ z ∈ support ((simulateQ cachingOracle (bindingInner A)).run ∅),
       z.1 = true → CacheHasCollision z.2 := by
   intro z hz hwin
@@ -141,7 +138,6 @@ private lemma binding_win_implies_collision {t : ℕ} (A : BindingAdversary M S 
   exact ⟨(m₀, s₀), (m₁, s₁), c₀, c₁, hpair_ne, hcache₃_m₀, hcache₃,
     heq_of_eq (by rw [hc₀, hc₁])⟩
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
 /-- `IsTotalQueryBound` for the binding game's inner computation: `t + 2`
 (adversary's `t` queries + 2 verification queries). -/
 private lemma bindingInner_totalBound {t : ℕ} (A : BindingAdversary M S C t) :
@@ -157,8 +153,8 @@ private lemma bindingInner_totalBound {t : ℕ} (A : BindingAdversary M S C t) :
 /-! ## Fresh-query branch: bounding the verification-time guess -/
 
 /- In a collision-free cache, a value determines at most one query input. -/
-omit [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
-private lemma binding_rest_noCollision_le_inv
+private lemma binding_rest_noCollision_le_inv [Finite M] [Finite S] [Fintype C]
+    [Inhabited M] [Inhabited S] [Inhabited C]
     (c : C) (m₀ m₁ : M) (s₀ s₁ : S)
     (cache₁ : QueryCache (CMOracle M S C))
     (hno : ¬ CacheHasCollision cache₁) :
@@ -168,6 +164,8 @@ private lemma binding_rest_noCollision_le_inv
         let c₁ ← (CMOracle M S C).query (m₁, s₁)
         return (decide (m₀ ≠ m₁) && (c₀ == c) && (c₁ == c))).run cache₁] ≤
       (Fintype.card C : ℝ≥0∞)⁻¹ := by
+  haveI : Fintype M := Fintype.ofFinite M
+  haveI : Fintype S := Fintype.ofFinite S
   by_cases hneq : m₀ ≠ m₁
   · let q₀ : (CMOracle M S C).Domain := (m₀, s₀)
     let q₁ : (CMOracle M S C).Domain := (m₁, s₁)
@@ -278,12 +276,14 @@ private lemma binding_rest_noCollision_le_inv
  matched the commitment `c`. We bound each case separately:
  - Case 1 (collision in adversary's cache): ≤ `t(t-1)/(2|C|)` by tight birthday bound
  - Case 2 (no collision, fresh query matches `c`): ≤ `1/|C|` by unpredictability -/
-omit [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 private lemma binding_win_le_advCollision_add_fresh {t : ℕ}
+    [Finite M] [Finite S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C]
     (A : BindingAdversary M S C t) :
     Pr[fun z => z.1 = true | bindingGame A] ≤
     Pr[fun z => CacheHasCollision z.2 | (simulateQ cachingOracle A.run).run ∅] +
     (Fintype.card C : ℝ≥0∞)⁻¹ := by
+  haveI : Fintype M := Fintype.ofFinite M
+  haveI : Fintype S := Fintype.ofFinite S
   let restPart : (C × M × S × M × S) → OracleComp (CMOracle M S C) Bool
     | (c, m₀, s₀, m₁, s₁) => do
         let c₀ ← (CMOracle M S C).query (m₀, s₀)
@@ -305,7 +305,6 @@ private lemma binding_win_le_advCollision_add_fresh {t : ℕ}
         rintro ⟨⟨c, m₀, s₀, m₁, s₁⟩, cache₁⟩ _ hno
         simpa [restPart] using binding_rest_noCollision_le_inv c m₀ m₁ s₀ s₁ cache₁ hno))
 
-omit [Fintype M] [Fintype S] in
 /-- **Binding bound for the ROM commitment scheme (tight, Lemma cm-binding).**
 
 For every `t`-query binding adversary `A`,
@@ -328,9 +327,13 @@ verification query happening to land on the committed value (bounded by
 This is the bound a reader of the textbook lemma should reach for; the
 companion `binding_bound_via_cr_chain` produces the same shape of bound by
 factoring through the standard-model collision-resistance reduction. -/
-theorem binding_bound {t : ℕ} (A : BindingAdversary M S C t) :
+theorem binding_bound [Finite M] [Finite S] [Fintype C]
+    [Inhabited M] [Inhabited S] [Inhabited C]
+    {t : ℕ} (A : BindingAdversary M S C t) :
     Pr[fun z => z.1 = true | bindingGame A] ≤
     ((t * (t - 1) + 2 : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) := by
+  haveI : Fintype M := Fintype.ofFinite M
+  haveI : Fintype S := Fintype.ofFinite S
   calc Pr[fun z => z.1 = true | bindingGame A]
       ≤ Pr[fun z => CacheHasCollision z.2 | (simulateQ cachingOracle A.run).run ∅] +
         (Fintype.card C : ℝ≥0∞)⁻¹ := binding_win_le_advCollision_add_fresh A
@@ -343,7 +346,6 @@ theorem binding_bound {t : ℕ} (A : BindingAdversary M S C t) :
         simpa [Nat.mul_one, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
           add_div_two_mul_nat (t * (t - 1)) 1 (Fintype.card C)
 
-omit [Fintype M] [Fintype S] in
 /-- **Binding bound via the standard-model CR chain (looser).**
 
 For every `t`-query binding adversary `A`,
@@ -364,7 +366,8 @@ Proof: a binding-game win implies a collision in the final cache
 (`binding_win_implies_collision`), and the inner game makes at most `t + 2`
 total queries (`bindingInner_totalBound`); apply
 `probEvent_cacheCollision_le_birthday_total_tight` at `n = t + 2`. -/
-theorem binding_bound_via_cr_chain {t : ℕ} (A : BindingAdversary M S C t) :
+theorem binding_bound_via_cr_chain [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C]
+    {t : ℕ} (A : BindingAdversary M S C t) :
     Pr[fun z => z.1 = true | bindingGame A] ≤
     (((t + 2) * (t + 1) : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) := by
   rw [bindingGame_eq]

--- a/Examples/CommitmentScheme/Common.lean
+++ b/Examples/CommitmentScheme/Common.lean
@@ -56,6 +56,9 @@ variable {M S C : Type}
 
 instance : DecidableEq (M × S) := instDecidableEqProd
 
+noncomputable instance : IsUniformSpec (CMOracle M S C) :=
+  IsUniformSpec.ofFintypeInhabited _
+
 /-- Commit to message `m` with salt `s` by querying the random oracle at `(m, s)`. -/
 def CMCommit (m : M) (s : S) : OracleComp (CMOracle M S C) C :=
   (CMOracle M S C).query (m, s)

--- a/Examples/CommitmentScheme/Extractability.lean
+++ b/Examples/CommitmentScheme/Extractability.lean
@@ -61,8 +61,8 @@ open OracleSpec OracleComp ENNReal
 
 variable {M S C : Type}
   [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C]
+  -- [Fintype M] [Fintype S] [Fintype C]
+  -- [Inhabited M] [Inhabited S] [Inhabited C]
 
 /-! ## Adversary, extractor, and game -/
 
@@ -130,7 +130,6 @@ private def extractabilityInner {AUX : Type} {t : ℕ}
     | some (m', s') => (c == cm) && decide ((m', s') ≠ (m, s))
     | none => (c == cm))
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
 /-- The extractability game equals `simulateQ cachingOracle` on `extractabilityInner`. -/
 private lemma extractabilityGame_eq {t : ℕ} (A : ExtractAdversary M S C AUX t) :
     extractabilityGame CMExtract A =
@@ -153,7 +152,6 @@ private def extractabilityInner_tagged {AUX : Type} {t : ℕ}
     | some (m', s') => ((c == cm) && decide ((m', s') ≠ (m, s)), false)
     | none => ((c == cm), true))
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
 /-- The untagged inner computation is the first projection of the tagged one. -/
 private lemma extractabilityInner_eq_fst_tagged {t : ℕ}
     (A : ExtractAdversary M S C AUX t) :
@@ -178,8 +176,7 @@ commitment value, which directly witnesses a cache collision. -/
 When `CMExtract` finds an entry `(m', s')` in the commit trace with `H(m', s') = cm`,
 and verification gives `H(m, s) = cm` with `(m', s') ≠ (m, s)`, both distinct inputs
 map to `cm` in the final cache. -/
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
-private lemma extractability_someWin_implies_collision {t : ℕ}
+private lemma extractability_someWin_implies_collision {t : ℕ} [Finite C] [Inhabited C]
     (A : ExtractAdversary M S C AUX t) :
     ∀ z ∈ support ((simulateQ cachingOracle (extractabilityInner_tagged A)).run ∅),
       z.1.1 = true → z.1.2 = false → CacheHasCollision z.2 := by
@@ -238,7 +235,6 @@ private lemma extractability_someWin_implies_collision {t : ℕ}
     exact ⟨entry.1, (m, s), entry.2, c, hne, hcache₃_entry, hcache₃,
       heq_of_eq (by rw [hentry_cm, hceq])⟩
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited C] [Inhabited M] [Inhabited S] in
 /-- `IsTotalQueryBound` for the extractability game's inner computation.
 
 The inner computation consists of:
@@ -287,7 +283,6 @@ private lemma extractabilityInner_totalBound [Finite C] {t : ℕ}
     have := A.totalBound
     omega)
 
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
 /-- The tagged inner computation has the same query bound as the untagged one. -/
 private lemma extractabilityInner_tagged_totalBound [Finite C] {t : ℕ}
     (A : ExtractAdversary M S C AUX t) :
@@ -302,9 +297,8 @@ private lemma extractabilityInner_tagged_totalBound [Finite C] {t : ℕ}
 /- The some-case win event on the tagged game implies cache collision.
 
 Wraps `extractability_someWin_implies_collision` for use with `probEvent_mono`. -/
-omit [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 private lemma extractability_someWin_le_collision {t : ℕ}
-    (A : ExtractAdversary M S C AUX t) :
+    (A : ExtractAdversary M S C AUX t) [Fintype C] [Inhabited C] :
     Pr[fun z => z.1.1 = true ∧ z.1.2 = false |
       (simulateQ cachingOracle (extractabilityInner_tagged A)).run ∅] ≤
     Pr[fun z => CacheHasCollision z.2 |
@@ -342,6 +336,10 @@ private def extractabilityRestOa {t : ℕ}
       | some (m', s') => (c == cm) && decide ((m', s') ≠ (m, s))
       | none => (c == cm)
 
+variable [Inhabited C] [Finite C]
+
+attribute [local instance] Fintype.ofFinite
+
 /-! ## None-case branch: extractor returned nothing, fresh open/verify lands on `cm`
 
 If `CMExtract` returns `none`, every accepting opening corresponds to a
@@ -349,9 +347,9 @@ If `CMExtract` returns `none`, every accepting opening corresponds to a
 the probability of this by `(t₂ + 1) / |C|` via the per-query
 unpredictability of a fresh random-oracle answer. -/
 
+omit [Inhabited C] [Finite C] in
 /- Under a collision-free commit cache, any extractability win must create a fresh
 post-commit cache entry equal to the commitment value. -/
-omit [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
 private lemma extractability_rest_win_implies_fresh_cm {t : ℕ}
     (A : ExtractAdversary M S C AUX t)
     {cm : C} {aux : AUX} {tr : QueryLog (CMOracle M S C)}
@@ -375,6 +373,8 @@ private lemma extractability_rest_win_implies_fresh_cm {t : ℕ}
   rw [support_bind] at hz
   simp only [Set.mem_iUnion] at hz
   obtain ⟨⟨c, cache₃⟩, hmem₃, hz⟩ := hz
+  simp only [simulateQ_pure, StateT.run_pure, support_pure,
+    Set.mem_singleton_iff] at hz
   rw [hz] at hwin
   unfold CMExtract at hwin
   cases hfind : tr.find? (fun entry => decide (entry.2 = cm)) with
@@ -450,7 +450,6 @@ private lemma extractability_rest_win_implies_fresh_cm {t : ℕ}
       exact ⟨(m, s), c, hcache₃, hcache₁_none, heq_of_eq hc_eq⟩
 
 /- Winning the extractability rest-game implies a fresh cache entry matching `cm`. -/
-omit [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 private lemma extractability_rest_win_le_exists_fresh {t : ℕ}
     (A : ExtractAdversary M S C AUX t)
     (cm : C) (aux : AUX) (tr : QueryLog (CMOracle M S C))
@@ -468,8 +467,7 @@ private lemma extractability_rest_win_le_exists_fresh {t : ℕ}
 
 /- Conditioned on a collision-free commit trace, the later extractability failure
 probability is bounded by the fresh-hit term `(t₂ + 1) / |C|`. -/
-omit [Fintype M] [Fintype S] in
-private lemma extractability_rest_noCollision_le_inv {t : ℕ}
+private lemma extractability_rest_noCollision_le_inv {t : ℕ} [Inhabited M] [Inhabited S]
     (A : ExtractAdversary M S C AUX t)
     (cm : C) (aux : AUX) (tr : QueryLog (CMOracle M S C))
     (cache₁ : QueryCache (CMOracle M S C))
@@ -505,8 +503,8 @@ matching `cm`. The commit trace has `≤ t₁` entries (birthday bound `t₁(t�
 and the open+verify phase has `≤ t₂+1` fresh queries matching `cm` (`(t₂+1)/|C|`).
 Maximizing `t₁(t₁-1)/2 + t₂ + 1` over `t₁+t₂ ≤ t` gives `max{t+1, t(t-1)/2+1}`.
 For `t ≥ 3` this is `t(t-1)/2+1`, yielding `(t(t-1)+2)/(2|C|)`. -/
-omit [Fintype M] [Fintype S] in
-private lemma extractability_win_le_textbook_bound {t : ℕ} (ht : 3 ≤ t)
+private lemma extractability_win_le_textbook_bound [Inhabited M] [Inhabited S]
+    {t : ℕ} (ht : 3 ≤ t)
     (A : ExtractAdversary M S C AUX t) :
     Pr[fun z => z.1 = true | extractabilityGame CMExtract A] ≤
     ((t * (t - 1) : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) +
@@ -564,7 +562,6 @@ private lemma extractability_win_le_textbook_bound {t : ℕ} (ht : 3 ≤ t)
           simpa [Nat.mul_one, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
             add_div_two_mul_nat (t * (t - 1)) 1 (Fintype.card C)
 
-omit [Fintype M] [Fintype S] in
 /-- **Extractability bound for the ROM commitment scheme (Lemma cm-extractability).**
 
 For every two-phase `t`-query adversary `A = (A_commit, A_open)` with
@@ -589,7 +586,7 @@ displayed bound.
 This is the same proof shape as `binding_bound`: birthday collision +
 single fresh-query unpredictability. The `t ≥ 3` hypothesis is precisely
 where the case-split max collapses; the `t ≤ 2` regime is degenerate. -/
-theorem extractability_bound {t : ℕ} (ht : 3 ≤ t)
+theorem extractability_bound [Inhabited M] [Inhabited S] {t : ℕ} (ht : 3 ≤ t)
     (A : ExtractAdversary M S C AUX t) :
     Pr[fun z => z.1 = true | extractabilityGame CMExtract A] ≤
     ((t * (t - 1) + 2 : ℕ) : ℝ≥0∞) / (2 * Fintype.card C) := by

--- a/Examples/CommitmentScheme/Hiding/CountBounds.lean
+++ b/Examples/CommitmentScheme/Hiding/CountBounds.lean
@@ -8,11 +8,11 @@ import Examples.CommitmentScheme.Hiding.Defs
 open OracleSpec OracleComp ENNReal
 
 variable {M S C : Type}
-  [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C]
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+  [DecidableEq M] [DecidableEq S]
+  [Finite C] [Inhabited C]
+
+attribute [local instance] Fintype.ofFinite
+
 lemma hidingImplCountAll_run_totalBound_current {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) (s : S) :
     IsTotalQueryBound
@@ -21,8 +21,7 @@ lemma hidingImplCountAll_run_totalBound_current {AUX : Type} {t : ℕ}
   exact (hidingOa_totalBound_current A s).simulateQ_run_of_step
     (fun ms st => hidingImplCountAll_step_totalBound ms st) (∅, fun _ => 0)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Run-level projection: for any fixed `s`, the shared counted implementation
 projects to the `hidingImpl₁ s` execution on `hidingOa`. -/
 theorem hidingRun_countAll_proj_eq_impl₁ {AUX : Type} {t : ℕ}
@@ -37,7 +36,6 @@ theorem hidingRun_countAll_proj_eq_impl₁ {AUX : Type} {t : ℕ}
           (M := M) (S := S) (C := C) s ms st)
       (hidingOa A s) (∅, fun _ => 0))
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 /-- Probability bridge for bad events:
 `Pr[bad]` under `hidingImpl₁ s` is equal to the corresponding event on the
 shared counted run, projected at `s`. -/
@@ -62,10 +60,10 @@ theorem probEvent_hidingBad_eq_countAll {AUX : Type} {t : ℕ}
   rw [probEvent_map]
   rfl
 
-omit [DecidableEq C] [Fintype M] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- One-step growth bound for the shared counted hiding implementation:
 the total count increases by at most one. -/
-lemma sum_counts_step_le_succ_hidingImplCountAll (ms : M × S)
+lemma sum_counts_step_le_succ_hidingImplCountAll [Fintype S] (ms : M × S)
     (st : QueryCache (CMOracle M S C) × (S → ℕ))
     (x : C × (QueryCache (CMOracle M S C) × (S → ℕ)))
     (hx : x ∈ support ((hidingImplCountAll (M := M) (S := S) (C := C) ms).run st)) :
@@ -86,16 +84,15 @@ lemma sum_counts_step_le_succ_hidingImplCountAll (ms : M × S)
       rw [hx]
       simp [sum_update_succ_count]
 
-omit [DecidableEq C] [Fintype M] [Fintype C] [Inhabited M] in
+omit [Finite C] in
 lemma hiding_distinguish_totalBound_of_choose_count_support
-    [Finite M] [Finite C]
+    [Fintype S] [Inhabited S] [Finite M] [Finite C]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
     {x : (M × AUX) × (QueryCache (CMOracle M S C) × (S → ℕ))}
     (hx : x ∈ support ((simulateQ hidingImplCountAll A.choose).run (∅, fun _ => 0))) :
     ∀ cm : C, IsTotalQueryBound (A.distinguish x.1.2 cm) (t - ∑ s : S, x.2.2 s) := by
   haveI : Fintype M := Fintype.ofFinite M
-  haveI : Fintype C := Fintype.ofFinite C
   have hres :
       IsTotalQueryBound
         (((CMOracle M S C).query (x.1.1, default) : OracleComp (CMOracle M S C) _) >>= fun cm =>
@@ -125,8 +122,7 @@ lemma hiding_distinguish_totalBound_of_choose_count_support
     omega
   simpa [hbudget] using hcm
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- A single counted query can only increase a fixed salt counter. -/
 lemma count_mono_step_hidingImplCountAll (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × (S → ℕ))
@@ -154,8 +150,7 @@ lemma count_mono_step_hidingImplCountAll (s : S) (ms : M × S)
           exact hs hEq.symm
         simp [Function.update_of_ne hs']
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- A single counted query changes any fixed salt counter by at most one. -/
 lemma count_coord_le_succ_of_mem_support_step_hidingImplCountAll
     (s : S) (ms : M × S)
@@ -190,8 +185,7 @@ lemma count_coord_le_succ_of_mem_support_step_hidingImplCountAll
             exact hs hEq.symm
           simp [Function.update_of_ne hs']
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- A single counted query only changes the counter at its queried salt. -/
 lemma count_coord_le_add_hit_of_mem_support_step_hidingImplCountAll
     (s : S) (ms : M × S)
@@ -230,8 +224,7 @@ lemma count_coord_le_add_hit_of_mem_support_step_hidingImplCountAll
         rw [Function.update_of_ne hs']
         simp [hs]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- After the challenge step at salt `s`, removing the mandatory challenge hit leaves
 at most the pre-challenge salt count. -/
 lemma challenge_countPred_le_initialCount_of_mem_support_step_hidingImplCountAll
@@ -246,8 +239,7 @@ lemma challenge_countPred_le_initialCount_of_mem_support_step_hidingImplCountAll
       (M := M) (S := S) (C := C) s (m, s) st x hx).2
   omega
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Any support point of a counted step caches the queried point with the returned value. -/
 lemma self_mem_cache_of_mem_support_step_hidingImplCountAll (ms : M × S)
     (st : QueryCache (CMOracle M S C) × (S → ℕ))
@@ -274,8 +266,7 @@ lemma self_mem_cache_of_mem_support_step_hidingImplCountAll (ms : M × S)
 def HidingCountInv (st : QueryCache (CMOracle M S C) × (S → ℕ)) : Prop :=
   ∀ ms : M × S, ∀ u : C, st.1 ms = some u → 1 ≤ st.2 ms.2
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- The counted implementation preserves the hiding count invariant. -/
 lemma hidingCountInv_step_hidingImplCountAll (ms₀ : M × S)
     (st : QueryCache (CMOracle M S C) × (S → ℕ)) (hInv : HidingCountInv st)
@@ -310,8 +301,7 @@ lemma hidingCountInv_step_hidingImplCountAll (ms₀ : M × S)
           · simp [Function.update_of_ne hs]
         exact le_trans h_old h_mono
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Support points of `simulateQ hidingImplCountAll` have coordinatewise monotone counts. -/
 lemma count_mono_of_mem_support_run_hidingImplCountAll {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
@@ -330,7 +320,8 @@ lemma count_mono_of_mem_support_run_hidingImplCountAll {α : Type}
   induction ob using OracleComp.inductionOn with
   | pure x =>
       intro st y hy s'
-      simp only [simulateQ_pure] at hy
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff] at hy
       subst y
       exact Nat.le_refl _
   | query_bind t mx ih =>
@@ -343,8 +334,7 @@ lemma count_mono_of_mem_support_run_hidingImplCountAll {α : Type}
         (count_mono_step_hidingImplCountAll (M := M) (S := S) (C := C) s' t st qu hqu)
         (ih qu.1 qu.2 y hy' s')
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Every cached salt has a positive counter along the support of the counted run. -/
 lemma hidingCountInv_of_mem_support_run_hidingImplCountAll {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
@@ -364,7 +354,8 @@ lemma hidingCountInv_of_mem_support_run_hidingImplCountAll {α : Type}
   induction ob using OracleComp.inductionOn with
   | pure x =>
       intro st hInv y hy
-      simp only [simulateQ_pure] at hy
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff] at hy
       subst hy
       exact hInv
   | query_bind t mx ih =>
@@ -378,8 +369,7 @@ lemma hidingCountInv_of_mem_support_run_hidingImplCountAll {α : Type}
         hidingCountInv_step_hidingImplCountAll (M := M) (S := S) (C := C) t st hInv qu hqu
       exact ih qu.1 qu.2 hInv' y hy'
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- On the support of the counted choose run, a zero salt-count means no cache entry
 at that salt can already exist. -/
 lemma cache_none_of_zero_count_of_mem_support_run_hidingChoose
@@ -417,8 +407,7 @@ lemma cache_none_of_zero_count_of_mem_support_run_hidingChoose
 abbrev HidingCountState (M : Type) (S : Type) (C : Type) :=
   QueryCache (CMOracle M S C) × (S → ℕ)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 lemma fresh_step_state_of_mem_support_hidingImplCountAll
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -438,11 +427,11 @@ lemma fresh_step_state_of_mem_support_hidingImplCountAll
   simp only [hidingImplCountAll, StateT.run_bind, StateT.run_get, pure_bind, hnone] at hqch
   rw [mem_support_bind_iff] at hqch
   obtain ⟨u, _, hu⟩ := hqch
-  simp only [StateT.run_set, StateT.run_pure] at hu
+  simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
+    Set.mem_singleton_iff] at hu
   rcases hu with ⟨rfl, rfl⟩
   simp [hzero]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_fresh_challenge_branch_eq
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -470,7 +459,6 @@ lemma wp_fresh_challenge_branch_eq
   rw [OracleComp.ProgramLogic.wp_map]
   rfl
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_freshDistinguishIncrement_eq
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -512,10 +500,10 @@ lemma wp_freshDistinguishIncrement_eq
     rw [hpost, OracleComp.ProgramLogic.wp_const]
     simp [hzero]
 
-omit [DecidableEq C] [Fintype M] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- On the support of the counted hiding run, the total count is at most `n`
 plus the initial total count. -/
-lemma sum_counts_le_of_mem_support_run_hidingImplCountAll
+lemma sum_counts_le_of_mem_support_run_hidingImplCountAll [Fintype S]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
     (hbound : IsTotalQueryBound oa n)
     {st₀ : QueryCache (CMOracle M S C) × (S → ℕ)}
@@ -532,7 +520,8 @@ lemma sum_counts_le_of_mem_support_run_hidingImplCountAll
   intro β ob m hm st y hy
   induction ob using OracleComp.inductionOn generalizing m st y with
   | pure x =>
-      simp only [simulateQ_pure] at hy
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff] at hy
       subst y
       exact Nat.le_add_left _ _
   | query_bind t mx ih =>
@@ -549,8 +538,7 @@ lemma sum_counts_le_of_mem_support_run_hidingImplCountAll
         (ih (u := qu.1) (m := m - 1) (hm.2 qu.1)) (st := qu.2) (y := y) hy'
       omega
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 lemma cache_le_of_mem_support_run_hidingImplCountAll
     {α : Type} (oa : OracleComp (CMOracle M S C) α)
     {st₀ : HidingCountState M S C}
@@ -568,8 +556,7 @@ lemma cache_le_of_mem_support_run_hidingImplCountAll
       (M := M) (S := S) (C := C) oa st₀] using hzmap
   exact simulateQ_cachingOracle_cache_le (spec := CMOracle M S C) oa st₀.1 (z.1, z.2.1) hz'
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 lemma exists_new_salt_cacheEntry_of_count_gt_one
     {α : Type} (oa : OracleComp (CMOracle M S C) α)
     (m0 : M) (s : S)
@@ -583,7 +570,8 @@ lemma exists_new_salt_cacheEntry_of_count_gt_one
     ∃ m : M, ∃ v : C, m ≠ m0 ∧ z.2.1 (m, s) = some v := by
   induction oa using OracleComp.inductionOn generalizing cache₀ counts₀ z with
   | pure x =>
-      simp only [simulateQ_pure] at hz
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff] at hz
       subst z
       exfalso
       simp [hcount] at hgt
@@ -652,10 +640,10 @@ lemma exists_new_salt_cacheEntry_of_count_gt_one
               (counts₀ := Function.update counts₀ t.2 (counts₀ t.2 + 1)) (z := z)
               hcount' hself' hunique' hz' hgt
 
-omit [DecidableEq C] [Fintype M] [Fintype C] [Inhabited M] in
+omit [Finite C] in
 /-- Along the counted choose run, the total per-salt miss count is bounded by the
 adversary query budget `t`. -/
-lemma sum_counts_le_queryBound_of_mem_support_run_hidingChoose
+lemma sum_counts_le_queryBound_of_mem_support_run_hidingChoose [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × (QueryCache (CMOracle M S C) × (S → ℕ))}
@@ -670,8 +658,7 @@ lemma sum_counts_le_queryBound_of_mem_support_run_hidingChoose
       (z := qchoose)
       hqchoose)
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
-lemma wp_choose_sumCounts_le_queryBound
+lemma wp_choose_sumCounts_le_queryBound [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     OracleComp.ProgramLogic.wp
@@ -698,13 +685,14 @@ lemma wp_choose_sumCounts_le_queryBound
             · rw [probOutput_eq_zero_of_not_mem_support hqchoose]
               simp
     _ = t := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Every support point of `simulateQ hidingImplCountAll` is dominated by some
 `countingOracle.simulate` support point: the total count across all salts is
 bounded by the initial counts plus the counting oracle's total query cost. -/
 lemma exists_counting_support_of_mem_support_run_hidingImplCountAll
+    [Fintype M] [Fintype S]
     {α : Type} (oa : OracleComp (CMOracle M S C) α)
     {st₀ : QueryCache (CMOracle M S C) × (S → ℕ)}
     {z : α × (QueryCache (CMOracle M S C) × (S → ℕ))}
@@ -715,7 +703,8 @@ lemma exists_counting_support_of_mem_support_run_hidingImplCountAll
   classical
   induction oa using OracleComp.inductionOn generalizing st₀ z with
   | pure x =>
-      simp only [simulateQ_pure] at hz
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff] at hz
       subst z
       refine ⟨0, ?_, ?_⟩
       · simpa using
@@ -752,11 +741,11 @@ lemma exists_counting_support_of_mem_support_run_hidingImplCountAll
       refine ⟨qc, hqc, ?_⟩
       omega
 
-omit [DecidableEq C] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Per-coordinate variant of `exists_counting_support_of_mem_support_run_hidingImplCountAll`:
 for each salt `t`, the per-salt count `z.2.2 t` is bounded by the initial count
 plus the counting oracle's per-index query count at `t`. -/
-lemma exists_counting_support_of_mem_support_run_hidingImplCountAll_coord
+lemma exists_counting_support_of_mem_support_run_hidingImplCountAll_coord [Fintype M]
     {α : Type} (oa : OracleComp (CMOracle M S C) α)
     {st₀ : QueryCache (CMOracle M S C) × (S → ℕ)}
     {z : α × (QueryCache (CMOracle M S C) × (S → ℕ))}
@@ -767,7 +756,8 @@ lemma exists_counting_support_of_mem_support_run_hidingImplCountAll_coord
   classical
   induction oa using OracleComp.inductionOn generalizing st₀ z with
   | pure x =>
-      simp only [simulateQ_pure] at hz
+      simp only [simulateQ_pure, StateT.run_pure, support_pure,
+        Set.mem_singleton_iff] at hz
       subst z
       refine ⟨0, ?_, ?_⟩
       · simpa using
@@ -847,8 +837,7 @@ lemma exists_counting_support_of_mem_support_run_hidingImplCountAll_coord
           simpa [hs, add_assoc, add_left_comm, add_comm] using this
         exact le_trans hrest hstep'
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- On the support of the counted hiding run, the challenge salt count is positive. -/
 theorem challenge_count_pos_of_mem_support_hidingImplCountAll
     {AUX : Type} {t : ℕ}
@@ -887,8 +876,7 @@ theorem challenge_count_pos_of_mem_support_hidingImplCountAll
       (M := M) (S := S) (C := C) (oa := A.distinguish aux qch.1)
       (st₀ := qch.2) (z := z) hz' s)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- On support of the counted hiding run, the bad-event indicator at the challenge salt
 is bounded by the excess of that salt count over the mandatory challenge hit. -/
 lemma bad_indicator_le_count_pred_of_mem_support_run_hidingImplCountAll
@@ -906,8 +894,7 @@ lemma bad_indicator_le_count_pred_of_mem_support_run_hidingImplCountAll
     exact_mod_cast hcount
   · simp [hbad]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- On support of the counted hiding run, bad at salt `s` can only happen if the
 choose phase already queried salt `s`, or if the distinguish phase later
 increased the salt-`s` counter after the challenge step. -/
@@ -951,8 +938,7 @@ lemma bad_indicator_le_chooseHitIndicator_add_distinguishIncrementIndicator
       simp [OracleComp.ProgramLogic.propInd, hbad, hchoose, hinc]
   · simp [OracleComp.ProgramLogic.propInd, hbad]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Strengthened version of
 `bad_indicator_le_chooseHitIndicator_add_distinguishIncrementIndicator`:
 the distinguish-increment term is only charged on salts that were fresh after
@@ -998,8 +984,7 @@ lemma bad_indicator_le_chooseHitIndicator_add_freshDistinguishIncrementIndicator
       simp [OracleComp.ProgramLogic.propInd, hbad, hqzero, hinc]
   · simp [OracleComp.ProgramLogic.propInd, hbad]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- On support of the counted hiding run, the challenge-salt excess count is bounded
 by the adversary's total query budget. -/
 lemma count_pred_le_queryBound_of_mem_support_run_hidingImplCountAll
@@ -1025,10 +1010,9 @@ lemma count_pred_le_queryBound_of_mem_support_run_hidingImplCountAll
       (fun _ _ => Nat.zero_le _) (Finset.mem_univ s)
   omega
 
+omit [Finite C] [Inhabited C] in
 /- Combined pointwise bound used when converting the bad event to an indicator
 expectation over counted support points. -/
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
 lemma bad_indicator_le_queryBound_of_mem_support_run_hidingImplCountAll
     [Finite S]
     {AUX : Type} {t : ℕ}
@@ -1045,7 +1029,6 @@ lemma bad_indicator_le_queryBound_of_mem_support_run_hidingImplCountAll
         (count_pred_le_queryBound_of_mem_support_run_hidingImplCountAll
           (M := M) (S := S) (C := C) A s hz))
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 /-- Fixed-salt bridge from the counted bad event to the expected excess count. -/
 lemma probEvent_countAll_bad_le_wp_countPred
     {AUX : Type} {t : ℕ}
@@ -1068,7 +1051,6 @@ lemma probEvent_countAll_bad_le_wp_countPred
     simp [OracleComp.ProgramLogic.propInd_eq_ite]
 
 /- Fixed-salt expectation bound for the counted excess at the challenge salt. -/
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_countPred_le_queryBound_of_run_hidingImplCountAll
     [Finite S]
     {AUX : Type} {t : ℕ}
@@ -1099,12 +1081,11 @@ lemma wp_countPred_le_queryBound_of_run_hidingImplCountAll
           · rw [probOutput_eq_zero_of_not_mem_support hz]
             simp
     _ = t := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
 /-- For a fixed computation under the shared counted implementation, the sum of
 expected per-salt count increments is bounded by the total query bound. -/
-lemma sum_wp_countIncrements_le_queryBound_of_run_hidingImplCountAll
+lemma sum_wp_countIncrements_le_queryBound_of_run_hidingImplCountAll [Fintype S]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
     (hbound : IsTotalQueryBound oa n)
     (st₀ : QueryCache (CMOracle M S C) × (S → ℕ)) :
@@ -1170,14 +1151,13 @@ lemma sum_wp_countIncrements_le_queryBound_of_run_hidingImplCountAll
           · rw [probOutput_eq_zero_of_not_mem_support hz]
             simp
     _ = (n : ℝ≥0∞) := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
 /-- For a fixed computation under the shared counted implementation, the sum of
 expected indicators of whether each salt counter ever increases is bounded by the
 total query bound. -/
 lemma sum_wp_countIncrementIndicators_le_queryBound_of_run_hidingImplCountAll
-    [Finite M]
+    [Fintype S] [Finite M]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
     (hbound : IsTotalQueryBound oa n)
     (st₀ : QueryCache (CMOracle M S C) × (S → ℕ)) :
@@ -1267,9 +1247,8 @@ lemma sum_wp_countIncrementIndicators_le_queryBound_of_run_hidingImplCountAll
           · rw [probOutput_eq_zero_of_not_mem_support hz]
             simp
     _ = (n : ℝ≥0∞) := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 /-- A selected final count decomposes into the initial selected count plus the
 new increments made during the run. -/
 lemma wp_countPred_le_initialPred_add_wp_countIncrement
@@ -1313,8 +1292,7 @@ lemma wp_countPred_le_initialPred_add_wp_countIncrement
           (fun z : α × (QueryCache (CMOracle M S C) × (S → ℕ)) => (z.2.2 s - st₀.2 s : ℝ≥0∞)) := by
             rw [OracleComp.ProgramLogic.wp_add, OracleComp.ProgramLogic.wp_const]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_countPred_le_sum_initialPred_add_sum_wp_countIncrements
+lemma sum_wp_countPred_le_sum_initialPred_add_sum_wp_countIncrements [Fintype S]
     {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
     (st₀ : QueryCache (CMOracle M S C) × (S → ℕ)) :
@@ -1363,12 +1341,16 @@ of `m`. The salt counter is discarded by `run'`.
 Using `hidingImplSim` allows direct application of the distributional
 identical-until-bad lemma (`tvDist_simulateQ_le_probEvent_bad_dist`) to bound
 the distance between `hidingReal` and `hidingSim`. -/
-def hidingSim {AUX : Type} {t : ℕ} (A : HidingAdversary M S C AUX t) (s : S) :
+def hidingSim [Inhabited M] [Inhabited S]
+    {AUX : Type} {t : ℕ} (A : HidingAdversary M S C AUX t) (s : S) :
     OracleComp (CMOracle M S C) Bool :=
   (simulateQ (hidingImplSim s) (hidingOa A s)).run' (∅, 0)
 
 abbrev HidingAvgSpec (M : Type) (S : Type) (C : Type) :=
   (Unit →ₒ S) + CMOracle M S C
+
+noncomputable instance unitArrowSpecIsUniformSpec (S : Type) [Fintype S] [Inhabited S] :
+    IsUniformSpec (Unit →ₒ S) := IsUniformSpec.ofFintypeInhabited _
 
 abbrev hidingAvgLeftImpl :
     QueryImpl (Unit →ₒ S)

--- a/Examples/CommitmentScheme/Hiding/Defs.lean
+++ b/Examples/CommitmentScheme/Hiding/Defs.lean
@@ -66,8 +66,10 @@ open OracleSpec OracleComp ENNReal
 
 variable {M S C : Type}
   [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
+  [Fintype M] [Fintype S] [Finite C]
   [Inhabited M] [Inhabited S] [Inhabited C]
+
+attribute [local instance] Fintype.ofFinite
 
 /-! ## Hiding adversary and real game -/
 
@@ -147,7 +149,7 @@ def hidingImplCountAll :
       set (cache.cacheQuery ms u, counts')
       return u
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] [Inhabited S]
   [Inhabited C] in
 lemma hidingImpl₁_step_totalBound (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × ℕ) :
@@ -173,7 +175,7 @@ lemma hidingImpl₁_step_totalBound (s : S) (ms : M × S)
             rw [isTotalQueryBound_query_bind_iff]
             exact ⟨Nat.one_pos, fun _ => trivial⟩)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] [Inhabited S]
   [Inhabited C] in
 lemma hidingImplCountAll_step_totalBound (ms : M × S)
     (st : QueryCache (CMOracle M S C) × (S → ℕ)) :
@@ -200,7 +202,7 @@ lemma hidingImplCountAll_step_totalBound (ms : M × S)
             rw [isTotalQueryBound_query_bind_iff]
             exact ⟨Nat.one_pos, fun _ => trivial⟩)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] [Inhabited S]
   [Inhabited C] in
 /-- Single-step projection: projecting `hidingImplCountAll` to one salt counter
 recovers `hidingImpl₁ s`. -/
@@ -227,7 +229,7 @@ theorem hidingImplCountAll_proj_eq_hidingImpl₁
       · have hs : ¬ s = ms.2 := by simpa [eq_comm] using h
         simp [h, hs]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] [Inhabited S]
   [Inhabited C] in
 theorem hidingImplCountAll_proj_eq_cachingOracle
     (ms : M × S)
@@ -245,7 +247,7 @@ theorem hidingImplCountAll_proj_eq_cachingOracle
         StateT.run_bind, StateT.run_get, pure_bind, StateT.run_set,
         StateT.run_modifyGet, Prod.map]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] [Inhabited S]
   [Inhabited C] in
 theorem run_hidingImplCountAll_proj_eq_cachingOracle
     {α : Type}
@@ -315,7 +317,7 @@ def hidingOa {AUX : Type} {t : ℕ} (A : HidingAdversary M S C AUX t) (s : S) :
   let cm ← (CMOracle M S C).query (m, s)
   A.distinguish aux cm
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] [Inhabited S]
   [Inhabited C] in
 /-- Total query bound for the full two-phase hiding computation, matching the
 textbook's bounded-query setting: `t` adversary queries plus one challenge
@@ -325,7 +327,7 @@ lemma hidingOa_totalBound_current {AUX : Type} {t : ℕ}
     IsTotalQueryBound (hidingOa A s) (t + 1) := by
   simpa [hidingOa] using A.totalBound s
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] in
+omit [DecidableEq C] [Fintype M] [Fintype S] [Finite C] [Inhabited M] in
 lemma hiding_choose_totalBound {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     IsTotalQueryBound A.choose t := by
@@ -338,7 +340,7 @@ lemma hiding_choose_totalBound {AUX : Type} {t : ℕ}
       (n := t)
       (A.totalBound default))
 
-omit [DecidableEq C] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [DecidableEq C] [Finite C] [Inhabited M] [Inhabited S] [Inhabited C] in
 lemma hiding_distinguish_totalBound_of_choose_support
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) (s : S)
@@ -368,8 +370,7 @@ lemma hiding_distinguish_totalBound_of_choose_support
     omega
   simpa [hbudget] using hcm
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma hidingImpl₁_run_totalBound_current {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) (s : S) :
     IsTotalQueryBound

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/Average.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/Average.lean
@@ -9,9 +9,15 @@ import Examples.CommitmentScheme.Hiding.CountBounds
 open OracleSpec OracleComp ENNReal
 
 variable {M S C : Type}
-  [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C]
+  [DecidableEq M] [DecidableEq S]
+  [Finite C] [Inhabited C]
+
+attribute [local instance] Fintype.ofFinite
+
+section experiments
+
+variable [Inhabited M] [Inhabited S]
+
 /-- Combined query implementation for the averaged hiding experiment,
 merging the left (uniform-salt) and right (commitment oracle) implementations. -/
 def hidingAvgQueryImpl :
@@ -46,8 +52,9 @@ def hidingMixedSim {AUX : Type} {t : ℕ}
   let s ← (HidingAvgSpec M S C).query (Sum.inl ())
   OracleComp.liftComp (hidingSim A s) (HidingAvgSpec M S C)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+end experiments
+
+omit [Finite C] [Inhabited C] in
 lemma run_simulateQ_hidingAvgRightImpl_eq_liftComp {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
     (st : HidingCountState M S C) :
@@ -76,8 +83,9 @@ lemma run_simulateQ_hidingAvgRightImpl_eq_liftComp {α : Type}
       exact OracleComp.bind_congr' hstep (fun p => by
         simpa using ih p.1 p.2)
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited C] in
-lemma run_simulateQ_hidingAvgComp_eq_bind {AUX : Type} {t : ℕ}
+omit [Finite C] [Inhabited C] in
+lemma run_simulateQ_hidingAvgComp_eq_bind [Inhabited M] [Inhabited S]
+    {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (simulateQ hidingAvgQueryImpl (hidingAvgComp A)).run (∅, fun _ => 0) =
       (liftM ((Unit →ₒ S).query ()) >>= fun s =>
@@ -118,13 +126,13 @@ lemma run_simulateQ_hidingAvgComp_eq_bind {AUX : Type} {t : ℕ}
         (HidingAvgSpec M S C)))
   rfl
 
-omit [DecidableEq C] [Fintype M] in
 /-- Averaged-mass bridge for hiding.
 
 This packages the per-salt bad probabilities into the shared `hidingAvgComp`
 run, where the salt is sampled once up front and then the shared count-all
 simulation is reused for the rest of the game. -/
-theorem sum_probEvent_hidingBad_eq_avg_bad_mass {AUX : Type} {t : ℕ}
+theorem sum_probEvent_hidingBad_eq_avg_bad_mass [Fintype S] [Inhabited M] [Inhabited S]
+    {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (∑ s : S, Pr[hidingBad ∘ Prod.snd |
       (simulateQ (hidingImpl₁ s) (hidingOa A s)).run (∅, 0)]) =
@@ -178,8 +186,7 @@ theorem sum_probEvent_hidingBad_eq_avg_bad_mass {AUX : Type} {t : ℕ}
             (simulateQ hidingAvgQueryImpl (hidingAvgComp A)).run (∅, fun _ => 0)] := by
           rw [hprob]
 
-omit [DecidableEq C] [Fintype M] in
-lemma probEvent_hidingAvg_bad_le_wp_selectedCountPred
+lemma probEvent_hidingAvg_bad_le_wp_selectedCountPred [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     Pr[fun z : ((S × Bool) × HidingCountState M S C) => 2 ≤ z.2.2 z.1.1 |
@@ -202,8 +209,8 @@ lemma probEvent_hidingAvg_bad_le_wp_selectedCountPred
         simpa using hcast)
   simpa [oa] using h
 
-omit [DecidableEq C] [Fintype M] in
 lemma card_mul_wp_hidingAvg_selectedCountPred_eq_sum_wp_countPred
+    [Fintype S] [Inhabited M] [Inhabited S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (Fintype.card S : ℝ≥0∞) *
@@ -263,10 +270,10 @@ lemma card_mul_wp_hidingAvg_selectedCountPred_eq_sum_wp_countPred
             (fun z : Bool × HidingCountState M S C => (z.2.2 s - 1 : ℝ≥0∞)) := by
           simp [Q]
 
-omit [DecidableEq C] [Fintype M] in
 /-- Textbook outer bridge: the bad-mass sum is bounded by the per-salt
 count-pred expectations from the shared counted implementation. -/
-theorem sum_probEvent_hidingBad_le_sum_wp_countPred {AUX : Type} {t : ℕ}
+theorem sum_probEvent_hidingBad_le_sum_wp_countPred [Fintype S] [Inhabited M] [Inhabited S]
+    {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (∑ s : S, Pr[hidingBad ∘ Prod.snd |
       (simulateQ (hidingImpl₁ s) (hidingOa A s)).run (∅, 0)]) ≤
@@ -298,16 +305,14 @@ theorem sum_probEvent_hidingBad_le_sum_wp_countPred {AUX : Type} {t : ℕ}
                 card_mul_wp_hidingAvg_selectedCountPred_eq_sum_wp_countPred
                   (M := M) (S := S) (C := C) A
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- The real hiding game is `simulateQ cachingOracle` applied to the shared computation. -/
 theorem hidingReal_eq {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) (s : S) :
     hidingReal A s = (simulateQ cachingOracle (hidingOa A s)).run' ∅ := by
   simp only [hidingReal, hidingOa]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- The real hiding game equals `simulateQ hidingImpl₁` projected to discard the counter.
 This lifts cachingOracle's state by pairing it with the salt counter. -/
 theorem hidingReal_eq_impl₁ {AUX : Type} {t : ℕ}
@@ -328,11 +333,11 @@ theorem hidingReal_eq_impl₁ {AUX : Type} {t : ℕ}
         simp [StateT.run_set, StateT.run_pure, Prod.map, StateT.run_modifyGet]
     ) (hidingOa A s) (∅, 0)).symm
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- The implementations agree when `¬bad`: when the counter is less than 2,
 `hidingImpl₁` and `hidingImpl₂` produce the same monadic computation.
 The redirect condition `cnt ≥ 2 && salt = s` is `false` since `cnt < 2`. -/
-theorem hidingImpl_agree (s : S) (ms : M × S)
+theorem hidingImpl_agree [Inhabited M] [Inhabited S] (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × ℕ) (h : ¬hidingBad st) :
     (hidingImpl₁ s ms).run st = (hidingImpl₂ s ms).run st := by
   simp only [hidingBad, ge_iff_le, not_le] at h
@@ -349,17 +354,14 @@ theorem hidingImpl_agree (s : S) (ms : M × S)
       simp [this]
     rw [hcnt]
 
-omit [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [DecidableEq M] [DecidableEq S] [Finite C] [Inhabited C] in
 /-- `hidingBad` is upward-closed in the counter component. -/
 private lemma hidingBad_of_counter_le
     {st₁ st₂ : QueryCache (CMOracle M S C) × ℕ}
     (h : hidingBad st₁) (hle : st₁.2 ≤ st₂.2) : hidingBad st₂ := by
   simp only [hidingBad] at h ⊢; omega
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- One-step counter growth bound for `hidingImpl₁`:
 the salt counter is monotone and increases by at most one. -/
 theorem hidingImpl₁_counter_le_succ (s : S) (ms : M × S)
@@ -384,8 +386,7 @@ theorem hidingImpl₁_counter_le_succ (s : S) (ms : M × S)
     simp
     split <;> omega
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Bad is monotone for `hidingImpl₁`: once the counter reaches 2, it stays ≥ 2. -/
 theorem hidingImpl₁_bad_mono (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × ℕ) (h : hidingBad st)
@@ -407,10 +408,10 @@ The proof uses `hidingImplSim`, which redirects all salt-`s` cache misses to
 
 The `Pr[bad] ≤ t/|S|` bound requires `s` to be uniformly random (see below). -/
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- One-step counter growth bound for `hidingImplSim`:
 the salt counter is monotone and increases by at most one. -/
-theorem hidingImplSim_counter_le_succ (s : S) (ms : M × S)
+theorem hidingImplSim_counter_le_succ [Inhabited M] [Inhabited S] (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × ℕ)
     (x : C × (QueryCache (CMOracle M S C) × ℕ))
     (hx : x ∈ support ((hidingImplSim s ms).run st)) :
@@ -432,16 +433,15 @@ theorem hidingImplSim_counter_le_succ (s : S) (ms : M × S)
     simp
     split <;> omega
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- Bad is monotone for `hidingImplSim`: once cnt ≥ 2, it stays ≥ 2. -/
-theorem hidingImplSim_bad_mono (s : S) (ms : M × S)
+theorem hidingImplSim_bad_mono [Inhabited M] [Inhabited S] (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × ℕ) (h : hidingBad st)
     (x : C × (QueryCache (CMOracle M S C) × ℕ))
     (hx : x ∈ support ((hidingImplSim s ms).run st)) :
     hidingBad x.2 :=
   hidingBad_of_counter_le h (hidingImplSim_counter_le_succ s ms st x hx).1
 
-omit [DecidableEq C] [Fintype M] [Fintype S] in
 /-- `hidingImpl₁` and `hidingImplSim` agree **distributionally** when `¬bad`.
 
 When `cnt < 2`, the two implementations differ only in the query point for
@@ -451,7 +451,7 @@ queries at `(default, default)`. Since the underlying oracle is memoryless
 are `C`), the returned value has the same distribution. The cache update and
 counter increment are identical (both cache at `ms`, both increment when
 `ms.2 = s`). Therefore every `(output, state)` pair has the same probability. -/
-theorem hidingImpl_agree_dist (s : S) (ms : M × S)
+theorem hidingImpl_agree_dist [Inhabited M] [Inhabited S] (s : S) (ms : M × S)
     (st : QueryCache (CMOracle M S C) × ℕ) (h : ¬hidingBad st)
     (p : C × (QueryCache (CMOracle M S C) × ℕ)) :
     Pr[= p | (hidingImpl₁ s ms).run st] =
@@ -474,18 +474,17 @@ theorem hidingImpl_agree_dist (s : S) (ms : M × S)
     refine tsum_congr fun x => ?_
     congr 1
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 /-- The sim game equals `hidingImplSim` applied to `hidingOa`, projected to output.
 
 This lifts `cachingOracle`'s state by pairing it with the salt counter and
 shows that `hidingImplSim` acts as a state-projection of `cachingOracle` where
 all salt-s queries are redirected. -/
-theorem hidingSim_eq_implSim {AUX : Type} {t : ℕ}
+theorem hidingSim_eq_implSim [Inhabited M] [Inhabited S] {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) (s : S) :
     hidingSim A s = (simulateQ (hidingImplSim s) (hidingOa A s)).run' (∅, 0) := by
   rfl
 
-omit [DecidableEq C] [Fintype M] [Fintype S] in
 /-- For fixed `s`, the TV distance between real and sim games is bounded by
 the probability of the bad event under `hidingImpl₁`.
 
@@ -493,7 +492,8 @@ The proof uses the distributional identical-until-bad lemma
 (`tvDist_simulateQ_le_probEvent_bad_dist`): `hidingImpl₁` (real with counter) and
 `hidingImplSim` (sim with counter) agree distributionally when `¬bad` because the
 underlying oracle is memoryless. -/
-theorem tvDist_hidingReal_hidingSim_le_probBad {AUX : Type} {t : ℕ}
+theorem tvDist_hidingReal_hidingSim_le_probBad [Inhabited M] [Inhabited S]
+    {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) (s : S) :
     tvDist (hidingReal A s) (hidingSim A s) ≤
     Pr[hidingBad ∘ Prod.snd |
@@ -533,8 +533,7 @@ theorem indicator_le_natCast_count (P : Prop) [Decidable P] (n : ℕ)
   · simp [hP, h hP]
   · simp [hP]
 
-omit [DecidableEq M] [DecidableEq S] [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M]
-  [Inhabited S] in
+omit [DecidableEq M] [DecidableEq S] in
 lemma wp_finset_sum {α : Type}
     (oa : OracleComp (CMOracle M S C) α) (ss : Finset S) (f : S → α → ℝ≥0∞) :
     (ss.sum fun s => OracleComp.ProgramLogic.wp oa (f s)) =
@@ -545,8 +544,7 @@ lemma wp_finset_sum {α : Type}
   · intro s ss hs ih
     simp [Finset.sum_insert, hs, ih, OracleComp.ProgramLogic.wp_add]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_hidingOa_eq_wp_choose
+lemma sum_wp_hidingOa_eq_wp_choose [Fintype S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
     (post : S → Bool × HidingCountState M S C → ℝ≥0∞) :
@@ -607,8 +605,7 @@ lemma sum_wp_hidingOa_eq_wp_choose
                     ((simulateQ hidingImplCountAll (A.distinguish qchoose.1.2 qch.1)).run qch.2)
                     (post s))))
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_countPred_eq_wp_choose
+lemma sum_wp_countPred_eq_wp_choose [Fintype S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (∑ s : S,
@@ -630,7 +627,6 @@ lemma sum_wp_countPred_eq_wp_choose
       (M := M) (S := S) (C := C) A
       (fun s z => (z.2.2 s - 1 : ℝ≥0∞))
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_challenge_countPred_le_initialCount
     (m : M) (s : S) (st : HidingCountState M S C) :
     OracleComp.ProgramLogic.wp
@@ -658,10 +654,9 @@ lemma wp_challenge_countPred_le_initialCount
             · rw [probOutput_eq_zero_of_not_mem_support hqch]
               simp
     _ = st.2 s := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_challenge_countPred_le_initialCount
+lemma sum_wp_challenge_countPred_le_initialCount [Fintype S]
     (m : M) (st : HidingCountState M S C) :
     (∑ s : S,
       OracleComp.ProgramLogic.wp
@@ -672,8 +667,8 @@ lemma sum_wp_challenge_countPred_le_initialCount
   intro s hs
   exact wp_challenge_countPred_le_initialCount (M := M) (S := S) (C := C) m s st
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
 lemma sum_wp_distinguish_countPred_le_sum_initialPred_add_residual
+    [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ} [Finite M]
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × HidingCountState M S C}
@@ -710,8 +705,8 @@ lemma sum_wp_distinguish_countPred_le_sum_initialPred_add_residual
     simpa [add_assoc, add_left_comm, add_comm] using
       add_le_add_left hincr (∑ s : S, (qchoose.2.2 s - 1 : ℝ≥0∞)))
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
 lemma sum_wp_countPred_le_sum_initialPred_add_queryBound_of_run_hidingImplCountAll
+    [Fintype S]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
     (hbound : IsTotalQueryBound oa n)
     (st₀ : HidingCountState M S C) :
@@ -735,8 +730,8 @@ lemma sum_wp_countPred_le_sum_initialPred_add_queryBound_of_run_hidingImplCountA
     simpa [add_assoc, add_left_comm, add_comm] using
       add_le_add_left hincr (∑ s : S, (st₀.2 s - 1 : ℝ≥0∞)))
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
 lemma sum_wp_distinguish_countPred_le_queryBound_of_choose_count_support
+    [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ} [Finite M]
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × HidingCountState M S C}
@@ -805,8 +800,8 @@ lemma sum_wp_distinguish_countPred_le_queryBound_of_choose_count_support
         rw [Nat.cast_sum]
         exact tsub_add_cancel_of_le hcast
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
 lemma sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_support
+    [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ} [Finite M]
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × HidingCountState M S C}
@@ -856,8 +851,7 @@ lemma sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_su
     · simp [OracleComp.ProgramLogic.propInd, hslt]
   exact le_trans hmono hres
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_badIndicator_eq_wp_choose
+lemma sum_wp_badIndicator_eq_wp_choose [Fintype S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (∑ s : S, Pr[hidingBad ∘ Prod.snd |
@@ -904,8 +898,7 @@ lemma sum_wp_badIndicator_eq_wp_choose
             (M := M) (S := S) (C := C) A
             (fun s z => OracleComp.ProgramLogic.propInd (2 ≤ z.2.2 s))
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma wp_badIndicator_le_chooseHit_add_distinguishIncrement_of_choose_support
+lemma wp_badIndicator_le_chooseHit_add_distinguishIncrement_of_choose_support [Fintype S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × HidingCountState M S C}
@@ -997,7 +990,7 @@ lemma wp_badIndicator_le_chooseHit_add_distinguishIncrement_of_choose_support
                           OracleComp.ProgramLogic.propInd (qch.2.2 s < z.2.2 s) := by
                             simp_rw [mul_add]
                             rw [ENNReal.tsum_add, ENNReal.tsum_mul_right,
-                              HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+                              tsum_probOutput_of_liftM_PMF, one_mul]
               exact mul_le_mul' le_rfl hinner
             · rw [probOutput_eq_zero_of_not_mem_support hqch]
               simp
@@ -1013,10 +1006,9 @@ lemma wp_badIndicator_le_chooseHit_add_distinguishIncrement_of_choose_support
         rw [OracleComp.ProgramLogic.wp_eq_tsum]
         simp_rw [mul_add]
         rw [ENNReal.tsum_add, ENNReal.tsum_mul_right,
-          HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+          tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma wp_badIndicator_le_chooseHit_add_freshDistinguishIncrement_of_choose_support
+lemma wp_badIndicator_le_chooseHit_add_freshDistinguishIncrement_of_choose_support [Fintype S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × HidingCountState M S C}
@@ -1113,7 +1105,7 @@ lemma wp_badIndicator_le_chooseHit_add_freshDistinguishIncrement_of_choose_suppo
                             (qchoose.2.2 s = 0 ∧ qch.2.2 s < z.2.2 s) := by
                             simp_rw [mul_add]
                             rw [ENNReal.tsum_add, ENNReal.tsum_mul_right,
-                              HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+                              tsum_probOutput_of_liftM_PMF, one_mul]
               exact mul_le_mul' le_rfl hinner
             · rw [probOutput_eq_zero_of_not_mem_support hqch]
               simp
@@ -1130,10 +1122,10 @@ lemma wp_badIndicator_le_chooseHit_add_freshDistinguishIncrement_of_choose_suppo
         rw [OracleComp.ProgramLogic.wp_eq_tsum]
         simp_rw [mul_add]
         rw [ENNReal.tsum_add, ENNReal.tsum_mul_right,
-          HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+          tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq S] [Inhabited S] in
-lemma sum_chooseHitIndicators_le_sumCounts
+omit [DecidableEq S] in
+lemma sum_chooseHitIndicators_le_sumCounts [Fintype S]
     (counts : S → ℕ) :
     (∑ s : S, OracleComp.ProgramLogic.propInd (0 < counts s)) ≤
       (∑ s : S, counts s : ℝ≥0∞) := by
@@ -1144,8 +1136,7 @@ lemma sum_chooseHitIndicators_le_sumCounts
     exact_mod_cast hpos
   · simp [OracleComp.ProgramLogic.propInd, hpos]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_freshDistinguishIncrement_eq_query
+lemma sum_wp_freshDistinguishIncrement_eq_query [Fintype S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
     {qchoose : (M × AUX) × HidingCountState M S C}

--- a/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
+++ b/Examples/CommitmentScheme/Hiding/LoggingBounds/QuerySalt.lean
@@ -18,12 +18,12 @@ open OracleSpec OracleComp ENNReal
 open scoped OracleSpec.PrimitiveQuery
 
 variable {M S C : Type}
-  [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C]
+  [DecidableEq M] [DecidableEq S]
+  [Finite C] [Inhabited C]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
-lemma wp_choose_sumHitIndicators_le_queryBound
+attribute [local instance] Fintype.ofFinite
+
+lemma wp_choose_sumHitIndicators_le_queryBound [Fintype S] [Inhabited S]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     OracleComp.ProgramLogic.wp
@@ -37,8 +37,7 @@ lemma wp_choose_sumHitIndicators_le_queryBound
         sum_chooseHitIndicators_le_sumCounts qchoose.2.2))
     (wp_choose_sumCounts_le_queryBound (M := M) (S := S) (C := C) A)
 
-omit [DecidableEq M] [DecidableEq S] [DecidableEq C] [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [DecidableEq M] [DecidableEq S] [Finite C] [Inhabited C] in
 lemma run_simulateQ_loggingOracle_query_bind {α : Type}
     (t : (CMOracle M S C).Domain) (mx : (CMOracle M S C).Range t → OracleComp (CMOracle M S C) α) :
     (simulateQ loggingOracle (liftM (query t) >>= mx)).run =
@@ -49,9 +48,8 @@ lemma run_simulateQ_loggingOracle_query_bind {α : Type}
   simp [loggingOracle, QueryImpl.withLogging, OracleQuery.cont_query,
     Function.id_def]
 
-omit [DecidableEq M] [DecidableEq C] [Fintype M] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
-lemma sum_querySaltCounts_eq_length
+omit [DecidableEq M] [Finite C] [Inhabited C] in
+lemma sum_querySaltCounts_eq_length [Fintype S]
     (log : QueryLog (CMOracle M S C)) :
     (∑ s : S,
       QueryLog.countQ log (fun t : (CMOracle M S C).Domain => t.2 = s)) = log.length := by
@@ -93,9 +91,8 @@ lemma sum_querySaltCounts_eq_length
               rw [hsingle]
         _ = log.length + 1 := by rw [ih, Nat.add_comm]
 
-omit [DecidableEq M] [DecidableEq C] [Fintype M] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
-lemma sum_querySaltIndicators_le_logLength
+omit [DecidableEq M] [Finite C] [Inhabited C] in
+lemma sum_querySaltIndicators_le_logLength [Fintype S]
     (log : QueryLog (CMOracle M S C)) :
     (∑ s : S,
       OracleComp.ProgramLogic.propInd
@@ -109,8 +106,8 @@ lemma sum_querySaltIndicators_le_logLength
       (counts := fun s => QueryLog.countQ log (fun t : (CMOracle M S C).Domain => t.2 = s))) ?_
   exact le_of_eq hcounts
 
-omit [DecidableEq C] [Fintype C] [Inhabited M] [Inhabited S] [Inhabited C] in
-lemma log_length_le_of_mem_support_counting_simulate_run_logging
+omit [Finite C] [Inhabited C] in
+lemma log_length_le_of_mem_support_counting_simulate_run_logging [Fintype M] [Fintype S]
     {α : Type} (oa : OracleComp (CMOracle M S C) α)
     {z : (α × QueryLog (CMOracle M S C)) × QueryCount (M × S)}
     (hz : z ∈ support (countingOracle.simulate ((simulateQ loggingOracle oa).run) 0)) :
@@ -181,8 +178,7 @@ lemma log_length_le_of_mem_support_counting_simulate_run_logging
         simpa using Nat.succ_le_of_lt hlt
       simpa [hzlog] using hcons
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited C]
-  [Inhabited M] [Inhabited S] in
+omit [Finite C] in
 lemma log_length_le_of_mem_support_run_cached_logging
     [Finite M] [Finite S] [Finite C]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
@@ -194,7 +190,6 @@ lemma log_length_le_of_mem_support_run_cached_logging
     z.1.2.length ≤ n := by
   haveI : Fintype M := Fintype.ofFinite M
   haveI : Fintype S := Fintype.ofFinite S
-  haveI : Fintype C := Fintype.ofFinite C
   classical
   let cost : QueryCache (CMOracle M S C) → ℕ := fun _ => 0
   have hstep :
@@ -226,9 +221,8 @@ lemma log_length_le_of_mem_support_run_cached_logging
       hboundLog hqc
   exact le_trans hlen hqc_le
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
 lemma sum_wp_querySaltIndicators_le_queryBound_of_run_cached_logging
-    [Finite M]
+    [Fintype S] [Finite M]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
     (cache₀ : QueryCache (CMOracle M S C))
     (hbound : IsTotalQueryBound oa n) :
@@ -276,10 +270,10 @@ lemma sum_wp_querySaltIndicators_le_queryBound_of_run_cached_logging
             · rw [probOutput_eq_zero_of_not_mem_support hz]
               simp
     _ = (n : ℝ≥0∞) := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
 lemma sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_support_with_state
+    [Fintype S] [Inhabited S]
     [Finite M]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -336,8 +330,8 @@ lemma sum_wp_distinguish_incrementIndicators_le_queryResidual_of_choose_count_su
     · simp [OracleComp.ProgramLogic.propInd, hslt]
   exact le_trans hmono hres
 
-omit [DecidableEq M] [DecidableEq C] [Fintype M] [Inhabited M] [Inhabited S] in
-lemma sum_wp_querySaltIndicators_le_queryBound_of_run_logging
+omit [DecidableEq M] in
+lemma sum_wp_querySaltIndicators_le_queryBound_of_run_logging [Fintype S]
     {α : Type} {oa : OracleComp (CMOracle M S C) α} {n : ℕ}
     (hbound : IsTotalQueryBound oa n) :
     (∑ s : S,
@@ -379,10 +373,9 @@ lemma sum_wp_querySaltIndicators_le_queryBound_of_run_logging
           · rw [probOutput_eq_zero_of_not_mem_support hz]
             simp
     _ = (n : ℝ≥0∞) := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 theorem run_cached_logging_proj_eq_cachingOracle
     {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
@@ -412,8 +405,7 @@ theorem run_cached_logging_proj_eq_cachingOracle
           simpa [simulateQ_map, StateT.map, StateT.run, Function.comp_def] using
             ih u (cache₀.cacheQuery t u)
 
-omit [DecidableEq M] [DecidableEq S] [DecidableEq C] [Fintype M] [Fintype S] [Fintype C]
-  [Inhabited M] [Inhabited S] [Inhabited C] in
+omit [DecidableEq M] [DecidableEq S] [Finite C] [Inhabited C] in
 lemma queryLog_countQ_pos_of_mem
     {entry : (t : (CMOracle M S C).Domain) × (CMOracle M S C).Range t}
     {log : QueryLog (CMOracle M S C)}
@@ -432,7 +424,6 @@ lemma queryLog_countQ_pos_of_mem
         · simp only [hhd, ↓reduceIte]
           exact ih hmem
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma fresh_incrementIndicator_le_querySaltIndicator_cached_logging
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -531,8 +522,7 @@ lemma fresh_incrementIndicator_le_querySaltIndicator_cached_logging
           (M := M) (S := S) (C := C) hmem (by simp [hsalt])
   exact le_trans hcount_to_cache hcache_to_log
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Fintype C] [Inhabited M] [Inhabited S]
-  [Inhabited C] in
+omit [Finite C] [Inhabited C] in
 lemma cacheQuery_swap_of_ne
     (cache : QueryCache (CMOracle M S C))
     {t₀ t₁ : (CMOracle M S C).Domain}
@@ -549,7 +539,6 @@ lemma cacheQuery_swap_of_ne
       simp [QueryCache.cacheQuery_self, QueryCache.cacheQuery_of_ne, hne.symm]
     · simp [QueryCache.cacheQuery_of_ne, ht₀, ht₁]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_querySaltIndicator_prepend_eq_one
     {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
@@ -594,7 +583,6 @@ lemma wp_querySaltIndicator_prepend_eq_one
     simp [OracleComp.ProgramLogic.propInd, hpos]
   rw [hpost, OracleComp.ProgramLogic.wp_const]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_querySaltIndicator_prepend_eq_of_ne
     {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
@@ -645,7 +633,6 @@ lemma wp_querySaltIndicator_prepend_eq_of_ne
     simp [QueryLog.countQ, QueryLog.getQ_cons, hsalt, OracleComp.ProgramLogic.propInd]
   rw [hpost]
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entries
     {α : Type}
     (oa : OracleComp (CMOracle M S C) α)
@@ -828,7 +815,6 @@ lemma wp_querySaltIndicator_cached_logging_cacheQuery_eq_of_no_other_salt_entrie
               (cache := cache₀) (t₀ := (m, s)) (t₁ := t) cm u hmst_ne_t]
               using ih u (cache₀.cacheQuery t u) hself' hother'
 
-omit [DecidableEq C] [Fintype M] [Fintype S] [Inhabited M] [Inhabited S] in
 lemma wp_querySaltIndicator_cached_logging_freshCache_eq_common
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -861,8 +847,7 @@ lemma wp_querySaltIndicator_cached_logging_freshCache_eq_common
     exact cache_none_of_zero_count_of_mem_support_run_hidingChoose
       (M := M) (S := S) (C := C) A hqchoose m' s hzero
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
-lemma sum_wp_freshDistinguishIncrement_le_queryResidual_of_choose_support
+lemma sum_wp_freshDistinguishIncrement_le_queryResidual_of_choose_support [Fintype S] [Inhabited S]
     [Finite M]
     {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t)
@@ -995,8 +980,7 @@ lemma sum_wp_freshDistinguishIncrement_le_queryResidual_of_choose_support
           have hcard_top : (Fintype.card C : ℝ≥0∞) ≠ ∞ := by simp
           rw [ENNReal.mul_inv_cancel hcard0 hcard_top, one_mul]
 
-omit [DecidableEq C] [Fintype M] [Inhabited M] in
-theorem sum_probEvent_hidingBad_le [Finite M] {AUX : Type} {t : ℕ}
+theorem sum_probEvent_hidingBad_le [Fintype S] [Inhabited S] [Finite M] {AUX : Type} {t : ℕ}
     (A : HidingAdversary M S C AUX t) :
     (∑ s : S, Pr[hidingBad ∘ Prod.snd |
       (simulateQ (hidingImpl₁ s) (hidingOa A s)).run (∅, 0)]) ≤ t := by
@@ -1134,4 +1118,4 @@ theorem sum_probEvent_hidingBad_le [Finite M] {AUX : Type} {t : ℕ}
                 · rw [probOutput_eq_zero_of_not_mem_support hqchoose]
                   simp
     _ = t := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]

--- a/Examples/CommitmentScheme/Hiding/Main.lean
+++ b/Examples/CommitmentScheme/Hiding/Main.lean
@@ -31,8 +31,10 @@ open OracleSpec OracleComp ENNReal
 
 variable {M S C : Type}
   [DecidableEq M] [DecidableEq S] [DecidableEq C]
-  [Fintype M] [Fintype S] [Fintype C]
+  [Fintype M] [Fintype S] [Finite C]
   [Inhabited M] [Inhabited S] [Inhabited C]
+
+attribute [local instance] Fintype.ofFinite
 omit [DecidableEq M] [DecidableEq S] [DecidableEq C] [Fintype M] [Inhabited M] in
 private lemma tvDist_liftComp_hidingAvgSpec {α : Type}
     (oa ob : OracleComp (CMOracle M S C) α) :

--- a/Examples/ElGamal/Basic.lean
+++ b/Examples/ElGamal/Basic.lean
@@ -81,7 +81,7 @@ theorem correct [DecidableEq G] :
     rw [this, add_sub_cancel_right]
   simp [AsymmEncAlg.PerfectlyCorrect, ProbCompRuntime.probComp, ProbCompRuntime.evalDist,
     AsymmEncAlg.CorrectExp, elGamalAsymmEnc, hcancel,
-    HasEvalPMF.toSPMF_eq, SPMF.probFailure_liftM, HasEvalPMF.probFailure_eq_zero]
+    SPMF.probFailure_liftM, probFailure_of_liftM_PMF]
 
 section IND_CPA
 
@@ -280,7 +280,7 @@ private lemma IND_CPA_OneTime_DDHReduction_rand_half
         simp [probOutput_uniformSample]
       simp_rw [hbool]
       have hsum : ∑' x : G, Pr[= x | ($ᵗ G)] = 1 :=
-        HasEvalPMF.tsum_probOutput_eq_one ($ᵗ G)
+        tsum_probOutput_of_liftM_PMF ($ᵗ G)
       rw [ENNReal.tsum_mul_right, hsum, one_mul]
 
 omit [DecidableEq G] in
@@ -320,7 +320,7 @@ theorem elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
 /-- **Main theorem.** If an adversary makes at most `q` LR queries and every extracted one-time
 ElGamal DDH reduction has guess advantage at most `ε`, then ElGamal has IND-CPA advantage at most
 `q * (2 * ε)`. -/
-theorem elGamal_IND_CPA_le_q_mul_ddh
+theorem elGamal_IND_CPA_le_q_mul_ddh [Finite G]
     (hg : Function.Bijective (· • gen : F → G))
     (adversary : (elGamalAsymmEnc F G gen).IND_CPA_adversary)
     (q : ℕ) (ε : ℝ)

--- a/Examples/ElGamal/Basic.lean
+++ b/Examples/ElGamal/Basic.lean
@@ -320,7 +320,7 @@ theorem elGamal_oneTime_signedAdvantageReal_abs_eq_two_mul_ddhGuessAdvantage
 /-- **Main theorem.** If an adversary makes at most `q` LR queries and every extracted one-time
 ElGamal DDH reduction has guess advantage at most `ε`, then ElGamal has IND-CPA advantage at most
 `q * (2 * ε)`. -/
-theorem elGamal_IND_CPA_le_q_mul_ddh [Finite G]
+theorem elGamal_IND_CPA_le_q_mul_ddh
     (hg : Function.Bijective (· • gen : F → G))
     (adversary : (elGamalAsymmEnc F G gen).IND_CPA_adversary)
     (q : ℕ) (ε : ℝ)

--- a/Examples/ElGamal/Hash.lean
+++ b/Examples/ElGamal/Hash.lean
@@ -85,9 +85,13 @@ theorem correct :
   have hcomm : ∀ (a b : F), a • (b • g) = b • (a • g) := by
     intro a b; rw [← mul_smul, mul_comm, mul_smul]
   intro msg
-  simp [AsymmEncAlg.CorrectExp, ProbCompRuntime.probComp, ProbCompRuntime.evalDist,
-    hashedElGamal, hcomm,
-    HasEvalPMF.toSPMF_eq, SPMF.probFailure_liftM, HasEvalPMF.probFailure_eq_zero]
+  simp only [ProbCompRuntime.evalDist, ProbCompRuntime.probComp, AsymmEncAlg.CorrectExp,
+    hashedElGamal, bind_pure_comp, map_pure, Option.some.injEq, Functor.map_map, hcomm, bind_assoc,
+    bind_map_left, add_sub_cancel_left, decide_true, SPMFSemantics.ofMonadLift_evalDist, liftM_bind,
+    evalDist_uniformSample, liftM_map, probOutput_bind_const, SPMF.probFailure_liftM,
+    probFailure_of_liftM_PMF, tsub_zero, probOutput_map_const, probOutput_pure, ↓reduceIte, mul_one]
+  change 1 - Pr[⊥ | ($ᵗ HK : ProbComp HK)] = 1
+  simp
 
 /-! ## DDH Reduction -/
 
@@ -430,7 +434,7 @@ theorem esIdeal_eq_half
         simp [probOutput_uniformSample]
       simp_rw [hbool]
       have hsum : ∑' x : HK, Pr[= x | ($ᵗ HK)] = 1 :=
-        HasEvalPMF.tsum_probOutput_eq_one ($ᵗ HK)
+        tsum_probOutput_of_liftM_PMF ($ᵗ HK)
       rw [ENNReal.tsum_mul_right, hsum, one_mul]
 
 /-! ## Main theorem -/

--- a/Examples/EvalDistCompatible/Basic.lean
+++ b/Examples/EvalDistCompatible/Basic.lean
@@ -1,0 +1,62 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio.OracleComp.Constructions.SampleableType
+import VCVio.EvalDist.Instances.OptionT
+
+/-!
+# Compositional probability reasoning via `MonadLiftT`
+
+This example demonstrates the lift-based design of the `EvalDist` stack.
+`OptionT ProbComp` inherits `support`, `Pr[= _ | _]`, and `Pr[⊥ | _]` by
+composing the standard `MonadLiftT _ SetM` and `MonadLiftT _ SPMF`
+instances from `VCVio.EvalDist.Instances.OptionT` and
+`VCVio.OracleComp.EvalDist`.
+
+No `OptionT`-specific data class is registered. Every probability operation
+routes through `MonadLiftT _ SetM` (for `support`) and `MonadLiftT _ SPMF`
+(for `Pr[…]`), with the propositional `EvalDistCompatible` class connecting
+the two views where needed — and without introducing a diamond.
+
+The example: sample a Boolean uniformly and `guard` on heads, so half of
+the runs succeed with `()` and the other half fail.
+-/
+
+open OracleComp ENNReal
+
+namespace EvalDistCompatibleExample
+
+/-- Sample a Boolean uniformly; commit only on heads. -/
+noncomputable def maybeHeads : OptionT ProbComp Unit := do
+  let b ← (liftM ($ᵗ Bool) : OptionT ProbComp Bool)
+  guard (b = true)
+
+/-- The success branch has probability `1/2`. The proof routes
+`Pr[…]` through `MonadLiftT (OptionT ProbComp) SPMF` and reduces to the
+generic `OracleComp` lemma `probOutput_uniformSample`. -/
+theorem probOutput_maybeHeads : Pr[= () | maybeHeads] = 1 / 2 := by
+  change Pr[= () | (do
+      let b ← (liftM ($ᵗ Bool) : OptionT ProbComp Bool)
+      guard (b = true) : OptionT ProbComp Unit)] = _
+  rw [probOutput_bind_eq_tsum]
+  simp only [OptionT.probOutput_liftM, probOutput_guard]
+  rw [tsum_fintype (L := .unconditional _), Fintype.sum_bool]
+  simp [probOutput_uniformSample, Fintype.card_bool]
+
+/-- The failure mass has probability `1/2`. Because `maybeHeads` returns
+`Unit`, the total support mass at `()` plus the failure mass is `1`. -/
+theorem probFailure_maybeHeads : Pr[⊥ | maybeHeads] = 1 / 2 := by
+  rw [probFailure_eq_sub_tsum,
+      tsum_eq_single () (fun x hx => absurd (Subsingleton.elim x ()) hx),
+      probOutput_maybeHeads, ENNReal.sub_half ENNReal.one_ne_top]
+
+/-- Sanity check: success and failure mass sum to one. The lemma uses no
+`OptionT`-specific machinery — just the generic identity from
+[`tsum_probOutput_add_probFailure`]. -/
+theorem probOutput_add_probFailure_maybeHeads :
+    Pr[= () | maybeHeads] + Pr[⊥ | maybeHeads] = 1 := by
+  rw [probOutput_maybeHeads, probFailure_maybeHeads, ENNReal.add_halves]
+
+end EvalDistCompatibleExample

--- a/Examples/OneTimePad/Basic.lean
+++ b/Examples/OneTimePad/Basic.lean
@@ -45,7 +45,7 @@ lemma complete (sp : ℕ) : (oneTimePad sp).Complete := by
         ($ᵗ BitVec sp : ProbComp (BitVec sp)) := by
     simp [SymmEncAlg.CompleteExp, oneTimePad, monad_norm]
   rw [hsimp, probOutput_eq_one_iff]
-  exact ⟨HasEvalPMF.probFailure_eq_zero _,
+  exact ⟨probFailure_of_liftM_PMF _,
     support_map_const (mx := ($ᵗ BitVec sp : ProbComp (BitVec sp))) (y := some msg)
       (by simp [support_uniformSample])⟩
 

--- a/Examples/OneTimePad/UC.lean
+++ b/Examples/OneTimePad/UC.lean
@@ -313,7 +313,7 @@ noncomputable def realSmcSemantics (sp : ℕ)
   Result := Unit
   m := OptionT ProbComp
   instMonad := inferInstance
-  sem := SPMFSemantics.ofHasEvalSPMF (OptionT ProbComp)
+  sem := SPMFSemantics.ofMonadLift (OptionT ProbComp)
   run := fun W => realCipherObserve sp (readMsg W) P
 
 /-- **Ideal SMC semantics.** Ignore the closed system beyond sampling
@@ -326,7 +326,7 @@ noncomputable def idealSmcSemantics (sp : ℕ) (P : BitVec sp → Bool) :
   Result := Unit
   m := OptionT ProbComp
   instMonad := inferInstance
-  sem := SPMFSemantics.ofHasEvalSPMF (OptionT ProbComp)
+  sem := SPMFSemantics.ofMonadLift (OptionT ProbComp)
   run := fun _ => idealCipherObserve sp P
 
 @[simp]

--- a/Examples/PRFTagReader.lean
+++ b/Examples/PRFTagReader.lean
@@ -970,7 +970,9 @@ private lemma unlinkBadReaderQueryImpl_state_eq
       z.2 = st := by
   intro z hz
   unfold unlinkBadReaderQueryImpl at hz
-  simpa using congrArg Prod.snd hz
+  simp only [StateT.run_bind, StateT.run_get, StateT.run_pure, pure_bind,
+    support_pure, Set.mem_singleton_iff] at hz
+  exact congrArg Prod.snd hz
 
 omit [Fintype TagId] [Nonempty TagId] [DecidableEq Digest] [NeZero sessionsPerTag] in
 /-- When the tag still has a free slot (`sessionsUsed tag < sessionsPerTag`), the tag oracle samples

--- a/Examples/ProgramLogic/Probability.lean
+++ b/Examples/ProgramLogic/Probability.lean
@@ -19,7 +19,7 @@ open ENNReal OracleSpec OracleComp
 open OracleComp.ProgramLogic
 open scoped OracleComp.ProgramLogic
 
-variable {ι : Type} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+variable {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec]
 variable {α β γ δ ε ζ : Type}
 
 /-! ## Congruence -/

--- a/Examples/ProgramLogic/ProofMode.lean
+++ b/Examples/ProgramLogic/ProofMode.lean
@@ -22,7 +22,7 @@ open scoped OracleComp.ProgramLogic
 universe u
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β γ : Type}
 
 /-! ## `game_trans` -/
@@ -39,7 +39,7 @@ example {g₁ g₂ g₃ : OracleComp spec α}
 section ByUpto
 
 variable {σ : Type} {ι : Type} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α : Type}
 
 example
@@ -68,7 +68,7 @@ end ByUpto
 section RelSim
 
 variable {σ₁ σ₂ : Type} {ι : Type} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α : Type}
 
 example
@@ -110,7 +110,7 @@ end RelSim
 section RelSimDist
 
 variable {σ : Type} {ι : Type} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α : Type}
 
 example
@@ -181,7 +181,7 @@ end ByDist
 
 section RelDist
 
-variable {ι : Type} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+variable {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec]
 variable {α : Type}
 
 example {oa ob : OracleComp spec α}

--- a/Examples/ProgramLogic/RelationalAnchored.lean
+++ b/Examples/ProgramLogic/RelationalAnchored.lean
@@ -28,7 +28,7 @@ namespace OracleComp.ProgramLogic.AnchoredExamples
 open ENNReal MAlgRelOrdered MAlgRelOrdered.Anchored
 
 variable {ι₁ ι₂ : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 
 /-! ## Pure-pure base cases -/
 

--- a/Examples/ProgramLogic/RelationalDerived.lean
+++ b/Examples/ProgramLogic/RelationalDerived.lean
@@ -21,7 +21,7 @@ open scoped OracleComp.ProgramLogic
 universe u
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β γ : Type}
 
 /-! ## `rel_conseq` / `rel_inline` / `rel_dist` -/

--- a/Examples/ProgramLogic/RelationalStep.lean
+++ b/Examples/ProgramLogic/RelationalStep.lean
@@ -22,7 +22,7 @@ open scoped OracleComp.ProgramLogic
 universe u
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β γ δ : Type}
 
 /-! ## Basic relational stepping -/

--- a/Examples/ProgramLogic/UnaryProbability.lean
+++ b/Examples/ProgramLogic/UnaryProbability.lean
@@ -21,7 +21,7 @@ open scoped OracleComp.ProgramLogic
 universe u
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β γ : Type}
 
 /-! ### Probability goal lowering -/

--- a/Examples/ProgramLogic/UnaryStep.lean
+++ b/Examples/ProgramLogic/UnaryStep.lean
@@ -24,7 +24,7 @@ open scoped OracleComp.ProgramLogic
 universe u
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 /-! ## Notation examples -/
@@ -429,7 +429,7 @@ example :
 section LiftComp
 
 variable {ι' : Type} {superSpec : OracleSpec ι'}
-variable [superSpec.Fintype] [superSpec.Inhabited]
+variable [IsUniformSpec superSpec]
 variable [h : spec ⊂ₒ superSpec] [spec ˡ⊂ₒ superSpec]
 
 example (oa : OracleComp spec α) (post : α → ℝ≥0∞) :

--- a/Examples/ProgramLogic/UnaryTriple.lean
+++ b/Examples/ProgramLogic/UnaryTriple.lean
@@ -21,7 +21,7 @@ open scoped OracleComp.ProgramLogic
 universe u
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β γ : Type}
 
 /-! ## `vcstep` on `Triple` goals -/

--- a/Examples/Regev.lean
+++ b/Examples/Regev.lean
@@ -39,7 +39,7 @@
 --     let sa := dotProduct s.get a.get
 --     let val := Fin.val (sa - b)
 --     return if val < p/4 then true else val > 3*p/4
---   toSPMFSemantics := SPMFSemantics.ofHasEvalSPMF ProbComp
+--   toSPMFSemantics := SPMFSemantics.ofMonadLift ProbComp
 --   toProbCompLift := ProbCompLift.id
 
 -- lemma relax_p_bound {p χ m: ℕ} [hm : NeZero m] (h : p > 4 * (χ * m + 1)) : p > 2 * χ := by

--- a/Examples/Schnorr/SigmaProtocol.lean
+++ b/Examples/Schnorr/SigmaProtocol.lean
@@ -222,7 +222,7 @@ theorem sigma_simCommitPredictability (g : G)
         probOutput_map_bijective_uniform_cross F (f := fun z : F => z • g - c • pk) (hbij_c c),
         probOutput_uniformSample (α := G)]
     simp_rw [h_inner_const]
-    rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul,
+    rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul,
       probOutput_uniformSample (α := G)]
   have h_eq : probOutput (Prod.fst <$> simTranscript F G g pk) c₀ =
       (Fintype.card F : ℝ≥0∞)⁻¹ := by

--- a/Examples/Schnorr/Signature.lean
+++ b/Examples/Schnorr/Signature.lean
@@ -184,7 +184,7 @@ Three Schnorr-specific facts feed in:
 
 The result is delivered in the textbook DLog form `dlogExp g reduction` via
 the conversion `hardRelationExp_dlogGenerable_eq_dlogExp`. -/
-theorem signature_euf_cma [Finite G] [Inhabited G] (g : G)
+theorem signature_euf_cma (g : G)
     (hg : Function.Bijective (· • g : F → G))
     (M : Type) [DecidableEq M]
     (adv : SignatureAlg.unforgeableAdv (signature F G g M))
@@ -197,6 +197,7 @@ theorem signature_euf_cma [Finite G] [Inhabited G] (g : G)
       eps * (eps / (qH + 1 : ENNReal) - FiatShamir.challengeSpaceInv F) ≤
         Pr[= true | dlogExp g reduction] := by
   haveI : Inhabited F := ⟨0⟩
+  haveI : Inhabited G := ⟨(0 : F) • g⟩
   obtain ⟨red, hred⟩ := FiatShamir.euf_cma_bound
     (Schnorr.sigma F G g) (dlogGenerable (F := F) g) M
     (Schnorr.sigma_speciallySound F G g)

--- a/Examples/Schnorr/Signature.lean
+++ b/Examples/Schnorr/Signature.lean
@@ -184,7 +184,7 @@ Three Schnorr-specific facts feed in:
 
 The result is delivered in the textbook DLog form `dlogExp g reduction` via
 the conversion `hardRelationExp_dlogGenerable_eq_dlogExp`. -/
-theorem signature_euf_cma (g : G)
+theorem signature_euf_cma [Finite G] [Inhabited G] (g : G)
     (hg : Function.Bijective (· • g : F → G))
     (M : Type) [DecidableEq M]
     (adv : SignatureAlg.unforgeableAdv (signature F G g M))

--- a/Interop/Hax/Adc.lean
+++ b/Interop/Hax/Adc.lean
@@ -111,7 +111,7 @@ heavyweight `hax_mvcgen <;> bv_decide` combination, transport to
 `RustOracleComp` is one line of Lean — no extra tactic machinery, no
 repeated `bv_decide`, no knowledge of the postcondition shape beyond
 what `triple_liftRustM` asks for. -/
-theorem adc_u32_Lifted_spec [spec.Fintype] [spec.Inhabited]
+theorem adc_u32_Lifted_spec [IsUniformSpec spec]
     (a b carry_in : u32) :
     ⦃⌜carry_in ≤ 1⌝⦄
     (adc_u32_Lifted (spec := spec) a b carry_in)

--- a/Interop/Hax/Barrett.lean
+++ b/Interop/Hax/Barrett.lean
@@ -212,7 +212,7 @@ The lifted full modular spec is also kept out of the build, since it
 depends directly on the disabled `barrett_reduce_spec`.
 
 ```lean
-theorem barrett_reduce_Lifted_spec [spec.Fintype] [spec.Inhabited]
+theorem barrett_reduce_Lifted_spec [IsUniformSpec spec]
     (value : i32) :
     ⦃⌜value.toInt64 ≥ -(4194304 : Int64) ∧
        value.toInt64 ≤ (4194304 : Int64)⌝⦄
@@ -250,7 +250,7 @@ section OracleComposition
 
 set_option mvcgen.warning false
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- Query an oracle for a field coefficient (represented via `spec.Range t`
 and a user-supplied cast), then reduce it modulo `FIELD_MODULUS`. -/

--- a/Interop/Hax/Bridge.lean
+++ b/Interop/Hax/Bridge.lean
@@ -166,7 +166,7 @@ spec as the hypothesis. For concrete constructor-level programs the
 `@[simp]` commutation lemmas above still do the job directly. -/
 
 @[spec]
-theorem triple_liftRustM [spec.Fintype] [spec.Inhabited]
+theorem triple_liftRustM [IsUniformSpec spec]
     (x : RustM α)
     {Q : PostCond α (.except Interop.Rust.Error (.except PUnit .pure))}
     {P : Assertion (.except Interop.Rust.Error (.except PUnit .pure))}

--- a/Interop/Hax/CenteredBinomial.lean
+++ b/Interop/Hax/CenteredBinomial.lean
@@ -276,7 +276,7 @@ branches against the zero target, and closes the resulting `4⁻¹ + 4⁻¹
 synthesizing large decidable equality instances for `i32` outputs. -/
 theorem sampleRandomCbd1_prob_zero :
     Pr[= some (Except.ok (0 : i32)) | sampleRandomCbd1.run.run] = 2⁻¹ := by
-  rw [sampleRandomCbd1_run_run, HasEvalSPMF.probOutput_bind_eq_sum_fintype,
+  rw [sampleRandomCbd1_run_run, probOutput_bind_eq_sum_fintype,
     Fin.sum_univ_four]
   change _ * Pr[= cbdOutputZero | (pure cbdOutputZero : OracleComp unifSpec _)] +
       _ * Pr[= cbdOutputZero | (pure cbdOutputPosOne : OracleComp unifSpec _)] +
@@ -292,7 +292,7 @@ contributes (bit pattern `01`, `a = 1`, `c = 0`), one of four
 equiprobable draws. -/
 theorem sampleRandomCbd1_prob_pos_one :
     Pr[= some (Except.ok (1 : i32)) | sampleRandomCbd1.run.run] = 4⁻¹ := by
-  rw [sampleRandomCbd1_run_run, HasEvalSPMF.probOutput_bind_eq_sum_fintype,
+  rw [sampleRandomCbd1_run_run, probOutput_bind_eq_sum_fintype,
     Fin.sum_univ_four]
   change _ * Pr[= cbdOutputPosOne | (pure cbdOutputZero : OracleComp unifSpec _)] +
       _ * Pr[= cbdOutputPosOne | (pure cbdOutputPosOne : OracleComp unifSpec _)] +
@@ -307,7 +307,7 @@ contributes (bit pattern `10`, `a = 0`, `c = 1`), one of four
 equiprobable draws. -/
 theorem sampleRandomCbd1_prob_neg_one :
     Pr[= some (Except.ok (-1 : i32)) | sampleRandomCbd1.run.run] = 4⁻¹ := by
-  rw [sampleRandomCbd1_run_run, HasEvalSPMF.probOutput_bind_eq_sum_fintype,
+  rw [sampleRandomCbd1_run_run, probOutput_bind_eq_sum_fintype,
     Fin.sum_univ_four]
   change _ * Pr[= cbdOutputNegOne | (pure cbdOutputZero : OracleComp unifSpec _)] +
       _ * Pr[= cbdOutputNegOne | (pure cbdOutputPosOne : OracleComp unifSpec _)] +

--- a/Interop/Hax/Computation.lean
+++ b/Interop/Hax/Computation.lean
@@ -110,7 +110,7 @@ The postcondition shape on the `RustOracleComp` side matches the hax
 side exactly; the `errorOfHax` rebrand inside `triple_liftRustM` is
 invisible because the precondition rules out the `fail` branch and
 the success component of the postcondition does not mention errors. -/
-theorem computationLifted_triple [spec.Fintype] [spec.Inhabited] (x : u32) :
+theorem computationLifted_triple [IsUniformSpec spec] (x : u32) :
     ⦃⌜2 * x.toNat + 1 < 2 ^ 32⌝⦄
     (computationLifted (spec := spec) x)
     ⦃⇓ r => ⌜r.toNat = 2 * x.toNat + 1⌝⦄ := by

--- a/Interop/Hax/Division.lean
+++ b/Interop/Hax/Division.lean
@@ -87,7 +87,7 @@ precondition preserved. The `errorOfHax` rebrand inside
 `triple_liftRustM` is again invisible at the Triple level because the
 precondition rules out the panic branch; the equality-level lemma
 below is the one that actually witnesses the rebrand. -/
-theorem checkedDivLifted_triple [spec.Fintype] [spec.Inhabited]
+theorem checkedDivLifted_triple [IsUniformSpec spec]
     (x y : u32) (h : y ≠ 0) :
     ⦃⌜True⌝⦄
     (checkedDivLifted (spec := spec) x y)
@@ -178,7 +178,7 @@ branch is triggered by the uniform draw `b = 0`, and it panics with
 theorem randomDiv_panic_prob (x : u32) :
     Pr[= some (Except.error Interop.Rust.Error.divisionByZero) |
         (randomDiv x).run.run] = 2⁻¹ := by
-  rw [randomDiv_run_run, HasEvalSPMF.probOutput_bind_eq_sum_fintype]
+  rw [randomDiv_run_run, probOutput_bind_eq_sum_fintype]
   -- ∑ b : Fin 2, Pr[= b | $[0..1]] * Pr[= some (.error .divisionByZero) | pure _].
   -- Each factor of `Pr[= · | $[0..1]]` is `(1 + 1)⁻¹`; only `b = 0` gives a
   -- nonzero second factor (coefficient `1`), so the sum is `(1 + 1)⁻¹ = 2⁻¹`.

--- a/Interop/Hax/Examples.lean
+++ b/Interop/Hax/Examples.lean
@@ -108,15 +108,14 @@ one-liner workaround for the fact that `mvcgen`/`simp` normalises
 the hypothesis at `2^32`; the two are definitionally equal in `Nat`.
 
 VCVio's `WP (OracleComp spec) .pure` (in
-`VCVio.ProgramLogic.Unary.StdDoBridge`) requires `[spec.Fintype]` and
-`[spec.Inhabited]` for probability reasoning, so the Triple spec
-carries those constraints. -/
+`VCVio.ProgramLogic.Unary.StdDoBridge`) requires `[IsUniformSpec spec]`
+for probability reasoning, so the Triple spec carries that constraint. -/
 
 section TripleSpec
 
 set_option mvcgen.warning false
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- `addOrPanicLifted` total-correctness spec. Under the no-overflow
 precondition, the lifted hax computation never panics, never diverges,
@@ -166,7 +165,7 @@ section OracleTripleSpec
 
 set_option mvcgen.warning false
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- If the oracle's response can never push `x + coe y` above `2^32`,
 then `oracleThenAdd` always returns a value `≥ x`. The interesting part
@@ -192,8 +191,8 @@ end OracleTripleSpec
 
 Everything so far was a `Triple`: universal over oracle outcomes, with
 no probabilistic content. The point of dropping `Hax.RustM` into
-`RustOracleComp spec` is that the `OracleComp spec` layer also carries
-`HasEvalSPMF` (via the `ExceptT` / `OptionT` instances in
+`RustOracleComp spec` is that the `OracleComp spec` layer also admits
+`evalDist` / `Pr[…]` (via the `MonadLiftT … SPMF` instances in
 `VCVio.EvalDist.Instances.{ErrorT,OptionT}`), so quantitative claims
 like `Pr[= some (.error e) | tossedAdd.run.run] = 1/2` are well-defined
 and provable.
@@ -257,7 +256,7 @@ the `Hax.RustM` level has no oracle to sample at all. -/
 theorem tossedAdd_panic_prob :
     Pr[= some (Except.error Interop.Rust.Error.integerOverflow) |
         tossedAdd.run.run] = 2⁻¹ := by
-  rw [tossedAdd_run_run, HasEvalSPMF.probOutput_bind_eq_sum_fintype]
+  rw [tossedAdd_run_run, probOutput_bind_eq_sum_fintype]
   -- ∑ x : Fin 2, Pr[= x | $[0..1]] * (if ... then 1 else 0).
   -- Both `Pr[= · | $[0..1]]` factors collapse to `(1 + 1 : ℝ≥0∞)⁻¹`, then the
   -- `x = 0` branch contributes `0` and the `x = 1` branch contributes the

--- a/Interop/Hax/README.md
+++ b/Interop/Hax/README.md
@@ -106,7 +106,7 @@ def addOrPanicLifted (x y : Nat) : Interop.Rust.RustOracleComp spec Nat :=
   liftRustM (addOrPanic x y)
 
 theorem addOrPanicLifted_triple (x y : Nat)
-    [spec.Fintype] [spec.Inhabited] :
+    [IsUniformSpec spec] :
     ⦃⌜x + y < 2 ^ 32⌝⦄
     (addOrPanicLifted (spec := spec) x y)
     ⦃⇓ r => ⌜r = x + y⌝⦄ := by
@@ -118,8 +118,8 @@ With `@[spec] triple_liftRustM` registered in the `mvcgen` index,
 the `RustM` body of `addOrPanic`, and closes the residual vc in a
 single tactic call.
 
-The `[spec.Fintype] [spec.Inhabited]` constraints are inherited from
-VCVio's `WP (OracleComp spec) .pure` and are the only additional
+The `[IsUniformSpec spec]` constraint is inherited from
+VCVio's `WP (OracleComp spec) .pure` and is the only additional
 obligation the oracle layer imposes.
 
 ## Compositional boundary lemma
@@ -129,7 +129,7 @@ through the lift in one step:
 
 ```lean
 @[spec]
-theorem triple_liftRustM [spec.Fintype] [spec.Inhabited]
+theorem triple_liftRustM [IsUniformSpec spec]
     (x : RustM α)
     {Q : PostCond α (.except Interop.Rust.Error (.except PUnit .pure))}
     {P : Assertion (.except Interop.Rust.Error (.except PUnit .pure))}
@@ -187,7 +187,7 @@ def oracleThenAdd (x : Nat) (t : ι) (coe : spec.Range t → Nat) :
   liftRustM (addOrPanic x (coe y))
 
 theorem oracleThenAdd_triple (x : Nat) (t : ι) (coe : spec.Range t → Nat)
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (hbound : ∀ y : spec.Range t, x + coe y < 2 ^ 32) :
     ⦃⌜True⌝⦄
     (oracleThenAdd (spec := spec) x t coe)
@@ -238,7 +238,7 @@ and transport it to `RustOracleComp` in one step via the boundary
 lemma:
 
 ```lean
-theorem computationLifted_triple [spec.Fintype] [spec.Inhabited]
+theorem computationLifted_triple [IsUniformSpec spec]
     (x : u32) :
     ⦃⌜2 * x.toNat + 1 < 2 ^ 32⌝⦄
     (computationLifted (spec := spec) x)
@@ -270,7 +270,7 @@ theorem checkedDiv_triple (x y : u32) (h : y ≠ 0) :
   unfold checkedDiv
   exact UInt32.haxDiv_spec x y h
 
-theorem checkedDivLifted_triple [spec.Fintype] [spec.Inhabited]
+theorem checkedDivLifted_triple [IsUniformSpec spec]
     (x y : u32) (h : y ≠ 0) :
     ⦃⌜True⌝⦄
     (checkedDivLifted (spec := spec) x y)
@@ -320,7 +320,7 @@ theorem adc_u32_spec (a b carry_in : u32) :
 Transport to `RustOracleComp` is still one line:
 
 ```lean
-theorem adc_u32_Lifted_spec [spec.Fintype] [spec.Inhabited]
+theorem adc_u32_Lifted_spec [IsUniformSpec spec]
     (a b carry_in : u32) :
     ⦃⌜carry_in ≤ 1⌝⦄
     (adc_u32_Lifted (spec := spec) a b carry_in)
@@ -409,7 +409,7 @@ def barrett_reduce_Lifted (value : i32) :
     Interop.Rust.RustOracleComp spec i32 :=
   liftRustM (barrett_reduce value)
 
-theorem barrett_reduce_Lifted_spec [spec.Fintype] [spec.Inhabited]
+theorem barrett_reduce_Lifted_spec [IsUniformSpec spec]
     (value : i32) :
     ⦃⌜value.toInt64 ≥ -(4194304 : Int64) ∧
        value.toInt64 ≤ (4194304 : Int64)⌝⦄
@@ -434,7 +434,7 @@ def oracleThenBarrett (t : ι) (coe : spec.Range t → i32) :
   barrett_reduce_Lifted (coe y)
 
 theorem oracleThenBarrett_triple
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (t : ι) (coe : spec.Range t → i32)
     (hbound : ∀ y : spec.Range t,
       (coe y).toInt64 ≥ -(4194304 : Int64) ∧
@@ -458,8 +458,8 @@ Every spec above is a `Std.Do.Triple`, which is universal over oracle
 outcomes and contains no probabilistic content; effectively we have
 just been wrapping the `RustM` spec. The payoff of dropping `Hax.RustM`
 into `Interop.Rust.RustOracleComp` is that the underlying `OracleComp`
-layer carries `HasEvalSPMF` (via the `ExceptT` and `OptionT` instances
-in `VCVio.EvalDist.Instances.{ErrorT,OptionT}`), so claims like
+layer admits `evalDist` / `Pr[…]` (via the `ExceptT` and `OptionT`
+`MonadLiftT … SPMF` instances in `VCVio.EvalDist.Instances.{ErrorT,OptionT}`), so claims like
 `Pr[panic] = 1/2` become well-defined and provable. Those claims
 cannot be stated at the hax level: `Hax.RustM` has no oracle to sample
 at all, and the `Triple` layer has no way to talk about probability.
@@ -490,7 +490,7 @@ theorem tossedAdd_run_run :
 ```
 
 after which the panic probability follows by a one-liner sum over
-`Fin 2` using `HasEvalSPMF.probOutput_bind_eq_sum_fintype` and
+`Fin 2` using `probOutput_bind_eq_sum_fintype` and
 `ProbComp.probOutput_uniformFin`:
 
 ```lean

--- a/LatticeCrypto/Falcon/Concrete/Sign.lean
+++ b/LatticeCrypto/Falcon/Concrete/Sign.lean
@@ -75,7 +75,7 @@ def sbytelenForLogn? (logn : Nat) : Option Nat :=
 
 /-! ## Retry randomness helpers -/
 
-@[inline] def signLoopCounterBytes (counter : UInt32) : ByteArray :=
+@[inline] private def signLoopCounterBytes (counter : UInt32) : ByteArray :=
   ByteArray.mk #[
     counter.toUInt8,
     (counter >>> 8).toUInt8,
@@ -83,7 +83,7 @@ def sbytelenForLogn? (logn : Nat) : Option Nat :=
     (counter >>> 24).toUInt8
   ]
 
-@[inline] def signLoopRandomBytes (seed : ByteArray) (counter : UInt32) : ByteArray :=
+@[inline] private def signLoopRandomBytes (seed : ByteArray) (counter : UInt32) : ByteArray :=
   FFI.Hashing.shake256 (seed ++ signLoopCounterBytes counter) 96
 
 /-! ## Type conversions -/

--- a/LatticeCrypto/Falcon/Concrete/Sign.lean
+++ b/LatticeCrypto/Falcon/Concrete/Sign.lean
@@ -75,7 +75,7 @@ def sbytelenForLogn? (logn : Nat) : Option Nat :=
 
 /-! ## Retry randomness helpers -/
 
-@[inline] private def signLoopCounterBytes (counter : UInt32) : ByteArray :=
+@[inline] def signLoopCounterBytes (counter : UInt32) : ByteArray :=
   ByteArray.mk #[
     counter.toUInt8,
     (counter >>> 8).toUInt8,
@@ -83,7 +83,7 @@ def sbytelenForLogn? (logn : Nat) : Option Nat :=
     (counter >>> 24).toUInt8
   ]
 
-@[inline] private def signLoopRandomBytes (seed : ByteArray) (counter : UInt32) : ByteArray :=
+@[inline] def signLoopRandomBytes (seed : ByteArray) (counter : UInt32) : ByteArray :=
   FFI.Hashing.shake256 (seed ++ signLoopCounterBytes counter) 96
 
 /-! ## Type conversions -/

--- a/LatticeCrypto/MLDSA/Security.lean
+++ b/LatticeCrypto/MLDSA/Security.lean
@@ -56,7 +56,7 @@ variable (p : Params) (prims : Primitives p) (nttOps : NTTRingOps)
 section Properties
 
 variable [SampleableType (RqVec p.l)] [SampleableType (CommitHashBytes p)]
-  [unifSpec.Fintype] [unifSpec.Inhabited]
+  [IsUniformSpec unifSpec]
 
 -- The algebraic core of completeness: whenever `respond` produces `some (z, h)`, the
 -- `verify` function accepts. This follows from the key generation relationship
@@ -82,7 +82,7 @@ theorem idsWithAbort_complete' :
   classical
   intro pk sk hvalid
   rw [probOutput_eq_one_iff_forall]
-  refine ⟨HasEvalPMF.probFailure_eq_zero _, ?_⟩
+  refine ⟨probFailure_of_liftM_PMF _, ?_⟩
   intro b hb
   rw [support_bind] at hb
   simp only [Set.mem_iUnion] at hb
@@ -133,7 +133,7 @@ theorem idsWithAbort_hvzk :
   classical
   sorry
 
-omit [SampleableType (CommitHashBytes p)] [unifSpec.Fintype] [unifSpec.Inhabited]
+omit [SampleableType (CommitHashBytes p)] [IsUniformSpec unifSpec]
 /-- Commitment recoverability for ML-DSA: the public commitment `w₁` can be reconstructed
 from `(pk, c̃, (z, h))` alone using `UseHint(h, Az - ct₁·2^d)`. This is the key property
 enabling the CMA-to-NMA reduction in the security proof.
@@ -159,7 +159,7 @@ section NMASecurity
 
 variable {M : Type}
   [SampleableType (RqVec p.l)] [SampleableType (CommitHashBytes p)]
-  [unifSpec.Fintype] [unifSpec.Inhabited]
+  [IsUniformSpec unifSpec]
 
 open scoped Classical in
 /-- **NMA Security (Lemma 7, CRYPTO 2023).**
@@ -234,7 +234,7 @@ section MainTheorem
 
 variable {M : Type}
   [SampleableType (RqVec p.l)] [SampleableType (CommitHashBytes p)]
-  [unifSpec.Fintype] [unifSpec.Inhabited]
+  [IsUniformSpec unifSpec]
 
 open scoped Classical in
 /-- **Main Security Theorem (EUF-CMA, Theorem 4, CRYPTO 2023).**

--- a/ToMathlib/ProbabilityTheory/Coupling.lean
+++ b/ToMathlib/ProbabilityTheory/Coupling.lean
@@ -164,7 +164,8 @@ theorem bind_const_of_toPMF_none_eq_zero {p : SPMF α} (hp : p.toPMF none = 0) (
 product forms a coupling.
 
 This is the core coupling result for reasoning about pairs of computations that never
-fail individually (e.g., `OracleComp spec α` via `HasEvalPMF`): the product distribution
+fail individually (e.g., `OracleComp spec α` via `MonadLiftT _ PMF` + `EvalDistCompatible`): the
+    product distribution
 `do let a ← p; let b ← q; pure (a, b)` witnesses that the pair has marginals `(p, q)`. -/
 theorem IsCoupling.prod {α β : Type u} {p : SPMF α} {q : SPMF β}
     (hp : p.toPMF none = 0) (hq : q.toPMF none = 0) :

--- a/ToMathlib/ProbabilityTheory/SPMF.lean
+++ b/ToMathlib/ProbabilityTheory/SPMF.lean
@@ -220,6 +220,19 @@ lemma support_liftM (p : PMF α) : (liftM p : SPMF α).support = p.support := by
 @[simp, grind =]
 lemma support_pure (x : α) : (pure x : SPMF α).support = {x} := by aesop
 
+@[simp, grind =]
+lemma support_bind (p : SPMF α) (q : α → SPMF β) :
+    (p >>= q).support = ⋃ x ∈ p.support, (q x).support := by
+  ext y
+  simp only [SPMF.mem_support_iff, bind_apply_eq_tsum, Set.mem_iUnion, exists_prop, ne_eq]
+  rw [ENNReal.tsum_eq_zero, not_forall]
+  constructor
+  · rintro ⟨x, hx⟩
+    rw [mul_eq_zero, not_or] at hx
+    exact ⟨x, hx.1, hx.2⟩
+  · rintro ⟨x, hpx, hqxy⟩
+    exact ⟨x, by rw [mul_eq_zero, not_or]; exact ⟨hpx, hqxy⟩⟩
+
 end support
 
 section gap

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/GenericLift.lean
@@ -102,8 +102,7 @@ private lemma IND_CPA_stepPrefix_query_inl (pk : PK) (k : ℕ) {α : Type}
         (encAlg'.IND_CPA_oracleSpec.query (Sum.inl tu) >>= mx) =
       (do
         let u ← $[0..tu]
-        IND_CPA_stepPrefix (encAlg' := encAlg') pk k (mx u)) := by
-  simp [IND_CPA_stepPrefix]
+        IND_CPA_stepPrefix (encAlg' := encAlg') pk k (mx u)) := rfl
 
 /-- Unfold `IND_CPA_stepPrefix` through an LR challenge query. -/
 private lemma IND_CPA_stepPrefix_query_inr (pk : PK) (k : ℕ) {α : Type}
@@ -124,8 +123,7 @@ private lemma IND_CPA_stepPrefix_query_inr (pk : PK) (k : ℕ) {α : Type}
               set (cache', st.2 + 1)
               IND_CPA_stepPrefix (encAlg' := encAlg') pk k (mx c)
             else
-              pure (.paused mm mx)) := by
-  simp [IND_CPA_stepPrefix]
+              pure (.paused mm mx)) := rfl
 
 /-- Once the counter has already crossed `k`, the `k` and `k + 1` counted hybrids agree. -/
 private lemma IND_CPA_hybridLR_counted_run'_evalDist_eq_above
@@ -641,7 +639,7 @@ theorem IND_CPA_stepAdversary_signedAdvantageReal_eq_hybridDiff_half
 /-- Planned generic one-time-to-many-time lift: bounded multi-query IND-CPA advantage is at most
 the sum of the extracted one-time signed advantages over the first `q` fresh LR queries. -/
 theorem IND_CPA_advantage_toReal_le_sum_step_signedAdvantageReal_abs
-    [Inhabited M]
+    [Inhabited M] [Finite C] [Inhabited C]
     (adversary : encAlg'.IND_CPA_adversary) (q : ℕ)
     (hq : adversary.MakesAtMostQueries q) :
     (IND_CPA_advantage (encAlg := encAlg') adversary).toReal ≤
@@ -727,7 +725,7 @@ theorem IND_CPA_advantage_toReal_le_sum_step_signedAdvantageReal_abs
 signed real advantage at most `ε`, then any `q`-query oracle adversary has IND-CPA advantage at
 most `q * ε`. -/
 theorem IND_CPA_advantage_toReal_le_q_mul_of_oneTime_signedAdvantageReal_bound
-    [Inhabited M]
+    [Inhabited M] [Finite C] [Inhabited C]
     (adversary : encAlg'.IND_CPA_adversary) (q : ℕ) (ε : ℝ)
     (hq : adversary.MakesAtMostQueries q)
     (hstep : ∀ adv : IND_CPA_Adv encAlg',

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
@@ -33,7 +33,7 @@ variable [DecidableEq M]
 
 /-- Oracle-based multi-query IND-CPA game. The adversary gets oracle access to an encryption
 oracle that encrypts one of two challenge messages depending on a hidden bit. -/
-def IND_CPA_oracleSpec (_encAlg : AsymmEncAlg ProbComp M PK SK C) :=
+abbrev IND_CPA_oracleSpec (_encAlg : AsymmEncAlg ProbComp M PK SK C) :=
   unifSpec + (M × M →ₒ C)
 
 /-- An oracle IND-CPA adversary chooses challenge messages by querying the LR oracle and returns
@@ -203,9 +203,10 @@ lemma IND_CPA_queryImpl'_counted_counter_le_succ
       · simp only [IND_CPA_challengeOracle'_counted, IND_CPA_countedChallengeOracle, hcache,
           StateT.run_bind, StateT.run_get, pure_bind,
           StateT.run_pure] at hp
-        have := congrArg (fun x => x.2.2) hp
-        simp at this
-        omega
+        change p ∈ support (pure _ : OracleComp _ _) at hp
+        rw [support_pure, Set.mem_singleton_iff] at hp
+        subst hp
+        simp
 
 private lemma IND_CPA_countedChallengeOracle_proj_eq_cached
     (pk : PK)
@@ -286,7 +287,7 @@ lemma IND_CPA_queryImpl_hybridLR_counted_proj_eq_queryImpl'_false
 /-- If a counted IND-CPA hybrid implementation agrees with the counted real implementation
 through the first `q` fresh LR queries, then any adversary making at most `q` LR queries sees
 the same output distribution as in the real IND-CPA game. -/
-theorem IND_CPA_run'_evalDist_eq_queryImpl'_of_bounded_eq
+theorem IND_CPA_run'_evalDist_eq_queryImpl'_of_bounded_eq [Finite C] [Inhabited C]
     (implCounted : PK → Bool → ℕ →
       QueryImpl encAlg'.IND_CPA_oracleSpec (StateT encAlg'.IND_CPA_CountedState ProbComp))
     (hsame : ∀ (pk : PK) (b : Bool) (realUntil : ℕ)
@@ -371,7 +372,7 @@ theorem IND_CPA_run'_evalDist_eq_queryImpl'_of_bounded_eq
 /-- A counted IND-CPA hybrid game agrees with the real IND-CPA experiment whenever the hybrid
 implementation matches the real counted implementation on all states that stay below the query
 budget. -/
-theorem IND_CPA_countedGame_eq_game_of_MakesAtMostQueries
+theorem IND_CPA_countedGame_eq_game_of_MakesAtMostQueries [Finite C] [Inhabited C]
     (implCounted : PK → Bool → ℕ →
       QueryImpl encAlg'.IND_CPA_oracleSpec (StateT encAlg'.IND_CPA_CountedState ProbComp))
     (hsame : ∀ (pk : PK) (b : Bool) (realUntil : ℕ)
@@ -433,7 +434,7 @@ theorem IND_CPA_LR_hybridGame_zero_evalDist_eq_right
 
 /-- If an adversary makes at most `q` fresh LR queries, then the `leftUntil = q` LR-hybrid is the
 all-left endpoint game. -/
-theorem IND_CPA_LR_hybridGame_q_evalDist_eq_left_of_MakesAtMostQueries
+theorem IND_CPA_LR_hybridGame_q_evalDist_eq_left_of_MakesAtMostQueries [Finite C] [Inhabited C]
     (adversary : encAlg'.IND_CPA_adversary) (q : ℕ)
     (hq : adversary.MakesAtMostQueries q) :
     𝒟[encAlg'.IND_CPA_LR_hybridGame adversary q] =
@@ -483,6 +484,7 @@ theorem IND_CPA_LR_hybridGame_zero_probOutput_eq_right
 /-- If an adversary makes at most `q` fresh LR queries, then the `leftUntil = q` LR-hybrid has
 the same success probability as the all-left endpoint. -/
 theorem IND_CPA_LR_hybridGame_q_probOutput_eq_left_of_MakesAtMostQueries
+    [Finite C] [Inhabited C]
     (adversary : encAlg'.IND_CPA_adversary) (q : ℕ)
     (hq : adversary.MakesAtMostQueries q) :
     Pr[= true | encAlg'.IND_CPA_LR_hybridGame adversary q] =
@@ -657,9 +659,10 @@ lemma IND_CPA_hybridLR_counted_counter_le
         omega
       · simp only [hcache, StateT.run_bind, StateT.run_get, pure_bind,
           StateT.run_pure] at hp
-        have := congrArg (fun x => x.2.2) hp
-        simp at this
-        omega
+        change p ∈ support (pure _ : OracleComp _ _) at hp
+        rw [support_pure, Set.mem_singleton_iff] at hp
+        subst hp
+        simp
 
 /-- Behavior of the hybrid challenge oracle on a cache miss. -/
 lemma IND_CPA_hybridChallengeOracleLR_counted_run_none

--- a/VCVio/CryptoFoundations/FiatShamir/QueryBounds.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/QueryBounds.lean
@@ -25,7 +25,10 @@ open OracleComp OracleSpec
 
 namespace FiatShamir
 
-variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
+variable {Stmt Wit Commit PrvState Chal Resp : Type}
+    {rel : Stmt → Wit → Bool}
+
+attribute [local instance] Fintype.ofFinite
 
 section bounds
 
@@ -110,12 +113,14 @@ lemma nmaHashQueryBound_bind {α β : Type}
       (oa := oa >>= ob) (Q₁ + Q₂) :=
   OracleComp.isQueryBoundP_bind h1 (fun x _ => h2 x)
 
-lemma nmaHashQueryBound_liftComp_zero {α : Type}
+lemma nmaHashQueryBound_liftComp_zero [Inhabited Chal] [Finite Chal] {α : Type}
     (oa : ProbComp α) :
     nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
       (oa := OracleComp.liftComp oa (unifSpec + (M × Commit →ₒ Chal))) 0 := by
   -- The lifted handler routes every uniform query into the `.inl` arm, which never matches
   -- `(· matches .inr _)`, so the predicate-targeted bound is uniformly 0 per step.
+  letI : IsUniformSpec ((M × Commit →ₒ Chal) : OracleSpec _) :=
+    IsUniformSpec.ofFintypeInhabited _
   rw [nmaHashQueryBound, OracleComp.liftComp_def]
   refine OracleComp.IsQueryBoundP.simulateQ_of_step
     (p := fun _ : ℕ => False)

--- a/VCVio/CryptoFoundations/FiatShamir/QueryBounds.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/QueryBounds.lean
@@ -28,8 +28,6 @@ namespace FiatShamir
 variable {Stmt Wit Commit PrvState Chal Resp : Type}
     {rel : Stmt → Wit → Bool}
 
-attribute [local instance] Fintype.ofFinite
-
 section bounds
 
 variable (M : Type)
@@ -119,6 +117,7 @@ lemma nmaHashQueryBound_liftComp_zero [Inhabited Chal] [Finite Chal] {α : Type}
       (oa := OracleComp.liftComp oa (unifSpec + (M × Commit →ₒ Chal))) 0 := by
   -- The lifted handler routes every uniform query into the `.inl` arm, which never matches
   -- `(· matches .inr _)`, so the predicate-targeted bound is uniformly 0 per step.
+  haveI : Fintype Chal := Fintype.ofFinite Chal
   letI : IsUniformSpec ((M × Commit →ₒ Chal) : OracleSpec _) :=
     IsUniformSpec.ofFintypeInhabited _
   rw [nmaHashQueryBound, OracleComp.liftComp_def]

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma.lean
@@ -35,7 +35,7 @@ universe u v
 open OracleComp OracleSpec
 
 variable {Stmt Wit Commit PrvState Chal Resp : Type}
-    {rel : Stmt → Wit → Bool} [SampleableType Stmt] [SampleableType Wit]
+    {rel : Stmt → Wit → Bool}
 
 /-- Given a Σ-protocol and a generable relation, the Fiat-Shamir transform produces a
 signature scheme. The signing algorithm commits, queries the random oracle on (message,
@@ -319,7 +319,8 @@ theorem sign_usesCostAsQueryCost {ω : Type} [AddMonoid ω]
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Fiat-Shamir signing has expected weighted query cost equal to the expectation of the queried
 commitment cost over the output signature distribution. -/
-theorem sign_expectedQueryCost_eq_outputExpectation {ω : Type} [AddMonoid ω] [HasEvalSPMF m]
+theorem sign_expectedQueryCost_eq_outputExpectation {ω : Type} [AddMonoid ω] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (M × Commit →ₒ Chal) m) (pk : Stmt) (sk : Wit) (msg : M)
     (costFn : M × Commit → ω) (val : ω → ENNReal) :
     ExpectedQueryCost[
@@ -388,7 +389,8 @@ theorem verify_usesExactQueryCost {ω : Type} [AddMonoid ω]
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Fiat-Shamir verification has expected weighted query cost equal to the weight of its single
 random-oracle query. -/
-theorem verify_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+theorem verify_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω] [MonadLiftT m PMF]
+    [LawfulMonadLiftT m PMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (M × Commit →ₒ Chal) m) (pk : Stmt) (msg : M)
     (sig : Commit × Resp) (costFn : M × Commit → ω) (val : ω → ENNReal) (hval : Monotone val) :
     ExpectedQueryCost[

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
@@ -33,7 +33,12 @@ open OracleComp OracleSpec
 
 namespace FiatShamir
 
-variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
+variable {Stmt Wit Commit PrvState Chal Resp : Type}
+    [Fintype Chal] [Finite Commit] [Finite Resp]
+    [Inhabited Chal] [Inhabited Commit] [Inhabited Resp]
+    {rel : Stmt → Wit → Bool}
+
+attribute [local instance] Fintype.ofFinite
 variable [SampleableType Stmt] [SampleableType Wit]
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
@@ -131,6 +136,7 @@ noncomputable def simulatedNmaAdv
       (Resp := Resp) simTranscript pk)
     (adv.main pk)).run ∅⟩
 
+omit [Fintype Chal] [Inhabited Chal] in
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Hash-query bound for `simulatedNmaAdv`: if the CMA adversary makes at most
 `qS` signing-oracle queries and `qH` random-oracle queries, the NMA reduction
@@ -149,7 +155,8 @@ theorem simulatedNmaAdv_hashQueryBound
       (oa := (simulatedNmaAdv (σ := σ) (hr := hr) (M := M)
         (simTranscript := simTranscript) (adv := adv)).main pk) qH := by
   classical
-  letI : Fintype Chal := Fintype.ofFinite Chal
+  letI : IsUniformSpec ((M × Commit →ₒ Chal) : OracleSpec _) :=
+    IsUniformSpec.ofFintypeInhabited _
   let spec := unifSpec + (M × Commit →ₒ Chal)
   let fwd : QueryImpl spec (StateT spec.QueryCache (OracleComp spec)) :=
     (HasQuery.toQueryImpl (spec := spec) (m := OracleComp spec)).liftTarget _

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
@@ -135,7 +135,7 @@ noncomputable def simulatedNmaAdv
       (Resp := Resp) simTranscript pk)
     (adv.main pk)).run ∅⟩
 
-omit [Fintype Chal] [Inhabited Chal] in
+omit [Finite Commit] [Finite Resp] [Fintype Chal] [Inhabited Chal] in
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Hash-query bound for `simulatedNmaAdv`: if the CMA adversary makes at most
 `qS` signing-oracle queries and `qH` random-oracle queries, the NMA reduction

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
@@ -38,7 +38,6 @@ variable {Stmt Wit Commit PrvState Chal Resp : Type}
     [Inhabited Chal] [Inhabited Commit] [Inhabited Resp]
     {rel : Stmt → Wit → Bool}
 
-attribute [local instance] Fintype.ofFinite
 variable [SampleableType Stmt] [SampleableType Wit]
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
@@ -143,8 +142,9 @@ omit [SampleableType Stmt] [SampleableType Wit] in
 makes at most `qH` live hash queries. The `qS` signing queries are absorbed
 into the managed cache rather than issued live. -/
 theorem simulatedNmaAdv_hashQueryBound
-    [DecidableEq M] [DecidableEq Commit]
+    [DecidableEq M] [DecidableEq Commit] [Finite Commit]
     [Finite Chal] [Inhabited Chal] [SampleableType Chal]
+    [Finite Resp]
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp))
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
@@ -154,7 +154,9 @@ theorem simulatedNmaAdv_hashQueryBound
     ∀ pk, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
       (oa := (simulatedNmaAdv (σ := σ) (hr := hr) (M := M)
         (simTranscript := simTranscript) (adv := adv)).main pk) qH := by
-  classical
+  haveI : Fintype Chal := Fintype.ofFinite Chal
+  haveI : Fintype Resp := Fintype.ofFinite Resp
+  haveI : Fintype Commit := Fintype.ofFinite Commit
   letI : IsUniformSpec ((M × Commit →ₒ Chal) : OracleSpec _) :=
     IsUniformSpec.ofFintypeInhabited _
   let spec := unifSpec + (M × Commit →ₒ Chal)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Fork.lean
@@ -33,8 +33,8 @@ open scoped OracleSpec.PrimitiveQuery
 
 namespace FiatShamir
 
-variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
-variable [SampleableType Stmt] [SampleableType Wit]
+variable {Stmt Wit Commit PrvState Chal Resp : Type}
+     {rel : Stmt → Wit → Bool}
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
 
@@ -186,7 +186,6 @@ noncomputable def roImpl (M Commit Chal : Type) [DecidableEq M] [DecidableEq Com
           log ++ [mc])
         pure v
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Running the inner `unifFwd + roImpl` simulator against a source computation with
 an `nmaHashQueryBound Q` can grow the internal `queryLog` by at most `Q`.
 
@@ -337,7 +336,6 @@ Two thin lemmas that describe the support of a single step of the layered simula
 one place. The `Sum.inl` step always issues a forwarded uniform query and logs it; the
 `Sum.inr` step branches on whether the cache already contains the asked hash point. -/
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Support of one `Sum.inl n` step: forward the uniform query, log it, leave the
 simulator state unchanged. -/
 private lemma support_step_inl
@@ -366,7 +364,6 @@ private lemma support_step_inl
   · rintro ⟨_, ⟨u, rfl⟩, hzeq⟩; exact ⟨u, hzeq⟩
   · rintro ⟨u, rfl⟩; exact ⟨_, ⟨u, rfl⟩, rfl⟩
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Support of one `Sum.inr mc` step: cache hit returns the cached value with no outer
 log entry; cache miss issues a `Sum.inr ()` query, logs it, caches the response, and
 appends `mc` to the trace's internal `queryLog`. -/
@@ -426,7 +423,6 @@ the per-step preservation in *three* concrete cases (Sum.inl, Sum.inr cache hit,
 cache miss) using the support characterizations above; the inductive bookkeeping is
 factored out once. -/
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Generic 1-state preservation for the "stateful inner simulation, then outer logging"
 pattern. Given a per-step preservation `hstep`, lift it to the whole layered simulation. -/
 private theorem preservesInv_layered
@@ -478,7 +474,6 @@ private theorem preservesInv_layered
       rw [← List.append_assoc]
       exact hih
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Coupling invariant for `runTrace`'s inner simulation: the trace's internal `queryLog`
 grows by exactly the number of `Sum.inr ()` queries issued to the outer wrapped spec.
 Each cache miss in `roImpl` simultaneously appends to the outer log and to the trace's
@@ -519,7 +514,6 @@ private theorem queryLog_length_eq_outer_inr_count
           rw [h1, hI]
           ring
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Lockstep value invariant for `runTrace`'s inner simulation. Three coupled invariants
 travel together along the simulation:
 
@@ -712,7 +706,6 @@ private theorem queryLog_cache_outer_lockstep
             rw [List.nil_append]
             exact hlogω
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Prefix monotonicity: running `(simulateQ (unifFwd + roImpl) Y).run (c₀, l₀)` produces a
 final simulator state whose `queryLog` component extends `l₀`. The resulting list always
 starts with the initial `l₀`: cache misses only append entries, and cache hits plus
@@ -828,7 +821,6 @@ private theorem queryLog_extends_l₀
             subst houter
             exact ih v c₀ l₀ hpw_split
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Outer-log **prefix**-determinism for `runTrace`'s inner simulation. If the two outer
 logs share a common prefix `p` (with `#{Sum.inr ()} = j` in `p`), then the first
 `l₀.length + j` positions of the final internal `queryLog`s coincide. This is the
@@ -1067,7 +1059,6 @@ private theorem inner_prefix_det
             subst houter₂
             exact ih v c₀ l₀ hpw₁_split hpw₂_split p suffix₁ suffix₂ houter₁_eq houter₂_eq
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- One-more-step extension of `inner_prefix_det`: if the outer logs of two runs share the
 prefix `p ++ [⟨Sum.inr (), v_i⟩]` (allowing the values `v₁, v₂` at position `|p|` to differ),
 then the internal `queryLog`s coincide for one more entry than `inner_prefix_det` guarantees,
@@ -1285,7 +1276,6 @@ private theorem inner_prefix_det_one_more_inr
             subst houter₂
             exact ih v c₀ l₀ hpw₁_split hpw₂_split p houter₁_eq houter₂_eq
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Specialization of `queryLog_length_eq_outer_inr_count` to `runTrace`'s initial state
 `(∅, [])`: the trace's `queryLog` has the same length as the count of `Sum.inr ()` outer
 queries in the recorded log. -/
@@ -1315,7 +1305,6 @@ lemma runTrace_queryLog_length_eq
     (nmaAdv.main pk) ∅ [] (z := a.1) (outerLog := a.2) ha_mem
   simpa using h
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Specialization of `queryLog_cache_outer_lockstep` to `runTrace`'s initial state
 `(∅, [])`: the trace's `queryLog[i]` is cached in `x.roCache`, and the cached value matches
 the outer log's `i`-th `Sum.inr ()` response. -/
@@ -1361,7 +1350,6 @@ lemma runTrace_cache_outer_lockstep
   · rw [← hlog_eq]
     simpa using hlog
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Decoding the `verified` flag of a trace produced by `runTrace`. If the trace's
 `verified` field is `true`, then there is a cached challenge `ω` for `x.target` and the
 corresponding `σ.verify` succeeds. Used by `forkSupportInvariant_of_mem_replayFirstRun`. -/
@@ -1403,7 +1391,6 @@ lemma runTrace_verified_imp_verify
       refine ⟨ω, rfl, ?_⟩
       simpa using hv
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The `forkPoint`-based reachability invariant for `runTrace`: whenever
 `forkPoint qH x = some s`, the outer `QueryLog` of `replayFirstRun (runTrace ...)` has a
 `Sum.inr ()` query at position `↑s`. This holds because each cache miss in `runTrace`'s
@@ -1436,7 +1423,6 @@ theorem runTrace_forkPoint_CfReachable
     exact hslt
   exact QueryLog.getQueryValue?_isSome_of_lt log (Sum.inr ()) ↑s hslt'
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- **Determinism of `runTrace`'s inner `queryLog` from the outer-log prefix.** If the outer
 logs of two runs of `runTrace` share a prefix `p` followed by a `Sum.inr ()` query (whose
 response may differ across runs), then the traces' internal `queryLog`s coincide on the first
@@ -1496,10 +1482,8 @@ The replay transcript gives a common outer-log prefix up to the consumed fork qu
 `runTrace_queryLog_take_eq` transfers that prefix equality to the internal logical
 `queryLog`, and `forkPoint_getElem?_eq_some_target` identifies each target with
 the selected logical query. -/
-omit [SampleableType Stmt] [SampleableType Wit] in
-open scoped Classical in
 lemma runTrace_target_eq_of_mem_forkReplay
-    [DecidableEq M] [DecidableEq Commit] [DecidableEq Chal] [SampleableType Chal]
+    [DecidableEq M] [DecidableEq Commit] [DecidableEq Chal] [SampleableType Chal] [Inhabited Chal]
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qH : ℕ) (pk : Stmt)
@@ -1513,6 +1497,9 @@ lemma runTrace_target_eq_of_mem_forkReplay
     (h₂ : forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)
       qH x₂ = some s) :
     x₁.target = x₂.target := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
+  letI : IsUniformSpec ((Unit →ₒ Chal) : OracleSpec _) :=
+    IsUniformSpec.ofFintypeInhabited _
   classical
   let qb : ℕ ⊕ Unit → ℕ := fun j => match j with | .inl _ => 0 | .inr () => qH
   obtain ⟨log₁, log₂, s', hx₁, hx₂, hcf₁, _hcf₂, _hneq, replacement, st, hz, hlog₂,
@@ -1674,7 +1661,6 @@ lemma runTrace_target_eq_of_mem_forkReplay
     rw [← htgt₁, ← htgt₂, ← hgetElem_take x₁.queryLog, ← hgetElem_take x₂.queryLog, htakeEq]
   exact Option.some.inj this
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Managed-RO replay-fork convenience theorem at a fixed public key, stated at the
 `OracleComp (unifSpec + (Unit →ₒ Chal))` level.
 
@@ -1730,6 +1716,8 @@ theorem replayForkingBound
     (hreach : CfReachable (runTrace σ hr M nmaAdv pk)
       (fun j : ℕ ⊕ Unit => match j with | .inl _ => 0 | .inr () => qH) (Sum.inr ())
       (forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH)) :
+    letI : IsUniformSpec ((Unit →ₒ Chal) : OracleSpec _) :=
+      IsUniformSpec.ofFintypeInhabited _
     let wrappedMain := runTrace σ hr M nmaAdv pk
     let cf := forkPoint (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) qH
     let qb : ℕ ⊕ Unit → ℕ := fun j => match j with | .inl _ => 0 | .inr () => qH
@@ -1750,6 +1738,8 @@ theorem replayForkingBound
             P_out x₁ log₁ ∧
             P_out x₂ log₂
         | forkReplay wrappedMain qb (Sum.inr ()) cf] := by
+  letI : IsUniformSpec ((Unit →ₒ Chal) : OracleSpec _) :=
+    IsUniformSpec.ofFintypeInhabited _
   intro wrappedMain cf qb acc
   -- Step 1: Rewrite `acc` as `∑ s, Pr[= some s | cf <$> wrappedMain]`, matching the LHS of
   -- `le_probEvent_isSome_forkReplay`.

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Reductions.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Reductions.lean
@@ -22,10 +22,23 @@ namespace FiatShamir
 open OracleComp OracleSpec
 open scoped OracleSpec.PrimitiveQuery
 
-variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
+variable {Stmt Wit Commit PrvState Chal Resp : Type}
+    [Fintype Stmt] [Fintype Commit] [Fintype Resp] [Fintype Chal]
+    [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] [Inhabited Chal]
+    {rel : Stmt → Wit → Bool}
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
 
+noncomputable local instance instIsUniformSpecChalSingleton :
+    IsUniformSpec ((Unit →ₒ Chal) : OracleSpec _) :=
+  IsUniformSpec.ofFintypeInhabited _
+
+noncomputable local instance instIsUniformSpecChalFn (M Commit : Type) :
+    IsUniformSpec ((M × Commit →ₒ Chal) : OracleSpec _) :=
+  IsUniformSpec.ofFintypeInhabited _
+
+omit [Fintype Stmt] [Fintype Commit] [Fintype Resp] [Fintype Chal]
+  [Inhabited Stmt] [Inhabited Chal] in
 /-- CMA-to-NMA reduction for Fiat-Shamir signatures built from a Sigma protocol.
 
 The reduction runs the CMA adversary with simulated signing transcripts and a
@@ -41,7 +54,8 @@ indexes `Fin (qH + 1)`, which is exactly the right number of forkable slots
 (the framework's structural `+1` in `Fin (qH + 1)` is precisely the wrapper's
 verifier slot). The replay-forking denominator is therefore `qH + 1`. -/
 theorem cma_to_nma_advantage_bound
-    [DecidableEq M] [DecidableEq Commit]
+    [DecidableEq M] [DecidableEq Commit] [SampleableType Stmt] [SampleableType Wit]
+    [Finite Stmt] [Finite Commit] [Finite Resp]
     [Finite Chal] [Inhabited Chal] [SampleableType Chal]
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp))
     (ζ_zk : ℝ) (hζ_zk : 0 ≤ ζ_zk)
@@ -75,7 +89,7 @@ theorem cma_to_nma_advantage_bound
 
 section evalDistBridge
 
-variable [Fintype Chal] [Inhabited Chal] [SampleableType Chal]
+variable [SampleableType Chal]
 
 /-- The `ofLift + uniformSampleImpl` simulation on `unifSpec + (Unit →ₒ Chal)` preserves
 `evalDist`. Both oracle components sample uniformly from their range. -/
@@ -137,7 +151,7 @@ private def forkSupportInvariant
       x.roCache x.target = some ω ∧
       σ.verify pk x.target.2 ω x.forgery.2.2 = true
 
-variable [SampleableType Wit] [SampleableType Chal] [Fintype Chal] [Inhabited Chal]
+variable [SampleableType Wit] [SampleableType Chal]
 
 /-- Witness-extraction computation used by the NMA reduction. -/
 private noncomputable def nmaForkExtract
@@ -172,7 +186,9 @@ private noncomputable def nmaReduction
   simulateQ (QueryImpl.ofLift unifSpec ProbComp +
     (uniformSampleImpl (spec := (Unit →ₒ Chal)))) (nmaForkExtract σ hr M nmaAdv qH pk)
 
-omit [SampleableType Wit] [Inhabited Chal] [Fintype Chal] in
+omit [Fintype Stmt] [Fintype Commit] [Fintype Resp] [Fintype Chal]
+  [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] [Inhabited Chal]
+  [SampleableType Wit] in
 /-- Every `(x, log)` in the support of `replayFirstRun (Fork.runTrace σ hr M nmaAdv pk)`
 satisfies the per-run invariant `forkSupportInvariant`. -/
 private theorem forkSupportInvariant_of_mem_replayFirstRun
@@ -214,6 +230,8 @@ private theorem forkSupportInvariant_of_mem_replayFirstRun
   rw [hωeq]
   exact hverify
 
+omit [Fintype Stmt] [Fintype Commit] [Fintype Resp]
+  [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] in
 /-- Given the structural forking event on `pk`, the NMA reduction recovers a valid witness
 with probability at least that of the fork event under `forkReplay`. -/
 private theorem perPk_extraction_bound
@@ -350,6 +368,8 @@ private theorem perPk_extraction_bound
 
 end nmaToExtraction
 
+omit [Fintype Stmt] [Fintype Commit] [Fintype Resp] [Fintype Chal]
+  [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] [Inhabited Chal] in
 /-- NMA-to-extraction via the forking lemma and special soundness.
 
 The parameter `qH` is the *fork slot parameter* passed to `Fork.forkPoint qH`,

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -38,7 +38,6 @@ variable {Stmt Wit Commit PrvState Chal Resp : Type}
     [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] [Inhabited Chal]
     {rel : Stmt → Wit → Bool}
 
-attribute [local instance] Fintype.ofFinite
 variable [SampleableType Stmt] [SampleableType Wit]
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Security.lean
@@ -33,12 +33,18 @@ open scoped OracleSpec.PrimitiveQuery
 
 namespace FiatShamir
 
-variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
+variable {Stmt Wit Commit PrvState Chal Resp : Type}
+    [Finite Stmt] [Finite Commit] [Finite Resp] [Fintype Chal]
+    [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] [Inhabited Chal]
+    {rel : Stmt → Wit → Bool}
+
+attribute [local instance] Fintype.ofFinite
 variable [SampleableType Stmt] [SampleableType Wit]
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
 
-omit [SampleableType Stmt] [SampleableType Wit] in
+omit [Fintype Chal] in
+omit [Inhabited Stmt] [Inhabited Chal] in
 /-- **CMA-to-NMA reduction via HVZK simulation and managed random-oracle programming.**
 
 For any EUF-CMA adversary `A` making at most `qS` signing-oracle queries and `qH`
@@ -75,6 +81,8 @@ theorem euf_cma_to_nma
   cma_to_nma_advantage_bound (σ := σ) (hr := hr) (M := M)
     simTranscript ζ_zk hζ_zk hHVZK β hPredSim adv qS qH hQ
 
+omit [Finite Stmt] [Finite Commit] [Finite Resp] [Inhabited Stmt] [Inhabited Commit]
+  [Inhabited Resp] [Fintype Chal] [Inhabited Chal] in
 omit [SampleableType Stmt] in
 /-- **NMA-to-extraction via the forking lemma and special soundness.**
 
@@ -105,7 +113,7 @@ theorem euf_nma_bound
         Pr[= true | hardRelationExp hr reduction] :=
   nma_to_hard_relation_bound (σ := σ) (hr := hr) (M := M) hss hss_nf nmaAdv qH
 
-omit [SampleableType Stmt] in
+omit [Inhabited Stmt] [Fintype Chal] [Inhabited Chal] in
 /-- **Combined EUF-CMA bound (Pointcheval-Stern with quantitative HVZK, β-parametric).**
 
 Composes `euf_cma_to_nma` and `euf_nma_bound`:

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Bridge.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Bridge.lean
@@ -25,8 +25,10 @@ open OracleSpec OracleComp ProbComp
 
 namespace FiatShamir.Stateful
 
-variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
-variable [SampleableType Stmt] [SampleableType Wit]
+variable {Stmt Wit Commit PrvState Chal Resp : Type}
+    -- [Fintype Stmt] [Fintype Commit] [Fintype Resp] [Fintype Chal]
+    -- [Inhabited Stmt] [Inhabited Commit] [Inhabited Resp] [Inhabited Chal]
+    {rel : Stmt → Wit → Bool}
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
 
@@ -239,7 +241,6 @@ computation. -/
     (cmaInit M Commit Chal Stmt Wit) (signedAdv σ hr M adv)
   pure (p.1.1, p.1.2, p.2.1.1)
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The initial public-key query in `signedAdv` factors `cmaRealRun` through
 the key generator and a fixed-key post-keygen run. -/
 lemma cmaRealRun_eq_keygen_bind
@@ -264,7 +265,6 @@ lemma cmaRealRun_eq_keygen_bind
     simp [cmaReal, cmaInit, StateT.run, StateT.mk]]
   simp only [monad_norm]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-! ## Joint signing/hash query bounds -/
 
 /-- A named CMA query is costly for H3 exactly when it targets the signing
@@ -306,7 +306,7 @@ def cmaSignHashQueryBound {α : Type}
       (IsHashQuery (M := M) (Commit := Commit) (Chal := Chal)
         (Resp := Resp) (Stmt := Stmt)) qH
 
-omit [SampleableType Stmt] [DecidableEq M] [DecidableEq Commit] [SampleableType Chal] in
+omit [DecidableEq M] [DecidableEq Commit] [SampleableType Chal] in
 /-- Query-bind form of the joint signing/hash query bound. -/
 @[simp]
 private lemma cmaSignHashQueryBound_query_bind_iff {α : Type}
@@ -366,7 +366,7 @@ private lemma cmaSignHashQueryBound_query_bind_iff {α : Type}
       · intro h
         exact ⟨fun u => (h u).1, fun u => (h u).2⟩
 
-omit [SampleableType Stmt] [DecidableEq M] [DecidableEq Commit] [SampleableType Chal] in
+omit [DecidableEq M] [DecidableEq Commit] [SampleableType Chal] in
 /-- A bind is joint-bounded by the sum of the budgets for its prefix and
 continuations. -/
 private lemma cmaSignHashQueryBound_bind {α β : Type}
@@ -382,7 +382,7 @@ private lemma cmaSignHashQueryBound_bind {α β : Type}
   exact ⟨isQueryBoundP_bind h₁.1 (fun x _ => (h₂ x).1),
     isQueryBoundP_bind h₁.2 (fun x _ => (h₂ x).2)⟩
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq M]
+omit [DecidableEq M]
   [DecidableEq Commit] [SampleableType Chal] in
 /-- Fiat-Shamir verification consumes exactly one random-oracle query and no
 signing queries in the named CMA interface. -/
@@ -406,7 +406,7 @@ private lemma fiatShamir_verify_cmaSignHashQueryBound
       ⟨⟨by simp [IsCostlyQuery], by simpa [IsHashQuery] using hQ⟩,
         by simp [cmaSignHashQueryBound]⟩
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq M]
+omit [DecidableEq M]
   [DecidableEq Commit] [SampleableType Chal] in
 /-- Lifting a source post-keygen CMA computation into the named CMA interface
 preserves its joint signing/hash query bound. -/
@@ -440,7 +440,7 @@ private theorem liftAdv_cmaSignHashQueryBound
           rcases t with (n | mc) | m <;> simp [IsHashQuery])
         hQ.2
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq M]
+omit [DecidableEq M]
   [DecidableEq Commit] [SampleableType Chal] in
 /-- Logging signing inputs while forwarding all queries preserves the joint
 signing/hash query bound. -/
@@ -468,7 +468,7 @@ theorem cmaSignLogImpl_cmaSignHashQueryBound
             StateT.run_get, StateT.run_set, monadLift_self, bind_pure_comp])
       signed
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq M] [SampleableType Chal]
+omit [DecidableEq M] [SampleableType Chal]
   [DecidableEq Commit] in
 /-- Candidate production, with signing queries logged before final verification,
 preserves the source adversary signing/hash query budget. -/
@@ -492,8 +492,7 @@ theorem signedCandidateAdv_cmaSignHashQueryBound
           (Chal := Chal) (Resp := Resp) (Stmt := Stmt)
           (oa := adv.main pk) qS qH (hQ pk))
 
-omit [SampleableType Stmt] [SampleableType Wit] [SampleableType Chal]
-  [DecidableEq Commit] in
+omit [DecidableEq Commit] [SampleableType Chal] in
 /-- The final freshness-preserving Boolean adversary is bounded by the source
 adversary budget plus one verifier hash query. -/
 theorem signedFreshAdv_cmaSignHashQueryBound
@@ -522,8 +521,7 @@ theorem signedFreshAdv_cmaSignHashQueryBound
             (Commit := Commit) (Chal := Chal) (Resp := Resp) pk msg sig 0 1
             (Nat.succ_pos 0))
 
-omit [SampleableType Stmt] [SampleableType Wit] [SampleableType Chal]
-  [DecidableEq Commit] in
+omit [DecidableEq Commit] [SampleableType Chal] in
 /-- Predicate-targeted signing-query bound for the final freshness-preserving
 CMA adversary. -/
 theorem signedFreshAdv_isQueryBoundP_costly
@@ -538,7 +536,7 @@ theorem signedFreshAdv_isQueryBoundP_costly
       (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
       adv qS qH hQ).1
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq M] [SampleableType Chal]
+omit [DecidableEq M] [SampleableType Chal]
   [DecidableEq Commit] in
 /-- Predicate-targeted signing-query bound for candidate production before the
 final verification suffix. -/
@@ -554,7 +552,7 @@ theorem signedCandidateAdv_isQueryBoundP_costly
       (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
       adv qS qH hQ).1
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq M] [SampleableType Chal]
+omit [DecidableEq M] [SampleableType Chal]
   [DecidableEq Commit] in
 /-- Predicate-targeted hash-query bound for candidate production before the
 final verification suffix. -/
@@ -570,8 +568,7 @@ theorem signedCandidateAdv_isQueryBoundP_hash
       (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
       adv qS qH hQ).2
 
-omit [SampleableType Stmt] [SampleableType Wit] [SampleableType Chal]
-  [DecidableEq Commit] in
+omit [DecidableEq Commit] [SampleableType Chal] in
 /-- Predicate-targeted hash-query bound for the final freshness-preserving CMA
 adversary. The extra query is the final Fiat-Shamir verification. -/
 theorem signedFreshAdv_isQueryBoundP_hash

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -44,6 +44,10 @@ variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [DecidableEq M] [DecidableEq Commit] [SampleableType Chal]
   [Finite Chal] [Inhabited Chal]
 
+noncomputable local instance instIsUniformSpecChalSingleton [Fintype Chal] :
+    IsUniformSpec ((Unit →ₒ Chal) : OracleSpec _) :=
+  IsUniformSpec.ofFintypeInhabited _
+
 /-! ## CMA-to-NMA adversary -/
 
 /-- The CMA-to-NMA reduction at the managed random-oracle interface. -/
@@ -57,6 +61,7 @@ noncomputable def nmaAdvFromCma
 omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Hash-query bound for `nmaAdvFromCma`. -/
 theorem nmaAdvFromCma_nmaHashQueryBound
+    [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (qS qH : ℕ)
@@ -64,6 +69,8 @@ theorem nmaAdvFromCma_nmaHashQueryBound
       (S' := Commit × Resp) (oa := adv.main pk) qS qH) :
     ∀ pk, nmaHashQueryBound (M := M) (Commit := Commit) (Chal := Chal)
       (oa := (nmaAdvFromCma σ hr M adv simT).main pk) qH := by
+  letI : Fintype Commit := Fintype.ofFinite Commit
+  letI : Fintype Resp := Fintype.ofFinite Resp
   intro pk
   have hbase :=
     FiatShamir.simulatedNmaAdv_hashQueryBound σ hr M simT adv qS qH hQ pk
@@ -393,7 +400,6 @@ private def cmaSimLoggedLeftOrnament
   proj := cmaSimLoggedProj (M := M) (Commit := Commit)
     (Chal := Chal) (Stmt := Stmt) (Wit := Wit)
   preserves_inv := fun t s hs => by
-    letI : Fintype Chal := Fintype.ofFinite Chal
     rcases s with ⟨signed, ⟨⟨log, cache, keypair⟩, bad⟩⟩
     simp only [cmaSimFixedKeyInv] at hs ⊢
     rcases t with ((n | mc) | m)
@@ -461,7 +467,6 @@ private def cmaSimLoggedLeftOrnament
           subst a
           simp [hxinner]
   project_step := fun t s hs => by
-    letI : Fintype Chal := Fintype.ofFinite Chal
     rcases s with ⟨signed, ⟨⟨log, cache, keypair⟩, bad⟩⟩
     simp only [cmaSimFixedKeyInv] at hs
     rcases t with ((n | mc) | m)
@@ -687,7 +692,7 @@ private lemma forkInitialState_inv :
   · intro mc ch hcache
     simp [forkInitialState] at hcache
 
-omit [SampleableType Chal] [Finite Chal] [Inhabited Chal] in
+omit [SampleableType Chal] in
 private lemma simulatedNmaUnifFork_flatten_preserves_state
     {α : Type} (A : ProbComp α)
     (advCache : (fsRoSpec M Commit Chal).QueryCache)
@@ -699,6 +704,7 @@ private lemma simulatedNmaUnifFork_flatten_preserves_state
           (simulatedNmaUnifSim (M := M) (Commit := Commit) (Chal := Chal))).flattenStateT
         A).run (advCache, liveSt))) :
     z.2 = (advCache, liveSt) := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
   exact OracleComp.simulateQ_run_preserves_inv_of_query
     (impl := ((Fork.unifFwd M Commit Chal + Fork.roImpl M Commit Chal).mapStateTBase
       (simulatedNmaUnifSim (M := M) (Commit := Commit) (Chal := Chal))).flattenStateT)
@@ -713,7 +719,7 @@ private lemma simulatedNmaUnifFork_flatten_preserves_state
       rfl)
     A (advCache, liveSt) rfl z hz
 
-omit [SampleableType Chal] [Finite Chal] [Inhabited Chal] in
+omit [SampleableType Chal] in
 private lemma simulatedNmaUnifFork_nested_preserves_state
     {α : Type} (A : ProbComp α)
     (advCache : (fsRoSpec M Commit Chal).QueryCache)
@@ -724,6 +730,7 @@ private lemma simulatedNmaUnifFork_nested_preserves_state
         ((simulateQ (simulatedNmaUnifSim (M := M) (Commit := Commit)
           (Chal := Chal)) A).run advCache)).run liveSt)) :
     z.1.2 = advCache ∧ z.2 = liveSt := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
   rw [OracleComp.simulateQ_mapStateTBase_run_eq_map_flattenStateT
     (outer := Fork.unifFwd M Commit Chal + Fork.roImpl M Commit Chal)
     (inner := simulatedNmaUnifSim (M := M) (Commit := Commit) (Chal := Chal))
@@ -746,6 +753,7 @@ private lemma forkLoggedImpl_preserves_inv_step
       ∀ z ∈ support ((forkLoggedImpl (M := M) (Commit := Commit)
         (Chal := Chal) (Resp := Resp) simT pk t).run s),
         forkAwareInv (M := M) (Commit := Commit) (Chal := Chal) z.2 := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
   intro t s hs z hz
   rcases s with ⟨⟨advCache, liveCache, queryLog⟩, signed⟩
   rcases hs with ⟨hfreshInv, hlogInv⟩
@@ -850,6 +858,7 @@ private lemma forkLoggedImpl_preserves_inv
       (Commit := Commit) (Chal := Chal) (Resp := Resp) simT pk) A).run
       (forkInitialState M Commit Chal))) :
     forkAwareInv (M := M) (Commit := Commit) (Chal := Chal) z.2 := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
   exact OracleComp.simulateQ_run_preserves_inv_of_query
     (impl := forkLoggedImpl (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp) simT pk)
@@ -868,6 +877,7 @@ private lemma forkLoggedImpl_preserves_live_adv_inv_step
       ∀ z ∈ support ((forkLoggedImpl (M := M) (Commit := Commit)
         (Chal := Chal) (Resp := Resp) simT pk t).run s),
         forkLiveCacheAdvCacheInv (M := M) (Commit := Commit) (Chal := Chal) z.2 := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
   intro t s hs z hz
   rcases s with ⟨⟨advCache, liveCache, queryLog⟩, signed⟩
   rcases t with ((n | mc) | m)
@@ -944,6 +954,7 @@ private lemma forkLoggedImpl_preserves_live_adv_inv
       (Commit := Commit) (Chal := Chal) (Resp := Resp) simT pk) A).run
       (forkInitialState M Commit Chal))) :
     forkLiveCacheAdvCacheInv (M := M) (Commit := Commit) (Chal := Chal) z.2 := by
+  letI : Fintype Chal := Fintype.ofFinite Chal
   exact OracleComp.simulateQ_run_preserves_inv_of_query
     (impl := forkLoggedImpl (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp) simT pk)
@@ -1549,6 +1560,7 @@ private lemma forkLogged_base_support
 
 omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma forkLogged_queryLog_length_le
+    [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
@@ -1561,6 +1573,8 @@ private lemma forkLogged_queryLog_length_le
         (Chal := Chal) (Resp := Resp) simT pk) (adv.main pk)).run
         (forkInitialState M Commit Chal))) :
     z.2.1.2.2.length ≤ qH := by
+  letI : Fintype Commit := Fintype.ofFinite Commit
+  letI : Fintype Resp := Fintype.ofFinite Resp
   have hbase := forkLogged_base_support (M := M) (Commit := Commit)
     (Chal := Chal) (Resp := Resp) σ hr adv simT pk hz
   have hnested :
@@ -1622,7 +1636,7 @@ event for the verify-wrapped adversary. The fork slot parameter is `qH`:
 `Fork.forkPoint qH` indexes `Fin (qH + 1)`, accommodating the wrapped
 adversary's source-`qH` plus verifier-point query. -/
 private lemma forkLogged_verify_prob_true_le_forkPoint_run
-    [Fintype Chal]
+    [Fintype Chal] [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt)
@@ -1747,7 +1761,7 @@ fork advantage at slot parameter `qH`. The framework's `Fin (qH + 1)` indexing
 provides exactly enough slots for the wrapped adversary's source-`qH` plus
 verifier-point query. -/
 private lemma forkH5Body_prob_true_le_fork_advantage
-    [Fintype Chal]
+    [Fintype Chal] [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
@@ -2021,7 +2035,7 @@ terms of the verify-wrapped adversary `nmaAdvFromCmaWithFinalQuery` at fork
 slot parameter `qH` (the framework's `Fin (qH + 1)` indexing accommodates the
 wrapper's verifier-point query). -/
 theorem nma_runProb_shiftLeft_signedFreshAdv_le_fork
-    [Finite Chal]
+    [Finite Chal] [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (qS qH : ℕ)
@@ -2103,7 +2117,9 @@ private lemma verifyFreshComp_expectedQuerySlack_eq_zero
     · simp [IsCostlyQuery]
   · simp [verifyFreshComp, expectedQuerySlack_bad_eq_zero]
 
-omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] [Inhabited Chal] in
+omit [SampleableType Stmt] [SampleableType Wit] in
+omit [Finite Chal] in
+omit [Inhabited Chal] in
 /-- Tight native H3 bound for the freshness-preserving adversary, using the
 candidate/verifier split so the final verifier hash query is not charged to H3
 signing replacement. -/
@@ -2235,7 +2251,7 @@ omit [SampleableType Stmt] [SampleableType Wit] [Finite Chal] in
 /-- Native H5 boundary in the linked simulated-CMA form used by the top-level
 chain. -/
 theorem cmaSim_signedFreshAdv_le_fork
-    [Finite Chal]
+    [Finite Chal] [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (qS qH : ℕ)
@@ -2247,7 +2263,6 @@ theorem cmaSim_signedFreshAdv_le_fork
           (signedFreshAdv σ hr M adv)] ≤
       Fork.advantage σ hr M (nmaAdvFromCmaWithFinalQuery σ hr M adv simT)
         qH := by
-  letI : Fintype Chal := Fintype.ofFinite Chal
   exact cmaSim_signedFreshAdv_le_fork_of_shifted_h5 (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
     (Stmt := Stmt) (Wit := Wit) adv simT qH
@@ -2344,6 +2359,7 @@ omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Native stateful chain with H5 discharged by the replay-forking boundary,
 leaving only the public-to-stateful H1/H2 compatibility premise. -/
 theorem cma_advantage_le_fork_bound_of_h1h2
+    [Finite Commit] [Finite Resp] [Inhabited Commit] [Inhabited Resp]
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (ζ_zk : ℝ) (hζ_zk : 0 ≤ ζ_zk)
     (hHVZK : σ.HVZK simT ζ_zk)
@@ -2362,7 +2378,6 @@ theorem cma_advantage_le_fork_bound_of_h1h2
           (nmaAdvFromCmaWithFinalQuery σ hr M adv simT) qH +
         ENNReal.ofReal ((qS : ℝ) * ζ_zk) +
         (qS : ENNReal) * ((qS : ENNReal) + (qH : ENNReal)) * β := by
-  letI : Fintype Chal := Fintype.ofFinite Chal
   exact cma_advantage_le_fork_bound_of_h5 (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
     (Stmt := Stmt) (Wit := Wit) simT ζ_zk hζ_zk hHVZK β hPredSim

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -27,7 +27,8 @@ open OracleSpec OracleComp ProbComp
 namespace FiatShamir.Stateful
 
 variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
-variable [SampleableType Stmt] [SampleableType Wit]
+
+attribute [local instance] Fintype.ofFinite
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
 
@@ -89,7 +90,6 @@ def PublicCompatible
   publicUnforgeableAdvantage σ hr M adv =
     statefulCmaFreshAdvantage σ hr M adv
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Interpreting a lifted source-CMA computation through the named real-CMA
 handler is the same as interpreting it through the source-query full-state
 handler. -/
@@ -113,7 +113,6 @@ private lemma simulateQ_cmaReal_liftM_sourceCma_eq
     rw [simulateQ_spec_query]
     rfl
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The Fiat-Shamir public random-oracle interface has the same real-CMA
 semantics whether it is embedded directly into the named CMA interface or first
 through the source-CMA interface. -/
@@ -135,7 +134,6 @@ private lemma simulateQ_cmaReal_liftM_fsRo_eq_sourceCma
       · simp only [add_apply_inr]
         exact bind_congr ih
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Fixed-key `postKeygenAdv` over the named CMA interface is the source
 post-keygen computation interpreted by the full-state source handler. -/
 private lemma postKeygenAdv_runState_eq_postKeygenAdvBase_run
@@ -159,7 +157,6 @@ private lemma postKeygenAdv_runState_eq_postKeygenAdvBase_run
     (oa := (SourceSigAlg (σ := σ) (hr := hr) (M := M)).verify pk a.1.1 a.1.2)]
   simp
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The direct `cmaRealRun` endpoint and the fixed-key post-keygen endpoint are
 the same full-state freshness experiment. -/
 theorem statefulCmaFreshAdvantage_eq_statefulPostKeygenFreshAdvantage
@@ -233,7 +230,6 @@ private def cmaPostKeygenInv
     (s : CmaState M Commit Chal Stmt Wit) : Prop :=
   s.1.2.2 = some (pk, sk) ∧ s.2 = false
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaRealSourceFullSum_lift_ro_query_run
     (mc : M × Commit) (s : CmaState M Commit Chal Stmt Wit) :
     (simulateQ (cmaRealSourceFullSum M Commit Chal σ hr)
@@ -247,7 +243,6 @@ private lemma cmaRealSourceFullSum_lift_ro_query_run
         (Chal := Chal) (Resp := Resp)).query (.inl (.inr mc))))).run s = _
   rw [simulateQ_spec_query]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaRealSourceFullSum_sign_run_some
     (pk : Stmt) (sk : Wit) (m : M)
     (signed : List M) (cache : RoCache M Commit Chal) :
@@ -274,7 +269,6 @@ private lemma cmaRealSourceFullSum_sign_run_some
   | none =>
       simp [monad_norm]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private def cmaRealSourceFullSum_postKeygenOrnament
     (pk : Stmt) (sk : Wit) :
     QueryImpl.StateOrnament
@@ -357,7 +351,6 @@ private def cmaRealSourceFullSum_postKeygenOrnament
       | none =>
           simp [fs_simp, uniformSampleImpl, StateT.run_modifyGet, monad_norm]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma postKeygenAppendProdImpl_eq_flattenStateT
     (pk : Stmt) (sk : Wit) :
     postKeygenAppendProdImpl (σ := σ) (hr := hr) (M := M)
@@ -415,7 +408,6 @@ private noncomputable def postKeygenFreshAppendProb
             pk msg sig
         pure (!decide (msg ∈ signed) && verified)).run' (∅ : RoCache M Commit Chal)
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma postKeygenAppendImpl_run_eq_cmaRealSourceFullSum_run
     {α : Type}
     (oa : SourceCmaComp (M := M) (Commit := Commit) (Chal := Chal)
@@ -470,7 +462,6 @@ private lemma postKeygenAppendImpl_run_eq_cmaRealSourceFullSum_run
             hproj.symm
         simpa [impl, st, cmaPostKeygenProj, Functor.map_map] using hreassoc
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private theorem postKeygenFreshAppendProb_eq_statefulPostKeygenFreshProb
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) (sk : Wit) :
@@ -528,7 +519,6 @@ private theorem postKeygenFreshAppendProb_eq_statefulPostKeygenFreshProb
     (cmaSignLogImpl (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp) (Stmt := Stmt))).flattenStateT
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaRealLoggedProdImpl_lift_query_eq_cmaRealAppendProdImpl
     (t : (SourceCmaSpec (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp)).Domain) :
@@ -581,7 +571,6 @@ private lemma cmaRealLoggedProdImpl_lift_query_eq_cmaRealAppendProdImpl
     simp [fs_simp, QueryImpl.extendStateLeft, QueryImpl.mapStateTBase,
       QueryImpl.flattenStateT, StateT.run_bind, monad_norm]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaRealLoggedProdImpl_liftAdv_run {α : Type}
     (oa : SourceCmaComp (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp) α)
@@ -608,7 +597,6 @@ private lemma cmaRealLoggedProdImpl_liftAdv_run {α : Type}
     List M × CmaState M Commit Chal Stmt Wit :=
   (st.1.1, st)
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private def cmaRealAppendOrnament :
     QueryImpl.StateOrnament
       (cmaRealSourceFullSum M Commit Chal σ hr)
@@ -651,7 +639,6 @@ private def cmaRealAppendOrnament :
           | none =>
               simp [fs_simp, monad_norm]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma cmaReal_cmaSignLog_liftM_run_eq_cmaRealSourceFullSum_run
     {α : Type}
     (oa : SourceCmaComp (M := M) (Commit := Commit) (Chal := Chal)
@@ -709,7 +696,6 @@ private lemma cmaReal_cmaSignLog_liftM_run_eq_cmaRealSourceFullSum_run
   rw [happend]
   simp [st, cmaRealAppendProj, Functor.map_map]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- The post-keygen freshness endpoint is the same Boolean experiment as running
 `signedFreshAdv` in the direct stateful CMA game. -/
 theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
@@ -882,7 +868,6 @@ theorem statefulPostKeygenFreshAdvantage_eq_cmaRealRunProb_signedFreshAdv
             pk msg sig
         pure (!decide (msg ∈ signed) && verified)).run' ∅
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private theorem postKeygenWriterLog_eq_inputLog
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) (sk : Wit) :
@@ -924,7 +909,6 @@ private theorem postKeygenWriterLog_eq_inputLog
       (m₀ := StateT (RoCache M Commit Chal) ProbComp)
       so (adv.main pk) ([] : List M))
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private theorem postKeygenFreshWriterProb_eq_postKeygenFreshProb
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) (sk : Wit) :
@@ -988,7 +972,6 @@ private theorem postKeygenFreshWriterProb_eq_postKeygenFreshProb
   exact postKeygenFreshAppendProb_eq_statefulPostKeygenFreshProb (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp) adv pk sk
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private lemma fsBaseImpl_writerTMapBase_signingOracle_eq
     (pk : Stmt) (sk : Wit) :
     let baseW : QueryImpl (unifSpec + roSpec M Commit Chal)
@@ -1028,7 +1011,6 @@ private lemma fsBaseImpl_writerTMapBase_signingOracle_eq
       QueryImpl.withLogging_apply, cmaRealFixedSign, SourceSigAlg, FiatShamir,
       fsBaseImpl, randomOracle, StateT.run_bind, roSim.run_liftM]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 private theorem simulateQ_fsBaseImpl_postKeygenFreshWriterComp_run'_eq
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) (sk : Wit) :
@@ -1079,7 +1061,6 @@ private theorem simulateQ_fsBaseImpl_postKeygenFreshWriterComp_run'_eq
   conv_rhs =>
     simp [implS, baseS, fsBaseImpl, cmaRealFixedSign, SourceSigAlg, FiatShamir,
       randomOracle, QueryLog.wasQueried_eq_decide_mem_map_fst, StateT.run_bind]
-omit [SampleableType Stmt] [SampleableType Wit] in
 private theorem runtime_evalDist_postKeygenFreshWriterComp_eq
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) (sk : Wit) :
@@ -1097,7 +1078,7 @@ private theorem runtime_evalDist_postKeygenFreshWriterComp_eq
   rw [postKeygenFreshWriterProb_eq_postKeygenFreshProb (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp) adv pk sk]
 
-omit [SampleableType Stmt] [SampleableType Wit] [DecidableEq Commit] in
+omit [DecidableEq Commit] in
 /-- The public EUF-CMA experiment factors into keygen followed by the fixed-key
 WriterT post-keygen computation. -/
 private theorem unforgeableExp_eq_runtime_bind_postKeygenFreshWriterComp
@@ -1120,7 +1101,6 @@ private theorem unforgeableExp_eq_runtime_bind_postKeygenFreshWriterComp
   funext a
   congr
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Public EUF-CMA advantage in the shared fixed-key post-keygen normal form. -/
 theorem publicUnforgeableAdvantage_eq_statefulPostKeygenFreshAdvantage
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
@@ -1151,7 +1131,6 @@ theorem publicUnforgeableAdvantage_eq_statefulPostKeygenFreshAdvantage
   rw [runtime_evalDist_postKeygenFreshWriterComp_eq (σ := σ) (hr := hr)
     (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp) adv ps.1 ps.2]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Public compatibility for the legacy `SignatureAlg` endpoint. -/
 theorem publicCompatible
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
@@ -1164,7 +1143,6 @@ theorem publicCompatible
     (hr := hr) (M := M) (Commit := Commit) (Chal := Chal)
     (Resp := Resp) adv]
 
-omit [SampleableType Stmt] [SampleableType Wit] in
 /-- Public compatibility, in inequality form, against the direct stateful
 freshness experiment. -/
 theorem publicUnforgeableAdvantage_le_statefulCmaFresh

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -28,7 +28,6 @@ namespace FiatShamir.Stateful
 
 variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
 
-attribute [local instance] Fintype.ofFinite
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
 

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean
@@ -185,6 +185,7 @@ structure CmaH3RunFacts
 `simulateQ`. -/
 theorem simulateQ_bad_preserved_of_step
     {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {σ : Type} {α : Type}
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (hstep : ∀ (t : spec.Domain) (p : σ × Bool) (z),
@@ -864,7 +865,7 @@ private lemma cmaSimSignPublicBad_prob_le_roCacheCount_mul
         _ = (∑' key : Stmt × Wit, Pr[= key | hr.gen]) * (QueryCache.enncard cache * β) := by
               rw [ENNReal.tsum_mul_right]
         _ = QueryCache.enncard cache * β := by
-              rw [HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+              rw [tsum_probOutput_of_liftM_PMF, one_mul]
 
 private lemma cmaRealSignStep_evalDist_eq_ghost
     (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Spec.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Spec.lean
@@ -103,6 +103,16 @@ and public-key oracles. -/
     | .sign _ => Commit × Resp
     | .pk => Stmt
 
+instance {M Commit Chal Resp Stmt : Type}
+    [Fintype Chal] [Fintype Commit] [Fintype Resp] [Fintype Stmt] :
+    (cmaSpec M Commit Chal Resp Stmt).Fintype where
+  fintype_B q := by cases q <;> dsimp [cmaSpec, OracleSpec.ofFn] <;> infer_instance
+
+instance {M Commit Chal Resp Stmt : Type}
+    [Inhabited Chal] [Inhabited Commit] [Inhabited Resp] [Inhabited Stmt] :
+    (cmaSpec M Commit Chal Resp Stmt).Inhabited where
+  inhabited_B q := by cases q <;> dsimp [cmaSpec, OracleSpec.ofFn] <;> infer_instance
+
 /-- The non-signing portion of the CMA adversary's oracle view. -/
 @[reducible] def cmaPublicSpec (M Commit Chal Stmt : Type) :
     OracleSpec (CmaPublicQuery M Commit) :=

--- a/VCVio/CryptoFoundations/FiatShamir/WithAbort.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/WithAbort.lean
@@ -128,9 +128,9 @@ section correctness
 
 variable (ids : IdenSchemeWithAbort Stmt Wit Commit PrvState Chal Resp rel)
   (hr : GenerableRelation Stmt Wit rel) (M : Type)
+  [DecidableEq M] [DecidableEq Commit] [SampleableType Chal]
 
 omit hr in
-variable [DecidableEq M] [DecidableEq Commit] [SampleableType Chal] in
 /-- When the simulated signing loop produces `some (w, z)`, the random-oracle cache
 contains a challenge `c` at `(msg, w)` satisfying `ids.verify pk w c z = true`.
 
@@ -213,7 +213,8 @@ lemma fsAbortSignLoop_cache_invariant
           simp only [hs, StateT.run_bind] at h_query
           obtain ⟨⟨_, _⟩, _, h_cache⟩ :=
             (mem_support_bind_iff _ _ _).mp h_query
-          dsimp at h_cache
+          simp only [StateT.run_modifyGet, support_pure, Set.mem_singleton_iff,
+            Prod.mk.injEq] at h_cache
           obtain ⟨rfl, rfl⟩ := h_cache
           exact QueryCache.cacheQuery_self _ (msg, w_c) c_q
       · apply ids.verify_of_complete hc hrel
@@ -226,7 +227,6 @@ lemma fsAbortSignLoop_cache_invariant
           support_pure, Set.mem_singleton_iff]
         exact ⟨some z, h_rsp_mem, by simp [Option.map]⟩
 
-variable [DecidableEq M] [DecidableEq Commit] [SampleableType Chal] in
 /-- When the random-oracle cache already contains the challenge for `(msg, w)`,
 verification of signature `(w, z)` deterministically returns `true`. -/
 lemma verify_eq_true_of_cached
@@ -269,7 +269,6 @@ Unlike the CRYPTO 2023 paper and EasyCrypt formalization (which use an unbounded
 and do not state a correctness theorem), this formulation uses a bounded loop with
 `maxAttempts` iterations, matching FIPS 204 Algorithm 7 (ML-DSA.Sign_internal). -/
 theorem correct
-    [DecidableEq M] [DecidableEq Commit] [SampleableType Chal]
     (hc : ids.Complete) (maxAttempts : ℕ) (δ : ENNReal)
     (h_abort : ∀ (pk : Stmt) (sk : Wit), rel pk sk = true →
       ∀ msg : M,
@@ -309,7 +308,7 @@ theorem correct
     have habort := h_abort pk sk hrel msg
     have habort' : Pr[= none | 𝒟[signOnly pk sk]] ≤ δ := by
       convert habort using 2
-    have hnoFail : Pr[⊥ | signVerify pk sk] = 0 := HasEvalPMF.probFailure_eq_zero _
+    have hnoFail : Pr[⊥ | signVerify pk sk] = 0 := probFailure_of_liftM_PMF _
     rw [show (1 : ENNReal) - δ = 1 - δ from rfl]
     calc
       Pr[= true | signVerify pk sk]

--- a/VCVio/CryptoFoundations/FiatShamir/WithAbort/Cost.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/WithAbort/Cost.lean
@@ -137,7 +137,8 @@ theorem signAttempt_usesCostAsQueryCost {ω : Type} [AddMonoid ω]
 /-- The expected weighted query cost of one signing attempt is the expectation of the queried
 commitment cost over the attempt output distribution. -/
 theorem signAttempt_expectedQueryCost_eq_outputExpectation
-    {ω : Type} [AddMonoid ω] [HasEvalSPMF m]
+    {ω : Type} [AddMonoid ω] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (M × Commit →ₒ Chal) m) (pk : Stmt) (sk : Wit) (msg : M)
     (costFn : M × Commit → ω) (val : ω → ENNReal) :
     ExpectedQueryCost[
@@ -177,7 +178,7 @@ theorem signAttempt_expectedQueryCost_eq_outputExpectation
 
 section queryBounds
 
-variable [HasEvalSet m]
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 private lemma signAttempt_usesWeightedQueryCostAtMost
     {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
@@ -324,7 +325,8 @@ end queryBounds
 
 section expectedCost
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 section schemeCost
 
@@ -348,7 +350,6 @@ theorem sign_expectedQueries_eq_sum_reachedAttemptProbabilities
             (fun [HasQuery (M × Commit →ₒ Chal) (AddWriterT ℕ m)] =>
               (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
             runtime] := by
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   exact HasQuery.expectedQueries_eq_sum_tail_probs_of_usesAtMostQueries
     (oa := fun [HasQuery (M × Commit →ₒ Chal) (AddWriterT ℕ m)] =>
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
@@ -357,6 +358,7 @@ theorem sign_expectedQueries_eq_sum_reachedAttemptProbabilities
       (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
       (msg := msg) (maxAttempts := maxAttempts))
 
+omit [LawfulMonadLiftT m SPMF] in
 /-- Expected weighted query cost of signing is bounded by the worst-case `maxAttempts • w`
 budget whenever every query costs at most `w`. -/
 theorem sign_expectedQueryCost_le
@@ -368,13 +370,13 @@ theorem sign_expectedQueryCost_le
     ExpectedQueryCost[
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime by costFn via val
     ] ≤ val (maxAttempts • w) := by
-  let _ : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
     (sign_usesWeightedQueryCostAtMost
       (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
       (msg := msg) (costFn := costFn) (w := w) hcost (maxAttempts := maxAttempts))
     hval
 
+omit [LawfulMonadLiftT m SPMF] in
 /-- Unit-cost specialization: the expected number of signing queries is at most `maxAttempts`. -/
 theorem sign_expectedQueries_le
     (runtime : QueryImpl (M × Commit →ₒ Chal) m) (pk : Stmt) (sk : Wit) (msg : M)
@@ -382,7 +384,6 @@ theorem sign_expectedQueries_le
     ExpectedQueries[
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
     ] ≤ maxAttempts := by
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   exact HasQuery.expectedQueries_le_of_usesAtMostQueries
     (sign_usesAtMostMaxAttemptsQueries
       (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)

--- a/VCVio/CryptoFoundations/FiatShamir/WithAbort/ExpectedCost.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/WithAbort/ExpectedCost.lean
@@ -106,7 +106,8 @@ private lemma signLoop_queryCountDist_succ
 
 end
 
-variable [HasEvalPMF m]
+variable [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- The probability that a single Fiat-Shamir-with-aborts signing attempt aborts. -/
 noncomputable abbrev signAttemptAbortProbability
@@ -185,6 +186,7 @@ section
 
 variable [LawfulMonad m]
 
+omit [LawfulMonadLiftT m SetM] in
 private lemma signLoop_queryTailProbability_zero
     (runtime : QueryImpl (M × Commit →ₒ Chal) m) (pk : Stmt) (sk : Wit) (msg : M) (n : ℕ) :
     Pr[ fun q ↦ 0 < q |
@@ -218,6 +220,7 @@ private lemma signLoop_queryTailProbability_zero
     | none =>
         simp [probEvent_map]
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 private lemma signLoop_queryTailProbability_succ
     (runtime : QueryImpl (M × Commit →ₒ Chal) m) (pk : Stmt) (sk : Wit) (msg : M) (i n : ℕ) :
     Pr[ fun q ↦ i + 1 < q |
@@ -588,8 +591,6 @@ theorem sign_queryTailProbability_le_signAttemptAbortProbability_pow
           (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)
         runtime] ≤
       (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
-  letI : HasEvalSPMF m := HasEvalPMF.toHasEvalSPMF
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   by_cases hi : i < maxAttempts
   · rw [sign_queryTailProbability_eq_signAttemptAbortProbability_pow
       (ids := ids) (hr := hr) (M := M) (runtime := runtime) (pk := pk) (sk := sk)
@@ -630,8 +631,6 @@ theorem sign_expectedQueries_le_tsum_signAttemptAbortProbability_powers
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg in runtime
     ] ≤
       ∑' i : ℕ, (signAttemptAbortProbability (ids := ids) (M := M) runtime pk sk msg) ^ i := by
-  letI : HasEvalSPMF m := HasEvalPMF.toHasEvalSPMF
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   exact HasQuery.expectedQueries_le_tsum_of_tail_probs_le
     (oa := fun [HasQuery (M × Commit →ₒ Chal) (AddWriterT ℕ m)] =>
       (FiatShamirWithAbort ids hr M maxAttempts).sign pk sk msg)

--- a/VCVio/CryptoFoundations/Fischlin.lean
+++ b/VCVio/CryptoFoundations/Fischlin.lean
@@ -57,17 +57,15 @@ structure FischlinROInput (Stmt Commit Chal Resp : Type) (ρ : ℕ) (M : Type) w
   resp : Resp
   deriving DecidableEq
 
-variable (Stmt Commit Chal Resp : Type) (ρ b : ℕ) (M : Type) in
 /-- The random oracle specification for the Fischlin transform.
 Domain: `FischlinROInput` (statement, message, commitment list, index, challenge, response).
 Range: `Fin (2^b)` (b-bit hash values). -/
-abbrev fischlinROSpec :=
+abbrev fischlinROSpec (Stmt Commit Chal Resp : Type) (ρ b : ℕ) (M : Type) :=
   FischlinROInput Stmt Commit Chal Resp ρ M →ₒ Fin (2 ^ b)
 
-variable (Commit Chal Resp : Type) (ρ : ℕ) in
 /-- A Fischlin proof consists of one `(commitment, challenge, response)` triple
 per parallel repetition. -/
-abbrev FischlinProof := Fin ρ → Commit × Chal × Resp
+abbrev FischlinProof (Commit Chal Resp : Type) (ρ : ℕ) := Fin ρ → Commit × Chal × Resp
 
 /-! ## Prover Search -/
 
@@ -230,7 +228,7 @@ private lemma fischlinSearchAux_eq_withUnitCost
         QueryImpl.withUnitCost_apply, liftM, MonadLiftT.monadLift, ih]
 
 private lemma fischlinSearchAuxWithUnitCost_queryBoundedAboveBy
-    [HasEvalSet m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl (fischlinROSpec Stmt Commit Chal Resp ρ b M) m)
     (pk : Stmt) (sk : Wit) (sc : PrvState) (msg : M) (comList : List Commit) (i : Fin ρ)
     (challenges : List Chal) (best : Option (Chal × Resp × Fin (2 ^ b))) :
@@ -335,7 +333,7 @@ private lemma fischlinSearchAux_eq_withAddCost
 private lemma fischlinSearchAuxWithAddCost_pathwiseCostAtMost
     {κ : Type} [AddCommMonoid κ] [PartialOrder κ] [IsOrderedAddMonoid κ]
     [CanonicallyOrderedAdd κ]
-    [HasEvalSet m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl (fischlinROSpec Stmt Commit Chal Resp ρ b M) m)
     (pk : Stmt) (sk : Wit) (sc : PrvState) (msg : M) (comList : List Commit) (i : Fin ρ)
     (challenges : List Chal) (best : Option (Chal × Resp × Fin (2 ^ b)))
@@ -420,7 +418,7 @@ section verifyCostAccounting
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
   (hr : GenerableRelation Stmt Wit rel) (S : ℕ)
-  [DecidableEq M] [HasEvalSet m]
+  [DecidableEq M] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- Fischlin verification makes at most `ρ` random-oracle queries under unit-cost
 instrumentation. -/
@@ -529,7 +527,7 @@ section signCostAccounting
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
   (hr : GenerableRelation Stmt Wit rel) (S : ℕ)
-  [DecidableEq M] [HasEvalSet m]
+  [DecidableEq M] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- Fischlin signing makes at most `ρ * |Ω|` random-oracle queries under unit-cost
 instrumentation. -/
@@ -761,7 +759,8 @@ section expectedWeightedQueryCost
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
   (hr : GenerableRelation Stmt Wit rel) (S : ℕ)
-  [DecidableEq M] [HasEvalSPMF m]
+  [DecidableEq M] [MonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- Fischlin signing has expected weighted query cost at most `ρ • (|Ω| • w)` whenever every
 random-oracle query is weighted by at most `w`. -/
@@ -775,7 +774,6 @@ theorem sign_expectedQueryCost_le
     ExpectedQueryCost[
       (Fischlin σ hr ρ b S M).sign pk sk msg in runtime by costFn via val
     ] ≤ val (ρ • (FinEnum.card Chal • w)) := by
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   exact HasQuery.expectedQueryCost_le_of_usesCostAtMost
     (sign_usesWeightedQueryCostAtMost
       (σ := σ) (hr := hr) (ρ := ρ) (b := b) (S := S) (M := M)
@@ -790,7 +788,8 @@ section expectedQueries
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
   (hr : GenerableRelation Stmt Wit rel) (S : ℕ)
-  [DecidableEq M] [HasEvalSPMF m]
+  [DecidableEq M] [MonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- Fischlin signing has expected query count at most `ρ * |Ω|` in the unit-cost runtime model.
 
@@ -801,7 +800,6 @@ theorem sign_expectedQueries_le_rhoCardOmega
     (pk : Stmt) (sk : Wit) (msg : M) :
     ExpectedQueries[ (Fischlin σ hr ρ b S M).sign pk sk msg in runtime ]
       ≤ ρ * FinEnum.card Chal := by
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   simpa [Nat.cast_mul] using HasQuery.expectedQueries_le_of_usesAtMostQueries
     (sign_usesAtMostRhoCardOmegaQueries
       (σ := σ) (hr := hr) (ρ := ρ) (b := b) (S := S) (M := M)
@@ -814,15 +812,14 @@ section expectedQueriesPMF
 variable (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 variable [FinEnum Chal] [Inhabited Chal] [Inhabited Resp]
   (hr : GenerableRelation Stmt Wit rel) (S : ℕ)
-  [DecidableEq M] [HasEvalPMF m]
+  [DecidableEq M] [MonadLiftT m PMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- Fischlin verification has expected query count exactly `ρ` in the unit-cost runtime model. -/
 theorem verify_expectedQueries_eq_rho
     (runtime : QueryImpl (fischlinROSpec Stmt Commit Chal Resp ρ b M) m)
     (pk : Stmt) (msg : M) (π : FischlinProof Commit Chal Resp ρ) :
     ExpectedQueries[ (Fischlin σ hr ρ b S M).verify pk msg π in runtime ] = ρ := by
-  letI : HasEvalSPMF m := HasEvalPMF.toHasEvalSPMF
-  letI : HasEvalSet m := HasEvalSPMF.toHasEvalSet
   apply HasQuery.expectedQueries_eq_of_usesAtMostQueries_of_usesAtLeastQueries
   · exact verify_usesAtMostRhoQueries
       (σ := σ) (hr := hr) (ρ := ρ) (b := b) (S := S) (M := M)

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean
@@ -137,7 +137,8 @@ theorem encrypt_usesExactQueryCost {ω : Type} [AddMonoid ω]
 /-- T-transform encryption has expected weighted query cost equal to the weight of querying
 `msg`. -/
 theorem encrypt_expectedQueryCost_eq {ω : Type} [AddMonoid ω] [Preorder ω]
-    [HasEvalPMF m]
+    [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (pk : PK) (msg : M) (costFn : M → ω) (val : ω → ENNReal) (hval : Monotone val) :
@@ -181,7 +182,8 @@ theorem decrypt_usesZeroQueryCost_of_decrypt_eq_none {ω : Type} [AddMonoid ω]
 /-- If deterministic decryption fails immediately, the T-transform has expected weighted query
 cost `0`. -/
 theorem decrypt_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
-    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    [AddMonoid ω] [Preorder ω] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (pk : PK) (sk : SK) (c : C) (costFn : M → ω)
@@ -217,7 +219,8 @@ theorem decrypt_usesExactQueryCost_of_decrypt_eq_some {ω : Type} [AddMonoid ω]
 /-- If deterministic decryption returns a message, the T-transform has expected weighted query
 cost equal to the weight of querying that message. -/
 theorem decrypt_expectedQueryCost_eq_of_decrypt_eq_some {ω : Type}
-    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    [AddMonoid ω] [Preorder ω] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (pk : PK) (sk : SK) (c : C) (costFn : M → ω)
@@ -259,7 +262,7 @@ theorem decrypt_usesExactlyOneQuery_of_decrypt_eq_some
       (costFn := fun _ ↦ 1) hdec)
 
 /-- T-transform decryption makes at most one hash-oracle query under unit-cost instrumentation. -/
-theorem decrypt_usesAtMostOneQuery [HasEvalSet m]
+theorem decrypt_usesAtMostOneQuery [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl (M →ₒ R) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (pk : PK) (sk : SK) (c : C) :

--- a/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
+++ b/VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean
@@ -221,7 +221,8 @@ theorem encaps_usesExactFamilyWeightedCost {ω : Type} [AddMonoid ω]
 /-- Under per-family upper bounds on the two U-transform oracle families, encapsulation incurs
 weighted query cost at most the sum of those bounds. -/
 theorem encaps_usesWeightedQueryCostAtMost {ω : Type}
-    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [HasEvalSet m]
+    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [MonadLiftT m SetM] [LawfulMonadLiftT
+        m SetM]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -286,7 +287,8 @@ theorem encaps_usesExactlyTwoQueries
 
 /-- Expected weighted query cost of U-transform encapsulation under constant per-family weights. -/
 theorem encaps_expectedQueryCost_eq_of_constantOracleWeights {ω : Type}
-    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    [AddMonoid ω] [Preorder ω] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] [MonadLiftT m SetM]
+        [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -307,7 +309,8 @@ theorem encaps_expectedQueryCost_eq_of_constantOracleWeights {ω : Type}
 /-- Expected weighted query cost of U-transform encapsulation is bounded by the sum of the
 per-family bounds. -/
 theorem encaps_expectedQueryCost_le {ω : Type}
-    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [HasEvalPMF m]
+    [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [MonadLiftT m PMF] [LawfulMonadLiftT
+        m PMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -326,7 +329,8 @@ theorem encaps_expectedQueryCost_le {ω : Type}
     hval
 
 /-- Expected query count of U-transform encapsulation is exactly `2`. -/
-theorem encaps_expectedQueries_eq_two [HasEvalPMF m]
+theorem encaps_expectedQueries_eq_two [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -369,7 +373,7 @@ theorem decaps_usesZeroQueryCost_of_decrypt_eq_none {ω : Type} [AddMonoid ω]
 weighted query cost at most the sum of those bounds. -/
 theorem decaps_usesWeightedQueryCostAtMost {ω : Type}
     [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [CanonicallyOrderedAdd ω]
-    [HasEvalSet m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -434,7 +438,8 @@ theorem decaps_usesWeightedQueryCostAtMost {ω : Type}
 /-- If deterministic decryption fails immediately, decapsulation has expected weighted query cost
 `0`. -/
 theorem decaps_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
-    [AddMonoid ω] [Preorder ω] [HasEvalPMF m]
+    [AddMonoid ω] [Preorder ω] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] [MonadLiftT m SetM]
+        [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -456,7 +461,8 @@ theorem decaps_expectedQueryCost_eq_zero_of_decrypt_eq_none {ω : Type}
 per-family bounds. -/
 theorem decaps_expectedQueryCost_le {ω : Type}
     [AddCommMonoid ω] [PartialOrder ω] [IsOrderedAddMonoid ω] [CanonicallyOrderedAdd ω]
-    [HasEvalPMF m]
+    [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+        [EvalDistCompatible m]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -477,7 +483,7 @@ theorem decaps_expectedQueryCost_le {ω : Type}
     hval
 
 /-- Unit-cost specialization: U-transform decapsulation makes at most two oracle queries. -/
-theorem decaps_usesAtMostTwoQueries [HasEvalSet m]
+theorem decaps_usesAtMostTwoQueries [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)
@@ -491,7 +497,8 @@ theorem decaps_usesAtMostTwoQueries [HasEvalSet m]
       (hCoins := fun _ ↦ le_rfl) (hKeys := fun _ ↦ le_rfl))
 
 /-- Expected query count of U-transform decapsulation is at most `2`. -/
-theorem decaps_expectedQueries_le_two [HasEvalPMF m]
+theorem decaps_expectedQueries_le_two [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     (runtime : QueryImpl (UTransform.hashOracleSpec M R KD K) m)
     (pke : AsymmEncAlg.ExplicitCoins ProbComp M PK SK R C)
     (kdInput : M → C → KD)

--- a/VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean
@@ -34,7 +34,13 @@ protocol parameter.
 - `KeyedCRAdversary K X` — an adversary for the keyed variant.
 - `keyedCRExp` — the keyed collision-resistance experiment.
 - `keyedCRAdvantage` — the advantage of a keyed CR adversary.
-- `ROMHashSpec X Y` — random-oracle spec with domain `X` and range `Y`.
+- `ROMHashSpec X Y` — adversary-facing random-oracle spec; carries no
+  probability instances.
+- `ROMHashSpec.cached X Y` — post-simulation companion; defeq to
+  `ROMHashSpec X Y` but with the `IsUniformSpec` instance attached.
+- `ROMHashSpec.cachingOracle` — `QueryImpl` bridge that consumes pre-spec
+  queries and dispatches them through the generic `cachingOracle` on the
+  cached spec. The spec transition happens only via `simulateQ`.
 - `ROMCRAdversary X Y` — an adversary for the ROM variant.
 - `romCRExp` — the ROM collision-resistance experiment.
 - `romCRAdvantage` — the advantage of a ROM-CR adversary.
@@ -111,9 +117,12 @@ noncomputable def keyedCRAdvantage [DecidableEq X] [DecidableEq Y]
 
 Companion section modelling collision resistance directly in the random-oracle
 model. A ROM-CR adversary is an oracle computation outputting a candidate
-collision pair `(x, x')`. The experiment runs the adversary inside
-`cachingOracle`, then queries the random oracle on both candidates sharing
-the same cache; it wins iff `x ≠ x'` and the queried outputs coincide.
+collision pair `(x, x')`, expressed in the adversary-facing `ROMHashSpec X Y`
+which carries no probability instances. The experiment lifts the adversary
+into the post-simulation companion `ROMHashSpec.cached X Y` (defeq, distinct
+head symbol) where `IsUniformSpec` is in scope, then runs it inside
+`cachingOracle` and queries the random oracle on both candidates sharing the
+same cache; it wins iff `x ≠ x'` and the queried outputs coincide.
 
 For any `t`-query ROM-CR adversary the advantage is bounded by the birthday
 term `(t+2) * (t+1) / (2 * |Y|)` — a `(t+2)`-query game once the two
@@ -123,9 +132,61 @@ Closes one of the layers requested in
 [Verified-zkEVM/VCV-io#284](https://github.com/Verified-zkEVM/VCV-io/issues/284).
 -/
 
-/-- The random-oracle spec with domain `X` and range `Y`: each input `x : X` is
-a distinct oracle index returning a value in `Y`. -/
-abbrev ROMHashSpec (X Y : Type) : OracleSpec X := fun _ => Y
+/-- The random-oracle spec with domain `X` and range `Y`, as seen by the
+adversary. Each input `x : X` is a distinct oracle index returning a value in
+`Y`. This pre-cache spec carries no probability instances: a ROM-CR adversary
+is a syntactic object, and probability semantics only attach to the
+post-simulation spec `ROMHashSpec.cached` (defeq, distinct head symbol). -/
+def ROMHashSpec (X Y : Type) : OracleSpec X := fun _ => Y
+
+instance {X Y : Type} [DecidableEq X] [DecidableEq Y] :
+    (ROMHashSpec X Y).DecidableEq where
+  decidableEq_A := (inferInstanceAs (DecidableEq X))
+  decidableEq_B := fun _ => (inferInstanceAs (DecidableEq Y))
+
+/-- The post-simulation companion to `ROMHashSpec`: definitionally the same
+`OracleSpec X`, but with a distinct head symbol so the `IsUniformSpec`
+instance below is opted into only where probability reasoning is intended.
+The adversary's pre-cache computation is converted into a post-cache
+computation only via `simulateQ ROMHashSpec.cachingOracle`. -/
+def ROMHashSpec.cached (X Y : Type) : OracleSpec X := fun _ => Y
+
+instance {X Y : Type} [Fintype Y] : (ROMHashSpec.cached X Y).Fintype where
+  fintype_B := fun _ => (inferInstanceAs (Fintype Y))
+
+instance {X Y : Type} [Inhabited Y] : (ROMHashSpec.cached X Y).Inhabited where
+  inhabited_B := fun _ => (inferInstanceAs (Inhabited Y))
+
+instance {X Y : Type} [DecidableEq X] [DecidableEq Y] :
+    (ROMHashSpec.cached X Y).DecidableEq where
+  decidableEq_A := (inferInstanceAs (DecidableEq X))
+  decidableEq_B := fun _ => (inferInstanceAs (DecidableEq Y))
+
+noncomputable instance {X Y : Type} [Fintype Y] [Inhabited Y] :
+    IsUniformSpec (ROMHashSpec.cached X Y) := IsUniformSpec.ofFintypeInhabited _
+
+/-- Bridge caching oracle: a `QueryImpl` that takes adversary-facing
+`ROMHashSpec X Y` queries and dispatches them through the generic
+`cachingOracle` on the post-cache spec `ROMHashSpec.cached X Y`. The spec
+transition from pre to cached happens only here, via `simulateQ`. -/
+@[inline, reducible]
+def ROMHashSpec.cachingOracle {X Y : Type} [DecidableEq X] :
+    QueryImpl (ROMHashSpec X Y)
+      (StateT (QueryCache (ROMHashSpec.cached X Y))
+        (OracleComp (ROMHashSpec.cached X Y))) :=
+  OracleSpec.cachingOracle (spec := ROMHashSpec.cached X Y)
+
+/-- Specialised `simulateQ_query` lemma for the bridge: simulating a single
+pre-spec query through `ROMHashSpec.cachingOracle` is the generic
+`cachingOracle` action at the post-cache spec. True by `rfl` because the two
+specs are definitionally equal as `OracleSpec X`. -/
+@[simp]
+lemma ROMHashSpec.simulateQ_cachingOracle_query {X Y : Type} [DecidableEq X] (x : X) :
+    simulateQ ROMHashSpec.cachingOracle (liftM ((ROMHashSpec X Y).query x)) =
+      OracleSpec.cachingOracle (spec := ROMHashSpec.cached X Y) x := by
+  change simulateQ (OracleSpec.cachingOracle (spec := ROMHashSpec.cached X Y))
+      (liftM ((ROMHashSpec.cached X Y).query x)) = _
+  exact cachingOracle.simulateQ_query x
 
 /-- A ROM-CR adversary is an oracle computation outputting a candidate
 collision pair under the random oracle. -/
@@ -138,14 +199,18 @@ structure BoundedROMCRAdversary (X Y : Type) (t : ℕ) where
   /-- The adversary makes at most `t` total queries. -/
   queryBound : IsTotalQueryBound run t
 
-/-- ROM collision-resistance experiment: run the adversary inside
-`cachingOracle` from the empty cache, then query the random oracle on both
-candidate inputs (verification queries share the cache). Win iff the inputs
-are distinct and the queried outputs coincide. -/
+/-- ROM collision-resistance experiment: run the adversary inside the
+`ROMHashSpec.cachingOracle` bridge from the empty cache, then query the
+random oracle on both candidate inputs (verification queries share the
+cache). Win iff the inputs are distinct and the queried outputs coincide.
+The bridge takes the entire computation from `OracleComp (ROMHashSpec X Y)`
+into `OracleComp (ROMHashSpec.cached X Y)` in one step — no separate
+oracle-comp lift is needed. -/
 def romCRExp [DecidableEq X] [DecidableEq Y]
     {t : ℕ} (A : BoundedROMCRAdversary X Y t) :
-    OracleComp (ROMHashSpec X Y) (Bool × QueryCache (ROMHashSpec X Y)) :=
-  (simulateQ cachingOracle (do
+    OracleComp (ROMHashSpec.cached X Y)
+      (Bool × QueryCache (ROMHashSpec.cached X Y)) :=
+  (simulateQ ROMHashSpec.cachingOracle (do
     let (x, x') ← A.run
     let y ← (ROMHashSpec X Y).query x
     let y' ← (ROMHashSpec X Y).query x'
@@ -158,7 +223,9 @@ noncomputable def romCRAdvantage [DecidableEq X] [DecidableEq Y]
     {t : ℕ} (A : BoundedROMCRAdversary X Y t) : ℝ≥0∞ :=
   Pr[fun z => z.1 = true | romCRExp A]
 
-/-- The inner oracle computation of `romCRExp`, before `simulateQ`. -/
+/-- The inner oracle computation of `romCRExp`, before `simulateQ`. Lives
+entirely on the pre-cache spec — the spec transition happens at the
+`simulateQ ROMHashSpec.cachingOracle` step. -/
 private def romCRInner [DecidableEq X] [DecidableEq Y]
     {t : ℕ} (A : BoundedROMCRAdversary X Y t) :
     OracleComp (ROMHashSpec X Y) Bool := do
@@ -169,7 +236,7 @@ private def romCRInner [DecidableEq X] [DecidableEq Y]
 
 private lemma romCRExp_eq [DecidableEq X] [DecidableEq Y]
     {t : ℕ} (A : BoundedROMCRAdversary X Y t) :
-    romCRExp A = (simulateQ cachingOracle (romCRInner A)).run ∅ := rfl
+    romCRExp A = (simulateQ ROMHashSpec.cachingOracle (romCRInner A)).run ∅ := rfl
 
 /-- The total query bound on `romCRInner` is `t + 2` — `t` from the adversary
 plus the two verification queries. -/
@@ -187,9 +254,9 @@ private lemma romCRInner_totalBound [DecidableEq X] [DecidableEq Y]
 /-- A win in the ROM-CR experiment implies a collision in the final cache:
 the verification queries cache `x ↦ y` and `x' ↦ y'` with `x ≠ x'` and
 `y = y'`, which is exactly `CacheHasCollision`. -/
-private lemma romCRWin_implies_collision [DecidableEq X] [DecidableEq Y]
+private lemma romCRWin_implies_collision [DecidableEq X] [DecidableEq Y] [Finite Y] [Inhabited Y]
     {t : ℕ} (A : BoundedROMCRAdversary X Y t) :
-    ∀ z ∈ support ((simulateQ cachingOracle (romCRInner A)).run ∅),
+    ∀ z ∈ support ((simulateQ ROMHashSpec.cachingOracle (romCRInner A)).run ∅),
       z.1 = true → CacheHasCollision z.2 := by
   intro z hz hwin
   simp only [romCRInner, simulateQ_bind, simulateQ_pure] at hz
@@ -206,18 +273,19 @@ private lemma romCRWin_implies_collision [DecidableEq X] [DecidableEq Y]
   rw [hz] at hwin ⊢
   simp only [decide_eq_true_eq] at hwin
   obtain ⟨hne, hyy⟩ := hwin
-  rw [cachingOracle.simulateQ_query] at hmem₂
+  rw [ROMHashSpec.simulateQ_cachingOracle_query] at hmem₂
   have hcache₂ : cache₂ x = some y :=
     cachingOracle_query_caches x cache₁ y cache₂ hmem₂
   have hcache_mono : cache₂ ≤ cache₃ := by
     have hmem₃_co : (y', cache₃) ∈ support
-        (((ROMHashSpec X Y).cachingOracle x').run cache₂) := by
-      simp only [cachingOracle.simulateQ_query] at hmem₃; exact hmem₃
-    unfold cachingOracle at hmem₃_co
+        (((ROMHashSpec.cached X Y).cachingOracle x').run cache₂) := by
+      rw [ROMHashSpec.simulateQ_cachingOracle_query] at hmem₃
+      exact hmem₃
+    unfold OracleSpec.cachingOracle at hmem₃_co
     exact QueryImpl.withCaching_cache_le
-      (QueryImpl.ofLift (ROMHashSpec X Y) (OracleComp (ROMHashSpec X Y)))
+      (QueryImpl.ofLift (ROMHashSpec.cached X Y) (OracleComp (ROMHashSpec.cached X Y)))
       x' cache₂ (y', cache₃) hmem₃_co
-  rw [cachingOracle.simulateQ_query] at hmem₃
+  rw [ROMHashSpec.simulateQ_cachingOracle_query] at hmem₃
   have hcache₃ : cache₃ x' = some y' :=
     cachingOracle_query_caches x' cache₂ y' cache₃ hmem₃
   have hcache₃_x : cache₃ x = some y := hcache_mono hcache₂
@@ -234,16 +302,19 @@ theorem romCRAdvantage_le_birthday [DecidableEq X] [DecidableEq Y]
     romCRAdvantage A ≤ (((t + 2) * (t + 1) : ℕ) : ℝ≥0∞) / (2 * Fintype.card Y) := by
   unfold romCRAdvantage
   rw [romCRExp_eq]
-  have hrange : ∀ s : (ROMHashSpec X Y).Domain,
-      Fintype.card ((ROMHashSpec X Y).Range default) ≤
-        Fintype.card ((ROMHashSpec X Y).Range s) := fun _ => le_rfl
-  calc Pr[fun z => z.1 = true | (simulateQ cachingOracle (romCRInner A)).run ∅]
+  have hrange : ∀ s : (ROMHashSpec.cached X Y).Domain,
+      Fintype.card ((ROMHashSpec.cached X Y).Range default) ≤
+        Fintype.card ((ROMHashSpec.cached X Y).Range s) := fun _ => le_rfl
+  have hY' : 0 < Fintype.card ((ROMHashSpec.cached X Y).Range default) := hY
+  calc Pr[fun z => z.1 = true |
+          (simulateQ ROMHashSpec.cachingOracle (romCRInner A)).run ∅]
       ≤ Pr[fun z => CacheHasCollision z.2 |
-          (simulateQ cachingOracle (romCRInner A)).run ∅] :=
+          (simulateQ ROMHashSpec.cachingOracle (romCRInner A)).run ∅] :=
         probEvent_mono (romCRWin_implies_collision A)
     _ ≤ (((t + 2) * (t + 1) : ℕ) : ℝ≥0∞) / (2 * Fintype.card Y) :=
         probEvent_cacheCollision_le_birthday_total_tight
-          (spec := ROMHashSpec X Y) (romCRInner A) (t + 2)
-          (romCRInner_totalBound A) hY hrange
+          (spec := ROMHashSpec.cached X Y)
+          (romCRInner A : OracleComp (ROMHashSpec.cached X Y) Bool) (t + 2)
+          (romCRInner_totalBound A) hY' hrange
 
 end CollisionResistance

--- a/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/DiffieHellman.lean
@@ -259,10 +259,10 @@ theorem probOutput_ddhExpRand_cdhToDDHReduction_eq_uniformScalar
     rw [probOutput_bind_bind_swap]
     rw [probOutput_bind_of_const _ fun h _ =>
       probOutput_decide_smul_eq_inv_card g hg h]
-    simp [HasEvalPMF.probFailure_eq_zero]
+    simp [probFailure_of_liftM_PMF]
   rw [probOutput_bind_of_const _ fun a _ =>
     probOutput_bind_of_const _ fun b _ => key a b]
-  simp [HasEvalPMF.probFailure_eq_zero]
+  simp [probFailure_of_liftM_PMF]
 
 /-- Concrete form of the hardness implication `DDH ⇒ CDH`: a CDH solver can only beat the uniform
 DH-target baseline by the DDH distinguishing advantage of the associated adversary-map reduction. -/

--- a/VCVio/CryptoFoundations/IdenSchemeWithAbort.lean
+++ b/VCVio/CryptoFoundations/IdenSchemeWithAbort.lean
@@ -71,7 +71,7 @@ variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Boo
 
 section HonestExecution
 
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
+variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
 /-- A single honest execution producing an optional transcript `(Commit, Chal, Resp)`.
 Returns `none` if the prover aborts. -/
@@ -87,7 +87,7 @@ end HonestExecution
 
 section Completeness
 
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
+variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
 /-- An identification scheme with aborts is complete if: whenever the prover does not abort,
 the verifier always accepts. -/
@@ -124,7 +124,7 @@ end Completeness
 
 section HVZK
 
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
+variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
 /-- Approximate honest-verifier zero-knowledge for an identification scheme with aborts:
 the transcript distribution produced by the honest prover is within total variation
@@ -193,7 +193,7 @@ structure ImpAdv (ids : IdenSchemeWithAbort Stmt Wit Commit PrvState Chal Resp r
   commit (s : Stmt) : ProbComp (Commit × AdvSt)
   respond (s : Stmt) (c : Chal) (st : AdvSt) : ProbComp Resp
 
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
+variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
 /-- The impersonation experiment: the adversary tries to produce a valid transcript
 without knowing the witness, against a fixed statement `s`. -/

--- a/VCVio/CryptoFoundations/KEMDEM.lean
+++ b/VCVio/CryptoFoundations/KEMDEM.lean
@@ -41,8 +41,10 @@ def composeWithDEM [Monad m]
 
 section Correct
 
-variable [DecidableEq K] [DecidableEq M] [Monad m] [HasEvalSPMF m]
+variable [DecidableEq K] [DecidableEq M] [Monad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
+omit [LawfulMonadLiftT m SPMF] in
 /-- From KEM correctness at the monadic probability level, every reachable decapsulation of an
 honest ciphertext returns the encapsulated key. -/
 private lemma kem_decaps_mem_support

--- a/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
@@ -66,6 +66,12 @@ open List OracleSpec OracleComp BinaryTree
 
 variable {α : Type}
 
+/-- Local `IsUniformSpec` opt-in for `spec α`: the single Merkle hash oracle samples
+uniformly from `α` whenever `α` is finite and inhabited. Kept `local` so that downstream
+files outside this module do not silently pick up uniform semantics for `spec α`. -/
+noncomputable local instance instIsUniformSpec [Fintype α] [Inhabited α] :
+    IsUniformSpec (spec α) := IsUniformSpec.ofFintypeInhabited _
+
 /-! ## Adversary -/
 
 section Adversary
@@ -621,7 +627,7 @@ private lemma probOutput_getPutativeRoot_eq_inv_card_of_pos_depth
           fun a => (singleHash a proof.head : OracleComp (spec α) α) from rfl,
       probOutput_bind_eq_tsum]
     simp_rw [fun a => probOutput_singleHash_eq_inv_card a proof.head root,
-      ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+      ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
   | @ofRight sl sr idxRight =>
     rw [show (getPutativeRoot (m := OracleComp (spec α))
               (SkeletonLeafIndex.ofRight idxRight) leaf proof
@@ -630,7 +636,7 @@ private lemma probOutput_getPutativeRoot_eq_inv_card_of_pos_depth
           fun a => (singleHash proof.head a : OracleComp (spec α) α) from rfl,
       probOutput_bind_eq_tsum]
     simp_rw [fun a => probOutput_singleHash_eq_inv_card proof.head a root,
-      ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+      ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
 /--
 The probability that `verifyProof` evaluates to `true` at a positive-depth index

--- a/VCVio/CryptoFoundations/MerkleTree/Vector/Completeness.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Vector/Completeness.lean
@@ -40,7 +40,7 @@ theorem buildLayer_neverFails [DecidableEq α]
     (leaves : List.Vector α (2 ^ (n + 1))) : NeverFail
       ((simulateQ (spec α).randomOracle
         (buildLayer α n leaves)).run preexisting_cache) := by
-  grind only [buildLayer, = HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+  grind only [buildLayer, = neverFail_iff, = probFailure_of_liftM_PMF]
 
 /--
 Building a Merkle tree never results in failure
@@ -53,7 +53,7 @@ theorem buildMerkleTree_neverFails [DecidableEq α]
     NeverFail
       ((simulateQ (spec α).randomOracle
         (buildMerkleTree α n leaves)).run preexisting_cache) := by
-  grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+  grind only [= neverFail_iff, = probFailure_of_liftM_PMF]
 
 /-- A functional completeness theorem for Merkle proofs built from `buildMerkleTree_with_hash`. -/
 theorem functional_completeness {n : ℕ} (leaves : List.Vector α (2 ^ n)) (i : Fin (2 ^ n))

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -423,13 +423,13 @@ lemma fst_map_replayFirstRun (main : OracleComp spec α) :
     (loggingOracle.fst_map_run_simulateQ (spec := spec) main)
 
 @[simp]
-lemma probEvent_fst_replayFirstRun [spec.Fintype] [spec.Inhabited]
+lemma probEvent_fst_replayFirstRun [IsUniformSpec spec]
     (main : OracleComp spec α) (p : α → Prop) :
     Pr[ fun z => p z.1 | replayFirstRun main] = Pr[ p | main] := by
   simp [replayFirstRun]
 
 @[simp]
-lemma probOutput_fst_map_replayFirstRun [spec.Fintype] [spec.Inhabited]
+lemma probOutput_fst_map_replayFirstRun [IsUniformSpec spec]
     (main : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> replayFirstRun main] = Pr[= x | main] := by
   simp [replayFirstRun]
@@ -581,7 +581,7 @@ lemma fst_map_simulateQ_replayOracle_of_live [spec.DecidableEq]
 `evalDist` level. Once in live mode, the α-output distribution of the replay run is
 `evalDist main`. -/
 lemma evalDist_fst_map_simulateQ_replayOracle_of_live [spec.DecidableEq]
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (i : ι) (main : OracleComp spec α) (st : ReplayForkState spec i)
     (hst : st.forkConsumed = true ∨ st.mismatch = true) :
     𝒟[(Prod.fst <$> (simulateQ (replayOracle i) main).run st :
@@ -1032,7 +1032,7 @@ protected lemma replayOracle_preservesPrefixInvariant [spec.DecidableEq]
             simp [hflags.1] at hfc'
 
 /-- Every reachable replay state preserves the logged query-input prefix up to `cursor`. -/
-theorem replayRunWithTraceValue_preservesPrefixInvariant [spec.DecidableEq]
+theorem replayRunWithTraceValue_preservesPrefixInvariant [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1050,7 +1050,7 @@ theorem replayRunWithTraceValue_preservesPrefixInvariant [spec.DecidableEq]
 
 /-- Support-level replay-prefix lemma: before `cursor`, the second run queries the same oracle
 inputs as the logged first-run transcript. -/
-lemma replayRunWithTraceValue_prefix_input_eq [spec.DecidableEq]
+lemma replayRunWithTraceValue_prefix_input_eq [IsUniformSpec spec] [spec.DecidableEq]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1067,7 +1067,7 @@ lemma replayRunWithTraceValue_prefix_input_eq [spec.DecidableEq]
 response. This strengthens `replayRunWithTraceValue_prefix_input_eq` and is the key lemma
 for arguing that the adversary's query transcript prior to the fork is identical across
 the two runs. -/
-lemma replayRunWithTraceValue_prefix_getElem?_eq [spec.DecidableEq]
+lemma replayRunWithTraceValue_prefix_getElem?_eq [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1082,7 +1082,7 @@ lemma replayRunWithTraceValue_prefix_getElem?_eq [spec.DecidableEq]
 /-- Extract the "fork-position count" invariant: once the fork has fired, the prefix of `observed`
 up to the fork position contains exactly `st.forkQuery` entries of type `i`. This pins down where
 the replacement entry sits in the filtered `i`-log. -/
-lemma replayRunWithTraceValue_forkConsumed_imp_prefix_count [spec.DecidableEq]
+lemma replayRunWithTraceValue_forkConsumed_imp_prefix_count [IsUniformSpec spec] [spec.DecidableEq]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1095,7 +1095,7 @@ lemma replayRunWithTraceValue_forkConsumed_imp_prefix_count [spec.DecidableEq]
 
 /-- If replay has consumed the fork point, the last consumed log entry is the distinguished query
 input `i`. This is the pathwise "same target" fact used downstream. -/
-lemma replayRunWithTraceValue_forkConsumed_imp_last_input [spec.DecidableEq]
+lemma replayRunWithTraceValue_forkConsumed_imp_last_input [IsUniformSpec spec] [spec.DecidableEq]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1170,7 +1170,7 @@ protected lemma replayOracle_immutable_params [spec.DecidableEq]
           rcases hz with ⟨u, _, rfl⟩
           simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch]
 
-lemma replayRunWithTraceValue_forkQuery_eq [spec.DecidableEq]
+lemma replayRunWithTraceValue_forkQuery_eq [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1193,7 +1193,7 @@ lemma replayRunWithTraceValue_forkQuery_eq [spec.DecidableEq]
       main stInit ⟨rfl, rfl, rfl⟩ z (by simpa [stInit] using hz)
   simpa [ReplayForkState.init] using hparams.1
 
-lemma replayRunWithTraceValue_replacement_eq [spec.DecidableEq]
+lemma replayRunWithTraceValue_replacement_eq [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1216,7 +1216,7 @@ lemma replayRunWithTraceValue_replacement_eq [spec.DecidableEq]
       main stInit ⟨rfl, rfl, rfl⟩ z (by simpa [stInit] using hz)
   simpa [ReplayForkState.init] using hparams.2.1
 
-lemma replayRunWithTraceValue_trace_eq [spec.DecidableEq]
+lemma replayRunWithTraceValue_trace_eq [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1395,7 +1395,8 @@ protected lemma replayOracle_preservesReplacementInvariant [spec.DecidableEq]
             simp [ReplayForkState.markMismatch, ReplayForkState.noteObserved, hflags.1] at hfc
 
 /-- Every reachable replay state preserves the replacement invariant. -/
-theorem replayRunWithTraceValue_preservesReplacementInvariant [spec.DecidableEq]
+theorem replayRunWithTraceValue_preservesReplacementInvariant
+    [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1413,7 +1414,8 @@ theorem replayRunWithTraceValue_preservesReplacementInvariant [spec.DecidableEq]
 
 /-- If the replay has consumed the fork and the fork point is `forkQuery`, then the
 `forkQuery`-th distinguished-oracle entry in the observed log is exactly the replacement. -/
-lemma replayRunWithTraceValue_getQueryValue?_observed_eq_replacement [spec.DecidableEq]
+lemma replayRunWithTraceValue_getQueryValue?_observed_eq_replacement
+    [spec.DecidableEq] [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (trace : QueryLog spec)
     (forkQuery : Nat) (replacement : spec.Range i)
     {z : α × ReplayForkState spec i}
@@ -1541,11 +1543,11 @@ end support
 
 section quantitative
 
-variable [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
+variable [spec.DecidableEq]
 variable [∀ i, SampleableType (spec.Range i)] [unifSpec ⊂ₒ spec]
 variable [unifSpec ˡ⊂ₒ spec]
 
-omit [spec.Fintype] [spec.Inhabited] [∀ i, SampleableType (spec.Range i)]
+omit [∀ i, SampleableType (spec.Range i)]
     [unifSpec ⊂ₒ spec] [unifSpec ˡ⊂ₒ spec] in
 /-- Each step of `replayOracle` makes at most one oracle query. Either the oracle returns
 pure (matched-consumption or fork substitution), or it invokes `liftM (query t)` exactly
@@ -1596,7 +1598,7 @@ private lemma replayOracle_step_isTotalQueryBound
             Functor.map_map]
           exact hquery (fun u => (st.markMismatch).noteObserved t u)
 
-omit [spec.Fintype] [spec.Inhabited] [∀ i, SampleableType (spec.Range i)]
+omit [∀ i, SampleableType (spec.Range i)]
     [unifSpec ⊂ₒ spec] [unifSpec ˡ⊂ₒ spec] in
 /-- Replay does not increase the total number of oracle queries. If `main` makes at most
 `n` queries, then `replayRunWithTraceValue main i trace forkQuery replacement` also makes
@@ -1604,7 +1606,7 @@ at most `n` queries.
 
 Reduces to `IsTotalQueryBound.simulateQ_run_of_step` with
 `replayOracle_step_isTotalQueryBound` supplying the per-step bound of `1`. -/
-private theorem isTotalQueryBound_replayRunWithTraceValue
+private theorem isTotalQueryBound_replayRunWithTraceValue [IsUniformSpec spec]
     (main : OracleComp spec α) (n : ℕ)
     (hmain : IsTotalQueryBound main n)
     (i : ι) (trace : QueryLog spec) (forkQuery : Nat) (replacement : spec.Range i) :
@@ -1613,7 +1615,7 @@ private theorem isTotalQueryBound_replayRunWithTraceValue
   exact IsTotalQueryBound.simulateQ_run_of_step (impl := replayOracle i) hmain
     (fun t s => replayOracle_step_isTotalQueryBound i t s) _
 
-omit [spec.Fintype] [spec.Inhabited] [unifSpec ˡ⊂ₒ spec] in
+omit [unifSpec ˡ⊂ₒ spec] in
 /-- If `forkReplay` succeeds, both runs agree on the selected fork index. -/
 private theorem cf_eq_of_mem_support_forkReplay
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
@@ -1647,7 +1649,7 @@ private theorem cf_eq_of_mem_support_forkReplay
 omit [unifSpec ˡ⊂ₒ spec] in
 /-- On `forkReplay` support, first-projection success equals the pair-style success event.
 This mirrors `probEvent_seededFork_fst_eq_probEvent_pair` for the replay fork. -/
-private theorem probEvent_forkReplay_fst_eq_probEvent_pair
+private theorem probEvent_forkReplay_fst_eq_probEvent_pair [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
     Pr[ fun r => r.map (cf ∘ Prod.fst) = some (some s) | forkReplay main qb i cf] =
@@ -1720,8 +1722,7 @@ the fork query without mismatching the prefix. The proof has three parts:
 3. `replayRunWithTraceValue_state_correct`: the user-facing corollary obtained by
    instantiating the auxiliary invariant at the initial replay state. -/
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] in
 private lemma replayOracle_preservesConsumed
     (i t : ι) {st : ReplayForkState spec i}
@@ -1741,8 +1742,7 @@ private lemma replayOracle_preservesConsumed
   · simpa [ReplayForkState.noteObserved] using h_consumed
   · simpa [ReplayForkState.noteObserved] using h_mismatch
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] in
 private theorem replayRun_preservesConsumed
     (main : OracleComp spec α) (idx : ι) {st₀ : ReplayForkState spec idx}
@@ -1768,8 +1768,7 @@ private theorem replayRun_preservesConsumed
         replayOracle_preservesConsumed (i := idx) (t := t) h_consumed h_mismatch hus'
       exact ih (u := us.1) (st₀ := us.2) h_consumed' h_mismatch' hzcont
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] in
 /-- Coupled invariant for the replay simulation: starting from a state whose remaining
 trace coincides with a continuation produced by some first run of `main`, and which
@@ -1931,8 +1930,7 @@ private theorem replayRun_state_correct_aux
         exact ih u_first hp_first' h_st₁_mismatch h_st₁_obs_len
           h_st₁_trace_drop h_st₁_forkConsumed h_st₁_dlt h_can_reach' hzcont'
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] in
 /-- Replay correctness invariant: starting from a logged first run of `main` whose
 log already records an `i`-query at position `↑s`, replaying `main` against that log
@@ -2006,7 +2004,7 @@ private noncomputable def collisionReplayComp
   if QueryLog.getQueryValue? p.2 i ↑s = some u then return cf p.1 else return none
 
 /-- Replay-side collision bound. -/
-private lemma probOutput_collisionReplay_le_main_div
+private lemma probOutput_collisionReplay_le_main_div [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
     Pr[= (some s : Option (Fin (qb i + 1))) | collisionReplayComp main qb i cf s] ≤
@@ -2146,8 +2144,7 @@ private lemma probOutput_collisionReplay_le_main_div
 
 /-! ### Per-step unfolding of `replayOracle` -/
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Non-`i` lockstep step. -/
 private lemma replayOracle_run_lockstep_ne_i [spec.DecidableEq]
@@ -2165,8 +2162,7 @@ private lemma replayOracle_run_lockstep_ne_i [spec.DecidableEq]
   rw [dif_neg h_ti]
   simp [StateT.run_map, StateT.run_set]
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Distinguished-query lockstep before the fork point. -/
 private lemma replayOracle_run_lockstep_i_pre_fork [spec.DecidableEq]
@@ -2186,8 +2182,7 @@ private lemma replayOracle_run_lockstep_i_pre_fork [spec.DecidableEq]
   rw [if_neg h_fork]
   simp [StateT.run_map, StateT.run_set]
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Distinguished-query step at the fork point. -/
 private lemma replayOracle_run_fork_fires [spec.DecidableEq]
@@ -2209,8 +2204,7 @@ private lemma replayOracle_run_fork_fires [spec.DecidableEq]
   rw [if_pos h_fork]
   simp [StateT.run_map, StateT.run_set]
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Empty-trace step enters live mode. -/
 private lemma replayOracle_run_nextEntry_none [spec.DecidableEq]
@@ -2227,8 +2221,7 @@ private lemma replayOracle_run_nextEntry_none [spec.DecidableEq]
   simp [StateT.run_monadLift,
     StateT.run_map, StateT.run_set]
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Type-mismatch step enters live mode. -/
 private lemma replayOracle_run_mismatch_ne [spec.DecidableEq]
@@ -2248,6 +2241,7 @@ private lemma replayOracle_run_mismatch_ne [spec.DecidableEq]
 
 /-- Coupling auxiliary for prefix truncation. -/
 private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
+    [IsUniformSpec spec]
     (i : ι) (main : OracleComp spec α) :
     ∀ (stL stR : ReplayForkState spec i),
       stL.forkConsumed = false → stL.mismatch = false →
@@ -2633,8 +2627,7 @@ private theorem evalDist_uniform_bind_fst_simulateQ_replayOracle_run_coupled_aux
                 simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch]))
           simp_rw [hliveL, hliveR]
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- State-irrelevance for replay runs with the same readable fields. -/
 private theorem fst_map_simulateQ_replayOracle_state_equiv [spec.DecidableEq]
@@ -2828,8 +2821,7 @@ private theorem fst_map_simulateQ_replayOracle_state_equiv [spec.DecidableEq]
               (stR.markMismatch.noteObserved t v) (Or.inr (by
                 simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch]))]
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- The α-marginal of replay with an empty trace is `main`. -/
 private theorem fst_map_replayRunWithTraceValue_nil [spec.DecidableEq]
@@ -2862,8 +2854,7 @@ private theorem fst_map_replayRunWithTraceValue_nil [spec.DecidableEq]
       (Or.inr (by
         simp [ReplayForkState.noteObserved, ReplayForkState.markMismatch]))
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Replay step-unfolding for a non-`i` query. -/
 private theorem fst_map_replayRunWithTraceValue_query_bind_cons_ne [spec.DecidableEq]
@@ -2903,8 +2894,7 @@ private theorem fst_map_replayRunWithTraceValue_query_bind_cons_ne [spec.Decidab
     · exact Nat.zero_le _
   exact h_eqv
 
-omit [spec.Fintype] [spec.Inhabited]
-  [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
+omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Replay step-unfolding for an `i`-query before the fork point. -/
 private theorem fst_map_replayRunWithTraceValue_query_bind_cons_self_succ
@@ -2948,6 +2938,7 @@ private theorem fst_map_replayRunWithTraceValue_query_bind_cons_self_succ
 
 /-- Replay-side prefix-faithfulness for truncated first-run logs. -/
 private lemma evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
+    [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (log : QueryLog spec) (s : ℕ) :
     𝒟[(do
       let u ← liftComp ($ᵗ spec.Range i) spec
@@ -3022,6 +3013,7 @@ This is the direct consequence of
 `evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt`, restated at the
 `probOutput` level for convenient use in tsum manipulations. -/
 private lemma probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt
+    [IsUniformSpec spec]
     (main : OracleComp spec α) (i : ι) (log : QueryLog spec) (s : ℕ) (x : α) :
     Pr[= x | Prod.fst <$> (do
       let u ← liftComp ($ᵗ spec.Range i) spec
@@ -3051,7 +3043,7 @@ private lemma probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeFork
 omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
   [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 /-- Change variables in a `tsum` against a mapped computation. -/
-private lemma tsum_probOutput_map_mul {γ δ : Type} (mn : OracleComp spec γ)
+private lemma tsum_probOutput_map_mul [IsUniformSpec spec] {γ δ : Type} (mn : OracleComp spec γ)
     (f : γ → δ) (g : δ → ℝ≥0∞) :
     ∑' y : δ, Pr[= y | (f <$> mn : OracleComp spec δ)] * g y =
     ∑' x : γ, Pr[= x | mn] * g (f x) := by
@@ -3068,7 +3060,7 @@ private lemma tsum_probOutput_map_mul {γ δ : Type} (mn : OracleComp spec γ)
   · rw [probOutput_pure_self, one_mul]
 
 /-- Weighted replay prefix-faithfulness. -/
-private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
+private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt [IsUniformSpec spec]
     {β : Type} (main : OracleComp spec α) (i : ι) (s : ℕ)
     (f : α → β) (y : β) (h : QueryLog spec → ℝ≥0∞) :
     ∑' p, Pr[= p | replayFirstRun main] *
@@ -3225,11 +3217,11 @@ private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
                 (h ([] : QueryLog spec) *
                   Pr[= y | (f <$> main : OracleComp spec β)]) =
             h ([] : QueryLog spec) * Pr[= y | (f <$> main : OracleComp spec β)] := fun u => by
-          rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+          rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
         simp_rw [hLHS_inner, hRHS_inner]
         simp_rw [← mul_assoc, mul_comm _ (h ([] : QueryLog spec)), mul_assoc,
           ENNReal.tsum_mul_left]
-        rw [← hfmain, ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [← hfmain, ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
       | succ k =>
         have htrunc : ∀ (u : spec.Range t) (p' : α × QueryLog spec),
             QueryLog.takeBeforeForkAt
@@ -3329,7 +3321,7 @@ private lemma tsum_probOutput_replayFirstRun_weight_takeBeforeForkAt
         ih u s (fun τ => h ((⟨t, u⟩ : (i' : ι) × spec.Range i') :: τ))
 
 /-- Replay-side Jensen / Cauchy-Schwarz step. -/
-private lemma sq_probOutput_main_le_noGuardReplayComp
+private lemma sq_probOutput_main_le_noGuardReplayComp [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
     Pr[= s | cf <$> main] ^ 2 ≤
@@ -3481,7 +3473,7 @@ private lemma sq_probOutput_main_le_noGuardReplayComp
 
 omit [unifSpec ˡ⊂ₒ spec] in
 /-- Structural replay inequality for no-guard, genuine fork, and collision runs. -/
-private lemma noGuardReplayComp_le_forkReplay_add_collisionReplay
+private lemma noGuardReplayComp_le_forkReplay_add_collisionReplay [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
     (hreach : CfReachable main qb i cf) (s : Fin (qb i + 1)) :
@@ -3619,7 +3611,7 @@ private lemma noGuardReplayComp_le_forkReplay_add_collisionReplay
     exact zero_le _
 
 /-- Pointwise replay lower bound. -/
-private theorem le_probOutput_forkReplay
+private theorem le_probOutput_forkReplay [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
     (hreach : CfReachable main qb i cf) (s : Fin (qb i + 1)) :
@@ -3673,7 +3665,7 @@ private theorem le_probOutput_forkReplay
 omit [spec.DecidableEq] [∀ i, SampleableType (spec.Range i)] [unifSpec ⊂ₒ spec] in
 /-- The replay-fork precondition is itself bounded by `1`. This mirrors
 `seededFork_precondition_le_one`; the statement is independent of the fork mechanism. -/
-private theorem forkReplay_precondition_le_one
+private theorem forkReplay_precondition_le_one [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) :
     (let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
@@ -3686,7 +3678,7 @@ omit [unifSpec ˡ⊂ₒ spec] in
 /-- Sum of disjoint replay-fork success events is at most the total `some` probability.
 This mirrors `sum_probEvent_fork_le_tsum_some` in `Fork.lean`; the proof is purely
 algebraic on the underlying distribution and does not depend on the fork mechanism. -/
-private lemma sum_probEvent_forkReplay_le_tsum_some
+private lemma sum_probEvent_forkReplay_le_tsum_some [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) :
     ∑ s : Fin (qb i + 1),
@@ -3717,7 +3709,7 @@ private lemma sum_probEvent_forkReplay_le_tsum_some
     simp
 
 /-- Replay fork failure probability bound. -/
-private theorem probOutput_none_forkReplay_le
+private theorem probOutput_none_forkReplay_le [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
     let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
@@ -3732,7 +3724,7 @@ private theorem probOutput_none_forkReplay_le
     ne_top_of_le_ne_top one_ne_top
       (sum_probOutput_some_le_one (mx := cf <$> main) (α := Fin (qb i + 1)))
   have htotal := probOutput_none_add_tsum_some (mx := forkReplay main qb i cf)
-  rw [HasEvalPMF.probFailure_eq_zero, tsub_zero] at htotal
+  rw [probFailure_of_liftM_PMF, tsub_zero] at htotal
   have hne_top : (∑' p, Pr[= some p | forkReplay main qb i cf]) ≠ ⊤ :=
     ne_top_of_le_ne_top one_ne_top (htotal ▸ le_add_self)
   have hPr_eq : Pr[= none | forkReplay main qb i cf] =
@@ -3775,7 +3767,7 @@ private theorem probOutput_none_forkReplay_le
                     Finset.sum_add_distrib
 
 /-- Packaged replay forking theorem. -/
-theorem le_probEvent_isSome_forkReplay
+theorem le_probEvent_isSome_forkReplay [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (hreach : CfReachable main qb i cf) :
     (let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
@@ -3805,9 +3797,9 @@ theorem le_probEvent_isSome_forkReplay
   exact (ENNReal.le_sub_iff_add_le_right hnone_ne_top probOutput_le_one).2
     (by simpa [add_comm] using hfork)
 
-omit [spec.Fintype] [spec.Inhabited] [unifSpec ˡ⊂ₒ spec] in
+omit [unifSpec ˡ⊂ₒ spec] in
 /-- Structural success facts for `forkReplay`. -/
-theorem forkReplay_success_log_props
+theorem forkReplay_success_log_props [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
     {x₁ x₂ : α}
@@ -3884,9 +3876,9 @@ theorem forkReplay_success_log_props
             exact this
         · simp at h
 
-omit [spec.Fintype] [spec.Inhabited] [unifSpec ˡ⊂ₒ spec] in
+omit [unifSpec ˡ⊂ₒ spec] in
 /-- Transfer logged-run postconditions through a successful replay fork. -/
-theorem forkReplay_propertyTransfer
+theorem forkReplay_propertyTransfer [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
     (P_out : α → QueryLog spec → Prop)

--- a/VCVio/CryptoFoundations/ReplayForkStdDo.lean
+++ b/VCVio/CryptoFoundations/ReplayForkStdDo.lean
@@ -51,7 +51,7 @@ set_option mvcgen.warning false
 namespace OracleComp.ProgramLogic.StdDo
 
 variable {ι : Type}
-variable {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited] [spec.DecidableEq]
+variable {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec] [spec.DecidableEq]
 
 section replayOracle
 

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -15,8 +15,8 @@ import VCVio.OracleComp.Constructions.SampleableType
 
 This file defines simple security experiments that succeed unless they terminate with failure.
 Each experiment carries bundled subprobabilistic semantics, so the experiment can be interpreted
-through an internal semantic monad instead of requiring a global `HasEvalSPMF` instance on the
-ambient monad.
+through an internal semantic monad instead of requiring a global `MonadLiftT _ SPMF` instance
+on the ambient monad.
 
 We also define `BoundedAdversary α β` as an oracle computation bundled with a query bound.
 -/

--- a/VCVio/CryptoFoundations/SeededFork.lean
+++ b/VCVio/CryptoFoundations/SeededFork.lean
@@ -29,7 +29,8 @@ open OracleSpec OracleComp OracleComp.ProgramLogic ENNReal Function Finset
 
 namespace OracleComp
 
-variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι} {α β γ : Type}
+variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι} [IsUniformSpec spec]
+  {α β γ : Type}
 
 /-- Bundles the inputs to the forking lemma. -/
 structure SeededForkInput (spec : OracleSpec ι) (α : Type) where
@@ -99,6 +100,7 @@ def seededForkWithSeedValue (main : OracleComp spec α)
 
 end forkDef
 
+omit [IsUniformSpec spec] in
 /-- When the seed has at least `qb t` pre-generated answers for each oracle `t`, running `main`
 against the seed makes zero live oracle queries (every query is answered from the seed). -/
 theorem isPerIndexQueryBound_firstRun_seeded
@@ -110,6 +112,7 @@ theorem isPerIndexQueryBound_firstRun_seeded
   seededOracle.isPerIndexQueryBound_run'_zero
     (oa := main) (qb := qb) (seed := seed) hmain hseed
 
+omit [IsUniformSpec spec] in
 /-- After truncating the seed at query index `s` for oracle `i` and inserting a fresh answer `u`,
 the replayed run can make at most `qb i - (s + 1)` live queries, all to oracle `i`.
 All other oracle families remain fully covered by the seed. -/
@@ -125,6 +128,7 @@ theorem isPerIndexQueryBound_replayAfterFork
   seededOracle.isPerIndexQueryBound_run'_takeAtIndex_addValue
     (oa := main) (qb := qb) (seed := seed) (i := i) hmain hseed s u
 
+omit [IsUniformSpec spec] in
 private lemma isPerIndexQueryBound_if_pure
     {p : Prop} [Decidable p]
     {oa : OracleComp spec α} {qb : ι → ℕ} {x : α}
@@ -134,6 +138,7 @@ private lemma isPerIndexQueryBound_if_pure
   · simp [hp]
   · simpa [hp] using h
 
+omit [IsUniformSpec spec] in
 /-- `seededForkWithSeedValue` makes at most `qb i` live queries, all to oracle `i`.
 
 The first seeded run is query-free (covered by the seed); the replay after the fork point uses
@@ -235,11 +240,12 @@ section generateSeedCoverage
 
 variable [∀ i, SampleableType (spec.Range i)]
 
+omit [IsUniformSpec spec] in
 /-- The expected unit-cost query count of `seededForkWithSeedValue`, averaged over the randomly
 sampled seed and replacement value, is at most `qb i`. -/
 theorem expectedQueryCount_seededForkWithSeedValue_le
     [spec.DecidableEq]
-    [Finite ι] [spec.Fintype] [spec.Inhabited]
+    [Finite ι] [IsUniformSpec spec]
     (main : OracleComp spec α) (qb : ι → ℕ) (js : List ι) (i : ι)
     (cf : α → Option (Fin (qb i + 1)))
     (hmain : IsPerIndexQueryBound main qb)
@@ -293,12 +299,12 @@ theorem expectedQueryCount_seededForkWithSeedValue_le
             · rw [probOutput_eq_zero_of_not_mem_support hseed]; simp
     _ ≤ qb i := by
           exact le_of_eq (by
-            rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul])
+            rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul])
 
 section forkRuntime
 
 variable [spec.DecidableEq]
-variable [Finite ι] [spec.Fintype] [spec.Inhabited]
+variable [Finite ι]
 
 /-- Total expected query work of one fork attempt. The LHS decomposes as three terms:
 
@@ -344,9 +350,9 @@ end generateSeedCoverage
 variable (main : OracleComp spec α) (qb : ι → ℕ)
     (js : List ι) (i : ι) (cf : α → Option (Fin (qb i + 1)))
     [∀ i, SampleableType (spec.Range i)] [spec.DecidableEq] [unifSpec ⊂ₒ spec]
-    [spec.Fintype] [spec.Inhabited] [unifSpec ˡ⊂ₒ spec]
+    [unifSpec ˡ⊂ₒ spec]
 
-omit [spec.Fintype] [spec.Inhabited] [unifSpec ˡ⊂ₒ spec] in
+omit [IsUniformSpec spec] [unifSpec ˡ⊂ₒ spec] in
 /-- If `seededFork` succeeds (returns `some`), both runs agree on the fork index. -/
 theorem cf_eq_of_mem_support_seededFork (x₁ x₂ : α)
     (h : some (x₁, x₂) ∈ support (seededFork main qb js i cf)) :
@@ -1055,7 +1061,7 @@ theorem probOutput_none_seededFork_le :
     ne_top_of_le_ne_top one_ne_top
       (sum_probOutput_some_le_one (mx := cf <$> main) (α := Fin (qb i + 1)))
   have htotal := probOutput_none_add_tsum_some (mx := seededFork main qb js i cf)
-  rw [HasEvalPMF.probFailure_eq_zero, tsub_zero] at htotal
+  rw [probFailure_of_liftM_PMF, tsub_zero] at htotal
   have hne_top : (∑' p, Pr[= some p | seededFork main qb js i cf]) ≠ ⊤ :=
     ne_top_of_le_ne_top one_ne_top (htotal ▸ le_add_self)
   have hPr_eq : Pr[= none | seededFork main qb js i cf] =

--- a/VCVio/CryptoFoundations/SigmaProtocol.lean
+++ b/VCVio/CryptoFoundations/SigmaProtocol.lean
@@ -60,7 +60,7 @@ variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Boo
 
 section complete
 
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
+variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
 /-- A Σ-protocol is perfectly complete if the honest prover always convinces the verifier
 on valid statement-witness pairs. -/
@@ -103,7 +103,7 @@ end speciallySound
 
 section hvzk
 
-variable [SampleableType Chal] [unifSpec.Fintype] [unifSpec.Inhabited]
+variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
 /-- The honest prover's transcript distribution for a Σ-protocol. -/
 def realTranscript (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)

--- a/VCVio/CryptoFoundations/SignatureAlg.lean
+++ b/VCVio/CryptoFoundations/SignatureAlg.lean
@@ -137,7 +137,7 @@ lemma probOutput_bind_ge_of_forall_support
     _ = (1 - δ) * ∑' x, Pr[= x | gen] := by
         simp_rw [mul_comm]; exact ENNReal.tsum_mul_left
     _ = 1 - δ := by
-        rw [HasEvalPMF.tsum_probOutput_eq_one, mul_one]
+        rw [tsum_probOutput_of_liftM_PMF, mul_one]
 
 end correctness
 

--- a/VCVio/CryptoFoundations/SymmEncAlg.lean
+++ b/VCVio/CryptoFoundations/SymmEncAlg.lean
@@ -36,7 +36,7 @@ def CompleteExp (encAlg : SymmEncAlg m M K C) (msg : M) : m (Option M) := do
   let σ ← encAlg.encrypt k msg
   encAlg.decrypt k σ
 
-def Complete [HasEvalPMF m] (encAlg : SymmEncAlg m M K C) : Prop :=
+def Complete [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] (encAlg : SymmEncAlg m M K C) : Prop :=
   ∀ msg : M, Pr[= msg | encAlg.CompleteExp msg] = 1
 
 section perfectSecrecy
@@ -82,8 +82,10 @@ lemma PerfectSecrecyCipherExp_eq_bind [LawfulMonad m] (encAlg : SymmEncAlg m M K
         encAlg.PerfectSecrecyCipherGivenMsgExp msg := by
   simp [PerfectSecrecyCipherExp, PerfectSecrecyExp_eq_bind, monad_norm]
 
-variable [HasEvalPMF m]
+variable [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+  [MonadLiftT m SetM] [EvalDistCompatible m]
 
+omit [MonadLiftT m SetM] [EvalDistCompatible m] in
 lemma probOutput_PerfectSecrecyExp_eq_mul_cipherGivenMsg [LawfulMonad m]
     (encAlg : SymmEncAlg m M K C) (mgen : m M) (msg : M) (σ : C) :
     Pr[= (msg, σ) | encAlg.PerfectSecrecyExp mgen] =
@@ -110,6 +112,7 @@ lemma probOutput_PerfectSecrecyExp_eq_mul_cipherGivenMsg [LawfulMonad m]
           simp [hneq]
         · simp
 
+omit [MonadLiftT m SetM] [EvalDistCompatible m] in
 lemma probOutput_PerfectSecrecyCipherExp_eq_tsum [LawfulMonad m]
     (encAlg : SymmEncAlg m M K C) (mgen : m M) (σ : C) :
     Pr[= σ | encAlg.PerfectSecrecyCipherExp mgen] =
@@ -139,6 +142,8 @@ def ciphertextRowsEqualAt (encAlg : SymmEncAlg m M K C) : Prop :=
     Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp msg₀] =
       Pr[= σ | encAlg.PerfectSecrecyCipherGivenMsgExp msg₁]
 
+omit [LawfulMonadLiftT m PMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    in
 theorem perfectSecrecyAtAllPriors_iff_ciphertextRowsEqualAt
     (encAlg : SymmEncAlg m M K C) [Finite M] :
     encAlg.perfectSecrecyAtAllPriors ↔ encAlg.ciphertextRowsEqualAt := by
@@ -204,12 +209,16 @@ def perfectSecrecyJointFactorizationAt
     Pr[= (msg, σ) | encAlg.PerfectSecrecyExp mgen] =
       Pr[= msg | mgen] * Pr[= σ | encAlg.PerfectSecrecyCipherExp mgen]
 
+omit [LawfulMonadLiftT m PMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    in
 lemma perfectSecrecyAt_iff_posteriorEqPriorAt (encAlg : SymmEncAlg m M K C) :
     encAlg.perfectSecrecyAt ↔ encAlg.perfectSecrecyPosteriorEqPriorAt := by
   constructor <;> intro h <;> intro mgen msg σ
   · simpa [perfectSecrecyAt, perfectSecrecyPosteriorEqPriorAt, mul_comm] using h mgen msg σ
   · simpa [perfectSecrecyAt, perfectSecrecyPosteriorEqPriorAt, mul_comm] using h mgen msg σ
 
+omit [LawfulMonadLiftT m PMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    in
 lemma perfectSecrecyAt_iff_jointFactorizationAt (encAlg : SymmEncAlg m M K C) :
     encAlg.perfectSecrecyAt ↔ encAlg.perfectSecrecyJointFactorizationAt := by
   constructor
@@ -250,7 +259,7 @@ theorem cipherGivenMsg_uniform_of_uniformKey_of_uniqueKey
     have hsuppσ : support (encExp k0) = ({σ} : Set C) := by
       simpa [encExp, hσ_eq_c0] using hc0
     rw [probOutput_eq_one_iff]
-    exact ⟨HasEvalPMF.probFailure_eq_zero _, hsuppσ⟩
+    exact ⟨probFailure_of_liftM_PMF _, hsuppσ⟩
   simp only [PerfectSecrecyCipherGivenMsgExp, probOutput_bind_eq_tsum]
   calc
     ∑' k : K, Pr[= k | keyExp] * Pr[= σ | encExp k] =
@@ -318,7 +327,7 @@ theorem perfectSecrecyAt_of_uniformKey_of_uniqueKey [LawfulMonad m]
       _ = (∑' msg : M, Pr[= msg | mgen]) * invK := by
             rw [ENNReal.tsum_mul_right]
       _ = invK := by
-            rw [HasEvalPMF.tsum_probOutput_eq_one mgen, one_mul]
+            rw [tsum_probOutput_of_liftM_PMF mgen, one_mul]
   intro mgen msg σ
   calc
     Pr[= (msg, σ) | encAlg.PerfectSecrecyExp mgen] =

--- a/VCVio/EvalDist/BitVec.lean
+++ b/VCVio/EvalDist/BitVec.lean
@@ -8,7 +8,7 @@ import VCVio.EvalDist.Monad.Map
 /-!
 # Evaluation Distributions of Computations with `BitVec`
 
-Lemmas about `probOutput` involving `BitVec`, generic over any monad `m` with `[HasEvalSPMF m]`.
+Lemmas about `probOutput` involving `BitVec`, generic over any monad `m` with `[MonadLiftT m SPMF]`.
 
 The `SampleableType (BitVec n)` instance is defined in
 `VCVio.OracleComp.Constructions.SampleableType`.
@@ -16,7 +16,9 @@ The `SampleableType (BitVec n)` instance is defined in
 
 open BitVec
 
-variable {α β γ : Type _} {m : Type _ → Type _} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
+variable {α β γ : Type _} {m : Type _ → Type _} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 @[simp, grind =]
 lemma probOutput_ofFin_map {n : ℕ} (mx : m (Fin (2 ^ n))) (x : BitVec n) :
@@ -26,6 +28,7 @@ lemma probOutput_ofFin_map {n : ℕ} (mx : m (Fin (2 ^ n))) (x : BitVec n) :
 lemma probOutput_bitVec_toFin_map {n : ℕ} (mx : m (BitVec n)) (x : Fin (2 ^ n)) :
     Pr[= x | toFin <$> mx] = Pr[= ofFin x | mx] := by aesop
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 @[simp]
 lemma probOutput_xor_map {n : ℕ} (mx : m (BitVec n)) (x y : BitVec n) :
     Pr[= y | (x ^^^ ·) <$> mx] = Pr[= x ^^^ y | mx] := by

--- a/VCVio/EvalDist/Bool.lean
+++ b/VCVio/EvalDist/Bool.lean
@@ -9,39 +9,43 @@ import VCVio.EvalDist.Defs.NeverFails
 /-!
 # Evaluation Distributions on Boolean-Valued Computations
 
-Specialization lemmas for `HasEvalSPMF` computations returning `Bool`.
+Specialization lemmas for `MonadLiftT m SPMF` computations returning `Bool`.
 -/
 
-variable {m : Type _ → Type _} [Monad m] [HasEvalSPMF m] {α β : Type _}
+variable {m : Type _ → Type _} [Monad m] [MonadLiftT m SPMF] {α β : Type _}
 
+omit [Monad m] in
 @[simp, grind =]
 lemma probOutput_true_add_false (mx : m Bool) :
     Pr[= true | mx] + Pr[= false | mx] = 1 - Pr[⊥ | mx] := by
   have h := tsum_probOutput_eq_sub mx
   rwa [tsum_fintype (L := .unconditional _), Fintype.sum_bool] at h
 
+omit [Monad m] in
 @[simp, grind =]
 lemma probOutput_false_add_true (mx : m Bool) :
     Pr[= false | mx] + Pr[= true | mx] = 1 - Pr[⊥ | mx] := by
   rw [add_comm, probOutput_true_add_false]
 
+omit [Monad m] in
 lemma probOutput_true_eq_sub (mx : m Bool) :
     Pr[= true | mx] = 1 - Pr[⊥ | mx] - Pr[= false | mx] := by
   rw [← probOutput_true_add_false]
   exact (ENNReal.add_sub_cancel_right probOutput_ne_top).symm
 
+omit [Monad m] in
 lemma probOutput_false_eq_sub (mx : m Bool) :
     Pr[= false | mx] = 1 - Pr[⊥ | mx] - Pr[= true | mx] := by
   rw [← probOutput_false_add_true]
   exact (ENNReal.add_sub_cancel_right probOutput_ne_top).symm
 
 @[simp]
-lemma probOutput_not_map [LawfulMonad m] (mx : m Bool) :
+lemma probOutput_not_map [LawfulMonad m] [LawfulMonadLiftT m SPMF] (mx : m Bool) :
     Pr[= true | (! ·) <$> mx] = Pr[= false | mx] :=
   probOutput_map_injective mx (fun a b h => by cases a <;> cases b <;> simp_all) false
 
 @[simp]
-lemma probOutput_not_map' [LawfulMonad m] (mx : m Bool) :
+lemma probOutput_not_map' [LawfulMonad m] [LawfulMonadLiftT m SPMF] (mx : m Bool) :
     Pr[= false | (! ·) <$> mx] = Pr[= true | mx] :=
   probOutput_map_injective mx (fun a b h => by cases a <;> cases b <;> simp_all) true
 
@@ -49,15 +53,17 @@ lemma probOutput_not_map' [LawfulMonad m] (mx : m Bool) :
 lemma probOutput_true_add_false_of_neverFail {mx : m Bool} [NeverFail mx] :
     Pr[= true | mx] + Pr[= false | mx] = 1 := by simp
 
+omit [Monad m] in
 @[simp, grind =]
 lemma probEvent_true_eq_probOutput (mx : m Bool) :
     Pr[ (· = true) | mx] = Pr[= true | mx] := probEvent_eq_eq_probOutput mx true
 
+omit [Monad m] in
 @[simp, grind =]
 lemma probEvent_not_eq_probOutput (mx : m Bool) :
     Pr[ (· = false) | mx] = Pr[= false | mx] := probEvent_eq_eq_probOutput mx false
 
-lemma probOutput_true_bind_map_eq_probEvent [LawfulMonad m]
+lemma probOutput_true_bind_map_eq_probEvent [LawfulMonad m] [LawfulMonadLiftT m SPMF]
     (mx : m α) (my : α → m β) (p : α → β → Bool) :
     Pr[= true | mx >>= fun x => p x <$> my x] =
       Pr[fun (x, y) => p x y | do let x ← mx; return (x, ← my x)] := by

--- a/VCVio/EvalDist/Defs/AlternativeMonad.lean
+++ b/VCVio/EvalDist/Defs/AlternativeMonad.lean
@@ -8,7 +8,8 @@ import VCVio.EvalDist.Defs.Basic
 /-!
 # Denotational Semantics Over `AlternativeMonad`.
 
-This file defines a type-class for `HasEvalSet` when given an `AlternativeMonad` instance
+This file defines a type-class refining `MonadLiftT m SetM` when given an `AlternativeMonad`
+    instance
 on the base monad, enforcing that `failure` maps to the empty sub-distribution.
 
 Compatibility conditions then force the correct semantics for `evalDist`, see _.
@@ -20,37 +21,41 @@ universe u v w
 
 variable {m : Type u → Type v} [AlternativeMonad m] {α β γ : Type u}
 
-/-- Type-class for `HasEvalSet` when given an `AlternativeMonad` instance on the base monad,
-enforcing that `failure` maps to the empty sub-distribution.
-Compatibility conditions then force the correct semantics for `evalDist`, see below. -/
+/-- Refinement of `MonadLiftT m SetM` when given an `AlternativeMonad` instance on the
+base monad, enforcing that `failure` maps to the empty sub-distribution. Compatibility
+conditions then force the correct semantics for `evalDist`, see below. -/
 protected class HasEvalSet.LawfulFailure (m : Type u → Type v)
-    [AlternativeMonad m] [HasEvalSet m] : Prop where
+    [AlternativeMonad m] [MonadLiftT m SetM] : Prop where
   support_failure' {α : Type u} : support (failure : m α) = ∅
 
 open HasEvalSet (LawfulFailure)
 
 @[simp, grind =]
-lemma support_failure [HasEvalSet m] [LawfulFailure m] :
+lemma support_failure [MonadLiftT m SetM] [LawfulFailure m] :
     support (failure : m α) = ∅ :=
   HasEvalSet.LawfulFailure.support_failure'
 
 @[simp, grind =]
-lemma finSupport_failure [HasEvalSet m] [LawfulFailure m] [HasEvalFinset m]
+lemma finSupport_failure [MonadLiftT m SetM] [LawfulFailure m] [HasEvalFinset m]
     [DecidableEq α] : finSupport (failure : m α) = ∅ := by grind
 
 @[simp, grind =]
-lemma probOutput_failure [HasEvalSPMF m] [LawfulFailure m]
+lemma probOutput_failure [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [LawfulFailure m]
     (x : α) : Pr[= x | (failure : m α)] = 0 := by simp only [probOutput_eq_zero_iff,
       support_failure, Set.mem_empty_iff_false, not_false_eq_true]
 
 @[simp, grind =]
-lemma probEvent_failure [HasEvalSPMF m] [LawfulFailure m]
+lemma probEvent_failure [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [LawfulFailure m]
     (p : α → Prop) : Pr[ p | (failure : m α)] = 0 := by aesop
 
 @[simp, grind =]
-lemma probFailure_failure [HasEvalSPMF m] [LawfulFailure m] :
+lemma probFailure_failure [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [LawfulFailure m] :
     Pr[⊥ | (failure : m α)] = 1 := by simp
 
 @[simp, grind =]
-lemma evalDist_failure [HasEvalSPMF m] [LawfulFailure m] :
+lemma evalDist_failure [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [LawfulFailure m] :
     𝒟[(failure : m α)] = SPMF.mk (PMF.pure none) := by simp

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -24,8 +24,12 @@ variable {m : Type u → Type v} {α β γ : Type u}
 
 /-! ## `MonadLiftT m SetM` and `MonadLiftT m SPMF`
 
-Every lift exposed to users in this layer is declared as `MonadLiftT`, never
-`MonadLift`. There are two independent reasons.
+The `SetM` / `SPMF` lifts exposed by this layer are declared as `MonadLiftT`,
+not `MonadLift`. Total semantic sources may still expose a plain `MonadLift`
+into `PMF`; the important point here is that support is never obtained by a
+transitive `m → SPMF → SetM` path, and parameterized/typeclass-gated
+probability lifts avoid `MonadLift` instance search. There are two independent
+reasons.
 
 **No transitive `SPMF → SetM` lift.** The `MonadLiftT SPMF SetM` instance below
 exists so `support` and friends work on raw `SPMF α`. Crucially it is declared

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -9,7 +9,7 @@ import ToMathlib.ProbabilityTheory.SPMF
 /-!
 # Typeclasses for Denotational Monad Semantics
 
-This file defines typeclasses `HasEvalSPMF` and `HasEvalPMF` for assigning denotational
+This file builds atop `MonadLiftT m SPMF` / `MonadLiftT m PMF` for assigning denotational
 probability semantics to monadic computations. We also introduce functions
 `probOutput`, `probEvent`, and `probFailure` with associated notation.
 
@@ -20,45 +20,84 @@ open ENNReal
 
 universe u v w
 
-variable {m : Type u → Type v} [Monad m] {α β γ : Type u}
+variable {m : Type u → Type v} {α β γ : Type u}
 
-/-- The monad `m` can be evaluated to get a sub-distribution of outputs.
-Should not be implemented manually if a `HasEvalPMF` instance already exists. -/
-class HasEvalSPMF (m : Type u → Type v) [Monad m]
-    extends HasEvalSet m where
-  toSPMF : m →ᵐ SPMF
-  support_eq {α : Type u} (mx : m α) : support mx = SPMF.support (toSPMF mx)
-  toSet := MonadHom.comp {
-    toFun := @SPMF.support
-    toFun_pure' x := Set.ext fun _ => by simp
-    toFun_bind' p q := Set.ext fun x => by aesop
-   } toSPMF
+/-! ## `MonadLiftT m SetM` and `MonadLiftT m SPMF`
 
-/-- The resulting distribution of running the monadic computation `mx`.
-dtumad: I think we should eventually just deprecate this, just say `toSPMF`. -/
-def evalDist [HasEvalSPMF m] {α : Type u} (mx : m α) : SPMF α :=
-  HasEvalSPMF.toSPMF mx
+Every lift exposed to users in this layer is declared as `MonadLiftT`, never
+`MonadLift`. There are two independent reasons.
 
-/-- Evaluation distribution notation for any monad with `HasEvalSPMF`.
-For monads with `HasEvalPMF`, this uses the inherited `HasEvalSPMF`
-semantics. -/
+**No transitive `SPMF → SetM` lift.** The `MonadLiftT SPMF SetM` instance below
+exists so `support` and friends work on raw `SPMF α`. Crucially it is declared
+as `MonadLiftT` rather than `MonadLift`, which means Lean's `monadLiftTrans`
+(which requires `MonadLift n o` for the outer hop) cannot chain it: a monad
+`m` with `MonadLiftT m SPMF` does **not** automatically gain `MonadLiftT m SetM`
+via transitivity. Each monad declares its `MonadLiftT m SetM` directly — e.g.
+`OracleComp` uses the syntactic `simulateQ` into `SetM` (which doesn't require
+`[spec.Fintype]`), and `EvalDistCompatible` records the propositional coherence
+between that syntactic support and `SPMF.support ∘ evalDist`.
+
+**Resolution fragility for parameterized + typeclass-gated lifts.** Lifts whose
+source is parameterized (`OracleComp spec`, `OptionT m`, `StateT σ m`, …) and
+which are gated by a typeclass on the parameter (`[IsProbabilitySpec spec]`,
+`[MonadLiftT m SPMF]`, …) must also be `MonadLiftT`, not `MonadLift`. Demoting
+to `MonadLift` forces Lean to find the instance through its transitive
+instance, whose outer hop is `MonadLift n o` with `n` a `semiOutParam`. When
+the recursion lands on a parameterized head like `MonadLift (OracleComp ?spec) PMF`,
+Lean has to simultaneously unify `?spec` through the `semiOutParam`, discharge
+the typeclass premise on `?spec`, and pin down `?spec` from the inner reflexive
+premise — a combination Lean's instance search refuses to chase. The direct
+`MonadLiftT` declaration sidesteps this with a single-step head match. -/
+
+/-- Direct `MonadLiftT SPMF SetM` (only on `SPMF` itself — not the transitive
+`MonadLift` that would create a diamond). -/
+instance instMonadLiftTSPMFSetM : MonadLiftT SPMF SetM where
+  monadLift := SPMF.support
+
+instance instLawfulMonadLiftTSPMFSetM : LawfulMonadLiftT SPMF SetM where
+  monadLift_pure := SPMF.support_pure
+  monadLift_bind := SPMF.support_bind
+
+/-- Coherence between `support` (via `MonadLiftT m SetM`) and `evalDist`
+(via `MonadLiftT m SPMF`): `x ∈ support mx` iff `Pr[= x | mx] ≠ 0`.
+
+This typeclass is exported by every monad that admits both lifts and they
+agree on outputs — i.e. `support mx = SPMF.support (evalDist mx)`. -/
+class EvalDistCompatible (m : Type u → Type v) [MonadLiftT m SetM]
+    [MonadLiftT m SPMF] : Prop where
+  /-- The reachable outputs of `mx` (via `support`) are exactly the outputs with
+  nonzero probability in `evalDist mx`. -/
+  support_eq_SPMF_support {α : Type u} (mx : m α) :
+    SetM.run (liftM mx : SetM α) = SPMF.support (liftM mx : SPMF α)
+
+export EvalDistCompatible (support_eq_SPMF_support)
+
+/-- `SPMF` is trivially compatible: both lifts coincide on the nose. -/
+instance : EvalDistCompatible SPMF where
+  support_eq_SPMF_support _ := rfl
+
+/-- The resulting distribution of running the monadic computation `mx`. -/
+@[reducible, inline]
+def evalDist [MonadLiftT m SPMF] {α : Type u} (mx : m α) : SPMF α := liftM mx
+
+/-- Evaluation distribution notation for any monad lifting into `SPMF`. -/
 notation "𝒟[" mx "]" => evalDist mx
 
-lemma evalDist_def [HasEvalSPMF m] {α : Type u} (mx : m α) :
-    𝒟[mx] = HasEvalSPMF.toSPMF mx := rfl
+lemma evalDist_def [MonadLiftT m SPMF] {α : Type u} (mx : m α) :
+    𝒟[mx] = liftM mx := rfl
 
 section probability_notation
 
 /-- Probability that a computation `mx` returns the value `x`. -/
-def probOutput [HasEvalSPMF m] (mx : m α) (x : α) : ℝ≥0∞ :=
+def probOutput [MonadLiftT m SPMF] (mx : m α) (x : α) : ℝ≥0∞ :=
   𝒟[mx] x
 
 /-- Probability that a computation `mx` outputs a value satisfying `p`. -/
-noncomputable def probEvent [HasEvalSPMF m] (mx : m α) (p : α → Prop) : ℝ≥0∞ :=
+noncomputable def probEvent [MonadLiftT m SPMF] (mx : m α) (p : α → Prop) : ℝ≥0∞ :=
   (𝒟[mx]).run.toOuterMeasure (some '' {x | p x})
 
 /-- Probability that a computation `mx` will fail to return a value. -/
-def probFailure [HasEvalSPMF m] (mx : m α) : ℝ≥0∞ :=
+def probFailure [MonadLiftT m SPMF] (mx : m α) : ℝ≥0∞ :=
   (𝒟[mx]).run none
 
 /-- Probability that a computation returns a particular output. -/
@@ -73,16 +112,18 @@ notation "Pr[⊥" " | " mx "]" => probFailure mx
 
 section probOutput
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF]
 
 -- dtumad: I think maybe we want to simp in the `←` direction here?
 @[aesop norm (rule_sets := [UnfoldEvalDist]), grind =]
 lemma probOutput_def (mx : m α) (x : α) : Pr[= x | mx] = evalDist mx x := rfl
 
+variable [MonadLiftT m SetM] [EvalDistCompatible m]
+
 @[grind =]
 lemma mem_support_iff (mx : m α) (x : α) :
     x ∈ support mx ↔ Pr[= x | mx] ≠ 0 := by
-  simp [HasEvalSPMF.support_eq, probOutput_def, evalDist_def]
+  rw [support_def, support_eq_SPMF_support, SPMF.mem_support_iff, probOutput_def, evalDist_def]
 
 lemma mem_support_iff_evalDist_apply_ne_zero (mx : m α) (x : α) :
     x ∈ support mx ↔ 𝒟[mx] x ≠ 0 := by grind
@@ -128,7 +169,7 @@ lemma probOutput_pos_iff' [HasEvalFinset m] [DecidableEq α] :
     0 < Pr[= x | mx] ↔ x ∈ finSupport mx := by grind
 alias ⟨mem_finSupport_of_probOutput_pos, probOutput_pos'⟩ := probOutput_pos_iff'
 
-instance decidablePred_probOutput_eq_zero [HasEvalSPMF m]
+instance decidablePred_probOutput_eq_zero
     [hm : HasEvalSet.Decidable m] (mx : m α) :
     DecidablePred (Pr[= · | mx] = 0) := by
   simp only [probOutput_eq_zero_iff]
@@ -150,45 +191,45 @@ end probOutput
 section probEvent
 
 @[aesop norm (rule_sets := [UnfoldEvalDist])]
-lemma probEvent_def [HasEvalSPMF m] (mx : m α) (p : α → Prop) :
+lemma probEvent_def [MonadLiftT m SPMF] (mx : m α) (p : α → Prop) :
     Pr[ p | mx] = (𝒟[mx]).run.toOuterMeasure (some '' {x | p x}) := rfl
 
 @[grind =]
-lemma probEvent_eq_tsum_indicator [HasEvalSPMF m] (mx : m α) (p : α → Prop) :
+lemma probEvent_eq_tsum_indicator [MonadLiftT m SPMF] (mx : m α) (p : α → Prop) :
     Pr[ p | mx] = ∑' x : α, {x | p x}.indicator (Pr[= · | mx]) x := by
   simp [probEvent_def, PMF.toOuterMeasure_apply, tsum_option _ ENNReal.summable,
     Set.indicator_image (Option.some_injective _), Function.comp_def, probOutput_def,
     SPMF.apply_eq_toPMF_some]
 
 @[grind =]
-lemma probEvent_eq_sum_fintype_indicator [HasEvalSPMF m] [Fintype α]
+lemma probEvent_eq_sum_fintype_indicator [MonadLiftT m SPMF] [Fintype α]
     (mx : m α) (p : α → Prop) : Pr[ p | mx] = ∑ x : α, {x | p x}.indicator (Pr[= · | mx]) x :=
   (probEvent_eq_tsum_indicator mx p).trans (tsum_fintype _)
 
 @[grind =]
-lemma probEvent_eq_tsum_ite [HasEvalSPMF m] (mx : m α) (p : α → Prop) [DecidablePred p] :
+lemma probEvent_eq_tsum_ite [MonadLiftT m SPMF] (mx : m α) (p : α → Prop) [DecidablePred p] :
     Pr[ p | mx] = ∑' x : α, if p x then Pr[= x | mx] else 0 := by
   grind [Set.indicator]
 
 @[grind =]
-lemma probEvent_eq_sum_fintype_ite [HasEvalSPMF m] [Fintype α] (mx : m α)
+lemma probEvent_eq_sum_fintype_ite [MonadLiftT m SPMF] [Fintype α] (mx : m α)
     (p : α → Prop) [DecidablePred p] : Pr[ p | mx] = ∑ x : α, if p x then Pr[= x | mx] else 0 := by
   grind [Set.indicator]
 
-lemma probEvent_eq_tsum_subtype [HasEvalSPMF m] (mx : m α) (p : α → Prop) :
+lemma probEvent_eq_tsum_subtype [MonadLiftT m SPMF] (mx : m α) (p : α → Prop) :
     Pr[ p | mx] = ∑' x : {x | p x}, Pr[= x | mx] := by
   rw [probEvent_eq_tsum_indicator, tsum_subtype]
 
-lemma probEvent_eq_sum_filter_univ [HasEvalSPMF m] [Fintype α]
+lemma probEvent_eq_sum_filter_univ [MonadLiftT m SPMF] [Fintype α]
     (mx : m α) (p : α → Prop) [DecidablePred p] :
     Pr[ p | mx] = ∑ x ∈ Finset.univ.filter p, Pr[= x | mx] := by
   rw [probEvent_eq_sum_fintype_ite, Finset.sum_filter]
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF]
 
 section zero
 
-variable {mx : m α} {p : α → Prop}
+variable [MonadLiftT m SetM] [EvalDistCompatible m] {mx : m α} {p : α → Prop}
 
 @[simp, grind =]
 lemma probEvent_eq_zero_iff :
@@ -221,6 +262,10 @@ lemma probEvent_pos_iff' [HasEvalFinset m] [DecidableEq α] :
 alias ⟨_, probEvent_pos'⟩ := probEvent_pos_iff'
 
 end zero
+
+section supportMixed
+
+variable [MonadLiftT m SetM] [EvalDistCompatible m]
 
 lemma probEvent_eq_tsum_subtype_mem_support (mx : m α) (p : α → Prop) :
     Pr[ p | mx] = ∑' x : {x ∈ support mx | p x}, Pr[= x | mx] := by
@@ -266,6 +311,8 @@ lemma probEvent_ext {mx : m α} {p q : α → Prop}
   refine tsum_congr fun x => ?_
   split_ifs <;> grind
 
+end supportMixed
+
 @[simp, grind =_, aesop unsafe norm]
 lemma probEvent_eq_eq_probOutput (mx : m α) (x : α) :
     Pr[ (· = x) | mx] = Pr[= x | mx] := by
@@ -275,14 +322,15 @@ lemma probEvent_eq_eq_probOutput (mx : m α) (x : α) :
 @[simp, grind =_, aesop unsafe norm]
 lemma probEvent_eq_eq_probOutput' (mx : m α) (x : α) :
     Pr[ (x = ·) | mx] = Pr[= x | mx] := by
-  grind
+  have h : (fun y => x = y) = (fun y => y = x) := funext fun _ => propext eq_comm
+  rw [h]; exact probEvent_eq_eq_probOutput mx x
 
 end probEvent
 
 section probFailure
 
 @[aesop norm (rule_sets := [UnfoldEvalDist]), grind =]
-lemma probFailure_def [HasEvalSPMF m] (mx : m α) :
+lemma probFailure_def [MonadLiftT m SPMF] (mx : m α) :
     Pr[⊥ | mx] = (𝒟[mx]).run none := rfl
 
 end probFailure
@@ -305,7 +353,7 @@ macro_rules (kind := probEventBinding2)
   | `(Pr{$items*}[$t]) => `(probOutput (do $items:doSeqItem* return $t:term) True)
 
 /-- Tests for all the different probability notations. -/
-noncomputable example {m : Type → Type u} [Monad m] [HasEvalSPMF m] (mx : m ℕ) : Unit :=
+noncomputable example {m : Type → Type u} [Monad m] [MonadLiftT m SPMF] (mx : m ℕ) : Unit :=
   let _ := Pr[= 10 | mx]
   let _ := Pr[ fun x => x^2 + x < 10 | mx]
   let _ := Pr[ x^2 + x < 10 | x ← mx]
@@ -316,37 +364,38 @@ noncomputable example {m : Type → Type u} [Monad m] [HasEvalSPMF m] (mx : m �
 end probability_notation
 
 @[simp] -- TODO: versions for other constructions?
-lemma evalDist_cast {m} [Monad m] [HasEvalSPMF m] (h : α = β) (mx : m α) :
+lemma evalDist_cast {m} [Monad m] [MonadLiftT m SPMF] (h : α = β) (mx : m α) :
     𝒟[cast (congrArg m h) mx] =
       cast (congrArg SPMF h) (𝒟[mx]) := by
   induction h; rfl
 
-lemma evalDist_ext {m n} [Monad m] [HasEvalSPMF m] [Monad n] [HasEvalSPMF n]
+lemma evalDist_ext {m n} [Monad m] [MonadLiftT m SPMF] [Monad n] [MonadLiftT n SPMF]
     {mx : m α} {mx' : n α} (h : ∀ x, Pr[= x | mx] = Pr[= x | mx']) : 𝒟[mx] = 𝒟[mx'] :=
   SPMF.ext h
 
-lemma evalDist_ext_iff {m n} [Monad m] [HasEvalSPMF m] [Monad n] [HasEvalSPMF n]
+lemma evalDist_ext_iff {m n} [Monad m] [MonadLiftT m SPMF] [Monad n] [MonadLiftT n SPMF]
     {mx : m α} {mx' : n α} : 𝒟[mx] = 𝒟[mx'] ↔ ∀ x, Pr[= x | mx] = Pr[= x | mx'] := by
   refine ⟨fun h => ?_, evalDist_ext⟩
   simp [probOutput_def, h]
 
 @[simp, grind =]
-lemma evalDist_eq_liftM_iff [HasEvalSPMF m] (mx : m α) (p : PMF α) :
+lemma evalDist_eq_liftM_iff [MonadLiftT m SPMF] (mx : m α) (p : PMF α) :
     𝒟[mx] = liftM p ↔ ∀ x, Pr[= x | mx] = p x := by
   refine ⟨fun h x => ?_, fun h => ?_⟩
   · simp [probOutput_def, h]
   · simpa [SPMF.eq_liftM_iff_forall, probOutput_def] using h
 
 @[simp, grind =]
-lemma evalDist_eq_mk_iff [HasEvalSPMF m] (mx : m α) (p : PMF (Option α)) :
+lemma evalDist_eq_mk_iff [MonadLiftT m SPMF] (mx : m α) (p : PMF (Option α)) :
     𝒟[mx] = SPMF.mk p ↔ ∀ x, Pr[= x | mx] = p (some x) := by aesop
 
 @[aesop unsafe apply]
-lemma evalDist_eq_liftM [HasEvalSPMF m] {mx : m α} {p : PMF α}
+lemma evalDist_eq_liftM [MonadLiftT m SPMF] {mx : m α} {p : PMF α}
     (h : ∀ x, Pr[= x | mx] = p x) : 𝒟[mx] = liftM p := by aesop
 
 @[simp]
-lemma evalDist_apply_eq_zero_iff [HasEvalSPMF m] (mx : m α)
+lemma evalDist_apply_eq_zero_iff [MonadLiftT m SPMF] [MonadLiftT m SetM]
+    [EvalDistCompatible m] (mx : m α)
     (x : Option α) :
     (𝒟[mx]).run x = 0 ↔ x.rec (Pr[⊥ | mx] = 0) (· ∉ support mx) := by
   induction x with
@@ -355,7 +404,8 @@ lemma evalDist_apply_eq_zero_iff [HasEvalSPMF m] (mx : m α)
       SPMF.apply_eq_toPMF_some, SPMF.toPMF]
 
 @[simp]
-lemma evalDist_apply_eq_zero_iff' [HasEvalSPMF m] [HasEvalFinset m] [DecidableEq α] (mx : m α)
+lemma evalDist_apply_eq_zero_iff' [MonadLiftT m SPMF] [MonadLiftT m SetM]
+    [EvalDistCompatible m] [HasEvalFinset m] [DecidableEq α] (mx : m α)
     (x : Option α) : (𝒟[mx]).run x = 0 ↔ x.rec (Pr[⊥ | mx] = 0) (· ∉ finSupport mx) := by
   rw [evalDist_apply_eq_zero_iff]
   grind
@@ -364,32 +414,32 @@ section ite
 
 variable (p : Prop) [Decidable p]
 
-@[simp] lemma evalDist_ite [HasEvalSPMF m] (mx mx' : m α) :
+@[simp] lemma evalDist_ite [MonadLiftT m SPMF] (mx mx' : m α) :
     𝒟[if p then mx else mx'] = if p then 𝒟[mx] else 𝒟[mx'] := by grind
 
-@[simp] lemma probOutput_ite [HasEvalSPMF m] (x : α) (mx mx' : m α) :
+@[simp] lemma probOutput_ite [MonadLiftT m SPMF] (x : α) (mx mx' : m α) :
     Pr[= x | if p then mx else mx'] = if p then Pr[= x | mx] else Pr[= x | mx'] := by aesop
 
-@[simp] lemma probFailure_ite [HasEvalSPMF m] (mx mx' : m α) :
+@[simp] lemma probFailure_ite [MonadLiftT m SPMF] (mx mx' : m α) :
     Pr[⊥ | if p then mx else mx'] = if p then Pr[⊥ | mx] else Pr[⊥ | mx'] := by grind
 
-@[simp] lemma probEvent_ite [HasEvalSPMF m] (mx mx' : m α) (q : α → Prop) :
+@[simp] lemma probEvent_ite [MonadLiftT m SPMF] (mx mx' : m α) (q : α → Prop) :
     Pr[ q | if p then mx else mx'] = if p then Pr[ q | mx] else Pr[ q | mx'] := by aesop
 
 end ite
 
 section eqRec
 
-lemma evalDist_eqRec [HasEvalSPMF m] (h : α = β) (mx : m α) :
+lemma evalDist_eqRec [MonadLiftT m SPMF] (h : α = β) (mx : m α) :
     𝒟[(h ▸ mx : m β)] = h ▸ 𝒟[mx] := by grind
 
-lemma probOutput_eqRec [HasEvalSPMF m] (h : α = β) (mx : m α) (y : β) :
+lemma probOutput_eqRec [MonadLiftT m SPMF] (h : α = β) (mx : m α) (y : β) :
     Pr[= y | h ▸ mx] = Pr[= h ▸ y | mx] := by grind
 
-@[simp] lemma probFailure_eqRec [HasEvalSPMF m] (h : α = β) (mx : m α) :
+@[simp] lemma probFailure_eqRec [MonadLiftT m SPMF] (h : α = β) (mx : m α) :
     Pr[⊥ | h ▸ mx] = Pr[⊥ | mx] := by grind
 
-lemma probEvent_eqRec [HasEvalSPMF m] (h : α = β) (mx : m α) (q : β → Prop) :
+lemma probEvent_eqRec [MonadLiftT m SPMF] (h : α = β) (mx : m α) (q : β → Prop) :
     Pr[ q | h ▸ mx] = Pr[ fun x ↦ q (h ▸ x) | mx] := by induction h; rfl
 
 end eqRec
@@ -397,16 +447,17 @@ end eqRec
 section sums
 
 /-- Connection between the two different probability notations. -/
-lemma probOutput_true_eq_probEvent {α} {m : Type → Type u} [Monad m] [HasEvalSPMF m]
+lemma probOutput_true_eq_probEvent {α} {m : Type → Type u} [Monad m]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (mx : m α) (p : α → Prop) : Pr{let x ← mx}[p x] = Pr[ p | mx] := by
   simp [probEvent_eq_tsum_indicator, probOutput_def, evalDist, map_eq_bind_pure_comp]
   congr 1; aesop
 
-@[simp] lemma tsum_probOutput_add_probFailure [HasEvalSPMF m] (mx : m α) :
+@[simp] lemma tsum_probOutput_add_probFailure [MonadLiftT m SPMF] (mx : m α) :
     (∑' x, Pr[= x | mx]) + Pr[⊥ | mx] = 1 := by
   aesop (rule_sets := [UnfoldEvalDist])
 
-@[simp] lemma probFailure_add_tsum_probOutput [HasEvalSPMF m] (mx : m α) :
+@[simp] lemma probFailure_add_tsum_probOutput [MonadLiftT m SPMF] (mx : m α) :
     Pr[⊥ | mx] + ∑' x, Pr[= x | mx] = 1 := by
   aesop (rule_sets := [UnfoldEvalDist])
 
@@ -416,55 +467,55 @@ section bounds
 
 variable {mx : m α} {mxe : OptionT m α} {x : α} {p : α → Prop}
 
-@[simp, grind .] lemma probOutput_le_one [HasEvalSPMF m] :
+@[simp, grind .] lemma probOutput_le_one [MonadLiftT m SPMF] :
     Pr[= x | mx] ≤ 1 := PMF.coe_le_one (𝒟[mx]) x
-@[simp, grind .] lemma probOutput_ne_top [HasEvalSPMF m] :
+@[simp, grind .] lemma probOutput_ne_top [MonadLiftT m SPMF] :
     Pr[= x | mx] ≠ ∞ := PMF.apply_ne_top (𝒟[mx]) x
-@[simp, grind .] lemma probOutput_lt_top [HasEvalSPMF m] :
+@[simp, grind .] lemma probOutput_lt_top [MonadLiftT m SPMF] :
     Pr[= x | mx] < ∞ := PMF.apply_lt_top (𝒟[mx]) x
-@[simp, grind .] lemma not_one_lt_probOutput [HasEvalSPMF m] :
+@[simp, grind .] lemma not_one_lt_probOutput [MonadLiftT m SPMF] :
     ¬ 1 < Pr[= x | mx] := not_lt.2 probOutput_le_one
 
-@[simp] lemma tsum_probOutput_le_one [HasEvalSPMF m] : ∑' x : α, Pr[= x | mx] ≤ 1 :=
+@[simp] lemma tsum_probOutput_le_one [MonadLiftT m SPMF] : ∑' x : α, Pr[= x | mx] ≤ 1 :=
   le_of_le_of_eq (le_add_self) (probFailure_add_tsum_probOutput mx)
-@[simp] lemma tsum_probOutput_ne_top [HasEvalSPMF m] : ∑' x : α, Pr[= x | mx] ≠ ⊤ :=
+@[simp] lemma tsum_probOutput_ne_top [MonadLiftT m SPMF] : ∑' x : α, Pr[= x | mx] ≠ ⊤ :=
   ne_top_of_le_ne_top one_ne_top tsum_probOutput_le_one
 
-@[simp, grind .] lemma probEvent_le_one [HasEvalSPMF m] : Pr[ p | mx] ≤ 1 := by
+@[simp, grind .] lemma probEvent_le_one [MonadLiftT m SPMF] : Pr[ p | mx] ≤ 1 := by
   rw [probEvent_def, PMF.toOuterMeasure_apply]
   refine le_of_le_of_eq (ENNReal.tsum_le_tsum ?_) ((𝒟[mx]).tsum_coe)
   exact Set.indicator_le_self (some '' {x | p x}) _
 
-@[simp, grind .] lemma probEvent_ne_top [HasEvalSPMF m] :
+@[simp, grind .] lemma probEvent_ne_top [MonadLiftT m SPMF] :
     Pr[ p | mx] ≠ ∞ := ne_top_of_le_ne_top one_ne_top probEvent_le_one
-@[simp, grind .] lemma probEvent_lt_top [HasEvalSPMF m] :
+@[simp, grind .] lemma probEvent_lt_top [MonadLiftT m SPMF] :
     Pr[ p | mx] < ∞ := lt_top_iff_ne_top.2 probEvent_ne_top
-@[simp, grind .] lemma not_one_lt_probEvent [HasEvalSPMF m] :
+@[simp, grind .] lemma not_one_lt_probEvent [MonadLiftT m SPMF] :
     ¬ 1 < Pr[ p | mx] := not_lt.2 probEvent_le_one
 
-@[simp, grind .] lemma probFailure_le_one [HasEvalSPMF m] :
+@[simp, grind .] lemma probFailure_le_one [MonadLiftT m SPMF] :
     Pr[⊥ | mx] ≤ 1 := PMF.coe_le_one (𝒟[mx]) none
-@[simp, grind .] lemma probFailure_ne_top [HasEvalSPMF m] :
+@[simp, grind .] lemma probFailure_ne_top [MonadLiftT m SPMF] :
     Pr[⊥ | mx] ≠ ∞ := PMF.apply_ne_top (𝒟[mx]) none
-@[simp, grind .] lemma probFailure_lt_top [HasEvalSPMF m] :
+@[simp, grind .] lemma probFailure_lt_top [MonadLiftT m SPMF] :
     Pr[⊥ | mx] < ∞ := PMF.apply_lt_top (𝒟[mx]) none
-@[simp, grind .] lemma not_one_lt_probFailure [HasEvalSPMF m] :
+@[simp, grind .] lemma not_one_lt_probFailure [MonadLiftT m SPMF] :
     ¬ 1 < Pr[⊥ | mx] := not_lt.2 probFailure_le_one
 
 @[simp, grind =]
-lemma one_le_probOutput_iff [HasEvalSPMF m] : 1 ≤ Pr[= x | mx] ↔ Pr[= x | mx] = 1 := by
+lemma one_le_probOutput_iff [MonadLiftT m SPMF] : 1 ≤ Pr[= x | mx] ↔ Pr[= x | mx] = 1 := by
   simp only [le_iff_eq_or_lt, not_one_lt_probOutput, or_false, eq_comm]
 
 @[simp, grind =]
-lemma one_le_probEvent_iff [HasEvalSPMF m] : 1 ≤ Pr[ p | mx] ↔ Pr[ p | mx] = 1 := by
+lemma one_le_probEvent_iff [MonadLiftT m SPMF] : 1 ≤ Pr[ p | mx] ↔ Pr[ p | mx] = 1 := by
   simp only [le_iff_eq_or_lt, not_one_lt_probEvent, or_false, eq_comm]
 
 @[simp, grind =]
-lemma one_le_probFailure_iff [HasEvalSPMF m] : 1 ≤ Pr[⊥ | mx] ↔ Pr[⊥ | mx] = 1 := by
+lemma one_le_probFailure_iff [MonadLiftT m SPMF] : 1 ≤ Pr[⊥ | mx] ↔ Pr[⊥ | mx] = 1 := by
   simp only [le_iff_eq_or_lt, not_one_lt_probFailure, or_false, eq_comm]
 
 @[simp, grind =]
-lemma probOutput_eq_one_iff [HasEvalSPMF m] :
+lemma probOutput_eq_one_iff [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m] :
     Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by
   rw [← probEvent_eq_eq_probOutput]
   simp [probOutput_def, probFailure_def, SPMF.apply_eq_toPMF_some, PMF.apply_eq_one_iff,
@@ -472,25 +523,28 @@ lemma probOutput_eq_one_iff [HasEvalSPMF m] :
 alias ⟨_, probOutput_eq_one⟩ := probOutput_eq_one_iff
 
 @[simp, grind =]
-lemma one_eq_probOutput_iff [HasEvalSPMF m] :
+lemma one_eq_probOutput_iff [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m] :
     1 = Pr[= x | mx] ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by
   rw [eq_comm, probOutput_eq_one_iff]
 alias ⟨_, one_eq_probOutput⟩ := one_eq_probOutput_iff
 
 @[simp, grind =]
-lemma probOutput_eq_one_iff' [HasEvalSPMF m] [HasEvalFinset m] [DecidableEq α] :
+lemma probOutput_eq_one_iff' [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α] :
     Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ finSupport mx = {x} := by
   rw [probOutput_eq_one_iff, finSupport_eq_iff_support_eq_coe, Finset.coe_singleton]
 alias ⟨_, probOutput_eq_one'⟩ := probOutput_eq_one_iff'
 
 @[simp, grind =]
-lemma one_eq_probOutput_iff' [HasEvalSPMF m] [HasEvalFinset m] [DecidableEq α] :
+lemma one_eq_probOutput_iff' [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α] :
     1 = Pr[= x | mx] ↔ Pr[⊥ | mx] = 0 ∧ finSupport mx = {x} := by
   rw [eq_comm, probOutput_eq_one_iff']
 alias ⟨_, one_eq_probOutput'⟩ := one_eq_probOutput_iff'
 
 /-- If a non-failing computation can only return `x`, then it returns `x` with probability one. -/
-lemma probOutput_eq_one_of_support_subset_singleton [HasEvalSPMF m]
+lemma probOutput_eq_one_of_support_subset_singleton [MonadLiftT m SPMF] [MonadLiftT m SetM]
+    [EvalDistCompatible m]
     (hnf : Pr[⊥ | mx] = 0) (huniq : ∀ y ∈ support mx, y = x) :
     Pr[= x | mx] = 1 := by
   have hnot : ∀ y ≠ x, Pr[= y | mx] = 0 :=
@@ -505,7 +559,7 @@ end bounds
 
 section mono_le
 
-variable [HasEvalSPMF m] (mx : m α) (r : ℝ≥0∞)
+variable [MonadLiftT m SPMF] (mx : m α) (r : ℝ≥0∞)
 
 @[simp]
 lemma probFailure_mul_le : Pr[⊥ | mx] * r ≤ r :=
@@ -531,7 +585,7 @@ end mono_le
 
 section sum_probOutput
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF]
 
 @[simp]
 lemma tsum_probOutput_eq_sub (mx : m α) :
@@ -542,11 +596,12 @@ lemma tsum_probOutput_eq_one' {mx : m α} (h : Pr[⊥ | mx] = 0) :
     ∑' x : α, Pr[= x | mx] = 1 := by simp [h]
 
 @[simp]
-lemma tsum_support_probOutput_eq_sub (mx : m α) :
+lemma tsum_support_probOutput_eq_sub [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) :
     ∑' x : support mx, Pr[= x | mx] = 1 - Pr[⊥ | mx] := by
   rw [tsum_subtype_eq_of_support_subset] <;> simp
 
-lemma tsum_support_probOutput_eq_one' {mx : m α} (h : Pr[⊥ | mx] = 0) :
+lemma tsum_support_probOutput_eq_one' [MonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} (h : Pr[⊥ | mx] = 0) :
     ∑' x : support mx, Pr[= x | mx] = 1 := by simp [h]
 
 @[simp]
@@ -558,33 +613,36 @@ lemma sum_probOutput_eq_one [Fintype α] {mx : m α} (h : Pr[⊥ | mx] = 0) :
     ∑ x : α, Pr[= x | mx] = 1 := by simp [h]
 
 @[simp]
-lemma sum_finSupport_probOutput_eq_sub [HasEvalFinset m] [DecidableEq α] (mx : m α) :
+lemma sum_finSupport_probOutput_eq_sub [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α] (mx : m α) :
     ∑ x ∈ finSupport mx, Pr[= x | mx] = 1 - Pr[⊥ | mx] := by
   rw [← tsum_probOutput_eq_sub, tsum_eq_sum]
   simp
 
-lemma sum_finSupport_probOutput_eq_one [HasEvalFinset m] [DecidableEq α]
+lemma sum_finSupport_probOutput_eq_one [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α]
     {mx : m α} (h : Pr[⊥ | mx] = 0) : ∑ x ∈ finSupport mx, Pr[= x | mx] = 1 := by simp [h]
 
 end sum_probOutput
 
 @[grind =]
-lemma probFailure_eq_sub_tsum [HasEvalSPMF m] (mx : m α) :
+lemma probFailure_eq_sub_tsum [MonadLiftT m SPMF] (mx : m α) :
     Pr[⊥ | mx] = 1 - ∑' x : α, Pr[= x | mx] := by
   refine ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top tsum_probOutput_le_one)
     (probFailure_add_tsum_probOutput mx)
 
-lemma probFailure_eq_sub_sum [HasEvalSPMF m] [Fintype α] (mx : m α) :
+lemma probFailure_eq_sub_sum [MonadLiftT m SPMF] [Fintype α] (mx : m α) :
     Pr[⊥ | mx] = 1 - ∑ x : α, Pr[= x | mx] := by
   rw [← tsum_fintype (L := .unconditional _), probFailure_eq_sub_tsum]
 
 section bool
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF]
 
 @[simp]
 lemma probEvent_False (mx : m α) :
-    Pr[ fun _ => False | mx] = 0 := by grind
+    Pr[ fun _ => False | mx] = 0 := by
+  simp [probEvent_eq_tsum_indicator]
 
 @[simp]
 lemma probEvent_false (mx : m α) :
@@ -610,11 +668,13 @@ lemma probFailure_eq_one_iff_probEvent_true (mx : m α) :
   simp [tsub_eq_zero_iff_le, ENNReal.toReal_eq_one_iff]
 
 @[simp, grind =]
-lemma probFailure_eq_one_iff (mx : m α) : Pr[⊥ | mx] = 1 ↔ support mx = ∅ := by
+lemma probFailure_eq_one_iff [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) :
+    Pr[⊥ | mx] = 1 ↔ support mx = ∅ := by
   simp [probFailure_eq_one_iff_probEvent_true, probEvent_eq_tsum_subtype_mem_support, Set.ext_iff]
 
 @[aesop unsafe forward]
-lemma probFailure_eq_one {mx : m α} (h : support mx = ∅) : Pr[⊥ | mx] = 1 := by grind
+lemma probFailure_eq_one [MonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} (h : support mx = ∅) : Pr[⊥ | mx] = 1 := by grind
 
 @[simp, aesop norm]
 lemma probEvent_const (mx : m α) (p : Prop) [Decidable p] :
@@ -623,66 +683,85 @@ lemma probEvent_const (mx : m α) (p : Prop) [Decidable p] :
 
 end bool
 
-/-- The monad `m` can be evaluated to get a distribution of outputs. -/
-class HasEvalPMF (m : Type u → Type v) [Monad m]
-    extends HasEvalSPMF m where
-  toPMF : m →ᵐ PMF
-  toSPMF := MonadHom.comp (MonadHom.ofLift PMF SPMF) toPMF
-  toSPMF_eq {α : Type u} (mx : m α) : toSPMF mx = liftM (toPMF mx) := by rfl
+/-! ### Lemmas for monads with a total `PMF` denotation
 
-attribute [grind =] HasEvalPMF.toSPMF_eq
+These lemmas hold when `m` lifts into `PMF` (so computations never fail). They expose the
+absence of failure mass and total normalization of the resulting distribution. -/
 
-namespace HasEvalPMF
+section pmf_denotation
 
-variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
-  [HasEvalPMF m] (mx : m α) (x : α)
+variable {α β γ : Type u} {m : Type u → Type v}
+  [MonadLiftT m PMF]
 
-lemma evalDist_of_hasEvalPMF_def (mx : m α) :
-    𝒟[mx] = liftM (HasEvalPMF.toPMF mx) := by
-  simp [evalDist_def, HasEvalPMF.toSPMF_eq]
-
-/-- The `evalDist` arising from a `HasEvalPMF` instance never fails. -/
+/-- A computation interpreted via a `PMF` lift has zero failure probability. -/
 @[simp, grind =]
-lemma probFailure_eq_zero (mx : m α) : Pr[⊥ | mx] = 0 := by
-  simp [probFailure_def, evalDist_of_hasEvalPMF_def]
+lemma probFailure_of_liftM_PMF (mx : m α) : Pr[⊥ | mx] = 0 := by
+  rw [probFailure_def, show 𝒟[mx] = (liftM (liftM mx : PMF α) : SPMF α) from rfl,
+    SPMF.run_eq_toPMF]
+  change (some <$> (liftM mx : PMF α)) none = 0
+  simp [PMF.monad_map_eq_map, PMF.map_apply]
 
-lemma tsum_probOutput_eq_one (mx : m α) :
+lemma tsum_probOutput_of_liftM_PMF (mx : m α) :
     ∑' x, Pr[= x | mx] = 1 := by simp
 
-lemma tsum_support_probOutput_eq_one (mx : m α) :
+lemma tsum_support_probOutput_of_liftM_PMF [MonadLiftT m SetM] [EvalDistCompatible m]
+    (mx : m α) :
     ∑' x : support mx, Pr[= x | mx] = 1 := by simp
 
-lemma sum_probOutput_eq_one [Fintype α] (mx : m α) : ∑ x : α, Pr[= x | mx] = 1 := by simp
+lemma sum_probOutput_of_liftM_PMF [Fintype α] (mx : m α) :
+    ∑ x : α, Pr[= x | mx] = 1 := by simp
 
-lemma sum_finSupport_probOutput_eq_one [HasEvalFinset m] [DecidableEq α] (mx : m α) :
+lemma sum_finSupport_probOutput_of_liftM_PMF [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α] (mx : m α) :
     ∑ x ∈ finSupport mx, Pr[= x | mx] = 1 := by simp
 
-lemma finSupport_nonempty [HasEvalFinset m] [DecidableEq α] (mx : m α) :
+lemma finSupport_nonempty_of_liftM_PMF [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α] (mx : m α) :
     (finSupport mx).Nonempty := by
   by_contra h
-  have hsum := sum_finSupport_probOutput_eq_one mx
+  have hsum := sum_finSupport_probOutput_of_liftM_PMF (m := m) mx
   rw [Finset.not_nonempty_iff_eq_empty.mp h, Finset.sum_empty] at hsum
   exact zero_ne_one hsum
 
-lemma probOutput_eq_inv_finSupport_card [HasEvalFinset m] [DecidableEq α]
+lemma probOutput_eq_inv_finSupport_card_of_liftM_PMF [MonadLiftT m SetM] [EvalDistCompatible m]
+    [HasEvalFinset m] [DecidableEq α]
     {mx : m α} {c : ENNReal}
     (hconst : ∀ x ∈ support mx, Pr[= x | mx] = c) :
     c = 1 / (finSupport mx).card := by
   have hconst' : ∀ x ∈ finSupport mx, Pr[= x | mx] = c :=
     fun x hx => hconst x (mem_support_of_mem_finSupport hx)
   have hcard_mul : ((finSupport mx).card : ENNReal) * c = 1 := by
-    have h := sum_finSupport_probOutput_eq_one mx
+    have h := sum_finSupport_probOutput_of_liftM_PMF (m := m) mx
     rwa [show ∑ x ∈ finSupport mx, Pr[= x | mx] = ∑ x ∈ finSupport mx, c from
       Finset.sum_congr rfl fun x hx => hconst' x hx, Finset.sum_const, nsmul_eq_mul] at h
   have : c * ((finSupport mx).card : ENNReal) = 1 := by rwa [mul_comm] at hcard_mul
   calc c = ((finSupport mx).card : ENNReal)⁻¹ := ENNReal.eq_inv_of_mul_eq_one_left this
     _ = 1 / (finSupport mx).card := by rw [one_div]
 
-end HasEvalPMF
+end pmf_denotation
 
 section probEvent_mono_compl
 
-variable [HasEvalSPMF m] {mx : m α} {p q : α → Prop}
+variable [MonadLiftT m SPMF]
+  {mx : m α} {p q : α → Prop}
+
+lemma probEvent_compl (mx : m α) (p : α → Prop) :
+    Pr[ p | mx] + Pr[ fun x => ¬p x | mx] = 1 - Pr[⊥ | mx] := by
+  have := Classical.decPred p
+  rw [probEvent_eq_tsum_ite mx p, probEvent_eq_tsum_ite mx (fun x => ¬p x)]
+  rw [← ENNReal.tsum_add, ← tsum_probOutput_eq_sub]
+  refine tsum_congr fun x => ?_
+  split_ifs <;> simp_all
+
+/-- Union bound: the probability of `p ∨ q` is at most the sum of probabilities. -/
+lemma probEvent_or_le (mx : m α) (p q : α → Prop) :
+    Pr[ fun x => p x ∨ q x | mx] ≤ Pr[ p | mx] + Pr[ q | mx] := by
+  have := Classical.decPred p; have := Classical.decPred q
+  simp only [probEvent_eq_tsum_ite, ← ENNReal.tsum_add]
+  refine ENNReal.tsum_le_tsum fun x => ?_
+  by_cases hp : p x <;> by_cases hq : q x <;> simp [hp, hq]
+
+variable [MonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- If `p` implies `q` on the `support` of a computation then it is more likely to happen. -/
 lemma probEvent_mono (h : ∀ x ∈ support mx, p x → q x) : Pr[ p | mx] ≤ Pr[ q | mx] := by
@@ -704,22 +783,6 @@ lemma probEvent_mono' [HasEvalFinset m] [DecidableEq α]
 specialisation of `probEvent_mono` that drops the support hypothesis. -/
 lemma probEvent_mono'' (h : ∀ x, p x → q x) : Pr[ p | mx] ≤ Pr[ q | mx] :=
   probEvent_mono (fun x _ => h x)
-
-lemma probEvent_compl (mx : m α) (p : α → Prop) :
-    Pr[ p | mx] + Pr[ fun x => ¬p x | mx] = 1 - Pr[⊥ | mx] := by
-  have := Classical.decPred p
-  rw [probEvent_eq_tsum_ite mx p, probEvent_eq_tsum_ite mx (fun x => ¬p x)]
-  rw [← ENNReal.tsum_add, ← tsum_probOutput_eq_sub]
-  refine tsum_congr fun x => ?_
-  split_ifs <;> simp_all
-
-/-- Union bound: the probability of `p ∨ q` is at most the sum of probabilities. -/
-lemma probEvent_or_le (mx : m α) (p q : α → Prop) :
-    Pr[ fun x => p x ∨ q x | mx] ≤ Pr[ p | mx] + Pr[ q | mx] := by
-  have := Classical.decPred p; have := Classical.decPred q
-  simp only [probEvent_eq_tsum_ite, ← ENNReal.tsum_add]
-  refine ENNReal.tsum_le_tsum fun x => ?_
-  by_cases hp : p x <;> by_cases hq : q x <;> simp [hp, hq]
 
 @[simp low, grind =]
 lemma probEvent_eq_one_iff :
@@ -788,18 +851,23 @@ lemma function_support_probOutput :
     Function.support (Pr[= · | mx]) = support mx := by
   simp only [Function.support, ne_eq, probOutput_eq_zero_iff, not_not, Set.setOf_mem_eq]
 
-lemma mem_support_iff_of_evalDist_eq {m n} [Monad m] [HasEvalSPMF m] [Monad n] [HasEvalSPMF n]
+lemma mem_support_iff_of_evalDist_eq {m n} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
+    [Monad n] [MonadLiftT n SPMF] [MonadLiftT n SetM] [EvalDistCompatible n]
     {mx : m α} {mx' : n α} (h : 𝒟[mx] = 𝒟[mx']) (x : α) :
     x ∈ support mx ↔ x ∈ support mx' := by
   simp only [mem_support_iff, probOutput_def, h]
 
-lemma mem_finSupport_iff_of_evalDist_eq {m n} [Monad m] [HasEvalSPMF m] [Monad n] [HasEvalSPMF n]
+lemma mem_finSupport_iff_of_evalDist_eq {m n} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
+    [Monad n] [MonadLiftT n SPMF] [MonadLiftT n SetM] [EvalDistCompatible n]
     [HasEvalFinset m] [HasEvalFinset n] [DecidableEq α]
     {mx : m α} {mx' : n α} (h : 𝒟[mx] = 𝒟[mx']) (x : α) :
     x ∈ finSupport mx ↔ x ∈ finSupport mx' := by
   simp only [mem_finSupport_iff_mem_support, mem_support_iff_of_evalDist_eq h]
 
 open Classical in
+omit [MonadLiftT m SetM] [EvalDistCompatible m] in
 lemma indicator_objective_eq_probEvent (mx : m (α × β)) (R : α → β → Prop) :
     (∑' z, Pr[= z | mx] * (if R z.1 z.2 then 1 else 0)) = Pr[ fun z => R z.1 z.2 | mx] := by
   rw [probEvent_eq_tsum_ite]

--- a/VCVio/EvalDist/Defs/Instances.lean
+++ b/VCVio/EvalDist/Defs/Instances.lean
@@ -17,21 +17,12 @@ variable {α β γ : Type u}
 
 namespace SetM
 
-/-- Enable `support` notation for `SetM` (note the need for the monadic instance and not `Set`). -/
-instance : HasEvalSet SetM where
-  toSet := MonadHom.id SetM
-
 @[simp, grind =]
 lemma support_eq_run (s : SetM α) : support s = s.run := rfl
 
 end SetM
 
 namespace SPMF
-
-/-- Enable probability notation for `SPMF`, using identity as the `SPMF` embedding. -/
-instance : HasEvalSPMF SPMF where
-  toSPMF := MonadHom.id SPMF
-  support_eq _ := rfl
 
 @[simp, grind =]
 protected lemma evalDist_def (p : SPMF α) : evalDist p = p := rfl
@@ -42,18 +33,12 @@ protected lemma support_eq_support (p : SPMF α) : support p = SPMF.support p :=
 @[grind =]
 lemma probOutput_eq_apply (p : SPMF α) (x : α) : Pr[= x | p] = p x := rfl
 
-lemma evalDist_eq_iff {m} [Monad m] [HasEvalSPMF m] (mx : m α) (p : SPMF α) :
+lemma evalDist_eq_iff {m} [Monad m] [MonadLiftT m SPMF] (mx : m α) (p : SPMF α) :
     𝒟[mx] = p ↔ ∀ x, Pr[= x | mx] = p x := by aesop
 
 end SPMF
 
 namespace PMF
-
-/-- Enable probability notation for `PMF`, using `liftM` as the `SPMF` embedding. -/
-noncomputable instance : HasEvalPMF PMF where
-  toPMF := MonadHom.id PMF
-  support_eq _ := by grind
-  toSPMF_eq _ := rfl
 
 @[simp] lemma evalDist_eq (p : PMF α) : evalDist p = liftM p := rfl
 
@@ -76,20 +61,28 @@ end PMF
 
 namespace Id
 
-/-- The support of a computation in `Id` is the result being returned. -/
-noncomputable instance : HasEvalPMF Id where
-  toSet := MonadHom.pure SetM
-  toSPMF := MonadHom.pure SPMF
-  toPMF := MonadHom.pure PMF
-  support_eq mx := by grind
-  toSPMF_eq mx := by aesop
+/-- Lift `Id` into `PMF` (a `pure` of the result), giving `Id` the canonical total denotation. -/
+noncomputable instance : MonadLift Id PMF where
+  monadLift x := pure x.run
+
+noncomputable instance : LawfulMonadLift Id PMF where
+  monadLift_pure _ := rfl
+  monadLift_bind _ _ := by
+    change (PMF.pure _ : PMF _) = (pure _ : PMF _).bind fun x => pure _
+    simp [PMF.monad_pure_eq_pure]
 
 instance : HasEvalFinset Id where
   finSupport x := {x}
-  coe_finSupport x := by ext y; grind
+  coe_finSupport x := by
+    ext y
+    change y ∈ (↑({x.run} : Finset _) : Set _) ↔ y ∈ SetM.run (pure x.run : SetM _)
+    rw [Finset.coe_singleton]
+    rfl
 
 @[simp, grind =]
-lemma support_eq_singleton (x : Id α) : support x = {x.run} := rfl
+lemma support_eq_singleton (x : Id α) : support x = {x.run} := by
+  change SetM.run (pure x.run : SetM α) = _
+  rfl
 
 @[simp, grind =]
 lemma finSupport_eq_singleton [DecidableEq α] (x : Id α) : finSupport x = {x.run} := rfl
@@ -104,8 +97,10 @@ lemma probOutput_eq_ite [DecidableEq α] (x : Id α) (y : α) :
 lemma probEvent_eq_ite (x : Id α) (p : α → Prop) [DecidablePred p] :
     Pr[ p | x] = if p x.run then 1 else 0 := by
   classical
-  simp [probEvent_eq_sum_finSupport_ite]
+  rw [show x = pure x.run from rfl, probEvent_pure]
+  rfl
 
-lemma probFailure_eq_zero (x : Id α) : Pr[⊥ | x] = 0 := by aesop
+lemma probFailure_eq_zero (x : Id α) : Pr[⊥ | x] = 0 := by
+  rw [show x = pure x.run from rfl, probFailure_pure]
 
 end Id

--- a/VCVio/EvalDist/Defs/NeverFails.lean
+++ b/VCVio/EvalDist/Defs/NeverFails.lean
@@ -14,14 +14,15 @@ This file defines a predicate-as-typeclass stating that a probabilistic computat
 produces failure mass, together with lemmas for how the property behaves under common
 monadic combinators.
 
-Given a `HasEvalSPMF m` instance and a computation `mx : m α` in that monad, `NeverFail mx` means
+Given a `MonadLiftT m SPMF` instance and a computation `mx
+    : m α` in that monad, `NeverFail mx` means
 that `Pr[⊥ | mx] = 0`, i.e. that the computation never fails.
 
 Defined as a typeclass to allow it to be synthesized automatically in certain cases.
 However we don't include any instances for `bind` as this blows up the search space.
 Instances involving `bind` should be added manually as needed.
 
-The existence of a `HasEvalPMF m` instance implies that `NeverFail mx` holds for any computaiton
+The existence of a `MonadLiftT m PMF` instance implies that `NeverFail mx` holds for any computaiton
 in the monad, since the `PMF` doesn't allow any probability of failing.
 -/
 
@@ -42,7 +43,7 @@ Remarks:
   on the support of the left-hand side.
 -/
 class NeverFail {α : Type u} {m : Type u → Type v} [Monad m]
-    [HasEvalSPMF m] (mx : m α) : Prop where
+    [MonadLiftT m SPMF] (mx : m α) : Prop where
   mk :: probFailure_eq_zero : Pr[⊥ | mx] = 0
 
 export NeverFail (probFailure_eq_zero)
@@ -51,28 +52,26 @@ attribute [simp] probFailure_eq_zero
 attribute [aesop safe apply] NeverFail.mk
 
 /-- Version of `probFailure_eq_zero` that avoids typeclass search. -/
-lemma probFailure_eq_zero' [HasEvalSPMF m]
+lemma probFailure_eq_zero' [MonadLiftT m SPMF]
     {mx : m α} (h : NeverFail mx) : Pr[⊥ | mx] = 0 :=
   NeverFail.probFailure_eq_zero
 
-namespace HasEvalPMF
+/-- A computation in a monad with a total `PMF` lift can't fail. -/
+instance [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] (mx : m α) : NeverFail mx where
+  probFailure_eq_zero := probFailure_of_liftM_PMF mx
 
-/-- A computation in a monad with `HasEvalPMF` can't fail as outputs sum to probability `1`. -/
-instance [HasEvalPMF m] (mx : m α) : NeverFail mx where
-  probFailure_eq_zero := probFailure_eq_zero mx
+section neverFail_lemmas
 
-end HasEvalPMF
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
 
-namespace HasEvalSPMF
-
-variable [HasEvalSPMF m]
-
+omit [LawfulMonadLiftT m SPMF] in
 @[grind =]
 lemma neverFail_iff (mx : m α) : NeverFail mx ↔ Pr[⊥ | mx] = 0 :=
   ⟨by aesop, NeverFail.mk⟩
 
 @[simp, grind =]
-lemma neverFail_bind_iff (mx : m α) (my : α → m β) :
+lemma neverFail_bind_iff [MonadLiftT m SetM] [EvalDistCompatible m]
+    (mx : m α) (my : α → m β) :
     NeverFail (mx >>= my) ↔ NeverFail mx ∧ ∀ x ∈ support mx, NeverFail (my x) := by
   simp [neverFail_iff, probFailure_bind_eq_add_tsum, add_eq_zero]
   grind
@@ -83,7 +82,9 @@ lemma neverFail_map_iff [LawfulMonad m] (mx : m α) (f : α → β) :
   grind [= map_eq_bind_pure_comp]
 
 @[simp]
-lemma neverFail_seq_iff [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
+lemma neverFail_seq_iff [LawfulMonad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+    (mf : m (α → β)) (mx : m α) :
     NeverFail (mf <*> mx) ↔ NeverFail mf ∧ NeverFail mx := by
   simp only [seq_eq_bind_map, neverFail_bind_iff, neverFail_map_iff]
   constructor
@@ -94,22 +95,20 @@ lemma neverFail_seq_iff [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
     exact h _ hne.choose_spec
   · exact fun ⟨hf, hx⟩ => ⟨hf, fun _ _ => hx⟩
 
-end HasEvalSPMF
-
-namespace HasEvalSet
-
 @[simp]
 lemma not_neverFail_failure {m : Type u → Type v} [AlternativeMonad m]
-    [HasEvalSPMF m] [HasEvalSet.LawfulFailure m] :
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] [HasEvalSet.LawfulFailure m] :
     ¬ NeverFail (failure : m α) := by
-  simp [HasEvalSPMF.neverFail_iff]
+  simp [neverFail_iff]
 
-end HasEvalSet
+end neverFail_lemmas
 
 namespace NeverFail
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
 
+omit [LawfulMonadLiftT m SPMF] in
 lemma of_probFailure_eq_zero (mx : m α) (h : Pr[⊥ | mx] = 0) : NeverFail mx :=
   { probFailure_eq_zero := h }
 
@@ -133,12 +132,13 @@ the first term vanishes by `NeverFail mx`, while for `x ∉ support mx` the coef
 `Pr[= x | mx]` is `0`, and for `x ∈ support mx` the second factor vanishes by hypothesis.
 Hence the sum is `0`.
 -/
-lemma bind_of_mem_support {mx : m α} {my : α → m β}
+lemma bind_of_mem_support [MonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} {my : α → m β}
     [hx : NeverFail mx] (hy : ∀ x ∈ support mx, NeverFail (my x)) :
     NeverFail (mx >>= my) where
   probFailure_eq_zero := by
     simp [probFailure_bind_eq_add_tsum]
-    simp [HasEvalSPMF.neverFail_iff] at hy
+    simp [neverFail_iff] at hy
     tauto
 
 /--
@@ -148,7 +148,8 @@ then the bind never fails.
 This is a convenience corollary of `bind_of_mem_support`; it is often easy to apply when
 `my` is uniform in its input (e.g. ignores it) or is known to be never-failing globally.
 -/
-lemma bind_of_forall {mx : m α} {my : α → m β}
+lemma bind_of_forall [MonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} {my : α → m β}
     [hx : NeverFail mx] [hy : ∀ x, NeverFail (my x)] :
     NeverFail (mx >>= my) := bind_of_mem_support (hx := hx) (fun x _ => hy x)
 
@@ -156,7 +157,8 @@ lemma bind_of_forall {mx : m α} {my : α → m β}
 Mapping a value through a total function preserves `NeverFail`.
 -/
 @[simp, grind .]
-instance instMap [LawfulMonad m] {mx : m α} [h : NeverFail mx] (f : α → β) :
+instance instMap [LawfulMonad m] [MonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} [h : NeverFail mx] (f : α → β) :
     NeverFail (f <$> mx) := by
   simp only [monad_norm, bind_of_forall, Function.comp_def]
 
@@ -165,7 +167,8 @@ instance instMap [LawfulMonad m] {mx : m α} [h : NeverFail mx] (f : α → β) 
 /-- If both the function computation and the argument computation never fail,
 then their applicative sequencing also never fails. -/
 @[simp, grind .]
-instance instSeq [LawfulMonad m] {mf : m (α → β)} {mx : m α}
+instance instSeq [LawfulMonad m] [MonadLiftT m SetM] [EvalDistCompatible m]
+    {mf : m (α → β)} {mx : m α}
     [hf : NeverFail mf] [hx : NeverFail mx] :
     NeverFail (mf <*> mx) := by
   -- `mf <*> mx = mf >>= fun f => f <$> mx`, and mapping preserves `NeverFail` given `hx`.
@@ -175,15 +178,20 @@ instance instSeq [LawfulMonad m] {mf : m (α → β)} {mx : m α}
 
 /-- If `mx` and `my` never fail, then `mx <* my` never fails. -/
 @[simp, grind .]
-instance instSeqLeft [LawfulMonad m] {mx : m α} {my : m β}
+instance instSeqLeft [LawfulMonad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} {my : m β}
     [hx : NeverFail mx] [hy : NeverFail my] : NeverFail (mx <* my) := by aesop
 
 /-- If `mx` and `my` never fail, then `mx *> my` never fails. -/
 @[simp, grind .]
-instance instSeqRight [LawfulMonad m] {mx : m α} {my : m β}
+instance instSeqRight [LawfulMonad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} {my : m β}
     [hx : NeverFail mx] [hy : NeverFail my] : NeverFail (mx *> my) := by aesop
 
-example [LawfulMonad m] (mx : m α) [h : NeverFail mx] : NeverFail (do
+example [LawfulMonad m] [MonadLiftT m SetM] [EvalDistCompatible m]
+    (mx : m α) [h : NeverFail mx] : NeverFail (do
     let x ← mx
     let y ← mx
     return (x, y)) := by

--- a/VCVio/EvalDist/Defs/Semantics.lean
+++ b/VCVio/EvalDist/Defs/Semantics.lean
@@ -11,7 +11,7 @@ import VCVio.EvalDist.Defs.Basic
 This file defines bundled semantics for monads that factor through an internal semantic monad
 before being externally observed.
 
-The existing classes `HasEvalSPMF` and `HasEvalPMF` say that a monad already *has* an
+A `MonadLiftT m SPMF` / `MonadLiftT m PMF` instance says that a monad already *has* an
 `SPMF` or `PMF` denotation. That is convenient when the monad itself is the semantic object,
 but it is too rigid for constructions whose natural semantics has hidden internal structure.
 
@@ -128,25 +128,25 @@ lemma probFailure_le_one (sem : SPMFSemantics m) (mx : m α) :
     sem.probFailure mx ≤ 1 :=
   PMF.coe_le_one (sem.evalDist mx) none
 
-/-- Package an ordinary `HasEvalSPMF` instance as a bundled `SPMFSemantics`.
+/-- Package an ordinary `MonadLiftT m SPMF` instance as a bundled `SPMFSemantics`.
 
-This is the bridge back to the old style where the surface monad itself already carries its
+This is the bridge back to the case where the surface monad itself already carries its
 subprobabilistic denotation. In that case the internal semantic monad is just `m` itself, the
-interpreter is the identity monad morphism, and observation is `HasEvalSPMF.toSPMF`. -/
-protected def ofHasEvalSPMF (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
+interpreter is the identity monad morphism, and observation is `liftM`. -/
+protected def ofMonadLift (m : Type u → Type v) [Monad m] [MonadLiftT m SPMF] :
     SPMFSemantics m where
   Sem := m
   instMonadSem := inferInstance
   interpret := MonadHom.id m
-  observe := fun mx => HasEvalSPMF.toSPMF mx
+  observe := fun mx => liftM mx
 
 @[simp]
-lemma ofHasEvalSPMF_evalDist (mx : m α) [HasEvalSPMF m] :
-    (SPMFSemantics.ofHasEvalSPMF m).evalDist mx = HasEvalSPMF.toSPMF mx := rfl
+lemma ofMonadLift_evalDist (mx : m α) [MonadLiftT m SPMF] :
+    (SPMFSemantics.ofMonadLift m).evalDist mx = liftM mx := rfl
 
 @[simp]
-lemma ofHasEvalSPMF_probFailure (mx : m α) [HasEvalSPMF m] :
-    (SPMFSemantics.ofHasEvalSPMF m).probFailure mx = Pr[⊥ | mx] := rfl
+lemma ofMonadLift_probFailure (mx : m α) [MonadLiftT m SPMF] :
+    (SPMFSemantics.ofMonadLift m).probFailure mx = Pr[⊥ | mx] := rfl
 
 end SPMFSemantics
 
@@ -184,19 +184,19 @@ noncomputable def toSPMFSemantics (sem : PMFSemantics m) : SPMFSemantics m where
   interpret := sem.interpret
   observe := fun mx => liftM (sem.observePMF mx)
 
-/-- Package an ordinary `HasEvalPMF` instance as a bundled `PMFSemantics`.
+/-- Package an ordinary `MonadLiftT m PMF` instance as a bundled `PMFSemantics`.
 
-As with `SPMFSemantics.ofHasEvalSPMF`, this recovers the familiar case where the surface monad
+As with `SPMFSemantics.ofMonadLift`, this recovers the familiar case where the surface monad
 already comes with a total probabilistic denotation. -/
-protected def ofHasEvalPMF (m : Type u → Type v) [Monad m] [HasEvalPMF m] :
+protected def ofMonadLift (m : Type u → Type v) [Monad m] [MonadLiftT m PMF] :
     PMFSemantics m where
   Sem := m
   instMonadSem := inferInstance
   interpret := MonadHom.id m
-  observe := fun mx => HasEvalPMF.toPMF mx
+  observe := fun mx => liftM mx
 
 @[simp]
-lemma ofHasEvalPMF_evalDist (mx : m α) [HasEvalPMF m] :
-    (PMFSemantics.ofHasEvalPMF m).evalDist mx = HasEvalPMF.toPMF mx := rfl
+lemma ofMonadLift_evalDist (mx : m α) [MonadLiftT m PMF] :
+    (PMFSemantics.ofMonadLift m).evalDist mx = liftM mx := rfl
 
 end PMFSemantics

--- a/VCVio/EvalDist/Defs/Support.lean
+++ b/VCVio/EvalDist/Defs/Support.lean
@@ -7,17 +7,20 @@ import VCVio.Prelude
 import ToMathlib.ProbabilityTheory.SPMF
 
 /-!
-# Typeclasses for Denotational Monad Support
+# Support of a Monadic Computation
 
-This file defines typeclasses `HasEvalSet m` and `HasEvalFinset m` for asigning a
-set of possible outputs to computations in a monad `m`.
+This file defines `support mx` — the set of possible outputs of a monadic computation `mx`
+— as well as `HasEvalFinset`, a typeclass for assigning a finite version of the support.
+
+The support is built directly on `MonadLiftT m SetM`: any monad with a lift into `SetM`
+(possibly via the canonical `PMF → SPMF → SetM` chain) automatically has `support`.
 -/
 
 open ENNReal
 
 universe u v w
 
-variable {m : Type u → Type v} [Monad m] {α β γ : Type u}
+variable {m : Type u → Type v} {α β γ : Type u}
 
 section support
 
@@ -28,25 +31,19 @@ lemma SetM.pure_def (x : α) : (pure x : SetM α) = ({x} : Set α) := rfl
 lemma SetM.bind_def (mx : SetM α) (my : α → SetM β) :
     mx >>= my = ⋃ x ∈ mx.run, my x := rfl
 
-/-- The monad `m` can be evaluated to get a set of possible outputs.
-Note that we don't implement this for `Set` with the monad type-class strangeness.
-Should not be implemented manually if a `HasEvalSPMF` instance already exists. -/
-class HasEvalSet (m : Type u → Type v) [Monad m] where
-  toSet : m →ᵐ SetM
-
 /-- The set of possible outputs of running the monadic computation `mx`. -/
-def support [HasEvalSet m] {α : Type u} (mx : m α) : Set α :=
-  SetM.run (HasEvalSet.toSet mx)
+def support [MonadLiftT m SetM] {α : Type u} (mx : m α) : Set α :=
+  SetM.run (liftM mx)
 
 -- dtumad: not sure if this should actually be in the ruleset?
 @[aesop norm (rule_sets := [UnfoldEvalDist]), grind =]
-lemma support_def [HasEvalSet m] {α : Type u} (mx : m α) :
-    support mx = SetM.run (HasEvalSet.toSet mx) := rfl
+lemma support_def [MonadLiftT m SetM] {α : Type u} (mx : m α) :
+    support mx = SetM.run (liftM mx) := rfl
 
 /-- The monad `m` can be evaluated to get a finite set of possible outputs.
 We restrict to the case of decidable equality of the output type, so `Finset.biUnion` exists.
 Note: we can't use `MonadHomClass` since `Finset` has no `Monad` instance. -/
-class HasEvalFinset (m : Type u → Type v) [Monad m] [HasEvalSet m] where
+class HasEvalFinset (m : Type u → Type v) [MonadLiftT m SetM] where
   finSupport {α : Type u} [DecidableEq α] (mx : m α) : Finset α
   coe_finSupport {α : Type u} [DecidableEq α] (mx : m α) :
     (↑(finSupport mx) : Set α) = support mx
@@ -56,40 +53,40 @@ export HasEvalFinset (finSupport coe_finSupport)
 attribute [simp, grind =] coe_finSupport
 
 @[grind =, aesop unsafe norm]
-lemma mem_finSupport_iff_mem_support [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma mem_finSupport_iff_mem_support [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     (mx : m α) (x : α) : x ∈ finSupport mx ↔ x ∈ support mx := by
   rw [← Finset.mem_coe, coe_finSupport]
 
-lemma finSupport_eq_iff_support_eq_coe [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma finSupport_eq_iff_support_eq_coe [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     (mx : m α) (s : Finset α) : finSupport mx = s ↔ support mx = ↑s := by grind
 
 @[aesop unsafe 60% apply]
-lemma finSupport_eq_of_support_eq_coe [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma finSupport_eq_of_support_eq_coe [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     {mx : m α} {s : Finset α} (h : support mx = ↑s) : finSupport mx = s := by grind
 
 @[aesop unsafe 85% apply]
-lemma mem_finSupport_of_mem_support [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma mem_finSupport_of_mem_support [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     {mx : m α} {x : α} (h : x ∈ support mx) : x ∈ finSupport mx := by grind
 
-lemma mem_support_of_mem_finSupport [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma mem_support_of_mem_finSupport [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     {mx : m α} {x : α} (h : x ∈ finSupport mx) : x ∈ support mx := by grind
 
 @[aesop unsafe 85% apply]
-lemma not_mem_finSupport_of_not_mem_support [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma not_mem_finSupport_of_not_mem_support [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     {mx : m α} {x : α} (h : x ∉ support mx) : x ∉ finSupport mx := by grind
 
-lemma not_mem_support_of_not_mem_finSupport [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma not_mem_support_of_not_mem_finSupport [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α]
     {mx : m α} {x : α} (h : x ∉ finSupport mx) : x ∉ support mx := by grind
 
 end support
 
 section forall_support
 
-variable {m : Type u → Type v} [Monad m] [HasEvalSet m] {α : Type u}
+variable {m : Type u → Type v} [MonadLiftT m SetM] {α : Type u}
 
 /-- A predicate holds on every output reachable from a monadic computation `mx`,
 i.e. `∀ x ∈ support mx, p x`. This is the "almost-sure" assertion at the qualitative
-denotational level provided by `HasEvalSet`.
+denotational level provided by `MonadLiftT m SetM`.
 
 For `OracleComp`, see also the structural-recursion variant
 `OracleComp.allOutputsSatisfyWhen` in `VCVio/OracleComp/Traversal.lean`, which is
@@ -121,32 +118,32 @@ end forall_support
 
 variable (p : Prop) [Decidable p]
 
-@[simp] lemma support_ite [HasEvalSet m] (mx mx' : m α) :
+@[simp] lemma support_ite [MonadLiftT m SetM] (mx mx' : m α) :
     support (if p then mx else mx') = if p then support mx else support mx' := by aesop
 
-@[simp] lemma finSupport_ite [HasEvalSet m] [HasEvalFinset m] [DecidableEq α] (mx mx' : m α) :
+@[simp] lemma finSupport_ite [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq α] (mx mx' : m α) :
     finSupport (if p then mx else mx') = if p then finSupport mx else finSupport mx' := by aesop
 
-lemma support_eqRec [HasEvalSet m] (h : α = β) (mx : m α) :
+lemma support_eqRec [MonadLiftT m SetM] (h : α = β) (mx : m α) :
     support (h ▸ mx : m β) = h ▸ support mx := by grind
 
 -- dtumad: this is not really useful in this form very often...
-lemma finSupport_eqRec {m} [hm : Monad m] [hms : HasEvalSet m] [hmfs : HasEvalFinset m]
+lemma finSupport_eqRec {m} [hms : MonadLiftT m SetM] [hmfs : HasEvalFinset m]
     [hα : DecidableEq α] (h : α = β) (mx : m α) :
-    (@finSupport m hm hms hmfs β (h ▸ hα) (h ▸ mx : m β) : Finset β) =
-      (h ▸ (@finSupport m hm hms hmfs α hα mx : Finset α) : Finset β) := by grind
+    (@finSupport m hms hmfs β (h ▸ hα) (h ▸ mx : m β) : Finset β) =
+      (h ▸ (@finSupport m hms hmfs α hα mx : Finset α) : Finset β) := by grind
 
 section decidable
 
 /-- Membership in the support of computations in. -/
-protected class HasEvalSet.Decidable (m : Type u → Type v) [Monad m] [HasEvalSet m] where
+protected class HasEvalSet.Decidable (m : Type u → Type v) [MonadLiftT m SetM] where
   mem_support_decidable {α : Type u} (mx : m α) : DecidablePred (· ∈ support mx)
 
-instance decidablePred_mem_support [HasEvalSet m] [HasEvalSet.Decidable m]
+instance decidablePred_mem_support [MonadLiftT m SetM] [HasEvalSet.Decidable m]
     (mx : m α) : DecidablePred (· ∈ support mx) :=
   HasEvalSet.Decidable.mem_support_decidable mx
 
-instance decidablePred_mem_finSupport [HasEvalSet m] [HasEvalSet.Decidable m] [HasEvalFinset m]
+instance decidablePred_mem_finSupport [MonadLiftT m SetM] [HasEvalSet.Decidable m] [HasEvalFinset m]
     [DecidableEq α] (mx : m α) : DecidablePred (· ∈ finSupport mx) := by
   simpa only [mem_finSupport_iff_mem_support] using decidablePred_mem_support mx
 

--- a/VCVio/EvalDist/Fintype.lean
+++ b/VCVio/EvalDist/Fintype.lean
@@ -19,52 +19,17 @@ variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
 
 open ENNReal
 
-namespace HasEvalSPMF
-
-lemma probOutput_bind_eq_sum_fintype [HasEvalSPMF m]
+lemma probOutput_bind_eq_sum_fintype [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (mx : m α) (my : α → m β) [Fintype α] (y : β) :
     Pr[= y | mx >>= my] = ∑ x : α, Pr[= x | mx] * Pr[= y | my x] :=
   (probOutput_bind_eq_tsum mx my y).trans (tsum_fintype _)
 
-lemma probFailure_bind_eq_sum_fintype [HasEvalSPMF m]
+lemma probFailure_bind_eq_sum_fintype [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (mx : m α) (my : α → m β) [Fintype α] :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑ x : α, Pr[= x | mx] * Pr[⊥ | my x] :=
   (probFailure_bind_eq_add_tsum mx my).trans (congr_arg (Pr[⊥ | mx] + ·) <| tsum_fintype _)
 
-lemma probEvent_bind_eq_sum_fintype [HasEvalSPMF m]
+lemma probEvent_bind_eq_sum_fintype [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (mx : m α) (my : α → m β) [Fintype α] (q : β → Prop) :
     Pr[ q | mx >>= my] = ∑ x : α, Pr[= x | mx] * Pr[ q | my x] :=
   (probEvent_bind_eq_tsum mx my q).trans (tsum_fintype _)
-
-/-- Union bound: the probability that *some* event `E i` holds is at most the sum of the
-individual probabilities, over a finite index set `s`. -/
-lemma probEvent_exists_finset_le_sum [HasEvalSPMF m]
-    {ι : Type u} (s : Finset ι) (mx : m α) (E : ι → α → Prop) :
-    Pr[ (fun x => ∃ i ∈ s, E i x) | mx] ≤ s.sum (fun i => Pr[ E i | mx]) := by
-  classical
-  refine Finset.induction_on s (by simp) ?_
-  intro a s haNotMem ih
-  have hE : (fun x => ∃ i ∈ insert a s, E i x) = fun x => E a x ∨ ∃ i ∈ s, E i x := by
-    funext x; simp [Finset.mem_insert, or_and_right, exists_or]
-  have hor :
-      Pr[ (fun x => E a x ∨ ∃ i ∈ s, E i x) | mx]
-        ≤ Pr[ E a | mx] + Pr[ (fun x => ∃ i ∈ s, E i x) | mx] := by
-    rw [probEvent_eq_tsum_ite (mx := mx) (p := fun x => E a x ∨ ∃ i ∈ s, E i x),
-        probEvent_eq_tsum_ite (mx := mx) (p := E a),
-        probEvent_eq_tsum_ite (mx := mx) (p := fun x => ∃ i ∈ s, E i x)]
-    have hle : (∑' y : α, if (E a y ∨ ∃ i ∈ s, E i y) then Pr[= y | mx] else 0)
-        ≤ ∑' y : α, ((if E a y then Pr[= y | mx] else 0) +
-                     (if (∃ i ∈ s, E i y) then Pr[= y | mx] else 0)) :=
-      ENNReal.tsum_le_tsum fun y => by
-        by_cases ha' : E a y <;> by_cases hs' : (∃ i ∈ s, E i y) <;> simp [ha', hs']
-    calc _ ≤ _ := hle
-      _ = _ := by simpa using ENNReal.tsum_add
-  calc Pr[ (fun x => ∃ i ∈ insert a s, E i x) | mx]
-      = Pr[ (fun x => E a x ∨ ∃ i ∈ s, E i x) | mx] := by rw [hE]
-    _ ≤ Pr[ E a | mx] + Pr[ (fun x => ∃ i ∈ s, E i x) | mx] := hor
-    _ ≤ Pr[ E a | mx] + s.sum (fun i => Pr[ E i | mx]) := by
-        gcongr
-    _ = (insert a s).sum (fun i => Pr[ E i | mx]) := by
-        rw [Finset.sum_insert haNotMem]
-
-end HasEvalSPMF

--- a/VCVio/EvalDist/Fintype.lean
+++ b/VCVio/EvalDist/Fintype.lean
@@ -8,9 +8,9 @@ import VCVio.EvalDist.Monad.Basic
 /-!
 # Lemmas for Probability Over Finite Spaces
 
-This file houses lemmas about `HasEvalDist m` and related classes when a computation `mx : m α`
-is defined via a binding/mapping operation over a finite type.
-In particular `Finset.sum` versions of many `tsum` related lemmas about `HasEvalDist`.
+This file houses lemmas about computations with `MonadLiftT m SPMF` semantics when
+`mx : m α` is defined via a binding/mapping operation over a finite type.
+In particular it provides `Finset.sum` versions of many `tsum` related probability lemmas.
 -/
 
 universe u v w

--- a/VCVio/EvalDist/Inequalities.lean
+++ b/VCVio/EvalDist/Inequalities.lean
@@ -11,7 +11,7 @@ import ToMathlib.Data.ENNReal.SumSquares
 
 Inequalities relating per-element bounds and their probabilistic averages, for use in
 forking-lemma-style game-hopping arguments where the outermost step marginalizes over a
-random key (or, more generally, an arbitrary `HasEvalSPMF` monad output).
+random key (or, more generally, an arbitrary `MonadLiftT m SPMF` monad output).
 
 The headline lemma is `marginalized_jensen_forking_bound`: given a per-element bound
 `acc x · (acc x / q − hinv) ≤ B x` and weights `Pr[= x | mx]` for some monadic computation
@@ -32,13 +32,14 @@ universe u v
 
 namespace OracleComp.EvalDist
 
-variable {m : Type → Type v} [Monad m] [HasEvalSPMF m]
+variable {m : Type → Type v} [Monad m] [MonadLiftT m SPMF]
 
+omit [Monad m] in
 /-- **Marginalized Jensen / Cauchy-Schwarz step for the forking lemma.**
 
 If a per-element bound `acc x · (acc x / q − hinv) ≤ B x` holds for every `x` (with
 `acc x ≤ 1`), and we marginalize over the output distribution of any `mx : m X` with
-`HasEvalSPMF`, then the marginalized expectation `μ := ∑' x, Pr[= x | mx] · acc x`
+`[MonadLiftT m SPMF]`, then the marginalized expectation `μ := ∑' x, Pr[= x | mx] · acc x`
 satisfies the same forking-bound shape:
 
   `μ · (μ / q − hinv) ≤ ∑' x, Pr[= x | mx] · B x`.

--- a/VCVio/EvalDist/Instances/ErrorT.lean
+++ b/VCVio/EvalDist/Instances/ErrorT.lean
@@ -10,7 +10,7 @@ import Mathlib.Control.Lawful
 # Evaluation Semantics for ExceptT (ErrorT)
 
 This file provides evaluation semantics for `ExceptT ε m` computations, lifting
-`MonadLiftT m PMF` to `MonadLift (ExceptT ε m) SPMF`.
+`MonadLiftT m PMF` to `MonadLiftT (ExceptT ε m) SPMF`.
 
 `ExceptT ε m α` represents computations that can fail with an error of type `ε`
 or succeed with a value of type `α`. The underlying type is `m (Except ε α)`.
@@ -18,11 +18,11 @@ or succeed with a value of type `α`. The underlying type is `m (Except ε α)`.
 ## Main definitions
 
 * `ExceptT.toSPMF'`: Monad homomorphism `ExceptT ε m →ᵐ SPMF` when `m` lifts into `PMF`
-* Instance `MonadLift (ExceptT ε m) SPMF` when `[MonadLiftT m PMF] [LawfulMonadLiftT m PMF]`
+* Instance `MonadLiftT (ExceptT ε m) SPMF` when `[MonadLiftT m PMF] [LawfulMonadLiftT m PMF]`
 
 ## Design notes
 
-Similar to `OptionT`, we lift `MonadLiftT m PMF` to `MonadLift (ExceptT ε m) SPMF` because
+Similar to `OptionT`, we lift `MonadLiftT m PMF` to `MonadLiftT (ExceptT ε m) SPMF` because
 error cases contribute failure mass. We map:
 - `Except.ok x` → probability mass at `some x`
 - `Except.error e` → failure mass (mapped to `none`)
@@ -194,6 +194,34 @@ noncomputable instance instLawfulMonadLiftTSPMF (ε : Type u) (m : Type u → Ty
     LawfulMonadLiftT (ExceptT ε m) SPMF where
   monadLift_pure := ExceptT.toSPMF'.toFun_pure'
   monadLift_bind := ExceptT.toSPMF'.toFun_bind'
+
+/-- The successful-output support of `ExceptT ε m` agrees with the output support of its
+`SPMF` semantics, provided the underlying monad has the corresponding bridge. Errors only
+contribute failure mass, not successful outputs. -/
+instance instEvalDistCompatible (ε : Type u) (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [EvalDistCompatible m] :
+    EvalDistCompatible (ExceptT ε m) where
+  support_eq_SPMF_support {α} mx := by
+    change Except.ok ⁻¹' (SetM.run (liftM mx.run : SetM (Except ε α))) =
+      SPMF.support ((liftM mx.run : SPMF (Except ε α)) >>= fun r =>
+        match r with | Except.ok a => pure a | Except.error _ => failure)
+    rw [SPMF.support_bind]
+    have hbridge : SetM.run (liftM mx.run : SetM (Except ε α)) =
+        SPMF.support (liftM mx.run : SPMF (Except ε α)) :=
+      EvalDistCompatible.support_eq_SPMF_support mx.run
+    rw [hbridge]
+    ext a
+    simp only [Set.mem_preimage, Set.mem_iUnion, exists_prop]
+    refine ⟨fun h => ⟨Except.ok a, h, by simp [SPMF.support_pure]⟩, ?_⟩
+    rintro ⟨r, hr, ha⟩
+    cases r with
+    | ok b =>
+        rw [SPMF.support_pure, Set.mem_singleton_iff] at ha
+        exact ha ▸ hr
+    | error e =>
+        simp only [SPMF.mem_support_iff, SPMF.failure_apply, ne_eq, not_true_eq_false] at ha
 
 variable [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
 

--- a/VCVio/EvalDist/Instances/ErrorT.lean
+++ b/VCVio/EvalDist/Instances/ErrorT.lean
@@ -10,27 +10,25 @@ import Mathlib.Control.Lawful
 # Evaluation Semantics for ExceptT (ErrorT)
 
 This file provides evaluation semantics for `ExceptT ε m` computations, lifting
-`HasEvalPMF m` to `HasEvalSPMF (ExceptT ε m)`.
+`MonadLiftT m PMF` to `MonadLift (ExceptT ε m) SPMF`.
 
 `ExceptT ε m α` represents computations that can fail with an error of type `ε`
 or succeed with a value of type `α`. The underlying type is `m (Except ε α)`.
 
 ## Main definitions
 
-* `ExceptT.toSPMF`: Monad homomorphism `ExceptT ε m →ᵐ SPMF` when `m` has `HasEvalPMF`
-* Instance `HasEvalSPMF (ExceptT ε m)` when `[HasEvalPMF m]`
+* `ExceptT.toSPMF'`: Monad homomorphism `ExceptT ε m →ᵐ SPMF` when `m` lifts into `PMF`
+* Instance `MonadLift (ExceptT ε m) SPMF` when `[MonadLiftT m PMF] [LawfulMonadLiftT m PMF]`
 
 ## Design notes
 
-Similar to `OptionT`, we lift `HasEvalPMF m` to `HasEvalSPMF (ExceptT ε m)` because
+Similar to `OptionT`, we lift `MonadLiftT m PMF` to `MonadLift (ExceptT ε m) SPMF` because
 error cases contribute failure mass. We map:
 - `Except.ok x` → probability mass at `some x`
 - `Except.error e` → failure mass (mapped to `none`)
 
 This means we only support one layer of failure. If you need nested error handling,
 you'll need to work with the underlying `m (Except ε α)` type directly.
-
-NOTE: this should be a high priority to add for more complex proofs
 -/
 
 universe u v
@@ -39,21 +37,28 @@ variable {ε : Type u} {m : Type u → Type v} [Monad m] {α β γ : Type u}
 
 namespace ExceptT
 
-section HasEvalSet
+section EvalSet
 
-/-- Standalone `HasEvalSet (ExceptT ε m)` instance under the weaker `[HasEvalSet m]` assumption.
+/-- Standalone `MonadLiftT (ExceptT ε m) SetM` instance under the weaker `[MonadLiftT m SetM]`
+assumption. Keeping this standalone means `support` on `ExceptT ε m` works without requiring a
+full `MonadLiftT m SPMF` lift — only `MonadLiftT m SetM` is needed. -/
+noncomputable instance instMonadLiftTSetM (ε : Type u) (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SetM] : MonadLiftT (ExceptT ε m) SetM where
+  monadLift mx := Except.ok ⁻¹' (support mx.run)
 
-This is deliberately kept separate from the `HasEvalSPMF (ExceptT ε m)` instance below, which
-re-exports the same `toSet` to make the resulting typeclass diamond definitionally equal.
-Keeping this standalone instance means `support` on `ExceptT ε m` works without requiring a
-full `HasEvalSPMF m` — only `HasEvalSet m` is needed (e.g., for `support_liftM`). -/
-noncomputable instance (ε : Type u) (m : Type u → Type v) [Monad m] [HasEvalSet m] :
-    HasEvalSet (ExceptT ε m) where
-  toSet.toFun α mx := Except.ok ⁻¹' (support mx.run)
-  toSet.toFun_pure' x := Set.ext fun y => by
+noncomputable instance instLawfulMonadLiftTSetM (ε : Type u) (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] :
+    LawfulMonadLiftT (ExceptT ε m) SetM where
+  monadLift_pure x := by
+    change Except.ok ⁻¹' (support (pure (Except.ok x) : m _)) = pure x
+    ext y
     change Except.ok y ∈ support (pure (Except.ok x) : m _) ↔ y = x
     simp
-  toSet.toFun_bind' mx f := Set.ext fun x => by
+  monadLift_bind mx f := by
+    change (Except.ok ⁻¹' (support (mx >>= f : ExceptT ε m _).run) : SetM _) =
+      (Except.ok ⁻¹' (support mx.run) >>=
+        fun a => Except.ok ⁻¹' support (f a).run : SetM _)
+    ext x
     simp only [Set.mem_preimage]
     change Except.ok x ∈ support (mx.run >>= ExceptT.bindCont f) ↔ _
     rw [mem_support_bind_iff]
@@ -69,7 +74,11 @@ noncomputable instance (ε : Type u) (m : Type u → Type v) [Monad m] [HasEvalS
       obtain ⟨a, ha, hx⟩ := Set.mem_iUnion₂.mp h
       exact ⟨.ok a, ha, hx⟩
 
-variable [HasEvalSet m]
+@[simp]
+lemma run_liftM_eq_map_ok (mx : m α) :
+    (liftM mx : ExceptT ε m α).run = Except.ok <$> mx := rfl
+
+variable [MonadLiftT m SetM]
 
 @[aesop unsafe norm, grind =]
 lemma support_def (mx : ExceptT ε m α) :
@@ -79,10 +88,7 @@ lemma support_def (mx : ExceptT ε m α) :
 lemma mem_support_iff (mx : ExceptT ε m α) (x : α) :
     x ∈ support mx ↔ Except.ok x ∈ support mx.run := Iff.rfl
 
-omit [HasEvalSet m] in
-@[simp]
-lemma run_liftM_eq_map_ok (mx : m α) :
-    (liftM mx : ExceptT ε m α).run = Except.ok <$> mx := rfl
+variable [LawfulMonadLiftT m SetM]
 
 @[simp]
 lemma support_liftM [LawfulMonad m] (mx : m α) :
@@ -93,9 +99,9 @@ lemma support_liftM [LawfulMonad m] (mx : m α) :
   · rintro ⟨a, ha, h⟩; cases h; exact ha
   · exact fun h => ⟨x, h, rfl⟩
 
-end HasEvalSet
+end EvalSet
 
-section HasEvalFinset
+section EvalFinset
 
 private instance instDecidableEqExcept [DecidableEq ε] [DecidableEq α] :
     DecidableEq (Except ε α) := fun a b => match a, b with
@@ -107,14 +113,16 @@ private instance instDecidableEqExcept [DecidableEq ε] [DecidableEq α] :
   | .error _, .ok _ => isFalse (by intro h; cases h)
 
 noncomputable instance (ε : Type u) (m : Type u → Type v) [Monad m]
-    [DecidableEq ε] [HasEvalSet m] [HasEvalFinset m] :
+    [DecidableEq ε] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m] :
     HasEvalFinset (ExceptT ε m) where
   finSupport mx := (finSupport mx.run).preimage Except.ok
     (by intro a b; simp [Except.ok.injEq])
   coe_finSupport mx := by
-    ext x; simp
+    ext x; change x ∈ ((finSupport mx.run).preimage Except.ok _ : Set _) ↔
+      x ∈ Except.ok ⁻¹' support mx.run
+    simp
 
-variable [DecidableEq ε] [HasEvalSet m] [HasEvalFinset m]
+variable [DecidableEq ε] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
 
 @[aesop unsafe norm, grind =]
 lemma finSupport_def [DecidableEq α] (mx : ExceptT ε m α) :
@@ -129,37 +137,41 @@ lemma mem_finSupport_iff' [DecidableEq α] (mx : ExceptT ε m α) (x : α) :
 @[simp]
 lemma finSupport_liftM [LawfulMonad m] [DecidableEq α] (mx : m α) :
     finSupport (liftM mx : ExceptT ε m α) = finSupport mx := by
-  ext x; simp [mem_finSupport_iff']
+  ext x
+  rw [mem_finSupport_iff', mem_finSupport_iff_mem_support, mem_finSupport_iff_mem_support]
+  change Except.ok x ∈ support (Except.ok <$> mx) ↔ x ∈ support mx
+  simp
 
-end HasEvalFinset
+end EvalFinset
 
-section HasEvalSPMF
+section EvalSPMF
 
 /-- Monad homomorphism from `ExceptT ε m` to `SPMF`, treating errors as failure mass.
 Given `mx : ExceptT ε m α`, we evaluate the underlying `m (Except ε α)` to an `SPMF`,
 then route `Except.ok x` to `pure x` and `Except.error _` to `failure`. -/
-noncomputable def toSPMF' [HasEvalPMF m] : ExceptT ε m →ᵐ SPMF where
+noncomputable def toSPMF' [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] : ExceptT ε m →ᵐ SPMF where
   toFun {α} (mx : ExceptT ε m α) : SPMF α :=
-    HasEvalSPMF.toSPMF mx.run >>= fun r =>
+    (liftM mx.run : SPMF _) >>= fun r =>
       match r with
       | Except.ok x => pure x
       | Except.error _ => failure
   toFun_pure' x := by simp
   toFun_bind' mx f := by
-    change HasEvalSPMF.toSPMF (mx.run >>= ExceptT.bindCont f) >>= _ = _
-    simp only [MonadHom.toFun_bind', monad_norm]
+    change (liftM (mx.run >>= ExceptT.bindCont f) : SPMF _) >>= _ = _
+    simp only [liftM_bind, monad_norm]
     congr 1; funext r
     cases r with
     | ok a =>
-      change HasEvalSPMF.toSPMF (f a).run >>= _ =
-        pure a >>= fun b => HasEvalSPMF.toSPMF (f b).run >>= _
+      change (liftM (f a).run : SPMF _) >>= _ =
+        pure a >>= fun b => (liftM (f b).run : SPMF _) >>= _
       simp
     | error e => simp [ExceptT.bindCont]
 
-private lemma toSPMF'_apply_eq [HasEvalPMF m] (mx : ExceptT ε m α) (x : α) :
-    ExceptT.toSPMF' mx x = HasEvalSPMF.toSPMF mx.run (Except.ok x) := by
+private lemma toSPMF'_apply_eq [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    (mx : ExceptT ε m α) (x : α) :
+    ExceptT.toSPMF' mx x = (liftM mx.run : SPMF _) (Except.ok x) := by
   rw [show (ExceptT.toSPMF' mx : SPMF α) =
-    HasEvalSPMF.toSPMF mx.run >>= fun r =>
+    (liftM mx.run : SPMF _) >>= fun r =>
       match r with | Except.ok a => pure a | Except.error _ => failure from rfl]
   rw [SPMF.bind_apply_eq_tsum]
   refine (tsum_eq_single (Except.ok x) fun y hy => ?_).trans ?_
@@ -170,18 +182,20 @@ private lemma toSPMF'_apply_eq [HasEvalPMF m] (mx : ExceptT ε m α) (x : α) :
         simp [this]
   · simp
 
-/-- Lift `HasEvalPMF m` to `HasEvalSPMF (ExceptT ε m)`.
+/-- Lift `MonadLiftT m PMF` to `MonadLiftT (ExceptT ε m) SPMF`.
 Errors contribute to failure mass. -/
-noncomputable instance (ε : Type u) (m : Type u → Type v) [Monad m] [HasEvalPMF m] :
-    HasEvalSPMF (ExceptT ε m) where
-  toSPMF := ExceptT.toSPMF'
-  support_eq mx := by
-    ext x
-    rw [ExceptT.mem_support_iff, SPMF.mem_support_iff, toSPMF'_apply_eq]
-    change Except.ok x ∈ support mx.run ↔ 𝒟[mx.run] (Except.ok x) ≠ 0
-    exact mem_support_iff_evalDist_apply_ne_zero mx.run (Except.ok x)
+noncomputable instance instMonadLiftTSPMF (ε : Type u) (m : Type u → Type v) [Monad m]
+    [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] :
+    MonadLiftT (ExceptT ε m) SPMF where
+  monadLift mx := ExceptT.toSPMF' mx
 
-variable [HasEvalPMF m]
+noncomputable instance instLawfulMonadLiftTSPMF (ε : Type u) (m : Type u → Type v) [Monad m]
+    [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] :
+    LawfulMonadLiftT (ExceptT ε m) SPMF where
+  monadLift_pure := ExceptT.toSPMF'.toFun_pure'
+  monadLift_bind := ExceptT.toSPMF'.toFun_bind'
+
+variable [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
 
 lemma evalDist_eq (mx : ExceptT ε m α) :
     𝒟[mx] = ExceptT.toSPMF' mx := rfl
@@ -197,7 +211,7 @@ lemma probFailure_eq (mx : ExceptT ε m α) :
     Pr[⊥ | mx] = Pr[⊥ | mx.run] +
       Pr[ (fun r => match r with | Except.error _ => True | Except.ok _ => False) | mx.run] := by
   simp only [probFailure_def, probEvent_eq_tsum_indicator, probOutput_def]
-  rw [show 𝒟[mx] = (HasEvalSPMF.toSPMF mx.run >>= fun r =>
+  rw [show 𝒟[mx] = ((liftM mx.run : SPMF _) >>= fun r =>
       match r with | Except.ok a => pure a | Except.error _ => failure : SPMF α) from rfl]
   simp only [SPMF.run_eq_toPMF, SPMF.toPMF_bind, Option.elimM, PMF.monad_bind_eq_bind,
     PMF.bind_apply, ENNReal.summable, tsum_option, Option.elim_none, PMF.pure_apply, ↓reduceIte,
@@ -223,6 +237,6 @@ lemma probEvent_liftM [LawfulMonad m] (mx : m α) (p : α → Prop) :
     Pr[ p | (liftM mx : ExceptT ε m α)] = Pr[ p | mx] := by
   simp only [probEvent_def, evalDist_liftM]
 
-end HasEvalSPMF
+end EvalSPMF
 
 end ExceptT

--- a/VCVio/EvalDist/Instances/FinRatPMF.lean
+++ b/VCVio/EvalDist/Instances/FinRatPMF.lean
@@ -19,17 +19,51 @@ namespace Raw
 
 variable {α : Type u}
 
-noncomputable instance : HasEvalPMF Raw where
-  toPMF := Raw.toPMFHom
-  support_eq _ := rfl
-  toSPMF_eq _ := rfl
+noncomputable instance : MonadLift Raw PMF where
+  monadLift := Raw.toPMFHom.toFun _
+
+noncomputable instance : LawfulMonadLift Raw PMF where
+  monadLift_pure := Raw.toPMFHom.toFun_pure'
+  monadLift_bind := Raw.toPMFHom.toFun_bind'
+
+/-- Direct `MonadLiftT Raw SetM` defined via the underlying PMF support. The generic
+`MonadLiftT SPMF SetM` is non-transitive (declared as `MonadLiftT`, not `MonadLift`,
+so `monadLiftTrans` cannot chain through it), so every monad with probabilistic
+semantics declares its `SetM` lift directly. -/
+noncomputable instance instMonadLiftTRawSetM : MonadLiftT Raw SetM where
+  monadLift mx := ((liftM mx : PMF _).support : Set _)
+
+noncomputable instance instLawfulMonadLiftTRawSetM : LawfulMonadLiftT Raw SetM where
+  monadLift_pure x := by
+    change ((liftM (pure x : Raw _) : PMF _).support : Set _) = {x}
+    have : (liftM (pure x : Raw _) : PMF _) = pure x :=
+      LawfulMonadLift.monadLift_pure (m := Raw) (n := PMF) x
+    rw [this]; exact PMF.support_pure x
+  monadLift_bind mx my := by
+    change ((liftM (mx >>= my) : PMF _).support : Set _) =
+      Bind.bind (m := SetM)
+        ((liftM mx : PMF _).support : Set _)
+        (fun x => ((liftM (my x) : PMF _).support : Set _))
+    have hbind : (liftM (mx >>= my) : PMF _) =
+        (liftM mx : PMF _) >>= fun x => (liftM (my x) : PMF _) :=
+      LawfulMonadLift.monadLift_bind (m := Raw) (n := PMF) mx my
+    rw [hbind]; exact PMF.support_bind _ _
+
+/-- Compatibility: `Raw`'s SetM support equals the SPMF support of its `evalDist`. -/
+noncomputable instance : EvalDistCompatible Raw where
+  support_eq_SPMF_support mx := by
+    change ((liftM mx : PMF _).support : Set _) =
+      SPMF.support (liftM (liftM mx : PMF _) : SPMF _)
+    rw [SPMF.support_liftM]
 
 instance : HasEvalFinset Raw where
   finSupport := Raw.support
   coe_finSupport mx := by
     ext x
     rw [Finset.mem_coe, _root_.mem_support_iff, Raw.mem_support_iff]
-    rw [probOutput_def, HasEvalPMF.evalDist_of_hasEvalPMF_def, SPMF.liftM_apply]
+    rw [probOutput_def, evalDist_def]
+    change mx.prob x ≠ 0 ↔ (liftM (liftM mx : PMF _) : SPMF _) x ≠ 0
+    rw [SPMF.liftM_apply]
     change mx.prob x ≠ 0 ↔ ((@Raw.toPMF _ (Classical.decEq _) mx) x) ≠ 0
     simp [Raw.toPMF_apply, Raw.prob_eq_prob inferInstance (Classical.decEq _) mx x]
 

--- a/VCVio/EvalDist/Instances/OptionT.lean
+++ b/VCVio/EvalDist/Instances/OptionT.lean
@@ -10,8 +10,8 @@ import VCVio.EvalDist.Defs.AlternativeMonad
 /-!
 # Probability Distributions on Potentially Failing Computations
 
-This file gives an instance to extend a `evalDist` instance on a monad to one transformed by
-the `OptionT` monad transformer.
+This file lifts `MonadLiftT _ SetM` and `MonadLiftT _ SPMF` semantics through the
+`OptionT` monad transformer.
 
 dt: should add more instances and connecting lemmas
 -/
@@ -117,7 +117,7 @@ end HasEvalFinset
 
 section EvalSPMF
 
-/-- Lift a `MonadLiftT m SPMF` instance to `MonadLift (OptionT m) SPMF`. Failure in `OptionT`
+/-- Lift a `MonadLiftT m SPMF` instance to `MonadLiftT (OptionT m) SPMF`. Failure in `OptionT`
 contributes to the failure mass of the resulting `SPMF`. -/
 noncomputable instance instMonadLiftTSPMF (m : Type u → Type v) [Monad m]
     [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] :

--- a/VCVio/EvalDist/Instances/OptionT.lean
+++ b/VCVio/EvalDist/Instances/OptionT.lean
@@ -22,19 +22,28 @@ variable {m : Type u → Type v} [Monad m] {α β γ : Type u}
 
 namespace OptionT
 
-section HasEvalSet
+section EvalSet
 
-/-- Standalone `HasEvalSet (OptionT m)` instance under the weaker `[HasEvalSet m]` assumption.
+/-- Standalone `MonadLiftT (OptionT m) SetM` instance under the weaker `[MonadLiftT m SetM]`
+assumption. Keeping this standalone means `support` on `OptionT m` works without requiring a
+full `MonadLiftT m SPMF` lift — only `MonadLiftT m SetM` is needed.
 
-This is deliberately kept separate from the `HasEvalSPMF (OptionT m)` instance below, which
-re-exports the same `toSet` to make the resulting typeclass diamond definitionally equal.
-Keeping this standalone instance means `support` on `OptionT m` works without requiring a
-full `HasEvalSPMF m` — only `HasEvalSet m` is needed (e.g., for `support_liftM`). -/
-noncomputable instance (m : Type u → Type v) [Monad m] [HasEvalSet m] :
-    HasEvalSet (OptionT m) where
-  toSet.toFun α mx := some ⁻¹' (support (OptionT.run mx))
-  toSet.toFun_pure' mx := Set.ext fun x => by simp
-  toSet.toFun_bind' mx my := Set.ext fun x => by
+We declare a `MonadLiftT` (rather than `MonadLift`) so the instance has no `semiOutParam`
+arguments to synthesize — `OptionT m`'s `m` cannot be recovered from the `SetM` codomain. -/
+noncomputable instance instMonadLiftTSetM {m : Type u → Type v} [Monad m]
+    [MonadLiftT m SetM] : MonadLiftT (OptionT m) SetM where
+  monadLift mx := some ⁻¹' (support (OptionT.run mx))
+
+noncomputable instance instLawfulMonadLiftTSetM {m : Type u → Type v} [Monad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] :
+    LawfulMonadLiftT (OptionT m) SetM where
+  monadLift_pure mx := by
+    change some ⁻¹' (support (OptionT.run (pure mx : OptionT m _))) = pure mx
+    ext x; simp
+  monadLift_bind mx my := by
+    change (some ⁻¹' (support (OptionT.run (mx >>= my))) : SetM _) =
+      ((some ⁻¹' (support mx.run)) >>= fun a => some ⁻¹' (support (my a).run) : SetM _)
+    ext x
     rw [Set.mem_preimage]
     calc
       some x ∈ support (OptionT.run (mx >>= my)) ↔
@@ -53,12 +62,14 @@ noncomputable instance (m : Type u → Type v) [Monad m] [HasEvalSet m] :
       _ ↔ x ∈ ⋃ a ∈ some ⁻¹' support mx.run, some ⁻¹' support (my a).run := by
             simp only [Set.mem_iUnion, Set.mem_preimage, exists_prop]
 
-variable [HasEvalSet m]
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
+omit [LawfulMonadLiftT m SetM] in
 @[aesop unsafe norm, grind =]
 lemma support_def (mx : OptionT m α) :
     support mx = some ⁻¹' (support mx.run) := rfl
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp low]
 lemma mem_support_iff (mx : OptionT m α) (x : α) :
     x ∈ support mx ↔ some x ∈ support mx.run := by grind
@@ -71,17 +82,17 @@ lemma support_liftM (mx : m α) :
 lemma support_lift (mx : m α) :
     support (OptionT.lift mx) = support mx := by grind
 
-end HasEvalSet
+end EvalSet
 
 section HasEvalFinset
 
 /-- Lift a `HasEvalFinset` instance to `OptionT`. by just taking preimage under `some`. -/
-noncomputable instance (m : Type u → Type v) [Monad m] [HasEvalSet m] [HasEvalFinset m] :
+noncomputable instance (m : Type u → Type v) [Monad m] [MonadLiftT m SetM] [HasEvalFinset m] :
     HasEvalFinset (OptionT m) where
   finSupport mx := (finSupport mx.run).preimage some (by simp)
   coe_finSupport := by aesop
 
-variable [HasEvalSet m] [HasEvalFinset m]
+variable [MonadLiftT m SetM] [HasEvalFinset m]
 
 @[aesop unsafe norm, grind =]
 lemma finSupport_def [DecidableEq α] (mx : OptionT m α) :
@@ -93,61 +104,81 @@ lemma mem_finSupport_iff [DecidableEq α] (mx : OptionT m α) (x : α) :
   simp [finSupport_def, Finset.mem_preimage]
 
 @[simp]
-lemma finSupport_liftM [DecidableEq α] (mx : m α) :
+lemma finSupport_liftM [LawfulMonadLiftT m SetM] [LawfulMonad m] [DecidableEq α] (mx : m α) :
     finSupport (liftM mx : OptionT m α) = finSupport mx := by
-  grind only [= finSupport_def, = liftM_def, = coe_finSupport, = run_lift,
-    = mem_finSupport_iff_mem_support, = support_def, = Set.mem_preimage, = mem_support_bind_iff,
-    = support_pure, = Set.mem_singleton_iff]
+  ext x; simp [mem_finSupport_iff, mem_finSupport_iff_mem_support]
 
 @[simp]
-lemma finSupport_lift [DecidableEq α] (mx : m α) :
+lemma finSupport_lift [LawfulMonadLiftT m SetM] [LawfulMonad m] [DecidableEq α] (mx : m α) :
     finSupport (OptionT.lift mx) = finSupport mx := by
-  grind only [= finSupport_def, = run_lift, = coe_finSupport, = mem_finSupport_iff_mem_support,
-    = support_def, = Set.mem_preimage, = mem_support_bind_iff, = support_pure,
-    = Set.mem_singleton_iff]
+  ext x; simp [mem_finSupport_iff, mem_finSupport_iff_mem_support]
 
 end HasEvalFinset
 
-section HasEvalSPMF
+section EvalSPMF
 
-/-- Lift a `HasEvalSPMF m` instance to `HasEvalSPMF (OptionT m)`.
-Note: a more specific `HasEvalPMF m → HasEvalSPMF (OptionT m)` path would make explicit
-that failure comes solely from `OptionT`, but this general instance subsumes it.
+/-- Lift a `MonadLiftT m SPMF` instance to `MonadLift (OptionT m) SPMF`. Failure in `OptionT`
+contributes to the failure mass of the resulting `SPMF`. -/
+noncomputable instance instMonadLiftTSPMF (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] :
+    MonadLiftT (OptionT m) SPMF where
+  monadLift x := OptionT.mapM' (MonadHom.ofLift m SPMF) x
 
-Lean 4 automatically synthesizes `toSet` from the standalone `HasEvalSet (OptionT m)` instance
-above, ensuring the diamond is definitionally equal (per Mathlib convention). The `support_eq`
-field then serves as the coherence proof between the set-path and distribution-path. -/
-noncomputable instance (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
-    HasEvalSPMF (OptionT m) where
-  toSPMF := OptionT.mapM' HasEvalSPMF.toSPMF
-  support_eq mx := by
-    ext x
-    simp only [mem_support_iff, OptionT.mapM', SPMF.mem_support_iff, SPMF.bind_apply_eq_tsum, ne_eq,
-      ENNReal.tsum_eq_zero, mul_eq_zero, not_forall, not_or]
-    constructor
-    · simp only [mem_support_iff_evalDist_apply_ne_zero, ne_eq]
-      refine fun h => ⟨some x, by simpa using h⟩
-    · simp only [mem_support_iff_evalDist_apply_ne_zero, ne_eq, forall_exists_index, and_imp]
-      intro x
-      cases x <;> aesop
+noncomputable instance instLawfulMonadLiftTSPMF (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] :
+    LawfulMonadLiftT (OptionT m) SPMF where
+  monadLift_pure x := by
+    change OptionT.mapM' (MonadHom.ofLift m SPMF) (pure x : OptionT m _) = pure x
+    simp
+  monadLift_bind mx my := by
+    change OptionT.mapM' (MonadHom.ofLift m SPMF) (mx >>= my) =
+      OptionT.mapM' (MonadHom.ofLift m SPMF) mx >>=
+        fun a => OptionT.mapM' (MonadHom.ofLift m SPMF) (my a)
+    simp
 
-instance (m : Type u → Type v) [Monad m] [HasEvalSPMF m] :
+instance instLawfulFailure (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] :
     HasEvalSet.LawfulFailure (OptionT m) where
   support_failure' := by aesop
 
+/-- The SetM-lift of `OptionT m` (preimage of `support mx.run` under `some`) agrees with the
+SPMF-lift (the `OptionT.mapM'` bind into `SPMF`) on outputs, given `EvalDistCompatible m`. -/
+instance instEvalDistCompatible (m : Type u → Type v) [Monad m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [EvalDistCompatible m] :
+    EvalDistCompatible (OptionT m) where
+  support_eq_SPMF_support {α} mx := by
+    change some ⁻¹' (SetM.run (liftM mx.run : SetM (Option α))) =
+      SPMF.support ((MonadHom.ofLift m SPMF) mx.run >>=
+        fun y => match y with | some a => pure a | none => failure : SPMF α)
+    rw [SPMF.support_bind]
+    have hbridge : SetM.run (liftM mx.run : SetM (Option α)) =
+        SPMF.support ((MonadHom.ofLift m SPMF) mx.run) :=
+      EvalDistCompatible.support_eq_SPMF_support mx.run
+    rw [hbridge]
+    ext a
+    simp only [Set.mem_preimage, Set.mem_iUnion, exists_prop]
+    refine ⟨fun h => ⟨some a, h, by simp [SPMF.support_pure]⟩, ?_⟩
+    rintro ⟨y, hy, ha⟩
+    cases y with
+    | none => simp only [SPMF.mem_support_iff, SPMF.failure_apply, ne_eq, not_true_eq_false] at ha
+    | some b => rw [SPMF.support_pure, Set.mem_singleton_iff] at ha; exact ha ▸ hy
 
-variable [HasEvalSPMF m]
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
 
 lemma evalDist_eq (mx : OptionT m α) :
-    𝒟[mx] = OptionT.mapM' HasEvalSPMF.toSPMF mx := rfl
+    𝒟[mx] = OptionT.mapM' (MonadHom.ofLift m SPMF) mx := rfl
 
 @[grind =]
 lemma probOutput_eq (mx : OptionT m α) (x : α) :
     Pr[= x | mx] = Pr[= some x | mx.run] := by
   simp only [probOutput_def]
-  change (OptionT.mapM' HasEvalSPMF.toSPMF mx) x = HasEvalSPMF.toSPMF mx.run (some x)
-  rw [show (OptionT.mapM' HasEvalSPMF.toSPMF mx : SPMF α) =
-    HasEvalSPMF.toSPMF mx.run >>= fun y =>
+  change (OptionT.mapM' (MonadHom.ofLift m SPMF) mx) x = (MonadHom.ofLift m SPMF) mx.run (some x)
+  rw [show (OptionT.mapM' (MonadHom.ofLift m SPMF) mx : SPMF α) =
+    (MonadHom.ofLift m SPMF) mx.run >>= fun y =>
       match y with | some a => pure a | none => failure from rfl]
   rw [SPMF.bind_apply_eq_tsum]
   refine (tsum_eq_single (some x) fun y hy => ?_).trans (by simp)
@@ -170,18 +201,24 @@ lemma probEvent_eq (mx : OptionT m α) (p : α → Prop) [DecidablePred p] :
 lemma probFailure_eq (mx : OptionT m α) :
     Pr[⊥ | mx] = Pr[⊥ | mx.run] + Pr[= none | mx.run] := by
   simp only [probFailure_def, probOutput_def]
-  rw [show 𝒟[mx] = (HasEvalSPMF.toSPMF mx.run >>= fun y =>
+  rw [show 𝒟[mx] = ((MonadHom.ofLift m SPMF) mx.run >>= fun y =>
       match y with | some a => pure a | none => failure : SPMF α) from rfl]
   simp [SPMF.toPMF_bind, Option.elimM, PMF.bind_apply, tsum_option,
     SPMF.toPMF_failure, SPMF.toPMF_pure, SPMF.apply_eq_toPMF_some, evalDist_def]
 
 @[simp, grind =]
 lemma probOutput_liftM [LawfulMonad m] (mx : m α) (x : α) :
-    Pr[= x | liftM (n := OptionT m) mx] = Pr[= x | mx] := by simp [probOutput_eq]
+    Pr[= x | liftM (n := OptionT m) mx] = Pr[= x | mx] := by
+  rw [probOutput_eq]
+  show Pr[= some x | (liftM mx : OptionT m _).run] = Pr[= x | mx]
+  rw [show (liftM mx : OptionT m _).run = some <$> mx from by
+    simp [monad_norm]]
+  exact probOutput_map_injective (f := (some : α → Option α)) mx (Option.some_injective _) x
 
 @[simp, grind =]
 lemma probOutput_lift [LawfulMonad m] (mx : m α) (x : α) :
-    Pr[= x | OptionT.lift mx] = Pr[= x | mx] := by simp [probOutput_eq]
+    Pr[= x | OptionT.lift mx] = Pr[= x | mx] :=
+  probOutput_liftM mx x
 
 @[simp, grind =]
 lemma probEvent_liftM [LawfulMonad m] (mx : m α) (p : α → Prop) :
@@ -203,6 +240,6 @@ lemma probFailure_lift [LawfulMonad m] (mx : m α) :
     Pr[⊥ | OptionT.lift mx] = Pr[⊥ | mx] := by
   simp [probFailure_eq]
 
-end HasEvalSPMF
+end EvalSPMF
 
 end OptionT

--- a/VCVio/EvalDist/Instances/ReaderT.lean
+++ b/VCVio/EvalDist/Instances/ReaderT.lean
@@ -17,18 +17,18 @@ because the environment is read-only and doesn't change during computation.
 ## Main definitions
 
 * `ReaderT.evalAt ρ0`: Monad homomorphism `ReaderT ρ m →ᵐ m` by evaluation at `ρ0`
-* `HasEvalSPMF.readerAt ρ0`: Lift `HasEvalSPMF m` through `ReaderT` at fixed `ρ0`
-* `HasEvalPMF.readerAt ρ0`: Lift `HasEvalPMF m` through `ReaderT` at fixed `ρ0`
+* `ReaderT.toSPMF ρ0`: Lift `MonadLiftT m SPMF` through `ReaderT` at fixed `ρ0`
+* `ReaderT.toPMF ρ0`: Lift `MonadLiftT m PMF` through `ReaderT` at fixed `ρ0`
 
 ## Design notes
 
-We do NOT provide global `HasEvalSPMF (ReaderT ρ m)` instances because there's no
+We do NOT provide global `MonadLift (ReaderT ρ m) SPMF` instances because there's no
 canonical choice of environment. Instead, users explicitly provide the environment
 when constructing the evaluation homomorphism.
 
 For cryptographic games with random oracles, the typical pattern is:
 1. Generate oracle table with some distribution
-2. Use `readerAt` to evaluate the protocol at that table
+2. Use `toSPMF`/`toPMF` to evaluate the protocol at that table
 3. Compose with the table distribution to get overall game probability
 
 -/
@@ -57,78 +57,55 @@ def evalAt (ρ0 : ρ) : ReaderT ρ m →ᵐ m where
 
 end ReaderT
 
-/-- Lift `HasEvalSPMF m` to a homomorphism `ReaderT ρ m →ᵐ SPMF` by fixing `ρ0`.
+namespace ReaderT
+
+/-- Lift `m → SPMF` to a homomorphism `ReaderT ρ m →ᵐ SPMF` by fixing `ρ0`.
 
 This allows evaluating reader computations to sub-probability distributions
 when the base monad `m` has such an evaluation. -/
-noncomputable def HasEvalSPMF.readerAt (ρ0 : ρ) [HasEvalSPMF m] :
+noncomputable def toSPMF (ρ0 : ρ) [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] :
     ReaderT ρ m →ᵐ SPMF :=
-  HasEvalSPMF.toSPMF ∘ₘ ReaderT.evalAt (m := m) ρ0
+  MonadHom.ofLift m SPMF ∘ₘ ReaderT.evalAt (m := m) ρ0
 
-/-- Lift `HasEvalPMF m` to a homomorphism `ReaderT ρ m →ᵐ PMF` by fixing `ρ0`.
-
-This allows evaluating reader computations to probability distributions
-when the base monad `m` has such an evaluation. -/
-noncomputable def HasEvalPMF.readerAt (ρ0 : ρ) [HasEvalPMF m] :
+/-- Lift `m → PMF` to a homomorphism `ReaderT ρ m →ᵐ PMF` by fixing `ρ0`. -/
+noncomputable def toPMF (ρ0 : ρ) [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] :
     ReaderT ρ m →ᵐ PMF :=
-  HasEvalPMF.toPMF ∘ₘ ReaderT.evalAt (m := m) ρ0
-
-namespace ReaderT
+  MonadHom.ofLift m PMF ∘ₘ ReaderT.evalAt (m := m) ρ0
 
 section evalDist_lemmas
 
-variable [HasEvalSPMF m] (ρ0 : ρ)
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (ρ0 : ρ)
 
 /-- Evaluating `pure x` at any environment gives the same result as `pure x` in the base monad. -/
-@[simp] lemma evalSPMF_pure (x : α) :
-    HasEvalSPMF.readerAt ρ0 (pure x : ReaderT ρ m α) = HasEvalSPMF.toSPMF (pure x : m α) := by
-  simp only [HasEvalSPMF.readerAt, MonadHom.comp_apply, evalAt_apply, MonadHom.toFun_pure']
-  apply MonadHom.toFun_pure'
+@[simp] lemma toSPMF_pure (x : α) :
+    ReaderT.toSPMF ρ0 (pure x : ReaderT ρ m α) = (liftM (pure x : m α) : SPMF α) := by
+  change liftM ((ReaderT.evalAt ρ0).toFun α (pure x : ReaderT ρ m α)) = (liftM (pure x : m α)
+      : SPMF α)
+  rfl
 
 /-- Evaluating a bind distributes through the monad homomorphism. -/
-@[simp] lemma evalSPMF_bind (mx : ReaderT ρ m α) (f : α → ReaderT ρ m β) :
-    HasEvalSPMF.readerAt ρ0 (mx >>= f) =
-      HasEvalSPMF.readerAt ρ0 mx >>= fun x => HasEvalSPMF.readerAt ρ0 (f x) := by
-  simp only [HasEvalSPMF.readerAt, MonadHom.comp_apply, evalAt_apply]
-  apply MonadHom.toFun_bind'
+@[simp] lemma toSPMF_bind (mx : ReaderT ρ m α) (f : α → ReaderT ρ m β) :
+    ReaderT.toSPMF ρ0 (mx >>= f) =
+      ReaderT.toSPMF ρ0 mx >>= fun x => ReaderT.toSPMF ρ0 (f x) :=
+  (ReaderT.toSPMF ρ0).toFun_bind' mx f
 
 end evalDist_lemmas
 
 section evalPMF_lemmas
 
-variable [HasEvalPMF m] (ρ0 : ρ)
+variable [MonadLiftT m PMF] [LawfulMonadLiftT m PMF] (ρ0 : ρ)
 
-@[simp] lemma evalPMF_pure (x : α) :
-    HasEvalPMF.readerAt ρ0 (pure x : ReaderT ρ m α) = HasEvalPMF.toPMF (pure x : m α) := by
-  simp only [HasEvalPMF.readerAt, MonadHom.comp_apply, evalAt_apply, MonadHom.toFun_pure',
-    PMF.monad_pure_eq_pure]
-  apply MonadHom.toFun_pure'
+@[simp] lemma toPMF_pure (x : α) :
+    ReaderT.toPMF ρ0 (pure x : ReaderT ρ m α) = (liftM (pure x : m α) : PMF α) := by
+  change liftM ((ReaderT.evalAt ρ0).toFun α (pure x : ReaderT ρ m α)) = (liftM (pure x : m α)
+      : PMF α)
+  rfl
 
-@[simp] lemma evalPMF_bind (mx : ReaderT ρ m α) (f : α → ReaderT ρ m β) :
-    HasEvalPMF.readerAt ρ0 (mx >>= f) =
-      HasEvalPMF.readerAt ρ0 mx >>= fun x => HasEvalPMF.readerAt ρ0 (f x) := by
-  simp only [HasEvalPMF.readerAt, MonadHom.comp_apply, evalAt_apply, PMF.monad_bind_eq_bind]
-  apply MonadHom.toFun_bind'
+@[simp] lemma toPMF_bind (mx : ReaderT ρ m α) (f : α → ReaderT ρ m β) :
+    ReaderT.toPMF ρ0 (mx >>= f) =
+      ReaderT.toPMF ρ0 mx >>= fun x => ReaderT.toPMF ρ0 (f x) :=
+  (ReaderT.toPMF ρ0).toFun_bind' mx f
 
 end evalPMF_lemmas
 
 end ReaderT
-
-/-! ### Optional: Instances with canonical environments
-
-If you have a canonical choice of environment (e.g., via `[Inhabited ρ]`),
-you can uncomment these to get automatic `HasEvalSPMF/PMF` instances.
-
-However, for most cryptographic use cases, it's better to keep the environment
-explicit and use the `readerAt` homomorphisms directly.
-
-```lean
-noncomputable instance [HasEvalSPMF m] [Inhabited ρ] :
-    HasEvalSPMF (ReaderT ρ m) where
-  toSPMF := HasEvalSPMF.readerAt (m := m) default
-
-noncomputable instance [HasEvalPMF m] [Inhabited ρ] :
-    HasEvalPMF (ReaderT ρ m) where
-  toPMF := HasEvalPMF.readerAt (m := m) default
-```
--/

--- a/VCVio/EvalDist/Instances/ReaderT.lean
+++ b/VCVio/EvalDist/Instances/ReaderT.lean
@@ -22,7 +22,7 @@ because the environment is read-only and doesn't change during computation.
 
 ## Design notes
 
-We do NOT provide global `MonadLift (ReaderT ρ m) SPMF` instances because there's no
+We do NOT provide global `MonadLiftT (ReaderT ρ m) SPMF` instances because there's no
 canonical choice of environment. Instead, users explicitly provide the environment
 when constructing the evaluation homomorphism.
 

--- a/VCVio/EvalDist/List.lean
+++ b/VCVio/EvalDist/List.lean
@@ -12,24 +12,27 @@ import ToMathlib.General
 This file contains lemmas for `probEvent` and `probOutput` of computations involving `List`.
 We also include `Vector` as a related case.
 
-All lemmas are generic over any monad `m` with `[HasEvalSPMF m]`.
+All lemmas are generic over any monad `m` with `[MonadLiftT m SPMF]`.
 -/
 
 universe u v w
 
 variable {α β γ : Type v}
-    {m : Type _ → Type _} [Monad m] [HasEvalSPMF m]
+    {m : Type _ → Type _} [Monad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 open List
 
 section cons_append
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
 lemma cons_mem_support_seq_map_cons_iff [LawfulMonad m]
     (mx : m α) (my : m (List α)) (x : α) (xs : List α) :
     x :: xs ∈ support (cons <$> mx <*> my) ↔ x ∈ support mx ∧ xs ∈ support my := by
   rw [support_seq_map_eq_image2]
   exact Set.mem_image2_iff injective2_cons
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
 lemma cons_mem_finSupport_seq_map_cons_iff [LawfulMonad m] [HasEvalFinset m] [DecidableEq α]
     (mx : m α) (my : m (List α)) (x : α) (xs : List α) :
     x :: xs ∈ finSupport (cons <$> mx <*> my) ↔
@@ -37,11 +40,13 @@ lemma cons_mem_finSupport_seq_map_cons_iff [LawfulMonad m] [HasEvalFinset m] [De
   simp_rw [mem_finSupport_iff_mem_support]
   exact cons_mem_support_seq_map_cons_iff mx my x xs
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 lemma probOutput_cons_seq_map_cons_eq_mul [LawfulMonad m]
     (mx : m α) (my : m (List α)) (x : α) (xs : List α) :
     Pr[= x :: xs | cons <$> mx <*> my] = Pr[= x | mx] * Pr[= xs | my] :=
   probOutput_seq_map_eq_mul_of_injective2 mx my cons injective2_cons x xs
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 lemma probOutput_cons_seq_map_cons_eq_mul' [LawfulMonad m]
     (mx : m α) (my : m (List α)) (x : α) (xs : List α) :
     Pr[= x :: xs | (fun xs x => x :: xs) <$> my <*> mx] =
@@ -49,6 +54,7 @@ lemma probOutput_cons_seq_map_cons_eq_mul' [LawfulMonad m]
   (probOutput_seq_map_swap mx my cons (x :: xs)).trans
     (probOutput_cons_seq_map_cons_eq_mul mx my x xs)
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 @[simp]
 lemma probOutput_map_append_left [LawfulMonad m] [DecidableEq α]
     (xs : List α) (mx : m (List α)) (ys : List α) :
@@ -70,6 +76,7 @@ end cons_append
 
 section mapM
 
+omit [LawfulMonadLiftT m SetM] in
 lemma probFailure_list_mapM_loop (xs : List α) (f : α → m β) (ys : List β) :
     Pr[⊥ | List.mapM.loop f xs ys] = 1 - (xs.map (1 - Pr[⊥ | f ·])).prod := by
   revert ys
@@ -87,11 +94,13 @@ lemma probFailure_list_mapM_loop (xs : List α) (f : α → m β) (ys : List β)
       · simp
       · simp [h]
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp, grind =]
 lemma probFailure_list_mapM (xs : List α) (f : α → m β) :
     Pr[⊥ | xs.mapM f] = 1 - (xs.map (1 - Pr[⊥ | f ·])).prod := by
   rw [mapM, probFailure_list_mapM_loop]
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 @[simp]
 lemma probOutput_list_mapM_loop [DecidableEq β]
     (xs : List α) (f : α → m β) (ys : List β)
@@ -157,6 +166,7 @@ lemma probOutput_list_mapM_loop [DecidableEq β]
       intro y
       rw [if_neg (fun ⟨hl, ht⟩ => hcond ⟨by omega, take_mono y ht⟩), mul_zero]
 
+omit [LawfulMonadLiftT m SetM] in
 lemma probOutput_bind_eq_mul {mx : m α} {my : α → m β} {y : β} (x : α)
     (h : ∀ x' ∈ support mx, y ∈ support (my x') → x' = x) :
     Pr[= y | mx >>= my] = Pr[= x | mx] * Pr[= y | my x] := by
@@ -260,6 +270,7 @@ section ListVector
 
 variable {n : ℕ} (mx : m α) (my : m (List.Vector α n))
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
 @[simp]
 lemma support_seq_map_vector_cons [LawfulMonad m] :
     support ((· ::ᵥ ·) <$> mx <*> my) =
@@ -272,12 +283,14 @@ lemma support_seq_map_vector_cons [LawfulMonad m] :
   · rintro ⟨hh, ht⟩
     exact ⟨xs.head, hh, xs.tail, ht, List.Vector.cons_head_tail xs⟩
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 @[simp]
 lemma probOutput_seq_map_vector_cons_eq_mul [LawfulMonad m] (xs : List.Vector α (n + 1)) :
     Pr[= xs | (· ::ᵥ ·) <$> mx <*> my] = Pr[= xs.head | mx] * Pr[= xs.tail | my] := by
   conv_lhs => rw [show xs = xs.head ::ᵥ xs.tail from (List.Vector.cons_head_tail xs).symm]
   exact probOutput_seq_map_eq_mul_of_injective2 mx my _ Vector.injective2_cons xs.head xs.tail
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 @[simp]
 lemma probOutput_seq_map_vector_cons_eq_mul' [LawfulMonad m] (xs : List.Vector α (n + 1)) :
     Pr[= xs | (fun xs x => x ::ᵥ xs) <$> my <*> mx] =
@@ -302,13 +315,14 @@ section ListVectorMmap
 
 variable {n : ℕ}
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp]
 lemma neverFail_list_vector_mmap {f : α → m β} {as : List.Vector α n}
     (h : ∀ x ∈ as.toList, NeverFail (f x)) : NeverFail (List.Vector.mmap f as) := by
   induction as using List.Vector.inductionOn with
   | nil => simp [List.Vector.mmap]
   | @cons n x xs ih =>
-    simp only [List.Vector.mmap_cons, HasEvalSPMF.neverFail_bind_iff]
+    simp only [List.Vector.mmap_cons, neverFail_bind_iff]
     exact ⟨h x (by simp), fun _ _ =>
       ⟨ih (fun x' hx' => h x' (by simp [hx'])), fun _ _ => inferInstance⟩⟩
 
@@ -320,24 +334,28 @@ end ListVectorMmap
 
 -- TODO: mem_support_vector_mapM and neverFail_vector_mapM for Std.Vector —
 -- Vector.mapM (Std/Batteries) uses MonadSatisfying internally and doesn't
--- reduce cleanly for generic HasEvalSPMF monads.
+-- reduce cleanly for generic `[MonadLiftT m SPMF]` monads.
 
 /-! ## NeverFail lemmas for list monadic operations -/
 
 section NeverFail
 
-variable {α β : Type*} {m : Type _ → Type _} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
+variable {α β : Type*} {m : Type _ → Type _} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp]
 lemma neverFail_list_mapM {f : α → m β} {as : List α}
     (h : ∀ x ∈ as, NeverFail (f x)) : NeverFail (as.mapM f) := by
   induction as with
   | nil => rw [List.mapM_nil]; infer_instance
   | cons a as ih =>
-    simp only [List.mapM_cons, HasEvalSPMF.neverFail_bind_iff]
+    simp only [List.mapM_cons, neverFail_bind_iff]
     exact ⟨h a (.head ..), fun _ _ =>
       ⟨ih (fun x hx => h x (.tail _ hx)), fun _ _ => inferInstance⟩⟩
 
+omit [LawfulMonadLiftT m SetM] in
 omit [LawfulMonad m] in
 @[simp]
 lemma neverFail_list_mapM' {f : α → m β} {as : List α}
@@ -345,10 +363,11 @@ lemma neverFail_list_mapM' {f : α → m β} {as : List α}
   induction as with
   | nil => rw [List.mapM'_nil]; infer_instance
   | cons a as ih =>
-    simp only [List.mapM'_cons, HasEvalSPMF.neverFail_bind_iff]
+    simp only [List.mapM'_cons, neverFail_bind_iff]
     exact ⟨h a (.head ..), fun _ _ =>
       ⟨ih (fun x hx => h x (.tail _ hx)), fun _ _ => inferInstance⟩⟩
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp]
 lemma neverFail_list_flatMapM {f : α → m (List β)} {as : List α}
     (h : ∀ x ∈ as, NeverFail (f x)) : NeverFail (as.flatMapM f) := by
@@ -356,26 +375,28 @@ lemma neverFail_list_flatMapM {f : α → m (List β)} {as : List α}
   | nil => simp only [List.flatMapM_nil]; infer_instance
   | cons a as ih =>
     simp only [List.flatMapM_cons, bind_pure_comp,
-      HasEvalSPMF.neverFail_bind_iff, HasEvalSPMF.neverFail_map_iff]
+      neverFail_bind_iff, neverFail_map_iff]
     exact ⟨h a (.head ..), fun _ _ => ih (fun x hx => h x (.tail _ hx))⟩
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp]
 lemma neverFail_list_filterMapM {f : α → m (Option β)} {as : List α}
     (h : ∀ x ∈ as, NeverFail (f x)) : NeverFail (as.filterMapM f) := by
   induction as with
   | nil => simp only [List.filterMapM_nil]; infer_instance
   | cons a as ih =>
-    simp only [List.filterMapM_cons, HasEvalSPMF.neverFail_bind_iff]
+    simp only [List.filterMapM_cons, neverFail_bind_iff]
     refine ⟨h a (.head ..), fun y _ => ?_⟩
     have h_tail := ih (fun x hx => h x (.tail _ hx))
     cases y with
     | none => exact h_tail
     | some b =>
-      simp only [HasEvalSPMF.neverFail_bind_iff]
+      simp only [neverFail_bind_iff]
       exact ⟨h_tail, fun _ _ => inferInstance⟩
 
 variable {s : Type*}
 
+omit [LawfulMonadLiftT m SetM] in
 omit [LawfulMonad m] in
 @[simp]
 lemma neverFail_list_foldlM {f : s → α → m s} {init : s} {as : List α}
@@ -383,16 +404,17 @@ lemma neverFail_list_foldlM {f : s → α → m s} {init : s} {as : List α}
   induction as generalizing init with
   | nil => rw [List.foldlM_nil]; infer_instance
   | cons b bs ih =>
-    simp only [List.foldlM_cons, HasEvalSPMF.neverFail_bind_iff]
+    simp only [List.foldlM_cons, neverFail_bind_iff]
     exact ⟨h init b (.head ..), fun _ _ => ih (fun i x hx => h i x (.tail _ hx))⟩
 
+omit [LawfulMonadLiftT m SetM] in
 @[simp]
 lemma neverFail_list_foldrM {f : α → s → m s} {init : s} {as : List α}
     (h : ∀ i, ∀ x ∈ as, NeverFail (f x i)) : NeverFail (as.foldrM f init) := by
   induction as generalizing init with
   | nil => rw [List.foldrM_nil]; infer_instance
   | cons b bs ih =>
-    simp only [List.foldrM_cons, HasEvalSPMF.neverFail_bind_iff]
+    simp only [List.foldrM_cons, neverFail_bind_iff]
     exact ⟨ih (fun i x hx => h i x (.tail _ hx)), fun y _ => h y b (.head ..)⟩
 
 end NeverFail

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -20,82 +20,87 @@ open ENNReal
 
 section pure
 
-@[simp, grind =] lemma support_pure [HasEvalSet m] (x : α) :
-    support (pure x : m α) = {x} := HasEvalSet.toSet.toFun_pure' x
+@[simp, grind =] lemma support_pure [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (x : α) :
+    support (pure x : m α) = {x} := monadLift_pure x
 
-lemma mem_support_pure_iff [HasEvalSet m] (x y : α) :
+lemma mem_support_pure_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (x y : α) :
     x ∈ support (pure y : m α) ↔ x = y := by grind
-lemma mem_support_pure_iff' [HasEvalSet m] (x y : α) :
+lemma mem_support_pure_iff' [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (x y : α) :
     x ∈ support (pure y : m α) ↔ y = x := by aesop
 
-@[simp, grind =] lemma finSupport_pure [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
-    (x : α) : finSupport (pure x : m α) = {x} := by aesop
+@[simp, grind =]
+lemma finSupport_pure [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
+    [DecidableEq α] (x : α) : finSupport (pure x : m α) = {x} := by aesop
 
-lemma mem_finSupport_pure_iff [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma mem_finSupport_pure_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
+    [DecidableEq α]
     (x y : α) : x ∈ finSupport (pure y : m α) ↔ x = y := by grind
-lemma mem_finSupport_pure_iff' [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma mem_finSupport_pure_iff' [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
+    [DecidableEq α]
     (x y : α) : x ∈ finSupport (pure y : m α) ↔ y = x := by aesop
 
 @[simp, grind =, game_rule]
-lemma evalDist_pure [HasEvalSPMF m] {α : Type u} (x : α) :
+lemma evalDist_pure [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] {α : Type u} (x : α) :
     𝒟[(pure x : m α)] = pure x := by simp [evalDist]
 
 @[simp]
-lemma evalDist_comp_pure [HasEvalSPMF m] :
+lemma evalDist_comp_pure [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] :
     evalDist ∘ (pure : α → m α) = pure := by aesop
 
 @[simp]
-lemma evalDist_comp_pure' [HasEvalSPMF m] (f : α → β) :
+lemma evalDist_comp_pure' [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (f : α → β) :
     evalDist ∘ (pure : β → m β) ∘ f = pure ∘ f := by grind
 
 @[simp, grind =, game_rule]
-lemma probOutput_pure [HasEvalSPMF m] [DecidableEq α] (x y : α) :
+lemma probOutput_pure [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [DecidableEq α] (x y : α) :
     Pr[= x | (pure y : m α)] = if x = y then 1 else 0 := by
   aesop (rule_sets := [UnfoldEvalDist])
 
 @[simp, grind =]
-lemma probOutput_pure_self [HasEvalSPMF m] (x : α) :
+lemma probOutput_pure_self [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) :
     Pr[= x | (pure x : m α)] = 1 := by
   aesop (rule_sets := [UnfoldEvalDist])
 
 /-- Fallback when we don't have decidable equality. -/
 @[grind =]
-lemma probOutput_pure_eq_indicator [HasEvalSPMF m] (x y : α) :
+lemma probOutput_pure_eq_indicator [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x y : α) :
     Pr[= x | (pure y : m α)] = Set.indicator {y} (Function.const α 1) x := by
   aesop (rule_sets := [UnfoldEvalDist])
 
 @[simp, grind =]
-lemma probEvent_pure [HasEvalSPMF m] (x : α) (p : α → Prop) [DecidablePred p] :
+lemma probEvent_pure [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) (p : α → Prop)
+    [DecidablePred p] :
     Pr[ p | (pure x : m α)] = if p x then 1 else 0 := by
   aesop (rule_sets := [UnfoldEvalDist])
 
 /-- Fallback when we don't have decidable equality. -/
 @[grind =]
-lemma probEvent_pure_eq_indicator [HasEvalSPMF m] (x : α) (p : α → Prop) :
+lemma probEvent_pure_eq_indicator [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) (p : α
+    → Prop) :
     Pr[ p | (pure x : m α)] = Set.indicator {x | p x} (Function.const α 1) x := by
   aesop (rule_sets := [UnfoldEvalDist])
 
 @[simp, grind =]
-lemma probFailure_pure [HasEvalSPMF m] (x : α) :
+lemma probFailure_pure [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) :
     Pr[⊥ | (pure x : m α)] = 0 := by aesop (rule_sets := [UnfoldEvalDist])
 
 @[simp]
-lemma tsum_probOutput_pure [HasEvalSPMF m] (x : α) :
+lemma tsum_probOutput_pure [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) :
     ∑' y : α, Pr[= y | (pure x : m α)] = 1 := by
   have : DecidableEq α := Classical.decEq α; simp
 
 @[simp]
-lemma tsum_probOutput_pure' [HasEvalSPMF m] (x : α) :
+lemma tsum_probOutput_pure' [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) :
     ∑' y : α, Pr[= x | (pure y : m α)] = 1 := by
   have : DecidableEq α := Classical.decEq α; simp
 
 @[simp]
-lemma sum_probOutput_pure [Fintype α] [HasEvalSPMF m] (x : α) :
+lemma sum_probOutput_pure [Fintype α] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) :
     ∑ y : α, Pr[= y | (pure x : m α)] = 1 := by
   have : DecidableEq α := Classical.decEq α; simp
 
 @[simp]
-lemma sum_probOutput_pure' [Fintype α] [HasEvalSPMF m] (x : α) :
+lemma sum_probOutput_pure' [Fintype α] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (x : α) :
     ∑ y : α, Pr[= x | (pure y : m α)] = 1 := by
   have : DecidableEq α := Classical.decEq α; simp
 
@@ -104,41 +109,47 @@ end pure
 section bind
 
 @[simp, grind =]
-lemma support_bind [HasEvalSet m] (mx : m α) (my : α → m β) :
+lemma support_bind [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (mx : m α) (my : α → m β) :
     support (mx >>= my) = ⋃ x ∈ support mx, support (my x) :=
-  HasEvalSet.toSet.toFun_bind' mx my
+  monadLift_bind mx my
 
 @[grind =]
-lemma mem_support_bind_iff [HasEvalSet m] (mx : m α) (my : α → m β) (y : β) :
+lemma mem_support_bind_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (mx : m α) (my : α
+    → m β) (y : β) :
     y ∈ support (mx >>= my) ↔ ∃ x ∈ support mx, y ∈ support (my x) := by simp
 
 -- dt: do we need global assumptions about `decidable_eq` for the `finSupport` definition?
 @[simp, grind =]
-lemma finSupport_bind [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma finSupport_bind [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
+    [DecidableEq α]
     [DecidableEq β] (mx : m α) (my : α → m β) : finSupport (mx >>= my) =
       Finset.biUnion (finSupport mx) fun x => finSupport (my x) := by aesop
 
 @[grind =]
-lemma mem_finSupport_bind_iff [HasEvalSet m] [HasEvalFinset m] [DecidableEq α]
+lemma mem_finSupport_bind_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
+    [DecidableEq α]
     [DecidableEq β] (mx : m α) (my : α → m β) (y : β) : y ∈ finSupport (mx >>= my) ↔
       ∃ x ∈ finSupport mx, y ∈ finSupport (my x) := by aesop
 
 @[simp, grind =, game_rule]
-lemma evalDist_bind [HasEvalSPMF m] (mx : m α) (my : α → m β) :
+lemma evalDist_bind [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (mx : m α) (my : α → m β) :
     𝒟[mx >>= my] = 𝒟[mx] >>= fun x => 𝒟[my x] :=
-  MonadHom.toFun_bind' _ mx my
+  monadLift_bind mx my
 
-lemma evalDist_bind_of_support_eq_empty [HasEvalSPMF m] (mx : m α) (my : α → m β)
+lemma evalDist_bind_of_support_eq_empty [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β)
     (h : support mx = ∅) : 𝒟[mx >>= my] = failure := by
   simp [SPMF.ext_iff, ← probOutput_def, h]
 
 @[grind =, game_rule]
-lemma probOutput_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (y : β) :
+lemma probOutput_bind_eq_tsum [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (mx : m α) (my : α
+    → m β) (y : β) :
     Pr[= y | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[= y | my x] := by
   simp [probOutput_def]
 
 @[grind =]
-lemma probEvent_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (q : β → Prop) :
+lemma probEvent_bind_eq_tsum [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (mx : m α) (my : α
+    → m β) (q : β → Prop) :
     Pr[ q | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[ q | my x] := by
   simp only [probEvent_eq_tsum_indicator, Set.indicator, Set.mem_setOf_eq, probOutput_bind_eq_tsum,
     ← ENNReal.tsum_mul_left, mul_ite, mul_zero]
@@ -146,13 +157,15 @@ lemma probEvent_bind_eq_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) (q :
   refine tsum_congr fun x => by split_ifs <;> simp
 
 @[grind =]
-lemma probFailure_bind_eq_add_tsum [HasEvalSPMF m] (mx : m α) (my : α → m β) :
+lemma probFailure_bind_eq_add_tsum [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (mx : m α) (my
+    : α → m β) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑' x : α, Pr[= x | mx] * Pr[⊥ | my x] := by
   simp [probFailure_def, Option.elimM, tsum_option, probOutput_def,
     SPMF.apply_eq_toPMF_some]
 
 @[grind =]
-lemma probFailure_bind_eq_add_tsum_support [HasEvalSPMF m] (mx : m α) (my : α → m β) :
+lemma probFailure_bind_eq_add_tsum_support [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑' x : support mx, Pr[= x | mx] * Pr[⊥ | my x] := by
   rw [probFailure_bind_eq_add_tsum]
   congr 1
@@ -162,7 +175,8 @@ lemma probFailure_bind_eq_add_tsum_support [HasEvalSPMF m] (mx : m α) (my : α 
   aesop
 
 @[simp, grind =]
-lemma probFailure_bind_eq_zero_iff [HasEvalSPMF m] (mx : m α) (my : α → m β) :
+lemma probFailure_bind_eq_zero_iff [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = 0 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, Pr[⊥ | my x] = 0 := by
   simp [probFailure_bind_eq_add_tsum]
   grind
@@ -171,13 +185,15 @@ lemma probFailure_bind_eq_zero_iff [HasEvalSPMF m] (mx : m α) (my : α → m β
 of the first computation. This can be useful to avoid looking at edge cases that can't actually
 happen in practice after the first computation. A common example is if the first computation
 does some error handling to avoids returning malformed outputs. -/
-lemma probOutput_bind_eq_tsum_subtype [HasEvalSPMF m] (mx : m α) (my : α → m β) (y : β) :
+lemma probOutput_bind_eq_tsum_subtype [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β) (y : β) :
     Pr[= y | mx >>= my] = ∑' x : support mx, Pr[= x | mx] * Pr[= y | my x] := by
   rw [tsum_subtype _ (fun x => Pr[= x | mx] * Pr[= y | my x]), probOutput_bind_eq_tsum]
   refine tsum_congr (fun x => ?_)
   by_cases hx : x ∈ support mx <;> aesop
 
-lemma probEvent_bind_eq_tsum_subtype [HasEvalSPMF m] (mx : m α) (my : α → m β) (q : β → Prop) :
+lemma probEvent_bind_eq_tsum_subtype [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β) (q : β → Prop) :
     Pr[ q | mx >>= my] = ∑' x : support mx, Pr[= x | mx] * Pr[ q | my x] := by
   rw [tsum_subtype _ (fun x ↦ Pr[= x | mx] * Pr[ q | my x]), probEvent_bind_eq_tsum]
   refine tsum_congr (fun x ↦ ?_)
@@ -185,7 +201,8 @@ lemma probEvent_bind_eq_tsum_subtype [HasEvalSPMF m] (mx : m α) (my : α → m 
 
 /-- If `Pr[q | my x] ≤ ε` for every `x` in the support of `mx`, then the bound also
 holds for the bind. -/
-lemma probEvent_bind_le_of_forall_le [HasEvalSPMF m]
+lemma probEvent_bind_le_of_forall_le [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
     {mx : m α} {my : α → m β} {q : β → Prop} {ε : ENNReal}
     (h : ∀ x ∈ support mx, Pr[ q | my x] ≤ ε) :
     Pr[ q | mx >>= my] ≤ ε := by
@@ -200,25 +217,31 @@ lemma probEvent_bind_le_of_forall_le [HasEvalSPMF m]
     _ ≤ 1 * ε := mul_le_mul' tsum_probOutput_le_one le_rfl
     _ = ε := one_mul _
 
-lemma probOutput_bind_eq_sum_finSupport [HasEvalSPMF m] [HasEvalFinset m]
+lemma probOutput_bind_eq_sum_finSupport [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] [HasEvalFinset m]
     (mx : m α) (my : α → m β) [DecidableEq α] (y : β) :
     Pr[= y | mx >>= my] = ∑ x ∈ finSupport mx, Pr[= x | mx] * Pr[= y | my x] :=
   (probOutput_bind_eq_tsum mx my y).trans (tsum_eq_sum' <| by simp)
 
-lemma probEvent_bind_eq_sum_finSupport [HasEvalSPMF m] [HasEvalFinset m]
+lemma probEvent_bind_eq_sum_finSupport [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m] [HasEvalFinset m]
     (mx : m α) (my : α → m β) [DecidableEq α] (q : β → Prop) :
     Pr[ q | mx >>= my] = ∑ x ∈ finSupport mx, Pr[= x | mx] * Pr[ q | my x] :=
   (probEvent_bind_eq_tsum mx my q).trans (tsum_eq_sum' <| by simp)
 
 section const
 
+section support
+
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+
 @[simp]
-lemma support_bind_const [HasEvalSet m] (mx : m α) (my : m β) :
+lemma support_bind_const (mx : m α) (my : m β) :
     support (mx >>= fun _ => my) = {y ∈ support my | (support mx).Nonempty} := by
   grind [= Set.Nonempty]
 
 @[simp]
-lemma finSupport_bind_const [HasEvalSet m] [HasEvalFinset m]
+lemma finSupport_bind_const [HasEvalFinset m]
     [DecidableEq β] [DecidableEq α] (mx : m α) (my : m β) :
     finSupport (mx >>= fun _ => my) = if (finSupport mx).Nonempty then finSupport my else ∅ := by
   split_ifs with h
@@ -226,7 +249,12 @@ lemma finSupport_bind_const [HasEvalSet m] [HasEvalFinset m]
     aesop
   · aesop
 
-lemma probOutput_bind_of_const [HasEvalSPMF m] (mx : m α)
+end support
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [EvalDistCompatible m]
+
+lemma probOutput_bind_of_const (mx : m α)
     {my : α → m β} {y : β} {r : ℝ≥0∞} (h : ∀ x ∈ support mx, Pr[= y | my x] = r) :
     Pr[= y | mx >>= my] = (1 - Pr[⊥ | mx]) * r := by
   rw [probOutput_bind_eq_tsum, ← tsum_probOutput_eq_sub, ← ENNReal.tsum_mul_right]
@@ -236,11 +264,11 @@ lemma probOutput_bind_of_const [HasEvalSPMF m] (mx : m α)
   · aesop
 
 @[simp, grind =_]
-lemma probOutput_bind_const [HasEvalSPMF m] (mx : m α) (my : m β) (y : β) :
+lemma probOutput_bind_const (mx : m α) (my : m β) (y : β) :
     Pr[= y | mx >>= fun _ => my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by
   rw [probOutput_bind_of_const mx fun _ _ => rfl]
 
-lemma probEvent_bind_of_const [HasEvalSPMF m] (mx : m α)
+lemma probEvent_bind_of_const (mx : m α)
     {my : α → m β} {p : β → Prop} {r : ℝ≥0∞}
     (h : ∀ x ∈ support mx, Pr[ p | my x] = r) :
     Pr[ p | mx >>= my] = (1 - Pr[⊥ | mx]) * r := by
@@ -251,13 +279,13 @@ lemma probEvent_bind_of_const [HasEvalSPMF m] (mx : m α)
   · aesop
 
 @[simp, grind =_]
-lemma probEvent_bind_const [HasEvalSPMF m] (mx : m α) (my : m β) (p : β → Prop) :
+lemma probEvent_bind_const (mx : m α) (my : m β) (p : β → Prop) :
     Pr[ p | mx >>= fun _ => my] = (1 - Pr[⊥ | mx]) * Pr[ p | my] := by
   rw [probEvent_bind_of_const mx fun _ _ => rfl]
 
 /-- Write the probability of `mx >>= my` failing given that `my` has constant failure chance over
 the possible outputs in `support mx` as a fixed expression without any sums. -/
-lemma probFailure_bind_of_const [HasEvalSPMF m]
+lemma probFailure_bind_of_const
     {mx : m α} {my : α → m β} {r : ℝ≥0∞} (h : ∀ x ∈ support mx, Pr[⊥ | my x] = r) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + r * (1 - Pr[⊥ | mx]) := by
   calc Pr[⊥ | mx >>= my]
@@ -266,18 +294,18 @@ lemma probFailure_bind_of_const [HasEvalSPMF m]
     _ = Pr[⊥ | mx] + r * (1 - Pr[⊥ | mx]) := by
       rw [ENNReal.tsum_mul_right, mul_comm, tsum_support_probOutput_eq_sub]
 
-lemma probFailure_bind_of_const' [HasEvalSPMF m]
+lemma probFailure_bind_of_const'
     {mx : m α} {my : α → m β} {r : ℝ≥0∞} (hr : r ≠ ⊤) (h : ∀ x ∈ support mx, Pr[⊥ | my x] = r) :
     Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + r - Pr[⊥ | mx] * r := by
   rw [probFailure_bind_of_const h, ENNReal.mul_sub, AddLECancellable.add_tsub_assoc_of_le,
     mul_comm Pr[⊥ | mx] r, mul_one] <;> simp [hr, ENNReal.mul_eq_top]
 
 @[simp, grind =_]
-lemma probFailure_bind_const [HasEvalSPMF m] (mx : m α) (my : m β) :
+lemma probFailure_bind_const (mx : m α) (my : m β) :
     Pr[⊥ | mx >>= fun _ => my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by
   rw [probFailure_bind_of_const' (by simp) fun _ _ => rfl]
 
-lemma probFailure_bind_eq_sub_mul [HasEvalSPMF m]
+lemma probFailure_bind_eq_sub_mul
     (mx : m α) (my : α → m β) (r : ℝ≥0∞) (hr : r ≠ ⊤) (h : ∀ x ∈ support mx, Pr[⊥ | my x] = r) :
     Pr[⊥ | mx >>= my] = 1 - (1 - Pr[⊥ | mx]) * (1 - r) := by
   by_cases h' : (support mx).Nonempty
@@ -296,7 +324,10 @@ end const
 
 section mono
 
-lemma probFailure_bind_le_add_of_forall [HasEvalSPMF m] {mx : m α}
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [EvalDistCompatible m]
+
+lemma probFailure_bind_le_add_of_forall {mx : m α}
     {my : α → m β} {r : ℝ≥0∞}
     (hr : ∀ x ∈ support mx, Pr[⊥ | my x] ≤ r) :
     Pr[⊥ | mx >>= my] ≤ Pr[⊥ | mx] + (1 - Pr[⊥ | mx]) * r := by
@@ -309,7 +340,7 @@ lemma probFailure_bind_le_add_of_forall [HasEvalSPMF m] {mx : m α}
     _ ≤ Pr[⊥ | mx] + (1 - Pr[⊥ | mx]) * r := by simp [ENNReal.tsum_mul_right]
 
 /-- Version of `probFailure_bind_le_of_forall` with that allows a manual `Pr[⊥ | mx]` value. -/
-lemma probFailure_bind_le_of_forall' [HasEvalSPMF m] {mx : m α}
+lemma probFailure_bind_le_of_forall' {mx : m α}
     {s : ℝ≥0∞} (h' : Pr[⊥ | mx] = s) (my : α → m β) {r : ℝ≥0∞}
     (hr : ∀ x ∈ support mx, Pr[⊥ | my x] ≤ r) : Pr[⊥ | mx >>= my] ≤ s + r := by
   rw [probFailure_bind_eq_add_tsum_support]
@@ -323,14 +354,15 @@ lemma probFailure_bind_le_of_forall' [HasEvalSPMF m] {mx : m α}
     _ = r := one_mul r
 
 /-- Version of `probFailure_bind_le_of_forall` when `mx` never fails. -/
-lemma probFailure_bind_le_of_forall [HasEvalSPMF m] {mx : m α}
+lemma probFailure_bind_le_of_forall {mx : m α}
     (h' : Pr[⊥ | mx] = 0) {my : α → m β} {r : ℝ≥0∞}
     (hr : ∀ x ∈ support mx, Pr[⊥ | my x] ≤ r) : Pr[⊥ | mx >>= my] ≤ r := by
   refine (probFailure_bind_le_add_of_forall hr).trans (by simp [h'])
 
 end mono
 
-lemma probFailure_bind_of_probFailure_eq_zero [HasEvalSPMF m] {mx : m α}
+lemma probFailure_bind_of_probFailure_eq_zero [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] {mx
+    : m α}
     (h' : Pr[⊥ | mx] = 0) {my : α → m β} :
     Pr[⊥ | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[⊥ | my x] := by
   rw [probFailure_bind_eq_add_tsum, h', zero_add]
@@ -340,7 +372,7 @@ end bind
 
 section forall_support
 
-variable [HasEvalSet m]
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 @[simp] lemma allOutputsSatisfy_pure (p : α → Prop) (x : α) :
     allOutputsSatisfy p (pure x : m α) ↔ p x := by
@@ -373,7 +405,8 @@ end forall_support
 
 section congr_mono
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [EvalDistCompatible m]
 
 lemma mul_le_probEvent_bind {mx : m α} {my : α → m β}
     {p : α → Prop} {q : β → Prop} {r r' : ℝ≥0∞}
@@ -592,10 +625,10 @@ end congr_mono
 
 section swap_compl
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF]
 
 /-- Swapping two independent random draws preserves probability of any event. -/
-lemma probEvent_bind_bind_swap [LawfulMonad m]
+lemma probEvent_bind_bind_swap [LawfulMonadLiftT m SPMF] [LawfulMonad m]
     (mx : m α) (my : m β) (f : α → β → m γ) (q : γ → Prop) :
     Pr[ q | mx >>= fun a => my >>= fun b => f a b] =
       Pr[ q | my >>= fun b => mx >>= fun a => f a b] := by
@@ -624,13 +657,14 @@ lemma probEvent_bind_bind_swap [LawfulMonad m]
           simp [probEvent_bind_eq_tsum]
 
 /-- Swapping two independent random draws preserves the probability of any fixed output. -/
-lemma probOutput_bind_bind_swap [LawfulMonad m]
+lemma probOutput_bind_bind_swap [LawfulMonadLiftT m SPMF] [LawfulMonad m]
     (mx : m α) (my : m β) (f : α → β → m γ) (z : γ) :
     Pr[= z | mx >>= fun a => my >>= fun b => f a b] =
       Pr[= z | my >>= fun b => mx >>= fun a => f a b] := by
   simpa [probEvent_eq_eq_probOutput] using
     probEvent_bind_bind_swap mx my f (· = z)
 
+omit [Monad m] in
 /-- If `Pr[ p | mx] ≥ 1 - ε` and `mx` never fails, then `Pr[ ¬p | mx] ≤ ε`. -/
 lemma probEvent_compl_le_of_ge
     {mx : m α} {p : α → Prop} {ε : ℝ≥0∞}
@@ -653,6 +687,7 @@ lemma probEvent_compl_le_of_ge
     exact le_trans (tsub_le_tsub_left h _)
       (by simp [ENNReal.sub_sub_cancel ENNReal.one_ne_top hε'])
 
+omit [Monad m] in
 /-- If `Pr[ ¬p | mx] ≤ ε` and `mx` never fails, then `Pr[ p | mx] ≥ 1 - ε`. -/
 lemma probEvent_ge_of_compl_le
     {mx : m α} {p : α → Prop} {ε : ℝ≥0∞}
@@ -673,8 +708,9 @@ end swap_compl
 
 section union_bound
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 /-- Union bound for finset-indexed events: the probability that *some* event in `s` holds
 is at most the sum of the individual event probabilities. -/
 lemma probEvent_exists_finset_le_sum

--- a/VCVio/EvalDist/Monad/Disagreement.lean
+++ b/VCVio/EvalDist/Monad/Disagreement.lean
@@ -27,7 +27,8 @@ universe u v
 
 open ENNReal
 
-variable {α β γ : Type u} {m : Type u → Type v} [Monad m] [HasEvalSPMF m]
+variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- **Disagreement-aware additive bind bound.** If the disagreement set `D` has probability at
 most `ε₁` under `mx`, and off `D` the continuation `my` is within `ε₂` of the reference

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -25,35 +25,38 @@ variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
 open ENNReal
 
 @[simp, grind =]
-lemma support_map [HasEvalSet m] [LawfulMonad m] (f : α → β) (mx : m α) :
+lemma support_map [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [LawfulMonad m] (f : α
+    → β) (mx : m α) :
     support (f <$> mx) = f '' support mx := by
   simp [monad_norm]
   aesop
 
 @[simp, grind =]
-lemma finSupport_map [HasEvalSet m] [HasEvalFinset m] [LawfulMonad m]
+lemma finSupport_map [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m] [LawfulMonad m]
     [DecidableEq α] [DecidableEq β]
     (f : α → β) (mx : m α) : finSupport (f <$> mx) = (finSupport mx).image f := by
   grind [map_eq_bind_pure_comp]
 
 @[simp, grind =]
-lemma evalDist_map [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (f : α → β) :
+lemma evalDist_map [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [LawfulMonad m] (mx : m α) (f : α
+    → β) :
     𝒟[f <$> mx] = f <$> (𝒟[mx]) := by simp [monad_norm]
 
-lemma evalDist_map_eq_of_evalDist_eq [HasEvalSPMF m] [LawfulMonad m]
+lemma evalDist_map_eq_of_evalDist_eq [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [LawfulMonad m]
     {mx my : m α} (h : 𝒟[mx] = 𝒟[my]) (f : α → β) :
     𝒟[f <$> mx] = 𝒟[f <$> my] := by
   simpa [evalDist_map] using congrArg (fun p => f <$> p) h
 
-lemma probOutput_map_eq_of_evalDist_eq [HasEvalSPMF m] [LawfulMonad m]
+lemma probOutput_map_eq_of_evalDist_eq [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [LawfulMonad m]
     {mx my : m α} (h : 𝒟[mx] = 𝒟[my]) (f : α → β) (y : β) :
     Pr[= y | f <$> mx] = Pr[= y | f <$> my] := by
   exact (evalDist_ext_iff.mp (evalDist_map_eq_of_evalDist_eq h f)) y
 
-@[simp] lemma evalDist_comp_map [HasEvalSPMF m] [LawfulMonad m] (mx : m α) :
+@[simp]
+lemma evalDist_comp_map [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [LawfulMonad m] (mx : m α) :
     evalDist ∘ (fun f => f <$> mx) = fun f : (α → β) => f <$> 𝒟[mx] := by aesop
 
-variable [HasEvalSPMF m] (mx : m α) (f : α → β)
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] (mx : m α) (f : α → β)
 
 @[simp, grind =]
 lemma probEvent_bind_pure_comp (q : β → Prop) :
@@ -68,18 +71,21 @@ variable [LawfulMonad m]
 over all outputs such that they map to the correct final output, using subtypes.
 This lemma notably doesn't require decidable equality on the final type, unlike most
 lemmas about probability when mapping a computation. -/
-lemma probOutput_map_eq_tsum_subtype (y : β) :
+lemma probOutput_map_eq_tsum_subtype [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [EvalDistCompatible m] (y : β) :
     Pr[= y | f <$> mx] = ∑' x : {x ∈ support mx | y = f x}, Pr[= x | mx] := by
   simp only [map_eq_bind_pure_comp, tsum_subtype _, probOutput_bind_eq_tsum, Function.comp_apply,
     Set.indicator, Set.mem_setOf_eq]
   refine (tsum_congr (fun x ↦ ?_))
-  by_cases hy : y = f x <;> by_cases hx : x ∈ support mx <;> simp [hy, hx]
+  by_cases hy : y = f x <;> by_cases hx : x ∈ support mx <;>
+    simp [hy, hx, probOutput_eq_zero_of_not_mem_support]
 
 lemma probOutput_map_eq_tsum (y : β) :
     Pr[= y | f <$> mx] = ∑' x, Pr[= x | mx] * Pr[= y | (pure (f x) : m β)] := by
   simp [monad_norm, probOutput_bind_eq_tsum]
 
-lemma probOutput_map_eq_tsum_subtype_ite [DecidableEq β] (y : β) :
+lemma probOutput_map_eq_tsum_subtype_ite [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [EvalDistCompatible m] [DecidableEq β] (y : β) :
     Pr[= y | f <$> mx] = ∑' x : support mx, if y = f x then Pr[= x | mx] else 0 := by
   simp only [map_eq_bind_pure_comp, probOutput_bind_eq_tsum_subtype, Function.comp_apply,
     probOutput_pure, mul_ite, mul_one, mul_zero]
@@ -97,7 +103,8 @@ lemma probOutput_map_eq_sum_fintype_ite [Fintype α] [DecidableEq β] (y : β) :
     by simp only [Finset.coe_univ, Set.subset_univ])
 
 @[grind =]
-lemma probOutput_map_eq_sum_finSupport_ite [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
+lemma probOutput_map_eq_sum_finSupport_ite [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [EvalDistCompatible m] [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
     (y : β) : Pr[= y | f <$> mx] = ∑ x ∈ finSupport mx, if y = f x then Pr[= x | mx] else 0 :=
   (probOutput_map_eq_tsum_ite mx f y).trans (tsum_eq_sum' <|
     by simp only [coe_finSupport, Function.support_subset_iff, ne_eq, ite_eq_right_iff,
@@ -105,7 +112,8 @@ lemma probOutput_map_eq_sum_finSupport_ite [HasEvalFinset m] [DecidableEq α] [D
       imp_self, implies_true])
 
 @[grind =]
-lemma probOutput_map_eq_sum_filter_finSupport [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
+lemma probOutput_map_eq_sum_filter_finSupport [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [EvalDistCompatible m] [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
     (y : β) : Pr[= y | f <$> mx] = ∑ x ∈ (finSupport mx).filter (y = f ·), Pr[= x | mx] := by
   rw [Finset.sum_filter, probOutput_map_eq_sum_finSupport_ite]
 
@@ -126,44 +134,54 @@ lemma probFailure_eq_sub_sum_probOutput_map [Fintype β] (mx : m α) (f : α →
   rw [← probFailure_map (f := f), probFailure_eq_sub_tsum, tsum_fintype]
 
 @[aesop unsafe apply]
-lemma probOutput_map_eq_single {mx : m α} {f : α → β} {y : β}
+lemma probOutput_map_eq_single [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+    {mx : m α} {f : α → β} {y : β}
     (x : α) (h : ∀ x' ∈ support mx, y = f x' → x = x') (h' : f x = y) :
     Pr[= y | f <$> mx] = Pr[= x | mx] := by
   rw [probOutput_map_eq_tsum]
   refine (tsum_eq_single x (fun x' hx' ↦ ?_)).trans (by rw [h', probOutput_pure_self, mul_one])
   specialize h x'
-  simp only [mul_eq_zero, probOutput_eq_zero_iff, support_pure, Set.mem_singleton_iff]
-  tauto
+  by_cases hx' : x' ∈ support mx
+  · have := h hx'
+    simp only [mul_eq_zero]
+    right
+    aesop
+  · simp [probOutput_eq_zero_of_not_mem_support hx']
 
 section const
 
 variable (mx : m α) (y : β)
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] in
 @[aesop safe norm, grind .]
-lemma support_map_const (hx : (support mx).Nonempty) :
+lemma support_map_const [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    (hx : (support mx).Nonempty) :
     support ((fun _ => y) <$> mx) = {y} := by
   aesop
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] in
 @[simp, grind .]
-lemma finSupport_map_const [DecidableEq α] [DecidableEq β] [HasEvalFinset m]
+lemma finSupport_map_const [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [DecidableEq α] [DecidableEq β] [HasEvalFinset m]
     (hx : (finSupport mx).Nonempty) : finSupport ((fun _ => y) <$> mx) =
       if (finSupport mx).Nonempty then {y} else ∅ := by
   grind
 
 @[simp, aesop safe norm, grind =_]
-lemma probOutput_map_const (y' : β) :
+lemma probOutput_map_const [MonadLiftT m SetM] [EvalDistCompatible m] (y' : β) :
     Pr[= y' | (fun _ => y) <$> mx] =
       (1 - Pr[⊥ | mx]) * Pr[= y' | (pure y : m β)] := by
   simp only [monad_norm, Function.comp_def, probOutput_bind_const]
 
 @[simp, aesop safe norm, grind =_]
-lemma probEvent_map_const (p : β → Prop) :
+lemma probEvent_map_const [MonadLiftT m SetM] [EvalDistCompatible m] (p : β → Prop) :
     Pr[ p | (fun _ => y) <$> mx] =
       (1 - Pr[⊥ | mx]) * Pr[ p | (pure y : m β)] := by
   simp only [monad_norm, Function.comp_def, probEvent_bind_const]
 
 @[simp, aesop safe norm]
-lemma probEvent_map_const' (p : β → Prop) [DecidablePred p] :
+lemma probEvent_map_const' [MonadLiftT m SetM] [EvalDistCompatible m] (p : β → Prop)
+    [DecidablePred p] :
     Pr[ p | (fun _ => y) <$> mx] =
       if p y then (1 - Pr[⊥ | mx]) else 0 := by
   simp [Function.comp_def]
@@ -172,7 +190,8 @@ end const
 
 section inverse
 
-variable {f : α → β} {g : β → α} {y : β}
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+  {f : α → β} {g : β → α} {y : β}
 
 @[aesop unsafe norm]
 lemma probOutput_map_eq_probOutput_of_leftInvOn
@@ -201,6 +220,25 @@ end inverse
 
 section injective
 
+@[grind .]
+lemma probOutput_map_injective (mx : m α) {f : α → β} (hf : f.Injective) (x : α) :
+    Pr[= f x | f <$> mx] = Pr[= x | mx] := by
+  classical
+  rw [map_eq_bind_pure_comp, probOutput_bind_eq_tsum]
+  refine (tsum_eq_single x fun y hy => ?_).trans (by
+    simp only [Function.comp_apply, probOutput_pure_self, mul_one])
+  simp only [Function.comp_apply, probOutput_pure, mul_ite, mul_one, mul_zero]
+  exact if_neg fun h => hy (hf h.symm)
+
+lemma probOutput_map_eq_probOutput (mx : m α)
+    {f : α → β} (hf : ∀ x x', f x = f x' → x = x') (x : α) :
+    Pr[= f x | f <$> mx] = Pr[= x | mx] :=
+  probOutput_map_injective mx hf x
+
+section support
+
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+
 @[aesop unsafe norm]
 lemma probOutput_map_eq_probOutput_invFunOn [Nonempty α]
     (mx : m α) {f : α → β} (hf : Set.InjOn f (support mx))
@@ -216,14 +254,6 @@ lemma probOutput_map_eq_probOutput_invFunOn [Nonempty α]
   rw [dif_pos hy]
   rw [(Classical.choose_spec hy).2]
 
-@[grind .]
-lemma probOutput_map_injective (mx : m α) {f : α → β} (hf : f.Injective) (x : α) :
-    Pr[= f x | f <$> mx] = Pr[= x | mx] := by
-  aesop
-
-lemma probOutput_map_eq_probOutput (mx : m α)
-    {f : α → β} (hf : ∀ x x', f x = f x' → x = x') (x : α) :
-    Pr[= f x | f <$> mx] = Pr[= x | mx] := by
-  aesop
+end support
 
 end injective

--- a/VCVio/EvalDist/Monad/Seq.lean
+++ b/VCVio/EvalDist/Monad/Seq.lean
@@ -16,75 +16,104 @@ TODO: many lemmas should probably have mirrored versions for `bind_map`.
 
 universe u v w
 
-variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
+variable {α β γ : Type u} {m : Type u → Type v} [Monad m] [LawfulMonad m]
 
 open ENNReal
 
 section seq
 
-@[simp] lemma support_seq [HasEvalSet m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
+section support
+
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+
+@[simp]
+lemma support_seq (mf : m (α → β)) (mx : m α) :
     support (mf <*> mx) = ⋃ f ∈ support mf, f '' support mx := by
   simp [seq_eq_bind_map]
 
-lemma mem_support_seq_iff [HasEvalSet m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) (y : β) :
-    y ∈ support (mf <*> mx) ↔ ∃ f ∈ support mf, ∃ x ∈ support mx, f x = y := by simp
+lemma mem_support_seq_iff (mf : m (α → β)) (mx : m α) (y : β) :
+    y ∈ support (mf <*> mx) ↔ ∃ f ∈ support mf, ∃ x ∈ support mx, f x = y := by
+  rw [support_seq]; simp
 
-@[simp] lemma finSupport_seq [HasEvalSet m] [HasEvalFinset m] [LawfulMonad m]
+@[simp]
+lemma finSupport_seq [HasEvalFinset m]
     [DecidableEq (α → β)] [DecidableEq α] [DecidableEq β]
     (mf : m (α → β)) (mx : m α) :
     finSupport (mf <*> mx) = (finSupport mf).biUnion fun f => (finSupport mx).image f := by
   simp [seq_eq_bind_map]
 
-@[simp] lemma evalDist_seq [HasEvalSPMF m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
+end support
+
+section spmf
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+
+@[simp]
+lemma evalDist_seq (mf : m (α → β)) (mx : m α) :
     𝒟[mf <*> mx] = 𝒟[mf] <*> 𝒟[mx] := by simp [monad_norm]
 
-lemma probOutput_seq_eq_tsum [HasEvalSPMF m] [LawfulMonad m]
-    (mf : m (α → β)) (mx : m α) (y : β) :
+lemma probOutput_seq_eq_tsum (mf : m (α → β)) (mx : m α) (y : β) :
     Pr[= y | mf <*> mx] =
       ∑' f, ∑' x, Pr[= f | mf] * Pr[= x | mx] * Pr[= y | (pure (f x) : m β)] := by
   simp [seq_eq_bind_map, probOutput_bind_eq_tsum, probOutput_map_eq_tsum,
     ← ENNReal.tsum_mul_left, mul_assoc]
 
-lemma probOutput_seq_eq_tsum_ite [HasEvalSPMF m] [LawfulMonad m] [DecidableEq β]
+lemma probOutput_seq_eq_tsum_ite [DecidableEq β]
     (mf : m (α → β)) (mx : m α) (y : β) :
     Pr[= y | mf <*> mx] =
       ∑' f, ∑' x, if y = f x then Pr[= f | mf] * Pr[= x | mx] else 0 := by
   simp [seq_eq_bind_map, probOutput_bind_eq_tsum,
     probOutput_map_eq_tsum_ite, ← ENNReal.tsum_mul_left]
 
-@[simp, grind =_]
-lemma probFailure_seq [HasEvalSPMF m] [LawfulMonad m] (mf : m (α → β)) (mx : m α) :
-    Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by
-  rw [seq_eq_bind_map]
-  exact probFailure_bind_of_const' probFailure_ne_top (fun g _ => probFailure_map mx g)
-
-lemma probEvent_seq_eq_tsum [HasEvalSPMF m] [LawfulMonad m]
-    (mf : m (α → β)) (mx : m α) (p : β → Prop) :
+lemma probEvent_seq_eq_tsum (mf : m (α → β)) (mx : m α) (p : β → Prop) :
     Pr[ p | mf <*> mx] = ∑' f, Pr[= f | mf] * Pr[ p ∘ f | mx] := by
   simp only [seq_eq_bind_map, probEvent_bind_eq_tsum, probEvent_map]
 
-lemma probEvent_seq_eq_tsum_ite [HasEvalSPMF m] [LawfulMonad m]
-    (mf : m (α → β)) (mx : m α) (p : β → Prop) [DecidablePred p] :
+lemma probEvent_seq_eq_tsum_ite (mf : m (α → β)) (mx : m α)
+    (p : β → Prop) [DecidablePred p] :
     Pr[ p | mf <*> mx] = ∑' (f : α → β) (x : α),
       if p (f x) then Pr[= f | mf] * Pr[= x | mx] else 0 := by
   simp_rw [probEvent_seq_eq_tsum, probEvent_eq_tsum_ite, ← ENNReal.tsum_mul_left,
     Function.comp_apply, mul_ite, mul_zero]
 
+variable [MonadLiftT m SetM] [EvalDistCompatible m]
+
+@[simp, grind =_]
+lemma probFailure_seq (mf : m (α → β)) (mx : m α) :
+    Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by
+  rw [seq_eq_bind_map]
+  exact probFailure_bind_of_const' probFailure_ne_top (fun g _ => probFailure_map mx g)
+
+end spmf
+
 end seq
 
 section seqLeft
 
-@[simp] lemma support_seqLeft [HasEvalSet m] [LawfulMonad m]
-    (mx : m α) (my : m β) [Decidable (support my).Nonempty] :
+section support
+
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+
+@[simp]
+lemma support_seqLeft (mx : m α) (my : m β) [Decidable (support my).Nonempty] :
     support (mx <* my) = if (support my).Nonempty then support mx else ∅ := by
   rw [seqLeft_eq, Set.ext_iff]; aesop
 
-@[simp] lemma evalDist_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
+end support
+
+section spmf
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [EvalDistCompatible m]
+
+omit [MonadLiftT m SetM] [EvalDistCompatible m] in
+@[simp]
+lemma evalDist_seqLeft (mx : m α) (my : m β) :
     𝒟[mx <* my] = 𝒟[mx] <* 𝒟[my] := by
   simp [seqLeft_eq]
 
 @[simp, grind =_]
-lemma probOutput_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) (x : α) :
+lemma probOutput_seqLeft (mx : m α) (my : m β) (x : α) :
     Pr[= x | mx <* my] = (1 - Pr[⊥ | my]) * Pr[= x | mx] := by
   rw [seqLeft_eq, seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc]
   simp only [Function.comp_apply, pure_bind, probOutput_bind_eq_tsum]
@@ -94,13 +123,12 @@ lemma probOutput_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
   rw [ENNReal.tsum_mul_left, ← probOutput_bind_eq_tsum, bind_pure]
 
 @[simp, grind =_]
-lemma probFailure_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
+lemma probFailure_seqLeft (mx : m α) (my : m β) :
     Pr[⊥ | mx <* my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by
   rw [seqLeft_eq, probFailure_seq, probFailure_map]
 
 @[simp, grind =_]
-lemma probEvent_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
-    (p : α → Prop) :
+lemma probEvent_seqLeft (mx : m α) (my : m β) (p : α → Prop) :
     Pr[ p | mx <* my] = (1 - Pr[⊥ | my]) * Pr[ p | mx] := by
   rw [seqLeft_eq, seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc]
   simp only [Function.comp_apply, pure_bind, probEvent_bind_eq_tsum]
@@ -109,73 +137,98 @@ lemma probEvent_seqLeft [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
     mul_left_comm _ (1 - Pr[⊥ | my])]
   rw [ENNReal.tsum_mul_left, ← probEvent_bind_eq_tsum, bind_pure]
 
+end spmf
+
 end seqLeft
 
 section seqRight
 
-@[simp] lemma support_seqRight [HasEvalSet m] [LawfulMonad m]
-    (mx : m α) (my : m β) [Decidable (support mx).Nonempty] :
+section support
+
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+
+@[simp]
+lemma support_seqRight (mx : m α) (my : m β) [Decidable (support mx).Nonempty] :
     support (mx *> my) = if (support mx).Nonempty then support my else ∅ := by
   rw [seqRight_eq, Set.ext_iff]; aesop
 
-@[simp] lemma evalDist_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
+end support
+
+section spmf
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [EvalDistCompatible m]
+
+omit [MonadLiftT m SetM] [EvalDistCompatible m] in
+@[simp]
+lemma evalDist_seqRight (mx : m α) (my : m β) :
     𝒟[mx *> my] = 𝒟[mx] *> 𝒟[my] := by
   simp [seqRight_eq]
 
 @[simp, grind =_]
-lemma probOutput_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) (y : β) :
+lemma probOutput_seqRight (mx : m α) (my : m β) (y : β) :
     Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by
   have h : mx *> my = mx >>= fun _ => my := by simp [seqRight_eq, seq_eq_bind_map]
   rw [h, probOutput_bind_const]
 
 @[simp, grind =_]
-lemma probFailure_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β) :
+lemma probFailure_seqRight (mx : m α) (my : m β) :
     Pr[⊥ | mx *> my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by
   rw [seqRight_eq, probFailure_seq, probFailure_map]
 
 @[simp, grind =_]
-lemma probEvent_seqRight [HasEvalSPMF m] [LawfulMonad m] (mx : m α) (my : m β)
-    (p : β → Prop) :
+lemma probEvent_seqRight (mx : m α) (my : m β) (p : β → Prop) :
     Pr[ p | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[ p | my] := by
   have h : mx *> my = mx >>= fun _ => my := by simp [seqRight_eq, seq_eq_bind_map]
   rw [h, probEvent_bind_const]
+
+end spmf
 
 end seqRight
 
 section seq_map
 
-variable [LawfulMonad m] (mx : m α) (my : m β) (f : α → β → γ)
+variable (mx : m α) (my : m β) (f : α → β → γ)
+
+section support
+
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 @[simp low + 1]
-lemma support_seq_map_eq_image2 [HasEvalSet m] :
+lemma support_seq_map_eq_image2 :
     support (f <$> mx <*> my) = Set.image2 f (support mx) (support my) := by
   ext z; simp [seq_eq_bind_map, Set.mem_image2]
 
 @[simp low + 1]
-lemma finSupport_seq_map_eq_image2 [HasEvalSet m] [HasEvalFinset m]
+lemma finSupport_seq_map_eq_image2 [HasEvalFinset m]
     [DecidableEq α] [DecidableEq β] [DecidableEq γ] :
     finSupport (f <$> mx <*> my) = Finset.image₂ f (finSupport mx) (finSupport my) := by
   ext z; simp [seq_eq_bind_map, Finset.mem_image₂]
 
-lemma evalDist_seq_map [HasEvalSPMF m] :
+end support
+
+section spmf
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+
+lemma evalDist_seq_map :
     𝒟[f <$> mx <*> my] = f <$> 𝒟[mx] <*> 𝒟[my] := by
   rw [evalDist_seq, evalDist_map]
 
-lemma probOutput_seq_map_eq_tsum [HasEvalSPMF m]
-    (z : γ) : Pr[= z | f <$> mx <*> my] = ∑' (x : α) (y : β),
+lemma probOutput_seq_map_eq_tsum (z : γ) :
+    Pr[= z | f <$> mx <*> my] = ∑' (x : α) (y : β),
       Pr[= x | mx] * Pr[= y | my] * Pr[= z | (pure (f x y) : m γ)] := by
   simp only [monad_norm, Function.comp,
     probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_left, mul_assoc]
 
-lemma probOutput_seq_map_eq_tsum_ite [HasEvalSPMF m] [DecidableEq γ]
-    (z : γ) : Pr[= z | f <$> mx <*> my] =
+lemma probOutput_seq_map_eq_tsum_ite [DecidableEq γ] (z : γ) :
+    Pr[= z | f <$> mx <*> my] =
       ∑' (x : α) (y : β), if z = f x y then Pr[= x | mx] * Pr[= y | my] else 0 := by
   simp only [probOutput_seq_map_eq_tsum, probOutput_pure, mul_ite, mul_one, mul_zero]
 
 section injective2
 
-lemma probOutput_seq_map_eq_mul_of_injective2 [HasEvalSPMF m]
-    (hf : f.Injective2) (x : α) (y : β) :
+lemma probOutput_seq_map_eq_mul_of_injective2 (hf : f.Injective2) (x : α) (y : β) :
     Pr[= f x y | f <$> mx <*> my] = Pr[= x | mx] * Pr[= y | my] := by
   rw [probOutput_seq_map_eq_tsum]
   simp only [probOutput_pure_eq_indicator, Set.indicator, mul_ite, mul_zero]
@@ -186,12 +239,54 @@ lemma probOutput_seq_map_eq_mul_of_injective2 [HasEvalSPMF m]
     · exact if_neg (show f x y ≠ f x y' from fun h' => hy' (hf h').2.symm)
     · simp
 
-lemma mem_support_seq_map_iff_of_injective2 [HasEvalSet m]
-    (hf : f.Injective2) (x : α) (y : β) :
+end injective2
+
+section swap
+
+lemma probOutput_seq_map_swap (z : γ) :
+    Pr[= z | Function.swap f <$> my <*> mx] = Pr[= z | f <$> mx <*> my] := by
+  simp only [probOutput_seq_map_eq_tsum, Function.swap]
+  rw [ENNReal.tsum_comm]
+  refine tsum_congr fun x' => tsum_congr fun y' => ?_
+  rw [mul_comm (Pr[= y' | my])]
+
+lemma evalDist_seq_map_swap :
+    𝒟[Function.swap f <$> my <*> mx] = 𝒟[f <$> mx <*> my] := by
+  have : DecidableEq γ := Classical.decEq γ
+  exact evalDist_ext (probOutput_seq_map_swap mx my f)
+
+lemma probEvent_seq_map_swap (p : γ → Prop) :
+    Pr[ p | Function.swap f <$> my <*> mx] = Pr[ p | f <$> mx <*> my] := by
+  have : DecidableEq γ := Classical.decEq γ
+  simp only [probEvent_eq_tsum_indicator, probOutput_seq_map_swap]
+
+end swap
+
+lemma probEvent_seq_map_eq_probEvent_comp_uncurry (p : γ → Prop) :
+    Pr[ p | f <$> mx <*> my] = Pr[ p ∘ Function.uncurry f | Prod.mk <$> mx <*> my] := by
+  rw [← probEvent_map]
+  congr 1
+  rw [map_seq, Functor.map_map]
+  congr 1
+
+lemma probEvent_seq_map_eq_probEvent (p : γ → Prop) :
+    Pr[ p | f <$> mx <*> my] = Pr[ fun z => p (f z.1 z.2) | Prod.mk <$> mx <*> my] :=
+  probEvent_seq_map_eq_probEvent_comp_uncurry mx my f p
+
+end spmf
+
+section mixed
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
+lemma mem_support_seq_map_iff_of_injective2 (hf : f.Injective2) (x : α) (y : β) :
     f x y ∈ support (f <$> mx <*> my) ↔ x ∈ support mx ∧ y ∈ support my := by
   rw [support_seq_map_eq_image2, Set.mem_image2_iff hf]
 
-lemma mem_finSupport_seq_map_iff_of_injective2 [HasEvalSet m] [HasEvalFinset m]
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
+lemma mem_finSupport_seq_map_iff_of_injective2 [HasEvalFinset m]
     [DecidableEq α] [DecidableEq β] [DecidableEq γ]
     (hf : f.Injective2) (x : α) (y : β) :
     f x y ∈ finSupport (f <$> mx <*> my) ↔ x ∈ finSupport mx ∧ y ∈ finSupport my := by
@@ -202,40 +297,19 @@ lemma mem_finSupport_seq_map_iff_of_injective2 [HasEvalSet m] [HasEvalFinset m]
     exact ⟨(hf hab).1 ▸ ha, (hf hab).2 ▸ hb⟩
   · exact fun ⟨hx, hy⟩ => ⟨x, hx, y, hy, rfl⟩
 
-end injective2
-
-section swap
-
-lemma probOutput_seq_map_swap [HasEvalSPMF m] (z : γ) :
-    Pr[= z | Function.swap f <$> my <*> mx] = Pr[= z | f <$> mx <*> my] := by
-  simp only [probOutput_seq_map_eq_tsum, Function.swap]
-  rw [ENNReal.tsum_comm]
-  refine tsum_congr fun x' => tsum_congr fun y' => ?_
-  rw [mul_comm (Pr[= y' | my])]
-
-lemma evalDist_seq_map_swap [HasEvalSPMF m] :
-    𝒟[Function.swap f <$> my <*> mx] = 𝒟[f <$> mx <*> my] := by
-  have : DecidableEq γ := Classical.decEq γ
-  exact evalDist_ext (probOutput_seq_map_swap mx my f)
-
-lemma probEvent_seq_map_swap [HasEvalSPMF m] (p : γ → Prop) :
-    Pr[ p | Function.swap f <$> my <*> mx] = Pr[ p | f <$> mx <*> my] := by
-  have : DecidableEq γ := Classical.decEq γ
-  simp only [probEvent_eq_tsum_indicator, probOutput_seq_map_swap]
-
-lemma support_seq_map_swap [HasEvalSet m] :
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
+lemma support_seq_map_swap :
     support (Function.swap f <$> my <*> mx) = support (f <$> mx <*> my) := by
   simp only [support_seq_map_eq_image2, Set.image2_swap f]
 
-lemma finSupport_seq_map_swap [HasEvalSet m] [HasEvalFinset m] [DecidableEq γ] :
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m] in
+lemma finSupport_seq_map_swap [HasEvalFinset m] [DecidableEq γ] :
     finSupport (Function.swap f <$> my <*> mx) = finSupport (f <$> mx <*> my) := by
   classical
   simp only [finSupport_seq_map_eq_image2, Finset.image₂_swap f]
 
-end swap
-
-lemma probEvent_seq_map_eq_mul [HasEvalSPMF m]
-    (p : γ → Prop) (q1 : α → Prop) (q2 : β → Prop)
+omit [LawfulMonadLiftT m SetM] in
+lemma probEvent_seq_map_eq_mul (p : γ → Prop) (q1 : α → Prop) (q2 : β → Prop)
     (h : ∀ x ∈ support mx, ∀ y ∈ support my, p (f x y) ↔ q1 x ∧ q2 y) :
     Pr[ p | f <$> mx <*> my] = Pr[ q1 | mx] * Pr[ q2 | my] := by
   classical
@@ -257,7 +331,8 @@ lemma probEvent_seq_map_eq_mul [HasEvalSPMF m]
   · simp [probOutput_eq_zero_of_not_mem_support hx]
   · simp [probOutput_eq_zero_of_not_mem_support hx]
 
-lemma probOutput_seq_map_eq_mul [HasEvalSPMF m] (x : α) (y : β) (z : γ)
+omit [LawfulMonadLiftT m SetM] in
+lemma probOutput_seq_map_eq_mul (x : α) (y : β) (z : γ)
     (h : ∀ x' ∈ support mx, ∀ y' ∈ support my, z = f x' y' ↔ x' = x ∧ y' = y) :
     Pr[= z | f <$> mx <*> my] = Pr[= x | mx] * Pr[= y | my] := by
   have : DecidableEq γ := Classical.decEq γ
@@ -281,15 +356,6 @@ lemma probOutput_seq_map_eq_mul [HasEvalSPMF m] (x : α) (y : β) (z : γ)
         · simp [probOutput_eq_zero_of_not_mem_support hys]
       · simp [probOutput_eq_zero_of_not_mem_support hxs]
 
-lemma probEvent_seq_map_eq_probEvent_comp_uncurry [HasEvalSPMF m] (p : γ → Prop) :
-    Pr[ p | f <$> mx <*> my] = Pr[ p ∘ Function.uncurry f | Prod.mk <$> mx <*> my] := by
-  rw [← probEvent_map]
-  congr 1
-  rw [map_seq, Functor.map_map]
-  congr 1
-
-lemma probEvent_seq_map_eq_probEvent [HasEvalSPMF m] (p : γ → Prop) :
-    Pr[ p | f <$> mx <*> my] = Pr[ fun z => p (f z.1 z.2) | Prod.mk <$> mx <*> my] :=
-  probEvent_seq_map_eq_probEvent_comp_uncurry mx my f p
+end mixed
 
 end seq_map

--- a/VCVio/EvalDist/Option.lean
+++ b/VCVio/EvalDist/Option.lean
@@ -14,26 +14,33 @@ File for lemmas about `evalDist` on involving `Option`.
 
 universe u v w
 
-variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalSPMF m] {α β γ : Type u}
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m SPMF]
+  [LawfulMonadLiftT m SPMF] {α β γ : Type u}
 
 @[simp, grind =]
 lemma probOutput_some_map_some (mx : m α) (x : α) :
     Pr[= some x | some <$> mx] = Pr[= x | mx] :=
   probOutput_map_injective mx (Option.some_injective α) x
 
+@[simp, grind =]
 lemma probOutput_some_map_none (mx : m α) :
-    Pr[= none | some <$> mx] = 0 := by simp
+    Pr[= none | some <$> mx] = 0 := by
+  classical
+  rw [probOutput_map_eq_tsum_ite]
+  simp
 
 section double_option
 
 variable (mx : m (Option α))
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 omit [LawfulMonad m] in
 lemma probOutput_none_add_tsum_some :
     Pr[= none | mx] + ∑' x, Pr[= some x | mx] = 1 - Pr[⊥ | mx] := by
   rw [← tsum_probOutput_eq_sub mx]
   rw [← tsum_option _ ENNReal.summable]
 
+omit [LawfulMonadLiftT m SPMF] in
 omit [LawfulMonad m] in
 lemma probEvent_isSome_eq_one_sub_probOutput_none [NeverFail mx] :
     Pr[ fun r => r.isSome | mx] = 1 - Pr[= none | mx] := by
@@ -48,6 +55,7 @@ lemma probEvent_isSome_eq_one_sub_probOutput_none [NeverFail mx] :
     simpa [add_comm] using htotal
   exact ENNReal.eq_sub_of_add_eq hnone_ne_top htotal'
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 omit [LawfulMonad m] in
 lemma sum_probOutput_some_le_one [Fintype α] :
     ∑ x : α, Pr[= (some x : Option α) | mx] ≤ 1 := by

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -8,15 +8,17 @@ import VCVio.EvalDist.Monad.Seq
 /-!
 # Evaluation Distributions of Computations with `Prod`
 
-Lemmas about `evalDist` and `support` involving `Prod`, ported to generic `[HasEvalSPMF m]`.
+Lemmas about `evalDist` and `support` involving `Prod`, ported to generic `[MonadLiftT m SPMF]`.
 -/
 
 open ENNReal Prod
 
 universe u v
 
-variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalSPMF m] {α β γ δ : Type u}
+variable {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m SPMF]
+  [LawfulMonadLiftT m SPMF] {α β γ δ : Type u}
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 omit [LawfulMonad m] in
 lemma probOutput_prod_mk_eq_probEvent (mx : m (α × β)) (x : α) (y : β) :
     Pr[= (x, y) | mx] = Pr[ fun z => z.1 = x ∧ z.2 = y | mx] := by
@@ -68,6 +70,7 @@ lemma probOutput_snd_map_eq_probEvent (mx : m (α × β)) (y : β) :
 lemma probEvent_snd_map (mx : m (α × β)) (p : β → Prop) :
     Pr[ p | Prod.snd <$> mx] = Pr[ fun y => p y.2 | mx] := by grind
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 omit [LawfulMonad m] in
 @[simp, grind =]
 lemma probEvent_fst_eq_snd (mx : m (α × α)) :
@@ -87,11 +90,15 @@ lemma probOutput_seq_map_prod_mk_eq_mul (z : α × β) :
     Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] :=
   probOutput_seq_map_eq_mul_of_injective2 mx my Prod.mk Prod.mk.injective2 z.1 z.2
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] in
 @[simp high]
-lemma support_seq_map_prod_mk : support (Prod.mk <$> mx <*> my) = support mx ×ˢ support my := by
+lemma support_seq_map_prod_mk [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] :
+    support (Prod.mk <$> mx <*> my) = support mx ×ˢ support my := by
   simp [Set.ext_iff]
 
-lemma finSupport_seq_map_prod_mk [HasEvalFinset m] [DecidableEq α] [DecidableEq β] :
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] in
+lemma finSupport_seq_map_prod_mk [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [HasEvalFinset m] [DecidableEq α] [DecidableEq β] :
     finSupport (Prod.mk <$> mx <*> my) = Finset.product (finSupport mx) (finSupport my) := by
   simp
 
@@ -121,12 +128,15 @@ lemma probOutput_bind_map_prod_mk_eq_mul'
   simpa [monad_norm] using
     probOutput_seq_map_prod_mk_map_eq_mul' mx my f g z
 
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] in
 @[simp high]
-lemma support_seq_map_prod_mk_eq_sprod :
+lemma support_seq_map_prod_mk_eq_sprod [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] :
     support ((f ·, g ·) <$> mx <*> my) = (f '' support mx) ×ˢ (g '' support my) := by
   simp [Set.ext_iff]; grind
 
-lemma finSupport_seq_map_prod_mk_eq_product [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
+omit [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] in
+lemma finSupport_seq_map_prod_mk_eq_product [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+    [HasEvalFinset m] [DecidableEq α] [DecidableEq β]
     [DecidableEq γ] [DecidableEq δ] : finSupport ((f ·, g ·) <$> mx <*> my) =
       ((finSupport mx).image f).product ((finSupport my).image g) := by
   simp [Finset.ext_iff]; grind

--- a/VCVio/EvalDist/RenyiDivergence.lean
+++ b/VCVio/EvalDist/RenyiDivergence.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence
-import VCVio.EvalDist.Defs.Basic
+import VCVio.EvalDist.Monad.Map
 
 /-!
 # Rényi Divergence for SPMFs and Monadic Computations
@@ -13,7 +13,7 @@ This file extends the Rényi divergence from `PMF` (defined in
 `ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence`) to:
 
 1. `SPMF.renyiDiv` — on sub-probability mass functions (via `toPMF`)
-2. `renyiDiv` — on any monad with `HasEvalSPMF` (via `evalDist`)
+2. `renyiDiv` — on any monad with `MonadLiftT m SPMF` (via `evalDist`)
 
 This mirrors the structure of `VCVio.EvalDist.TVDist`, which performs the same lift for
 total variation distance.
@@ -81,13 +81,14 @@ end SPMF
 
 section monadic
 
-variable {m : Type u → Type v} [Monad m] [HasEvalSPMF m] {α : Type u}
+variable {m : Type u → Type v} [Monad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] {α : Type u}
 
 /-- Rényi divergence between two monadic computations,
 defined via their evaluation distributions. -/
 noncomputable def renyiDiv (a : ℝ) (mx my : m α) : ℝ≥0∞ :=
   SPMF.renyiDiv a (𝒟[mx]) (𝒟[my])
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 @[simp]
 theorem renyiDiv_self (a : ℝ) (mx : m α) : renyiDiv a mx mx = 1 :=
   SPMF.renyiDiv_self _ _
@@ -95,17 +96,18 @@ theorem renyiDiv_self (a : ℝ) (mx : m α) : renyiDiv a mx mx = 1 :=
 theorem renyiDiv_map_le [LawfulMonad m] {β : Type u} (a : ℝ) (ha : 1 < a)
     (f : α → β) (mx my : m α) :
     renyiDiv a (f <$> mx) (f <$> my) ≤ renyiDiv a mx my := by
-  simp only [renyiDiv, evalDist_def, MonadHom.mmap_map]
+  simp only [renyiDiv, _root_.evalDist_map]
   exact SPMF.renyiDiv_map_le a ha f _ _
 
 theorem renyiDiv_bind_right_le [LawfulMonad m] {β : Type u} (a : ℝ) (ha : 1 < a)
     (f : α → m β) (mx my : m α) :
     renyiDiv a (mx >>= f) (my >>= f) ≤ renyiDiv a mx my := by
-  simp only [renyiDiv, evalDist_def, MonadHom.mmap_bind]
+  simp only [renyiDiv, _root_.evalDist_bind]
   exact SPMF.renyiDiv_bind_right_le a ha _ _ _
 
 /-! ### Rényi to Probability Bounds -/
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 /-- If the Rényi divergence between two computations is at most `R`, then for any
 output `x`, `Pr[= x | my] ≥ Pr[= x | mx]^{a/(a-1)} / R`. -/
 theorem probOutput_le_of_renyiDiv (a : ℝ) (ha : 1 < a) (mx my : m α)

--- a/VCVio/EvalDist/TVDist.lean
+++ b/VCVio/EvalDist/TVDist.lean
@@ -15,7 +15,7 @@ This file extends the TV distance from `PMF` (defined in
 `ToMathlib.ProbabilityTheory.TotalVariation`) to:
 
 1. `SPMF.tvDist` — on sub-probability mass functions (via `toPMF`)
-2. `tvDist` — on any monad with `HasEvalSPMF` (via `evalDist`)
+2. `tvDist` — on any monad with `MonadLiftT m SPMF` (via `evalDist`)
 -/
 
 noncomputable section
@@ -65,42 +65,50 @@ end SPMF
 
 section monadic
 
-variable {m : Type u → Type v} [Monad m] [HasEvalSPMF m] {α : Type u}
+variable {m : Type u → Type v} [Monad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] {α : Type u}
 
 /-- Total variation distance between two monadic computations,
 defined via their evaluation distributions. -/
 noncomputable def tvDist (mx my : m α) : ℝ :=
   SPMF.tvDist (𝒟[mx]) (𝒟[my])
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 @[simp] lemma tvDist_self (mx : m α) : tvDist mx mx = 0 := SPMF.tvDist_self _
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 @[simp] lemma tvDist_eq_zero_iff (mx my : m α) :
     tvDist mx my = 0 ↔ 𝒟[mx] = 𝒟[my] := by
   unfold tvDist
   rw [SPMF.tvDist_eq_zero_iff, SPMF.toPMF_inj]
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 lemma tvDist_comm (mx my : m α) : tvDist mx my = tvDist my mx :=
   SPMF.tvDist_comm _ _
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 lemma tvDist_nonneg (mx my : m α) : 0 ≤ tvDist mx my := SPMF.tvDist_nonneg _ _
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 lemma tvDist_triangle (mx my mz : m α) :
     tvDist mx mz ≤ tvDist mx my + tvDist my mz :=
   SPMF.tvDist_triangle _ _ _
 
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
 lemma tvDist_le_one (mx my : m α) : tvDist mx my ≤ 1 := SPMF.tvDist_le_one _ _
 
 lemma tvDist_map_le [LawfulMonad m] {β : Type u} (f : α → β) (mx my : m α) :
     tvDist (f <$> mx) (f <$> my) ≤ tvDist mx my := by
-  simp only [tvDist, evalDist_def, MonadHom.mmap_map]
+  simp only [tvDist, evalDist_map]
   exact SPMF.tvDist_map_le f _ _
 
 lemma tvDist_bind_right_le [LawfulMonad m] {β : Type u} (f : α → m β) (mx my : m α) :
     tvDist (mx >>= f) (my >>= f) ≤ tvDist mx my := by
-  simp only [tvDist, evalDist_def, MonadHom.mmap_bind]
+  simp only [tvDist, evalDist_bind]
   exact SPMF.tvDist_bind_right_le _ _ _
 
 /-! ### TV distance bounds -/
+
+omit [LawfulMonadLiftT m SPMF] in
 lemma tvDist_le_probEvent_of_probOutput_eq_of_not
     {mx my : m α} [NeverFail mx] [NeverFail my]
     (p : α → Prop) (h_eq : ∀ x, ¬p x → Pr[= x | mx] = Pr[= x | my])
@@ -227,31 +235,40 @@ private lemma spmf_tvDist_bind_left_le_liftM
       (fun a => PMF.map Option.some (g a))
 
 lemma tvDist_bind_left_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx : m α) (f g : α → m β) :
     tvDist (mx >>= f) (mx >>= g) ≤ ∑' a, Pr[= a | mx].toReal * tvDist (f a) (g a) := by
   rw [tvDist, evalDist_bind, evalDist_bind]
-  simp_rw [HasEvalPMF.evalDist_of_hasEvalPMF_def]
+  simp_rw [evalDist_def]
   calc
     SPMF.tvDist
-        ((liftM (HasEvalPMF.toPMF mx) : SPMF α) >>= fun a => liftM (HasEvalPMF.toPMF (f a)))
-        ((liftM (HasEvalPMF.toPMF mx) : SPMF α) >>= fun a => liftM (HasEvalPMF.toPMF (g a)))
-      ≤ ∑' a, (HasEvalPMF.toPMF mx a).toReal *
-          SPMF.tvDist (liftM (HasEvalPMF.toPMF (f a))) (liftM (HasEvalPMF.toPMF (g a))) := by
-            exact spmf_tvDist_bind_left_le_liftM (HasEvalPMF.toPMF mx)
-              (fun a => HasEvalPMF.toPMF (f a))
-              (fun a => HasEvalPMF.toPMF (g a))
+        ((liftM (liftM mx : PMF α) : SPMF α) >>= fun a => liftM (liftM (f a) : PMF β))
+        ((liftM (liftM mx : PMF α) : SPMF α) >>= fun a => liftM (liftM (g a) : PMF β))
+      ≤ ∑' a, ((liftM mx : PMF α) a).toReal *
+          SPMF.tvDist (liftM (liftM (f a) : PMF β)) (liftM (liftM (g a) : PMF β)) := by
+            exact spmf_tvDist_bind_left_le_liftM (liftM mx : PMF α)
+              (fun a => (liftM (f a) : PMF β))
+              (fun a => (liftM (g a) : PMF β))
     _ = ∑' a, Pr[= a | mx].toReal * tvDist (f a) (g a) := by
           refine tsum_congr fun a => ?_
-          simp [probOutput_def, tvDist, HasEvalPMF.evalDist_of_hasEvalPMF_def]
+          have h1 : ((liftM mx : PMF α) a).toReal = Pr[= a | mx].toReal := by
+            congr 1
+            rw [probOutput_def, evalDist_def]
+            exact (SPMF.liftM_apply (liftM mx : PMF α) a).symm
+          have h2 : (liftM (liftM (f a) : PMF β) : SPMF β).tvDist
+              (liftM (liftM (g a) : PMF β) : SPMF β) = tvDist (f a) (g a) := by
+            rw [tvDist, evalDist_def,
+              evalDist_def]
+            rfl
+          rw [h1, h2]
 
 /-! ### TV distance for bind with a bad event -/
 
 /-- Bound the weighted TV sum from `tvDist_bind_left_le` by the probability of a bad event
 when the two continuations are distributionally equal off that event. -/
 lemma tsum_probOutput_toReal_mul_tvDist_le_probEvent
-    {m : Type u → Type v} [Monad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -310,7 +327,7 @@ lemma tsum_probOutput_toReal_mul_tvDist_le_probEvent
 /-- If two continuations are equal off a bad event, binding them over the same base
 computation changes TV distance by at most the probability of that bad event. -/
 lemma tvDist_bind_left_event_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -321,7 +338,7 @@ lemma tvDist_bind_left_event_le
 /-- `ENNReal` form of `tvDist_bind_left_event_le`, matching the quantitative
 identical-until-bad APIs. -/
 lemma ofReal_tvDist_bind_left_event_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -333,7 +350,7 @@ lemma ofReal_tvDist_bind_left_event_le
 /-- Bind/event TV bound with different base computations: the base TV distance plus the
 bad-event probability controls the whole bind. -/
 lemma tvDist_bind_event_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx my : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -348,7 +365,7 @@ lemma tvDist_bind_event_le
 
 /-- `ENNReal` form of `tvDist_bind_event_le`. -/
 lemma ofReal_tvDist_bind_event_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx my : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -363,7 +380,7 @@ lemma ofReal_tvDist_bind_event_le
 probability under the right base computation. This is the symmetric orientation of
 `tvDist_bind_event_le`, useful when the bad event is introduced by the simulated side. -/
 lemma tvDist_bind_event_right_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx my : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -378,7 +395,7 @@ lemma tvDist_bind_event_right_le
 
 /-- `ENNReal` form of `tvDist_bind_event_right_le`. -/
 lemma ofReal_tvDist_bind_event_right_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} {β : Type u}
     (mx my : m α) (f g : α → m β) (bad : α → Prop)
     (h_eq : ∀ a, ¬ bad a → 𝒟[f a] = 𝒟[g a]) :
@@ -391,7 +408,7 @@ lemma ofReal_tvDist_bind_event_right_le
 
 section bool_tvdist
 
-variable {m : Type → Type v} [Monad m] [HasEvalSPMF m]
+variable {m : Type → Type v} [MonadLiftT m SPMF]
 
 /-- For any `Bool` computation, the difference of `Pr[= true]` values is bounded by
 TV distance. -/

--- a/VCVio/Interaction/UC/AsyncRuntime.lean
+++ b/VCVio/Interaction/UC/AsyncRuntime.lean
@@ -331,7 +331,7 @@ noncomputable def processSemanticsAsync
 
 /--
 Coin-flip-only specialization of `processSemanticsAsync` (`m = ProbComp`,
-`sem := SPMFSemantics.ofHasEvalSPMF ProbComp`). Companion of
+`sem := SPMFSemantics.ofMonadLift ProbComp`). Companion of
 `processSemanticsProbComp`.
 -/
 noncomputable def processSemanticsAsyncProbComp
@@ -349,7 +349,7 @@ noncomputable def processSemanticsAsyncProbComp
       p.Proc → State → RuntimeTrace Event → ProbComp Result) :
     Semantics (openTheory.{u, 0, 0, 0} Party ProbComp schedulerSampler) :=
   processSemanticsAsync Party schedulerSampler
-    (SPMFSemantics.ofHasEvalSPMF ProbComp)
+    (SPMFSemantics.ofMonadLift ProbComp)
     envAction initEnvState
     init envScheduler fuel observe
 

--- a/VCVio/Interaction/UC/Computational.lean
+++ b/VCVio/Interaction/UC/Computational.lean
@@ -42,7 +42,7 @@ two resulting `SPMF Result` distributions.
 This lets the same framework express:
 
 * coin-flip-only protocols with `m = ProbComp` and
-  `SPMFSemantics.ofHasEvalSPMF ProbComp`;
+  `SPMFSemantics.ofMonadLift ProbComp`;
 * protocols with shared oracles where `m = OracleComp superSpec` and
   the internal semantic monad is `StateT σ ProbComp` via `simulateQ`;
 * observation-style semantics that deliberately introduce failure, for

--- a/VCVio/Interaction/UC/Runtime.lean
+++ b/VCVio/Interaction/UC/Runtime.lean
@@ -26,7 +26,7 @@ externally visible `SPMF Result`.
 
 Common instantiations:
 
-* `m = ProbComp` with `sem := SPMFSemantics.ofHasEvalSPMF ProbComp` for
+* `m = ProbComp` with `sem := SPMFSemantics.ofMonadLift ProbComp` for
   coin-flip-only protocols. Use `processSemanticsProbComp`.
 
 * `m = OracleComp (unifSpec + roSpec)` with a hand-rolled
@@ -37,7 +37,7 @@ Common instantiations:
 
 * Observation-style semantics that deliberately carry failure mass,
   for example `m = OptionT ProbComp` with
-  `SPMFSemantics.ofHasEvalSPMF (OptionT ProbComp)`. This is what
+  `SPMFSemantics.ofMonadLift (OptionT ProbComp)`. This is what
   cryptographic smoke tests (OTP-style privacy, guess games) use so
   that the `guard` branch contributes a real failure mass to the
   resulting visible `SPMF`.
@@ -206,7 +206,7 @@ noncomputable def processSemantics (Party : Type u)
 /--
 `processSemanticsProbComp` is the specialization of `processSemantics`
 for `m = ProbComp` with its canonical `SPMFSemantics`
-(`SPMFSemantics.ofHasEvalSPMF`).
+(`SPMFSemantics.ofMonadLift`).
 This is the right entry point for coin-flip-only protocols with no
 shared oracles and no deliberate failure mass.
 -/
@@ -218,7 +218,7 @@ noncomputable def processSemanticsProbComp (Party : Type u)
     (observe : ∀ (p : Closed Party ProbComp schedulerSampler),
       p.Proc → ProbComp Result) :
     Semantics (openTheory.{u, 0, 0, 0} Party ProbComp schedulerSampler) :=
-  processSemantics Party schedulerSampler (SPMFSemantics.ofHasEvalSPMF ProbComp)
+  processSemantics Party schedulerSampler (SPMFSemantics.ofMonadLift ProbComp)
     init fuel observe
 
 /--
@@ -254,7 +254,7 @@ noncomputable def processSemanticsOracle (Party : Type u)
     { Sem := StateT σ ProbComp
       instMonadSem := inferInstance
       interpret := simulateQ' impl
-      observe := fun {_} mx => HasEvalSPMF.toSPMF (mx.run' initOracle) }
+      observe := fun {_} mx => liftM (mx.run' initOracle) }
   processSemantics Party (m := OracleComp superSpec) schedulerSampler oracleSem
     init fuel observe
 

--- a/VCVio/OracleComp/Coercions/SubSpec.lean
+++ b/VCVio/OracleComp/Coercions/SubSpec.lean
@@ -278,7 +278,7 @@ section liftComp_evalDist
 
 variable {ι : Type u} {τ : Type v}
   {spec : OracleSpec ι} {superSpec : OracleSpec τ} {α : Type w}
-variable [spec.Fintype] [spec.Inhabited] [superSpec.Fintype] [superSpec.Inhabited]
+variable [spec.IsUniformSpec] [superSpec.IsUniformSpec]
     [h : spec ⊂ₒ superSpec] [spec ˡ⊂ₒ superSpec]
 
 @[simp, grind =] lemma evalDist_liftComp (mx : OracleComp spec α) :
@@ -290,10 +290,17 @@ variable [spec.Fintype] [spec.Inhabited] [superSpec.Fintype] [superSpec.Inhabite
       OracleQuery.input_query]
     rw [evalDist_bind, evalDist_bind]; simp_rw [ih]
     congr 1
-    simp only [evalDist_eq_simulateQ (spec := superSpec), evalDist_eq_simulateQ (spec := spec),
-      simulateQ_query, OracleQuery.cont_query, OracleQuery.input_query, id_map]
+    have hsuper : (𝒟[(liftM (query t) : OracleComp superSpec _)] : SPMF (spec.Range t)) =
+        liftM ((PMF.uniformOfFintype (superSpec.Range
+          ((liftM (n := OracleQuery superSpec) (spec.query t)).input))).map
+          ((liftM (n := OracleQuery superSpec) (spec.query t)).cont)) := by
+      rw [show (liftM (query t) : OracleComp superSpec (spec.Range t)) =
+            liftM (liftM (spec.query t) : OracleQuery superSpec _) from rfl, evalDist_liftM]
+    have hspec : (𝒟[(liftM (query t) : OracleComp spec _)] : SPMF _) =
+        liftM (PMF.uniformOfFintype (spec.Range t)) := by rw [evalDist_query]
+    rw [hsuper, hspec]
     congr 1
-    exact LawfulSubSpec.evalDist_liftM_query t
+    exact LawfulSubSpec.evalDist_liftM_query (spec := spec) (superSpec := superSpec) t
 
 @[simp, grind =] lemma probOutput_liftComp (mx : OracleComp spec α) (x : α) :
     Pr[= x | liftComp mx superSpec] = Pr[= x | mx] :=
@@ -320,7 +327,7 @@ variable {ι : Type u} {τ : Type v}
 
 /-- Support is preserved by `liftComp`: lifting a computation to a larger oracle spec
 does not change which outputs are reachable. This is the support analogue of
-`evalDist_liftComp` and does not require `Fintype`/`Inhabited` instances. -/
+`evalDist_liftComp`. -/
 @[simp] lemma support_liftComp (mx : OracleComp spec α) :
     support (liftComp mx superSpec) = support mx := by
   simp only [liftComp]

--- a/VCVio/OracleComp/Constructions/GenerateSeed.lean
+++ b/VCVio/OracleComp/Constructions/GenerateSeed.lean
@@ -180,7 +180,7 @@ lemma tail_length_of_mem_support_generateSeed
       seed i hseed hlenPos with ⟨u, us, hus⟩
   rw [hus] at hlen ⊢; simp at hlen ⊢; omega
 
-lemma probOutput_pop_none_eq_zero_of_count_pos [spec.Fintype] [spec.Inhabited]
+lemma probOutput_pop_none_eq_zero_of_count_pos [IsUniformSpec spec]
     (i : ι) (hpos : 0 < qc i * js.count i) :
     Pr[= none | (fun seed => seed.pop i) <$> generateSeed spec qc js] = 0 := by
   rw [probOutput_eq_zero_iff]
@@ -201,8 +201,8 @@ lemma probOutput_pop_some_eq_probOutput_prepend
           (pure (seed'.pop i) : ProbComp (Option (spec.Range i × QuerySeed spec))) →
         seed' = rest.prependValues [u] := by
     intro seed' _ hs
-    have hpop : seed'.pop i = some (u, rest) := by
-      simpa [support_pure, Set.mem_singleton_iff] using hs.symm
+    have hpop : seed'.pop i = some (u, rest) :=
+      (mem_support_pure_iff' (m := ProbComp) _ _).mp hs
     have hcons : u :: rest i = seed' i :=
       QuerySeed.cons_of_pop_eq_some seed' i u rest hpop
     have hrest : rest = Function.update seed' i ((seed' i).tail) :=
@@ -308,8 +308,8 @@ lemma probOutput_generateSeed [spec.Fintype] (seed : QuerySeed spec)
       intro xs' hxs' hseed'
       rw [mem_support_bind_iff] at hseed'
       obtain ⟨rest', _, hpure⟩ := hseed'
-      have hEq : rest'.prependValues xs' = seed := by
-        simpa [support_pure, Set.mem_singleton_iff] using hpure.symm
+      have hEq : rest'.prependValues xs' = seed :=
+        (mem_support_pure_iff' (m := ProbComp) _ _).mp hpure
       have hlen_xs' : xs'.length = qc j := by
         rw [support_replicate] at hxs'; exact hxs'.1
       exact (QuerySeed.eq_of_prependValues_eq seed rest' xs' hlen_xs' hEq).1 ▸ rfl
@@ -318,8 +318,8 @@ lemma probOutput_generateSeed [spec.Fintype] (seed : QuerySeed spec)
           seed ∈ support (return rest'.prependValues xs : ProbComp (QuerySeed spec)) →
             rest' = rest := by
       intro rest' _ hseed'
-      have hEq : rest'.prependValues xs = seed := by
-        simpa [support_pure, Set.mem_singleton_iff] using hseed'.symm
+      have hEq : rest'.prependValues xs = seed :=
+        (mem_support_pure_iff' (m := ProbComp) _ _).mp hseed'
       exact (QuerySeed.eq_of_prependValues_eq seed rest' xs hxs_len hEq).2
     -- Factor probability via probOutput_bind_eq_mul
     have houter :
@@ -370,10 +370,10 @@ lemma probOutput_generateSeed' [spec.Fintype]
       1 / (finSupport (generateSeed spec qc js)).card := by
   classical
   rw [probOutput_generateSeed spec qc js seed h]
-  exact HasEvalPMF.probOutput_eq_inv_finSupport_card fun s hs =>
+  exact probOutput_eq_inv_finSupport_card_of_liftM_PMF fun s hs =>
     probOutput_generateSeed spec qc js s hs
 
-lemma evalDist_generateSeed_eq_of_countEq [spec.Fintype] [spec.Inhabited]
+lemma evalDist_generateSeed_eq_of_countEq [IsUniformSpec spec]
     (qc' : ι → ℕ) (js' : List ι)
     (hcount : ∀ i, qc i * js.count i = qc' i * js'.count i) :
     𝒟[generateSeed spec qc js] = 𝒟[generateSeed spec qc' js'] := by
@@ -427,7 +427,7 @@ lemma evalDist_generateSeed_eq_of_countEq [spec.Fintype] [spec.Inhabited]
       (probOutput_eq_zero_iff (generateSeed spec qc' js') seed).2 hsupp
     rw [hzero, hzero']
 
-lemma probOutput_generateSeed_prependValues [spec.Fintype] [spec.Inhabited]
+lemma probOutput_generateSeed_prependValues [IsUniformSpec spec]
     {t : ι} (u : spec.Range t) (s' : QuerySeed spec)
     (hpos : 0 < qc t * js.count t) :
     Pr[= s'.prependValues [u] | generateSeed spec qc js] =
@@ -586,17 +586,24 @@ theorem generateSeed_queryCostExactly
       simpa [probCompUnitQueryRun] using
         (AddWriterT.queryCostExactly_pure (∅ : QuerySeed spec))
   | cons j js ih =>
-      simpa [probCompUnitQueryRun, OracleComp.generateSeed_cons, simulateQ_bind, simulateQ_pure,
-        simulateQ_map, List.sum_cons, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using
-        (AddWriterT.queryCostExactly_bind
-          (n₁ := qc j * sampleCost j)
-          (n₂ := (js.map fun j => qc j * sampleCost j).sum)
-          (oa := probCompUnitQueryRun (replicate (qc j) ($ᵗ spec.Range j)))
-          (f := fun xs =>
-            (fun rest : QuerySeed spec => rest.prependValues xs) <$>
+      have hmap : ∀ xs : List (spec.Range j),
+          AddWriterT.QueryCostExactly
+            ((fun rest : QuerySeed spec => rest.prependValues xs) <$>
               probCompUnitQueryRun (generateSeed spec qc js))
-          (queryCostExactly_replicate_probComp ($ᵗ spec.Range j) (hSample j) (qc j))
-          (fun xs => AddWriterT.queryCostExactly_map (fun rest => rest.prependValues xs) ih))
+            ((js.map fun j => qc j * sampleCost j).sum) := fun xs =>
+        AddWriterT.queryCostExactly_map (m := ProbComp)
+          (fun rest : QuerySeed spec => rest.prependValues xs) ih
+      have hbind := AddWriterT.queryCostExactly_bind (m := ProbComp)
+        (n₁ := qc j * sampleCost j)
+        (n₂ := (js.map fun j => qc j * sampleCost j).sum)
+        (oa := probCompUnitQueryRun (replicate (qc j) ($ᵗ spec.Range j)))
+        (f := fun xs =>
+          (fun rest : QuerySeed spec => rest.prependValues xs) <$>
+            probCompUnitQueryRun (generateSeed spec qc js))
+        (queryCostExactly_replicate_probComp ($ᵗ spec.Range j) (hSample j) (qc j))
+        hmap
+      simpa [probCompUnitQueryRun, OracleComp.generateSeed_cons, simulateQ_bind, simulateQ_pure,
+        simulateQ_map, List.sum_cons, Nat.add_comm, Nat.add_left_comm, Nat.add_assoc] using hbind
 
 open ENNReal in
 /-- The expected number of uniform-oracle calls made by `generateSeed spec qc js` equals

--- a/VCVio/OracleComp/Constructions/Replicate.lean
+++ b/VCVio/OracleComp/Constructions/Replicate.lean
@@ -77,7 +77,7 @@ lemma replicate_pure (x : α) :
   | zero => rfl
   | succ n hn => simp [hn, List.replicate]
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 lemma probFailure_replicate :
     Pr[⊥ | oa.replicate n] = 1 - (1 - Pr[⊥ | oa]) ^ n := by
@@ -118,25 +118,33 @@ lemma probEvent_replicate_of_probEvent_cons
         (fun x _ xs _ => hq x xs),
       ih, pow_succ, mul_comm]
 
+omit [IsUniformSpec spec] in
 /-- Possible outputs of `replicate n oa` are lists of length `n` where
 each element in the list is a possible output of `oa`. -/
 @[simp]
 lemma support_replicate :
     support (oa.replicate n) = {xs | xs.length = n ∧ ∀ x ∈ xs, x ∈ support oa} := by
-  apply Set.ext; intro xs
-  simp only [Set.mem_setOf_eq, mem_support_iff, probOutput_replicate, ne_eq]
-  constructor
-  · intro h
-    split_ifs at h with hlen
-    · refine ⟨hlen, fun x hx hzero => ?_⟩
-      exact h (List.prod_eq_zero (List.mem_map.mpr ⟨x, hx, hzero⟩))
-    · exact absurd rfl h
-  · intro ⟨hlen, hmem⟩
-    rw [if_pos hlen]
-    refine List.prod_ne_zero ?_
-    intro hzero
-    rw [List.mem_map] at hzero
-    exact hzero.elim fun x ⟨hx, hxa⟩ => hmem x hx hxa
+  induction n with
+  | zero =>
+    ext xs
+    simp only [replicate_zero, support_pure, Set.mem_singleton_iff, Set.mem_setOf_eq,
+      List.length_eq_zero_iff]
+    refine ⟨fun h => ⟨h, ?_⟩, fun h => h.1⟩
+    intro x hx; subst h; exact (List.not_mem_nil hx).elim
+  | succ n ih =>
+    rw [replicate_succ]
+    ext xs
+    cases xs with
+    | nil =>
+      rw [support_seq_map_eq_image2]
+      simp only [Set.mem_image2, Set.mem_setOf_eq, List.length_nil]
+      refine ⟨?_, fun ⟨h, _⟩ => absurd h (Nat.succ_ne_zero n).symm⟩
+      rintro ⟨_, _, _, _, ⟨⟩⟩
+    | cons x xs =>
+      rw [cons_mem_support_seq_map_cons_iff, ih]
+      simp only [Set.mem_setOf_eq, List.length_cons, Nat.add_right_cancel_iff, List.mem_cons,
+        forall_eq_or_imp]
+      tauto
 
 @[simp]
 lemma mem_finSupport_replicate [spec.DecidableEq] [DecidableEq α]
@@ -159,7 +167,7 @@ section SimulateQ
 variable {ι'} {spec' : OracleSpec ι'} {r : Type v → Type*}
   [Monad r] [LawfulMonad r] (impl : QueryImpl spec r)
 
-omit [spec.Fintype] [spec.Inhabited] in
+omit [IsUniformSpec spec] in
 /-- `simulateQ` distributes over `replicate`: simulating a replicated computation
 equals running the simulated body `n` times via monadic recursion. -/
 lemma simulateQ_replicate :

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -510,7 +510,7 @@ lemma evalDist_uniformSample_bind_update
   letI := Fintype.ofFinite R
   haveI : Nonempty (D → R) := ⟨fun _ => Classical.arbitrary R⟩
   refine evalDist_ext fun h => ?_
-  rw [probOutput_uniformSample (D → R) h, HasEvalSPMF.probOutput_bind_eq_sum_fintype]
+  rw [probOutput_uniformSample (D → R) h, probOutput_bind_eq_sum_fintype]
   -- For each fixed `u`, count the tables `g` whose `t`-update equals `h`.
   have hinner : ∀ u : R,
       Pr[= h | (do let g ← $ᵗ (D → R); pure (Function.update g t u))]

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -323,7 +323,8 @@ instance SampleableType.Finite (α : Type) [SampleableType α] : Finite α :=
 /-- We avoid making this an instance globally as many types already have a `Fintype` instance
 that would not be definitionally equal to this one. -/
 @[reducible]
-def SampleableType.Fintype (α : Type) [h : SampleableType α] [DecidableEq α] : Fintype α where
+noncomputable def SampleableType.Fintype (α : Type) [h : SampleableType α] [DecidableEq α] :
+    Fintype α where
   elems := finSupport ($ᵗ α)
   complete := by grind
 
@@ -579,7 +580,7 @@ lemma probOutput_decide_eq_uniformBool_half
       Pr[= false | f false] := by
     rw [probOutput_bind_eq_tsum]; simp
   have hsum : Pr[= true | f false] + Pr[= false | f false] = 1 := by
-    have := HasEvalPMF.sum_probOutput_eq_one (f false)
+    have := sum_probOutput_of_liftM_PMF (f false)
     rwa [Fintype.sum_bool] at this
   rw [htrue, hfalse, h true, ← mul_add, hsum, mul_one]
   simp [one_div]
@@ -600,7 +601,7 @@ namespace uniformSampleImpl
 variable [∀ i, SampleableType (spec.Range i)]
 
 @[simp]
-lemma evalDist_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
+lemma evalDist_simulateQ [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) :
     𝒟[simulateQ uniformSampleImpl oa] = 𝒟[oa] := by
   induction oa using OracleComp.inductionOn with
@@ -608,19 +609,19 @@ lemma evalDist_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
   | query_bind t mx h => simp [h, uniformSampleImpl]
 
 @[simp]
-lemma probOutput_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
+lemma probOutput_simulateQ [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (x : α) :
     Pr[= x | simulateQ uniformSampleImpl oa] = Pr[= x | oa] :=
   congrFun (congrArg DFunLike.coe (evalDist_simulateQ oa)) x
 
 @[simp]
-lemma probEvent_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
+lemma probEvent_simulateQ [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) :
     Pr[ p | simulateQ uniformSampleImpl oa] = Pr[ p | oa] := by
   simp only [probEvent_eq_tsum_indicator, probOutput_simulateQ]
 
 @[simp]
-lemma support_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
+lemma support_simulateQ [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) :
     support (simulateQ uniformSampleImpl oa) = support oa := by
   induction oa using OracleComp.inductionOn with
@@ -628,7 +629,7 @@ lemma support_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
   | query_bind t mx h => simp [h, uniformSampleImpl]
 
 @[simp]
-lemma finSupport_simulateQ [spec.Fintype] [spec.Inhabited] {α : Type}
+lemma finSupport_simulateQ [IsUniformSpec spec] {α : Type}
     [DecidableEq α] (oa : OracleComp spec α) :
     finSupport (simulateQ uniformSampleImpl oa) = finSupport oa := by
   simp [finSupport_eq_iff_support_eq_coe]

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -19,11 +19,461 @@ universe u v w
 
 open scoped OracleSpec.PrimitiveQuery
 
+namespace OracleSpec
+
+variable {ι} {spec : OracleSpec ι}
+
+/-- A per-query distribution on an `OracleSpec`. Each query index `t : ι` is
+assigned a `PMF (spec t)` for its responses. This is the abstract data needed
+to lift `OracleComp spec` into `PMF`; uniformity is **not** assumed — see
+`IsUniformSpec` for the uniform-sampling specialization.
+
+Specs that should opt into uniform sampling are best registered via
+`IsUniformSpec`, which extends this class and additionally carries
+`Fintype` / `Inhabited` on each range plus a propositional witness that
+`toPMF` is the canonical uniform distribution. -/
+class IsProbabilitySpec (spec : OracleSpec ι) where
+  /-- The distribution of responses to query `t`. -/
+  toPMF (t : ι) : PMF (spec t)
+
+/-- An `OracleSpec` whose responses are uniformly sampled from finite, inhabited
+ranges. Bundles `spec.Fintype`, `spec.Inhabited`, and `IsProbabilitySpec spec`
+together with a `Prop` witness that the per-query distribution agrees with
+`PMF.uniformOfFintype`. Use this as the canonical input to lemmas that
+mention `Fintype.card (spec.Range _)` or `PMF.uniformOfFintype` in their
+statements. -/
+class IsUniformSpec (spec : OracleSpec ι) extends IsProbabilitySpec spec where
+  /-- Every response set is finite. -/
+  fintype : spec.Fintype
+  /-- Every response set is inhabited. -/
+  inhabited : spec.Inhabited
+  /-- The per-query distribution is the uniform distribution on the response set. -/
+  toPMF_eq_uniform : ∀ t, toPMF t = PMF.uniformOfFintype (spec.Range t)
+
+attribute [reducible, instance] IsUniformSpec.fintype IsUniformSpec.inhabited
+
+/-- Bridge from `[spec.Fintype] [spec.Inhabited]` to `IsUniformSpec spec`.
+Deliberately **not** an instance — `IsUniformSpec` must be opted into per
+spec so that uniform-sampling semantics never attach silently to a spec
+whose author didn't intend a probabilistic interpretation. Use this
+helper when declaring `IsUniformSpec` for a concrete spec. -/
+@[reducible] noncomputable def IsUniformSpec.ofFintypeInhabited
+    {ι : Type u} (spec : OracleSpec ι)
+    [hF : spec.Fintype] [hI : spec.Inhabited] : IsUniformSpec spec where
+  toPMF t := PMF.uniformOfFintype (spec.Range t)
+  fintype := hF
+  inhabited := hI
+  toPMF_eq_uniform _ := rfl
+
+noncomputable instance : IsUniformSpec unifSpec := IsUniformSpec.ofFintypeInhabited _
+noncomputable instance : IsUniformSpec coinSpec := IsUniformSpec.ofFintypeInhabited _
+
+/-- Propagate `IsUniformSpec` through `+`: each summand's uniformity is
+preserved on its branch. `IsProbabilitySpec (spec + spec')` is derived via
+the `extends` chain. -/
+noncomputable instance instIsUniformSpecAdd {ι ι'} (spec : OracleSpec ι)
+    (spec' : OracleSpec ι') [IsUniformSpec spec] [IsUniformSpec spec'] :
+    IsUniformSpec (spec + spec') := IsUniformSpec.ofFintypeInhabited _
+
+/-- Successor to the legacy empty marker `OracleSpec.IsProbSpec`. The replacement
+`IsUniformSpec` bundles `Fintype`, `Inhabited`, `IsProbabilitySpec`, and a uniformity
+witness. -/
+@[deprecated IsUniformSpec (since := "2026-05-20")]
+alias _root_.OracleSpec.IsProbSpec := IsUniformSpec
+
+end OracleSpec
+
+export OracleSpec (IsProbabilitySpec IsUniformSpec)
+
 namespace OracleComp
 
 variable {ι ι'} {spec : OracleSpec ι} {spec' : OracleSpec ι'} {α β γ : Type w}
 
-section support
+section evalDist_main
+
+/-- Embed `OracleComp` into `PMF` by interpreting each query via the per-query
+distribution provided by `IsProbabilitySpec`. -/
+noncomputable instance instMonadLiftTPMF [IsProbabilitySpec spec] :
+    MonadLiftT (OracleComp spec) PMF where
+  monadLift mx := simulateQ IsProbabilitySpec.toPMF mx
+
+noncomputable instance instLawfulMonadLiftTPMF [IsProbabilitySpec spec] :
+    LawfulMonadLiftT (OracleComp spec) PMF where
+  monadLift_pure := simulateQ_pure _
+  monadLift_bind := simulateQ_bind _
+
+/-- Direct `MonadLiftT (OracleComp spec) SetM`: the syntactic / operational
+support of `mx`, computed by folding queries to `Set.univ`. Independent of any
+probability structure on `spec` — works for arbitrary specs without `Fintype`
+or `Inhabited`. The bridge to the probability side is `EvalDistCompatible`
+below, supplied only when `[IsUniformSpec spec]`.
+
+Note: This is the *only* `MonadLiftT (OracleComp spec) SetM` instance Lean will
+find. The generic `MonadLiftT SPMF SetM` is declared as `MonadLiftT` (not
+`MonadLift`), so `monadLiftTrans` cannot chain `OracleComp → SPMF → SetM`. -/
+instance instMonadLiftTSetM : MonadLiftT (OracleComp spec) SetM where
+  monadLift mx := simulateQ (r := SetM) (fun _ => Set.univ) mx
+
+instance instLawfulMonadLiftTSetM : LawfulMonadLiftT (OracleComp spec) SetM where
+  monadLift_pure := simulateQ_pure _
+  monadLift_bind := simulateQ_bind _
+
+lemma evalDist_eq_simulateQ [IsProbabilitySpec spec] (mx : OracleComp spec α) :
+    𝒟[mx] = simulateQ IsProbabilitySpec.toPMF mx := rfl
+
+/-- Abstract distribution of a single lifted query under `IsProbabilitySpec`:
+the per-query distribution `toPMF` is pushed forward through the query's
+continuation. Uniform-content sibling: `evalDist_liftM`. -/
+lemma evalDist_liftM_toPMF [IsProbabilitySpec spec] (q : OracleQuery spec α) :
+    𝒟[(liftM q : OracleComp spec α)] =
+      (IsProbabilitySpec.toPMF q.input).map q.cont := by
+  simp [evalDist_eq_simulateQ, SPMF.liftM_eq_map, PMF.map_comp, PMF.monad_map_eq_map]
+
+/-- `liftM (query t) : OracleComp spec _` evaluates to the per-query distribution
+`IsProbabilitySpec.toPMF t`, lifted to `SPMF`. -/
+lemma evalDist_query_toPMF [IsProbabilitySpec spec] (t : spec.Domain) :
+    𝒟[(query t : OracleComp spec _)] =
+      (IsProbabilitySpec.toPMF t : SPMF (spec.Range t)) := by
+  rw [evalDist_liftM_toPMF]; simp [PMF.map_id]
+
+@[simp, grind =] lemma support_liftM (q : OracleQuery spec α) :
+    support (liftM q : OracleComp spec α) = Set.range q.cont := by
+  change SetM.run (simulateQ (r := SetM) (fun _ => Set.univ) (liftM q)) = Set.range q.cont
+  rw [simulateQ_query]
+  exact Set.image_univ
+
+@[grind =] lemma support_query (t : spec.Domain) :
+    support (query t : OracleComp spec _) = Set.univ := by
+  rw [support_liftM]; exact Set.range_id
+
+lemma mem_support_liftM_iff (q : OracleQuery spec α) (u : α) :
+    u ∈ support (liftM q : OracleComp spec α) ↔ ∃ t, q.cont t = u := by
+  rw [support_liftM]; exact Set.mem_range
+
+lemma mem_support_query (t : spec.Domain) (u : spec.Range t) :
+    u ∈ support (query t : OracleComp spec _) := by
+  rw [support_query]; trivial
+
+alias support_liftM_query := support_query
+
+/-- Support-aware bind congruence: if two continuations agree on all elements in the support
+    of `mx`, the resulting bind computations are equal. -/
+theorem bind_congr_of_forall_mem_support (mx : OracleComp spec α) {f g : α → OracleComp spec β}
+    (h : ∀ x ∈ support mx, f x = g x) : mx >>= f = mx >>= g := by
+  induction mx using OracleComp.inductionOn with
+  | pure a =>
+    simp only [monad_norm]
+    exact h a (by simp [support_pure])
+  | query_bind q k ih =>
+    change (query q : OracleComp spec _) >>= (fun u => k u >>= f) =
+      (query q : OracleComp spec _) >>= (fun u => k u >>= g)
+    exact bind_congr fun u => ih u (fun x hx =>
+      h x ((mem_support_bind_iff _ _ _).mpr ⟨u, by simp, hx⟩))
+
+@[simp, grind .]
+lemma support_finite [spec.Fintype] (mx : OracleComp spec α) : (support mx).Finite := by
+  induction mx using OracleComp.inductionOn with
+  | pure x => simp
+  | query_bind t f h => simpa using Set.finite_iUnion h
+
+end evalDist_main
+
+section finSupport
+
+variable [spec.Fintype]
+
+/-- Finite version of support for when oracles have a finite set of possible outputs.
+NOTE: we can't use `simulateQ` because `Finset` lacks a `Monad` instance. -/
+instance : HasEvalFinset (OracleComp spec) where
+  finSupport {α} _ mx := OracleComp.construct
+    (fun x => {x}) (fun _ _ r => Finset.univ.biUnion r) mx
+  coe_finSupport {α} _ mx := by
+    induction mx using OracleComp.inductionOn with
+    | pure x => simp
+    | query_bind t mx h => simp [h]
+
+@[simp, grind =] lemma finSupport_liftM [DecidableEq α] (q : OracleQuery spec α) :
+    finSupport (liftM q : OracleComp spec α) = Finset.univ.image q.cont := by grind
+
+lemma finSupport_query [spec.DecidableEq] (t : spec.Domain) :
+    finSupport (query t : OracleComp spec _) = Finset.univ := by grind
+
+lemma mem_finSupport_liftM_iff [DecidableEq α] (q : OracleQuery spec α) (x : α) :
+    x ∈ finSupport (liftM q : OracleComp spec α) ↔ ∃ t, q.cont t = x := by simp
+
+lemma mem_finSupport_query [spec.DecidableEq] (t : spec.Domain) (u : spec.Range t) :
+    u ∈ finSupport (query t : OracleComp spec _) := by grind
+
+end finSupport
+
+section evalDist
+
+variable [IsUniformSpec spec]
+
+@[simp low, grind =]
+lemma evalDist_liftM (q : OracleQuery spec α) :
+    𝒟[(liftM q : OracleComp spec α)] =
+      (PMF.uniformOfFintype (spec.Range q.input)).map q.cont := by
+  rw [evalDist_liftM_toPMF, IsUniformSpec.toPMF_eq_uniform]
+
+@[simp, grind =]
+lemma evalDist_query (t : spec.Domain) :
+    𝒟[(query t : OracleComp spec _)] = PMF.uniformOfFintype (spec.Range t) := by
+  rw [evalDist_liftM]; simp [PMF.map_id]
+
+@[simp low, grind =]
+lemma probOutput_liftM_eq_div (q : OracleQuery spec α) (x : α) :
+    Pr[= x | (liftM q : OracleComp spec α)] =
+      (∑' u : spec.Range q.input, Pr[= x | (return q.cont u : OracleComp spec α)])
+        / Fintype.card (spec.Range q.input) := by
+  have : DecidableEq α := Classical.decEq α
+  simp [probOutput_def, div_eq_mul_inv]
+
+@[simp, grind =]
+lemma probOutput_query (t : spec.Domain) (u : spec.Range t) :
+    Pr[= u | (query t : OracleComp spec _)] =
+      (Fintype.card (spec.Range t) : ℝ≥0∞)⁻¹ := by
+  simp; rfl
+
+@[grind =]
+lemma probEvent_liftM_eq_div (q : OracleQuery spec α) (p : α → Prop) :
+    Pr[ p | (liftM q : OracleComp spec α)] =
+      (∑' u : spec.Range q.input, Pr[ p | (return q.cont u : OracleComp spec α)])
+        / Fintype.card (spec.Range q.input) := by
+  have : DecidablePred p := Classical.decPred p
+  simp only [probEvent_eq_tsum_ite, probOutput_liftM_eq_div, tsum_fintype, div_eq_mul_inv]
+  rw [sum_eq_tsum_indicator]
+  simp only [Finset.coe_univ, Set.mem_univ, Set.indicator_of_mem]
+  rw [ENNReal.tsum_comm, ← ENNReal.tsum_mul_right]
+  refine tsum_congr fun x => by aesop
+
+@[grind =]
+lemma probOutput_query_eq_div (t : spec.Domain) (u : spec.Range t) :
+    Pr[= u | (query t : OracleComp spec _)] = 1 / Fintype.card (spec.Range t) := by
+  simp
+
+@[simp, grind =]
+lemma probEvent_query (t : spec.Domain) (p : spec.Range t → Prop) [DecidablePred p] :
+    Pr[ p | (query t : OracleComp spec _)] =
+      Finset.card {x | p x} / Fintype.card (spec.Range t) := by
+  simp [probEvent_liftM_eq_div]; rfl
+
+end evalDist
+
+section supportEvalDist
+
+variable [IsUniformSpec spec] (oa : OracleComp spec α) (x : α)
+
+/-- Bridge: support computed via the direct `MonadLiftT SetM` agrees with `SPMF.support` of the
+distribution semantics. This is the field body for the `EvalDistCompatible (OracleComp spec)`
+instance below. The equality is uniform-content: it relies on every response having nonzero
+probability, which requires `IsUniformSpec`. -/
+private lemma support_eq_SPMF_support (oa : OracleComp spec α) :
+    support oa = SPMF.support (𝒟[oa]) := by
+  induction oa using OracleComp.inductionOn with
+  | pure y => ext z; simp [support_pure]
+  | query_bind t mx ih =>
+      ext z
+      rw [support_bind, support_query]
+      simp only [Set.mem_univ, true_and, Set.mem_iUnion, exists_prop]
+      simp_rw [ih]
+      simp only [SPMF.mem_support_iff, ne_eq, SPMF.apply_eq_toPMF_some]
+      rw [evalDist_bind, evalDist_query]
+      change (∃ i, ¬ (𝒟[mx i]).toPMF (some z) = 0) ↔
+        ¬ ((liftM (PMF.uniformOfFintype (spec.Range t)) : SPMF _) >>= fun u =>
+            𝒟[mx u]).toPMF (some z) = 0
+      rw [SPMF.toPMF_bind, Option.elimM, PMF.monad_bind_eq_bind, PMF.bind_apply,
+        tsum_option _ ENNReal.summable]
+      have hzero : ((liftM (PMF.uniformOfFintype (spec.Range t))
+          : SPMF (spec.Range t))).toPMF none = 0 := by
+        simp [SPMF.toPMF_liftM]
+      rw [hzero, zero_mul, zero_add]
+      have hcontU : ∀ u : spec.Range t,
+          ((liftM (PMF.uniformOfFintype (spec.Range t)) : SPMF _)).toPMF (some u) ≠ 0 := by
+        intro u
+        simp [SPMF.toPMF_liftM, PMF.uniformOfFintype, PMF.uniformOfFinset_apply,
+          Finset.card_univ]
+      constructor
+      · intro h habs
+        rw [ENNReal.tsum_eq_zero] at habs
+        obtain ⟨u, hu⟩ := h
+        have := habs u
+        rw [mul_eq_zero] at this
+        exact this.elim (hcontU u) hu
+      · intro h
+        by_contra hcontra
+        push Not at hcontra
+        apply h
+        refine ENNReal.tsum_eq_zero.mpr fun u => ?_
+        have := hcontra u
+        rw [Option.elim_some, this, mul_zero]
+
+/-- `OracleComp spec` admits the bridge between its direct `support` semantics and the
+`SPMF.support` of its `evalDist`. -/
+instance instEvalDistCompatible : EvalDistCompatible (OracleComp spec) where
+  support_eq_SPMF_support oa := support_eq_SPMF_support oa
+
+/-- An output has non-zero probability in `evalDist` iff it is in computation support. -/
+@[simp]
+lemma mem_support_evalDist_iff :
+    some x ∈ (𝒟[oa]).run.support ↔ x ∈ support oa := by
+  rw [support_eq_SPMF_support, PMF.mem_support_iff, SPMF.mem_support_iff,
+    SPMF.apply_eq_toPMF_some, SPMF.run_eq_toPMF]
+
+alias ⟨mem_support_of_mem_support_evalDist, mem_support_evalDist⟩ := mem_support_evalDist_iff
+
+/-- Finite-support variant of `mem_support_evalDist_iff`. -/
+@[simp]
+lemma mem_support_evalDist_iff' [DecidableEq α] :
+    some x ∈ (𝒟[oa]).run.support ↔ x ∈ finSupport oa := by
+  rw [mem_support_evalDist_iff (oa := oa) (x := x), mem_finSupport_iff_mem_support]
+
+alias ⟨mem_finSupport_of_mem_support_evalDist, mem_support_evalDist'⟩ := mem_support_evalDist_iff'
+
+end supportEvalDist
+
+section NeverFail
+
+variable [IsProbabilitySpec spec]
+
+@[simp]
+lemma probFailure_eq_zero_iff (oa : OracleComp spec α) : probFailure oa = 0 ↔ NeverFail oa := by
+  simp [neverFail_iff]
+
+@[simp]
+lemma probFailure_pos_iff (oa : OracleComp spec α) : 0 < probFailure oa ↔ ¬ NeverFail oa := by
+  simp [neverFail_iff]
+
+lemma noFailure_of_probFailure_eq_zero {oa : OracleComp spec α} (h : probFailure oa = 0) :
+    NeverFail oa := by rwa [← probFailure_eq_zero_iff]
+
+lemma not_noFailure_of_probFailure_pos {oa : OracleComp spec α} (h : 0 < probFailure oa) :
+    ¬ NeverFail oa := by rwa [← probFailure_pos_iff]
+
+end NeverFail
+
+section evalDistConvenience
+
+variable [IsUniformSpec spec] [IsProbabilitySpec spec']
+
+lemma evalDist_query_bind
+    (t : spec.Domain) (ou : spec.Range t → OracleComp spec α) :
+    𝒟[(query t : OracleComp spec _) >>= ou] =
+      (OptionT.lift (PMF.uniformOfFintype (spec.Range t))) >>= (evalDist ∘ ou) := by
+  rw [evalDist_bind, evalDist_query]; rfl
+
+lemma probOutput_congr {x y : α} {oa : OracleComp spec α} {oa' : OracleComp spec' α}
+    (h1 : x = y) (h2 : 𝒟[oa] = 𝒟[oa']) : Pr[= x | oa] = Pr[= y | oa'] := by
+  simp_rw [probOutput_def, h1, h2]
+
+lemma probEvent_congr' {p q : α → Prop} {oa : OracleComp spec α} {oa' : OracleComp spec' α}
+    (h1 : ∀ x, x ∈ support oa → (p x ↔ q x))
+    (h2 : 𝒟[oa] = 𝒟[oa']) : Pr[ p | oa] = Pr[ q | oa'] := by
+  simp only [probEvent_eq_tsum_indicator, probOutput_def, h2]
+  congr 1; ext x
+  by_cases hx : x ∈ support oa
+  · unfold Set.indicator
+    split_ifs with hp hq hq
+    · rfl
+    · exact absurd ((h1 x hx).mp hp) hq
+    · exact absurd ((h1 x hx).mpr hq) hp
+    · rfl
+  · unfold Set.indicator
+    have : (𝒟[oa]) x = 0 := by
+      by_contra hne
+      apply hx
+      rw [support_eq_SPMF_support]
+      exact (SPMF.mem_support_iff _ _).mpr hne
+    rw [h2] at this
+    split_ifs <;> simp [this]
+
+lemma evalDist_ext_probEvent {oa : OracleComp spec α} {oa' : OracleComp spec' α}
+    (h : ∀ x, Pr[= x | oa] = Pr[= x | oa']) : (𝒟[oa]).run = (𝒟[oa']).run := by
+  have heval : 𝒟[oa] = 𝒟[oa'] := evalDist_ext h
+  simp [heval]
+
+lemma probFailure_eq_sub_probEvent' (oa : OracleComp spec α) :
+    Pr[⊥ | oa] = 1 - Pr[ fun _ => True | oa] :=
+  _root_.probFailure_eq_sub_probEvent oa
+
+end evalDistConvenience
+
+section guard
+
+variable [IsProbabilitySpec spec]
+
+@[simp] lemma probOutput_guard {p : Prop} [Decidable p] :
+    Pr[= () | (guard p : OptionT (OracleComp spec) Unit)] = if p then 1 else 0 := by
+  rw [OracleComp.guard_eq]
+  split_ifs with h
+  · exact probOutput_pure_self ()
+  · -- `probOutput_failure ()` would suit, but `LawfulFailure (OptionT (OracleComp spec))` does
+    -- not resolve through `OptionT.instLawfulFailure` due to a universe-inference quirk in the
+    -- post-refactor diamond. Compute directly.
+    rw [OptionT.probOutput_eq, OptionT.run_failure]
+    rw [show (pure none : OracleComp spec (Option Unit)) = pure none from rfl, probOutput_pure]
+    aesop
+
+@[simp] lemma probFailure_guard {p : Prop} [Decidable p] :
+    Pr[⊥ | (guard p : OptionT (OracleComp spec) Unit)] = if p then 0 else 1 := by
+  rw [OracleComp.guard_eq]
+  split_ifs with h
+  · exact probFailure_pure ()
+  · -- See note above.
+    rw [OptionT.probFailure_eq, OptionT.run_failure]
+    simp
+
+lemma probOutput_eq_sub_probFailure_of_unit {oa : OracleComp spec PUnit} :
+    Pr[= () | oa] = 1 - Pr[⊥ | oa] := by
+  have h := tsum_probOutput_add_probFailure oa
+  have hunit : ∑' x : PUnit, Pr[= x | oa] = Pr[= () | oa] :=
+    tsum_eq_single () (fun x hx => absurd (Subsingleton.elim x ()) hx)
+  rw [hunit] at h
+  exact ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top probFailure_le_one) h
+
+private lemma probOutput_bind_guard_eq_probEvent {α : Type} (oa : OracleComp spec α)
+    (p : α → Prop) [DecidablePred p] :
+    Pr[= () | (do let a ← oa; guard (p a) : OptionT (OracleComp spec) Unit)] = Pr[ p | oa] := by
+  rw [probOutput_bind_eq_tsum]
+  simp only [OptionT.probOutput_liftM, probOutput_guard]
+  rw [probEvent_eq_tsum_ite]
+  congr 1; ext a
+  split_ifs <;> simp
+
+lemma probOutput_guard_eq_sub_probOutput_guard_not {α : Type} {oa : OracleComp spec α}
+    [NeverFail oa] {p : α → Prop} [DecidablePred p] :
+    Pr[= () | (do let a ← oa; guard (p a) : OptionT (OracleComp spec) Unit)] =
+      1 - Pr[= () | (do let a ← oa; guard (¬ p a) : OptionT (OracleComp spec) Unit)] := by
+  rw [probOutput_bind_guard_eq_probEvent, probOutput_bind_guard_eq_probEvent]
+  have h := probEvent_compl oa p
+  simp only [probFailure_of_liftM_PMF, tsub_zero] at h
+  exact ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top probEvent_le_one) h
+
+end guard
+
+section simulateQ_evalDist
+
+variable [IsProbabilitySpec spec] [IsProbabilitySpec spec']
+
+/-- If an oracle implementation preserves the distribution of each source query, then
+`simulateQ` preserves the distribution of every source computation. -/
+lemma evalDist_simulateQ_eq_evalDist
+    (so : QueryImpl spec' (OracleComp spec))
+    (h : ∀ t : spec'.Domain, 𝒟[so t] =
+      𝒟[(query t : OracleComp spec' (spec'.Range t))])
+    (oa : OracleComp spec' α) :
+    𝒟[simulateQ so oa] = 𝒟[oa] := by
+  induction oa using OracleComp.inductionOn with
+  | pure x =>
+      simp
+  | query_bind t mx ih =>
+      simp only [simulateQ_bind, simulateQ_query, OracleQuery.cont_query, id_map,
+        OracleQuery.input_query, evalDist_bind, ih]
+      rw [h t]
+
+end simulateQ_evalDist
+
+section supportWhen
 
 /-- The possible outputs of `mx` when queries can output values in the specified sets.
 NOTE: currently proofs using this should reduce to `simulateQ`. A full API would be better -/
@@ -72,307 +522,15 @@ lemma supportWhen_mono {o₁ o₂ : QueryImpl spec Set}
       rcases hy with ⟨u, hu, hy⟩
       exact ⟨u, h q hu, ih u hy⟩
 
-/-- The `support` instance for `OracleComp`, defined as -/
-instance hasEvalSet : HasEvalSet (OracleComp spec) where
-  toSet := simulateQ' (r := SetM) fun _ : spec.Domain => Set.univ
+end supportWhen
 
-lemma support_eq_simulateQ (mx : OracleComp spec α) :
-    support mx = simulateQ (r := SetM) (fun _ : spec.Domain => Set.univ) mx := rfl
+section evalDistWhen
 
-@[simp, grind =] lemma support_liftM (q : OracleQuery spec α) :
-    support (liftM q : OracleComp spec α) = Set.range q.cont := by
-  simp only [support_eq_simulateQ, simulateQ_query]
-  change q.cont '' Set.univ = Set.range q.cont
-  exact Set.image_univ
-
-@[grind =] lemma support_query (t : spec.Domain) :
-    support (liftM (query t) : OracleComp spec _) = Set.univ := by simp
-
-lemma mem_support_liftM_iff (q : OracleQuery spec α) (u : α) :
-    u ∈ support (liftM q : OracleComp spec α) ↔ ∃ t, q.cont t = u := by grind
-
-lemma mem_support_query (t : spec.Domain) (u : spec.Range t) :
-    u ∈ support (liftM (query t) : OracleComp spec _) := by grind
-
-alias support_liftM_query := support_query
-
-/-- Support-aware bind congruence: if two continuations agree on all elements in the support
-    of `mx`, the resulting bind computations are equal. -/
-theorem bind_congr_of_forall_mem_support (mx : OracleComp spec α) {f g : α → OracleComp spec β}
-    (h : ∀ x ∈ support mx, f x = g x) : mx >>= f = mx >>= g := by
-  induction mx using OracleComp.inductionOn with
-  | pure a =>
-    simp only [monad_norm]
-    exact h a (by simp [support_pure])
-  | query_bind q k ih =>
-    change liftM (query q) >>= (fun u => k u >>= f) =
-      liftM (query q) >>= (fun u => k u >>= g)
-    exact bind_congr fun u => ih u (fun x hx =>
-      h x ((mem_support_bind_iff _ _ _).mpr ⟨u, by simp, hx⟩))
-
-@[simp, grind .]
-lemma support_finite [spec.Fintype] (mx : OracleComp spec α) : (support mx).Finite := by
-  induction mx using OracleComp.inductionOn with
-  | pure x => simp
-  | query_bind t f h => simpa using Set.finite_iUnion h
-
-end support
-
-section finSupport
-
-variable [spec.Fintype]
-
-/-- Finite version of support for when oracles have a finite set of possible outputs.
-NOTE: we can't use `simulateQ` because `Finset` lacks a `Monad` instance. -/
-instance : HasEvalFinset (OracleComp spec) where
-  finSupport {α} _ mx := OracleComp.construct
-    (fun x => {x}) (fun _ _ r => Finset.univ.biUnion r) mx
-  coe_finSupport {α} _ mx := by
-    induction mx using OracleComp.inductionOn with
-    | pure x => simp
-    | query_bind t mx h => simp [h]
-
-@[simp, grind =] lemma finSupport_liftM [DecidableEq α] (q : OracleQuery spec α) :
-    finSupport (liftM q : OracleComp spec α) = Finset.univ.image q.cont := by grind
-
-lemma finSupport_query [spec.DecidableEq] (t : spec.Domain) :
-    finSupport (liftM (query t) : OracleComp spec _) = Finset.univ := by grind
-
-lemma mem_finSupport_liftM_iff [DecidableEq α] (q : OracleQuery spec α) (x : α) :
-    x ∈ finSupport (liftM q : OracleComp spec α) ↔ ∃ t, q.cont t = x := by simp
-
-lemma mem_finSupport_query [spec.DecidableEq] (t : spec.Domain) (u : spec.Range t) :
-    u ∈ finSupport (liftM (query t) : OracleComp spec _) := by grind
-
-end finSupport
-
-section evalDist
-
-/-- The output distribution of `mx` when queries follow the specified distribution.
-NOTE: currently proofs using this should reduce to `simulateQ`. A full API would be better -/
-noncomputable def evalDistWhen (d : QueryImpl spec SPMF)
-    (mx : OracleComp spec α) : SPMF α :=
+/-- The output distribution of `mx` when queries follow the specified distribution. -/
+@[reducible, simp]
+noncomputable def evalDistWhen (d : QueryImpl spec SPMF) (mx : OracleComp spec α) : SPMF α :=
   simulateQ (r := SPMF) d mx
 
-variable [spec.Fintype] [spec.Inhabited]
-
-/-- Embed `OracleComp` into `SPMF` by mapping queries to uniform distributions over their range. -/
-noncomputable instance : HasEvalPMF (OracleComp spec) where
-  toPMF := simulateQ' fun t => PMF.uniformOfFintype (spec.Range t)
-  support_eq mx := by induction mx using OracleComp.inductionOn with
-    | pure x => simp
-    | query_bind t mx ht => simp [ht]
-  toSPMF_eq mx := rfl
-  __ := OracleComp.hasEvalSet (spec := spec)
-
-lemma evalDist_eq_simulateQ (mx : OracleComp spec α) :
-    𝒟[mx] = simulateQ (fun t => PMF.uniformOfFintype (spec.Range t)) mx := rfl
-
-@[simp low, grind =]
-lemma evalDist_liftM (q : OracleQuery spec α) :
-    𝒟[(liftM q : OracleComp spec α)] =
-      (PMF.uniformOfFintype (spec.Range q.input)).map q.cont := by
-  simp [evalDist_eq_simulateQ, SPMF.liftM_eq_map, PMF.map_comp, PMF.monad_map_eq_map]
-
-@[simp, grind =]
-lemma evalDist_query (t : spec.Domain) :
-    𝒟[(liftM (query t) : OracleComp spec _)] = PMF.uniformOfFintype (spec.Range t) := by
-  simp [PMF.map_id]
-
-@[simp low, grind =]
-lemma probOutput_liftM_eq_div (q : OracleQuery spec α) (x : α) :
-    Pr[= x | (liftM q : OracleComp spec α)] =
-      (∑' u : spec.Range q.input, Pr[= x | (return q.cont u : OracleComp spec α)])
-        / Fintype.card (spec.Range q.input) := by
-  have : DecidableEq α := Classical.decEq α
-  simp [probOutput_def, div_eq_mul_inv]
-
-@[simp, grind =]
-lemma probOutput_query (t : spec.Domain) (u : spec.Range t) :
-    Pr[= u | (query t : OracleComp spec _)] = (Fintype.card (spec.Range t) : ℝ≥0∞)⁻¹ := by
-  simp; rfl
-
-@[grind =]
-lemma probEvent_liftM_eq_div (q : OracleQuery spec α) (p : α → Prop) :
-    Pr[ p | (liftM q : OracleComp spec α)] =
-      (∑' u : spec.Range q.input, Pr[ p | (return q.cont u : OracleComp spec α)])
-        / Fintype.card (spec.Range q.input) := by
-  have : DecidablePred p := Classical.decPred p
-  simp only [probEvent_eq_tsum_ite, probOutput_liftM_eq_div, tsum_fintype, div_eq_mul_inv]
-  rw [sum_eq_tsum_indicator]
-  simp only [Finset.coe_univ, Set.mem_univ, Set.indicator_of_mem]
-  rw [ENNReal.tsum_comm, ← ENNReal.tsum_mul_right]
-  refine tsum_congr fun x => by aesop
-
-@[grind =]
-lemma probOutput_query_eq_div (t : spec.Domain) (u : spec.Range t) :
-    Pr[= u | (query t : OracleComp spec _)] = 1 / Fintype.card (spec.Range t) := by simp
-
-@[simp, grind =]
-lemma probEvent_query (t : spec.Domain) (p : spec.Range t → Prop) [DecidablePred p] :
-    Pr[ p | (query t : OracleComp spec _)] =
-      Finset.card {x | p x} / Fintype.card (spec.Range t) := by
-  simp [probEvent_liftM_eq_div]; rfl
-
-end evalDist
-
-section supportEvalDist
-
-variable [spec.Fintype] [spec.Inhabited] (oa : OracleComp spec α) (x : α)
-
-/-- An output has non-zero probability in `evalDist` iff it is in computation support. -/
-@[simp]
-lemma mem_support_evalDist_iff :
-    some x ∈ (𝒟[oa]).run.support ↔ x ∈ support oa := by
-  rw [PMF.mem_support_iff]
-  simpa [probOutput_def, SPMF.apply_eq_toPMF_some] using
-    (mem_support_iff (mx := oa) (x := x)).symm
-
-alias ⟨mem_support_of_mem_support_evalDist, mem_support_evalDist⟩ := mem_support_evalDist_iff
-
-/-- Finite-support variant of `mem_support_evalDist_iff`. -/
-@[simp]
-lemma mem_support_evalDist_iff' [DecidableEq α] :
-    some x ∈ (𝒟[oa]).run.support ↔ x ∈ finSupport oa := by
-  rw [mem_support_evalDist_iff (oa := oa) (x := x), mem_finSupport_iff_mem_support]
-
-alias ⟨mem_finSupport_of_mem_support_evalDist, mem_support_evalDist'⟩ := mem_support_evalDist_iff'
-
-end supportEvalDist
-
-section NeverFail
-
-variable [spec.Fintype] [spec.Inhabited]
-
-@[simp]
-lemma probFailure_eq_zero_iff (oa : OracleComp spec α) : probFailure oa = 0 ↔ NeverFail oa := by
-  simp [HasEvalSPMF.neverFail_iff]
-
-@[simp]
-lemma probFailure_pos_iff (oa : OracleComp spec α) : 0 < probFailure oa ↔ ¬ NeverFail oa := by
-  simp [HasEvalSPMF.neverFail_iff]
-
-lemma noFailure_of_probFailure_eq_zero {oa : OracleComp spec α} (h : probFailure oa = 0) :
-    NeverFail oa := by rwa [← probFailure_eq_zero_iff]
-
-lemma not_noFailure_of_probFailure_pos {oa : OracleComp spec α} (h : 0 < probFailure oa) :
-    ¬ NeverFail oa := by rwa [← probFailure_pos_iff]
-
-end NeverFail
-
-section evalDistConvenience
-
-variable [spec.Fintype] [spec.Inhabited]
-
-lemma evalDist_query_bind
-    (t : spec.Domain) (ou : spec.Range t → OracleComp spec α) :
-    𝒟[(query t : OracleComp spec _) >>= ou] =
-      (OptionT.lift (PMF.uniformOfFintype (spec.Range t))) >>= (evalDist ∘ ou) := by
-  rw [evalDist_bind, evalDist_query]; rfl
-
-lemma probOutput_congr {x y : α} {oa : OracleComp spec α} {oa' : OracleComp spec' α}
-    [spec'.Fintype] [spec'.Inhabited]
-    (h1 : x = y) (h2 : 𝒟[oa] = 𝒟[oa']) : Pr[= x | oa] = Pr[= y | oa'] := by
-  simp_rw [probOutput_def, h1, h2]
-
-lemma probEvent_congr' {p q : α → Prop} {oa : OracleComp spec α} {oa' : OracleComp spec' α}
-    [spec'.Fintype] [spec'.Inhabited]
-    (h1 : ∀ x, x ∈ support oa → (p x ↔ q x))
-    (h2 : 𝒟[oa] = 𝒟[oa']) : Pr[ p | oa] = Pr[ q | oa'] := by
-  simp only [probEvent_eq_tsum_indicator, probOutput_def, h2]
-  congr 1; ext x
-  by_cases hx : x ∈ support oa
-  · unfold Set.indicator
-    split_ifs with hp hq hq
-    · rfl
-    · exact absurd ((h1 x hx).mp hp) hq
-    · exact absurd ((h1 x hx).mpr hq) hp
-    · rfl
-  · unfold Set.indicator
-    have : (𝒟[oa]) x = 0 := by
-      rwa [← probOutput_def, probOutput_eq_zero_iff]
-    rw [h2] at this
-    split_ifs <;> simp [this]
-
-lemma evalDist_ext_probEvent {oa : OracleComp spec α} {oa' : OracleComp spec' α}
-    [spec'.Fintype] [spec'.Inhabited]
-    (h : ∀ x, Pr[= x | oa] = Pr[= x | oa']) : (𝒟[oa]).run = (𝒟[oa']).run := by
-  have heval : 𝒟[oa] = 𝒟[oa'] := evalDist_ext h
-  simp [heval]
-
-lemma probFailure_eq_sub_probEvent' (oa : OracleComp spec α) :
-    Pr[⊥ | oa] = 1 - Pr[ fun _ => True | oa] :=
-  _root_.probFailure_eq_sub_probEvent oa
-
-end evalDistConvenience
-
-section guard
-
-variable [spec.Fintype] [spec.Inhabited]
-
-@[simp] lemma probOutput_guard {p : Prop} [Decidable p] :
-    Pr[= () | (guard p : OptionT (OracleComp spec) Unit)] = if p then 1 else 0 := by
-  rw [OracleComp.guard_eq]
-  split_ifs with h
-  · exact probOutput_pure_self ()
-  · exact probOutput_failure ()
-
-@[simp] lemma probFailure_guard {p : Prop} [Decidable p] :
-    Pr[⊥ | (guard p : OptionT (OracleComp spec) Unit)] = if p then 0 else 1 := by
-  rw [OracleComp.guard_eq]
-  split_ifs with h
-  · exact probFailure_pure ()
-  · exact probFailure_failure
-
-lemma probOutput_eq_sub_probFailure_of_unit {oa : OracleComp spec PUnit} :
-    Pr[= () | oa] = 1 - Pr[⊥ | oa] := by
-  have h := tsum_probOutput_add_probFailure oa
-  have hunit : ∑' x : PUnit, Pr[= x | oa] = Pr[= () | oa] :=
-    tsum_eq_single () (fun x hx => absurd (Subsingleton.elim x ()) hx)
-  rw [hunit] at h
-  exact ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top probFailure_le_one) h
-
-private lemma probOutput_bind_guard_eq_probEvent {α : Type} (oa : OracleComp spec α)
-    (p : α → Prop) [DecidablePred p] :
-    Pr[= () | (do let a ← oa; guard (p a) : OptionT (OracleComp spec) Unit)] = Pr[ p | oa] := by
-  rw [probOutput_bind_eq_tsum]
-  simp only [OptionT.probOutput_liftM, probOutput_guard]
-  rw [probEvent_eq_tsum_ite]
-  congr 1; ext a
-  split_ifs <;> simp
-
-lemma probOutput_guard_eq_sub_probOutput_guard_not {α : Type} {oa : OracleComp spec α}
-    [NeverFail oa] {p : α → Prop} [DecidablePred p] :
-    Pr[= () | (do let a ← oa; guard (p a) : OptionT (OracleComp spec) Unit)] =
-      1 - Pr[= () | (do let a ← oa; guard (¬ p a) : OptionT (OracleComp spec) Unit)] := by
-  rw [probOutput_bind_guard_eq_probEvent, probOutput_bind_guard_eq_probEvent]
-  have h := probEvent_compl oa p
-  simp only [HasEvalPMF.probFailure_eq_zero, tsub_zero] at h
-  exact ENNReal.eq_sub_of_add_eq (ne_top_of_le_ne_top one_ne_top probEvent_le_one) h
-
-end guard
-
-section simulateQ_evalDist
-
-variable [spec.Fintype] [spec.Inhabited]
-
-/-- If an oracle implementation preserves the distribution of each source query, then
-`simulateQ` preserves the distribution of every source computation. -/
-lemma evalDist_simulateQ_eq_evalDist
-    [spec'.Fintype] [spec'.Inhabited]
-    (so : QueryImpl spec' (OracleComp spec))
-    (h : ∀ t : spec'.Domain, 𝒟[so t] =
-      𝒟[(liftM (query t) : OracleComp spec' (spec'.Range t))])
-    (oa : OracleComp spec' α) :
-    𝒟[simulateQ so oa] = 𝒟[oa] := by
-  induction oa using OracleComp.inductionOn with
-  | pure x =>
-      simp
-  | query_bind t mx ih =>
-      simp only [simulateQ_bind, simulateQ_query, OracleQuery.cont_query, id_map,
-        OracleQuery.input_query, evalDist_bind, ih]
-      rw [h t]
-
-end simulateQ_evalDist
+end evalDistWhen
 
 end OracleComp

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -10,7 +10,7 @@ import VCVio.OracleComp.SimSemantics.SimulateQ
 /-!
 # Output Distribution of Computations
 
-This file defines `HasEvalDist` and related instances for `OracleComp`.
+This file defines the `MonadLiftT`-based probability and support semantics for `OracleComp`.
 -/
 
 open OracleSpec Option ENNReal BigOperators

--- a/VCVio/OracleComp/FinRatPMF.lean
+++ b/VCVio/OracleComp/FinRatPMF.lean
@@ -33,6 +33,9 @@ variable [spec.Inhabited] [∀ t : spec.Domain, FinEnum (spec.Range t)]
 local instance instSpecFintypeOfFinEnum : spec.Fintype where
   fintype_B _ := inferInstance
 
+noncomputable local instance instIsUniformSpec : IsUniformSpec spec :=
+  IsUniformSpec.ofFintypeInhabited _
+
 @[simp] lemma toPMF_apply (t : spec.Domain) :
     @Raw.toPMF _ (Classical.decEq _) (finRatImpl (spec := spec) t) =
       PMF.uniformOfFintype (spec.Range t) := by
@@ -62,15 +65,15 @@ local instance instSpecFintypeOfFinEnum : spec.Fintype where
 
 @[simp] lemma evalDist_apply (t : spec.Domain) :
     𝒟[finRatImpl (spec := spec) t] = liftM (PMF.uniformOfFintype (spec.Range t)) := by
-  rw [HasEvalPMF.evalDist_of_hasEvalPMF_def]
-  change liftM (@Raw.toPMF _ (Classical.decEq _) (finRatImpl (spec := spec) t)) = _
+  rw [evalDist_def]
+  change (liftM (@Raw.toPMF _ (Classical.decEq _) (finRatImpl (spec := spec) t)) : SPMF _) = _
   rw [toPMF_apply]
 
 @[simp] lemma evalDist_simulateQ {α : Type v} (oa : OracleComp spec α) :
     𝒟[simulateQ (finRatImpl (spec := spec)) oa] = 𝒟[oa] := by
   induction oa using OracleComp.inductionOn with
   | pure x => simp
-  | query_bind t mx h => simp [evalDist_bind, evalDist_apply, OracleComp.evalDist_query, h]
+  | query_bind t mx h => simp [evalDist_apply, OracleComp.evalDist_query, h]
 
 @[simp] lemma probOutput_simulateQ {α : Type v}
     (oa : OracleComp spec α) (x : α) :
@@ -84,14 +87,18 @@ local instance instSpecFintypeOfFinEnum : spec.Fintype where
 
 @[simp] lemma support_simulateQ {α : Type v} (oa : OracleComp spec α) :
     support (simulateQ (finRatImpl (spec := spec)) oa) = support oa := by
-  ext x
-  exact mem_support_iff_of_evalDist_eq (evalDist_simulateQ (spec := spec) oa) x
+  have hLHS : support (simulateQ (finRatImpl (spec := spec)) oa) =
+      SPMF.support 𝒟[simulateQ (finRatImpl (spec := spec)) oa] :=
+    EvalDistCompatible.support_eq_SPMF_support _
+  have hRHS : support oa = SPMF.support 𝒟[oa] :=
+    EvalDistCompatible.support_eq_SPMF_support _
+  rw [hLHS, evalDist_simulateQ, ← hRHS]
 
 @[simp] lemma finSupport_simulateQ {α : Type v} [DecidableEq α]
     (oa : OracleComp spec α) :
     finSupport (simulateQ (finRatImpl (spec := spec)) oa) = finSupport oa := by
-  ext x
-  exact mem_finSupport_iff_of_evalDist_eq (evalDist_simulateQ (spec := spec) oa) x
+  apply Finset.coe_injective
+  rw [coe_finSupport, coe_finSupport, support_simulateQ]
 
 end finRatImpl
 

--- a/VCVio/OracleComp/OracleSpec.lean
+++ b/VCVio/OracleComp/OracleSpec.lean
@@ -53,13 +53,6 @@ instance {spec : OracleSpec ι} [h : spec.DecidableEq] :
 instance {spec : OracleSpec ι} [h : spec.DecidableEq] (t : spec.Domain) :
   DecidableEq (spec.Range t) := h.decidableEq_B t
 
-/-- Type-class gadget to enable probability notation for computation over an `OracleSpec`.
-Can be defined for any `spec` with `spec.Range` finite and inhabited, but generally should
-only be instantied for things like `coinSpec` or `unifSpec`.
-TODO: Examine if this should be used as a requirement in `evalDist` instances.
-Just forces more explicit differentiation of when the semantics should apply. -/
-protected class IsProbSpec (spec : OracleSpec ι) [spec.Inhabited] [spec.Fintype]
-
 section ofFn
 
 @[reducible, always_inline] def ofFn {ι : Type u} (F : ι → Type v) : OracleSpec ι := F

--- a/VCVio/OracleComp/ProbComp.lean
+++ b/VCVio/OracleComp/ProbComp.lean
@@ -60,11 +60,12 @@ lemma uniformFin_def (n : ℕ) : $[0..n] = unifSpec.query n := rfl
 
 @[simp]
 lemma support_uniformFin (n : ℕ) :
-    support (do $[0..n]) = Set.univ := by grind
+    support (do $[0..n]) = Set.univ := by simp [uniformFin_def]
 
 @[simp]
 lemma finSupport_uniformFin (n : ℕ) :
-    finSupport (do $[0..n]) = Finset.univ := by grind
+    finSupport (do $[0..n]) = Finset.univ := by
+  rw [finSupport_eq_iff_support_eq_coe, support_uniformFin]; simp
 
 @[grind =]
 lemma probOutput_uniformFin_eq_div (n : ℕ) (m : Fin (n + 1)) :

--- a/VCVio/OracleComp/ProbCompLift.lean
+++ b/VCVio/OracleComp/ProbCompLift.lean
@@ -80,7 +80,7 @@ def liftProbComp (runtime : ProbCompRuntime m) : ProbComp →ᵐ m :=
 
 /-- Canonical runtime for `ProbComp` itself. -/
 noncomputable def probComp : ProbCompRuntime ProbComp where
-  toSPMFSemantics := SPMFSemantics.ofHasEvalSPMF ProbComp
+  toSPMFSemantics := SPMFSemantics.ofMonadLift ProbComp
   toProbCompLift := ProbCompLift.id
 
 end ProbCompRuntime

--- a/VCVio/OracleComp/QueryTracking/Birthday.lean
+++ b/VCVio/OracleComp/QueryTracking/Birthday.lean
@@ -21,7 +21,7 @@ open scoped OracleSpec.PrimitiveQuery
 namespace OracleComp
 
 variable {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι}
-  [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
+  [spec.DecidableEq] [IsUniformSpec spec]
 
 /-! ## Per-Pair Collision Bound (Textbook Step 3)
 
@@ -186,7 +186,7 @@ theorem probEvent_log_output_match_le {α : Type}
         · intro h; exact ⟨t, u', by simp, h⟩
       simp_rw [hpred]
       -- Inner Pr is constant: either 1 (if HEq u₀ u') or 0 (otherwise).
-      simp_rw [probEvent_const, HasEvalPMF.probFailure_eq_zero, tsub_zero]
+      simp_rw [probEvent_const, probFailure_of_liftM_PMF, tsub_zero]
       -- Goal: ∑' u', Pr[=u'|query t] * (if HEq u₀ u' then 1 else 0) ≤ 1/|Range default|
       simp_rw [probOutput_query]
       rw [ENNReal.tsum_mul_left]
@@ -607,8 +607,9 @@ theorem probEvent_cacheCollision_le_birthday_total_tight {α : Type}
         (simulateQ cachingOracle (pure x)).run cache₀] = 0 := by
       rw [simulateQ_pure]
       refine probEvent_eq_zero fun z hz h => ?_
-      simp only [StateT.run] at hz
-      obtain ⟨rfl, rfl⟩ := hz
+      change z ∈ support (pure (x, cache₀) : OracleComp _ _) at hz
+      rw [support_pure, Set.mem_singleton_iff] at hz
+      subst hz
       exact hnocoll h
     rw [this]; exact zero_le _
   | query_bind t mx ih =>

--- a/VCVio/OracleComp/QueryTracking/CachingLoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingLoggingOracle.lean
@@ -93,7 +93,7 @@ private lemma _root_.QueryImpl.withCachingTraceAppend_run_proj_eq
 
 omit [Monad m] [spec.DecidableEq] in
 theorem isTotalQueryBound_run_simulateQ_withCachingTraceAppend
-    [LawfulAppend ω]
+    [IsUniformSpec spec] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
     {oa : OracleComp spec α} {n : ℕ}
@@ -108,7 +108,7 @@ theorem isTotalQueryBound_run_simulateQ_withCachingTraceAppend
 
 omit [Monad m] [spec.DecidableEq] in
 theorem isQueryBoundP_run_simulateQ_withCachingTraceAppend
-    [LawfulAppend ω]
+    [IsUniformSpec spec'] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
     {oa : OracleComp spec α}
@@ -186,8 +186,8 @@ The log overlay does not change the underlying query count, so the `cachingOracl
 transfer through `fst_map_run_simulateQ` via `isQueryBound_iff_of_map_eq`. -/
 
 theorem isTotalQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0, 0} ι₀} [spec₀.DecidableEq] {α : Type}
-    {oa : OracleComp spec₀ α} {n : ℕ}
+    {spec₀ : OracleSpec.{0, 0} ι₀} [spec₀.DecidableEq] [IsUniformSpec spec₀]
+    {α : Type} {oa : OracleComp spec₀ α} {n : ℕ}
     (h : OracleComp.IsTotalQueryBound oa n)
     (s : QueryCache spec₀ × QueryLog spec₀) :
     OracleComp.IsTotalQueryBound ((simulateQ spec₀.cachingLoggingOracle oa).run s) n :=
@@ -195,8 +195,8 @@ theorem isTotalQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
     (cachingOracle.isTotalQueryBound_run_simulateQ h s.1)
 
 theorem isQueryBoundP_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0, 0} ι₀} [spec₀.DecidableEq] {α : Type}
-    {oa : OracleComp spec₀ α} {p : ι₀ → Prop} [DecidablePred p] {n : ℕ}
+    {spec₀ : OracleSpec.{0, 0} ι₀} [spec₀.DecidableEq] [IsUniformSpec spec₀]
+    {α : Type} {oa : OracleComp spec₀ α} {p : ι₀ → Prop} [DecidablePred p] {n : ℕ}
     (h : OracleComp.IsQueryBoundP oa p n)
     (s : QueryCache spec₀ × QueryLog spec₀) :
     OracleComp.IsQueryBoundP ((simulateQ spec₀.cachingLoggingOracle oa).run s) p n :=
@@ -204,8 +204,8 @@ theorem isQueryBoundP_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
     (cachingOracle.isQueryBoundP_run_simulateQ h s.1)
 
 theorem isPerIndexQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0, 0} ι₀} [spec₀.DecidableEq] {α : Type}
-    {oa : OracleComp spec₀ α} {qb : ι₀ → ℕ}
+    {spec₀ : OracleSpec.{0, 0} ι₀} [spec₀.DecidableEq] [IsUniformSpec spec₀]
+    {α : Type} {oa : OracleComp spec₀ α} {qb : ι₀ → ℕ}
     (h : OracleComp.IsPerIndexQueryBound oa qb)
     (s : QueryCache spec₀ × QueryLog spec₀) :
     OracleComp.IsPerIndexQueryBound ((simulateQ spec₀.cachingLoggingOracle oa).run s) qb :=

--- a/VCVio/OracleComp/QueryTracking/CachingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CachingOracle.lean
@@ -151,7 +151,7 @@ end CacheAuxProjection
 section CachingAuxInvariant
 
 variable {Q : Type w} {m' : Type (max u w) → Type v} [Monad m'] [LawfulMonad m']
-  [HasEvalSet m']
+  [MonadLiftT m' SetM] [LawfulMonadLiftT m' SetM]
 
 /-- One-step invariant preservation for the auxiliary component of `withCachingAux`. -/
 theorem withCachingAux_aux_inv_of_mem
@@ -200,7 +200,7 @@ variable [spec.DecidableEq]
 omit [spec.DecidableEq] in
 /-- Running `withCaching` at state `cache` produces a result whose cache is `≥ cache`.
 On a cache hit the state is unchanged; on a miss a single entry is added. -/
-lemma withCaching_cache_le [LawfulMonad m] [HasEvalSet m]
+lemma withCaching_cache_le [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (so : QueryImpl spec m) (t : spec.Domain) (cache₀ : QueryCache spec)
     (z) (hz : z ∈ support ((so.withCaching t).run cache₀)) :
     cache₀ ≤ z.2 := by
@@ -272,7 +272,7 @@ lemma isTotalQueryBound_run_withCaching
       rw [withCaching_run_some _ hcache]
       trivial
 
-lemma isPerIndexQueryBound_run_withCaching
+lemma isPerIndexQueryBound_run_withCaching [IsUniformSpec spec]
     (so : QueryImpl spec (OracleComp spec)) (t : spec.Domain) {qb : ι → ℕ}
     (h : OracleComp.IsPerIndexQueryBound (so t) qb) (cache : spec.QueryCache) :
     OracleComp.IsPerIndexQueryBound ((so.withCaching t).run cache) qb := by
@@ -293,7 +293,7 @@ end QueryImpl
 namespace OracleComp
 
 variable {ι : Type u} [DecidableEq ι] {spec : OracleSpec ι}
-  {ι' : Type u} {spec' : OracleSpec ι'} {α : Type u}
+  {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec'] {α : Type u}
 
 theorem IsQueryBoundP.simulateQ_run_withCaching
     {p : ι → Prop} [DecidablePred p] {q : ι' → Prop} [DecidablePred q]
@@ -320,7 +320,7 @@ theorem IsTotalQueryBound.simulateQ_run_withCaching
     (fun t s' => QueryImpl.isTotalQueryBound_run_withCaching so t (hstep t) s')
     cache
 
-theorem IsPerIndexQueryBound.simulateQ_run_withCaching
+theorem IsPerIndexQueryBound.simulateQ_run_withCaching [IsUniformSpec spec]
     (so : QueryImpl spec (OracleComp spec))
     {oa : OracleComp spec α} {qb : ι → ℕ}
     (h : IsPerIndexQueryBound oa qb)
@@ -368,19 +368,19 @@ A generic `withCaching` version for arbitrary base monads would require a separa
 because caching changes the oracle semantics (cache hits skip the underlying oracle call). -/
 @[simp]
 lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
-    [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
+    [IsUniformSpec spec₀] {α : Type}
     (oa : OracleComp spec₀ α) (cache : QueryCache spec₀) :
     Pr[⊥ | (simulateQ spec₀.cachingOracle oa).run cache] = Pr[⊥ | oa] := by
-  simp only [HasEvalPMF.probFailure_eq_zero]
+  simp only [probFailure_of_liftM_PMF]
 
 /-- Trivially true via `probFailure_eq_zero`; see `probFailure_run_simulateQ`. -/
 @[simp]
 lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
-    [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
+    [IsUniformSpec spec₀] {α : Type}
     (oa : OracleComp spec₀ α) (cache : QueryCache spec₀) :
     NeverFail ((simulateQ spec₀.cachingOracle oa).run cache) ↔ NeverFail oa := by
   rw [← probFailure_eq_zero_iff, ← probFailure_eq_zero_iff,
-    HasEvalPMF.probFailure_eq_zero, HasEvalPMF.probFailure_eq_zero]
+    probFailure_of_liftM_PMF, probFailure_of_liftM_PMF]
 
 @[simp]
 lemma simulateQ_query (t : spec.Domain) :
@@ -392,7 +392,7 @@ lemma simulateQ_query (t : spec.Domain) :
 Forward only — the reverse fails because cache hits strictly reduce the simulated count. -/
 
 theorem isTotalQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0, 0} ι₀} {α : Type}
+    {spec₀ : OracleSpec.{0, 0} ι₀} [IsUniformSpec spec₀] {α : Type}
     {oa : OracleComp spec₀ α} {n : ℕ}
     (h : OracleComp.IsTotalQueryBound oa n) (cache : spec₀.QueryCache) :
     OracleComp.IsTotalQueryBound ((simulateQ spec₀.cachingOracle oa).run cache) n := by
@@ -401,7 +401,7 @@ theorem isTotalQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
     (fun t => (OracleComp.isQueryBound_query_iff t 1 _ _).mpr Nat.one_pos) cache
 
 theorem isQueryBoundP_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0, 0} ι₀} {α : Type}
+    {spec₀ : OracleSpec.{0, 0} ι₀} [IsUniformSpec spec₀] {α : Type}
     {oa : OracleComp spec₀ α} {p : ι₀ → Prop} [DecidablePred p] {n : ℕ}
     (h : OracleComp.IsQueryBoundP oa p n) (cache : spec₀.QueryCache) :
     OracleComp.IsQueryBoundP ((simulateQ spec₀.cachingOracle oa).run cache) p n := by
@@ -412,7 +412,7 @@ theorem isQueryBoundP_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
     cache
 
 theorem isPerIndexQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀]
-    {spec₀ : OracleSpec.{0, 0} ι₀} {α : Type}
+    {spec₀ : OracleSpec.{0, 0} ι₀} [IsUniformSpec spec₀] {α : Type}
     {oa : OracleComp spec₀ α} {qb : ι₀ → ℕ}
     (h : OracleComp.IsPerIndexQueryBound oa qb) (cache : spec₀.QueryCache) :
     OracleComp.IsPerIndexQueryBound ((simulateQ spec₀.cachingOracle oa).run cache) qb := by
@@ -523,9 +523,9 @@ end withCacheOverlay
 
 namespace OracleComp
 
-variable [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
+variable [spec.DecidableEq]
 
-omit [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
+omit [spec.DecidableEq] in
 /-- `simulateQ cachingOracle` only grows the cache: for any `oa`, if
 `z ∈ support ((simulateQ cachingOracle oa).run cache₀)` then `cache₀ ≤ z.2`. -/
 theorem simulateQ_cachingOracle_cache_le {α : Type u}
@@ -536,7 +536,11 @@ theorem simulateQ_cachingOracle_cache_le {α : Type u}
   induction oa using OracleComp.inductionOn generalizing cache₀ z with
   | pure a =>
       simp only [StateT.run, simulateQ_pure] at hmem
-      rw [hmem]
+      change z ∈ support (pure (a, cache₀) : OracleComp spec _) at hmem
+      rw [support_pure] at hmem
+      have hz_eq : z = (a, cache₀) := hmem
+      subst hz_eq
+      exact le_rfl
   | query_bind t mx ih =>
       simp only [simulateQ_query_bind, StateT.run_bind] at hmem
       rw [support_bind] at hmem
@@ -548,7 +552,7 @@ theorem simulateQ_cachingOracle_cache_le {α : Type u}
         exact QueryImpl.withCaching_cache_le _ _ cache₀ _ hmid
       exact le_trans hle_mid (ih _ cache_mid z hrest)
 
-omit [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
+omit [spec.DecidableEq] in
 /-- After running `cachingOracle` on a single query at `t`, the resulting cache
 maps `t` to the returned value. -/
 theorem cachingOracle_query_caches (t : spec.Domain)

--- a/VCVio/OracleComp/QueryTracking/Collision.lean
+++ b/VCVio/OracleComp/QueryTracking/Collision.lean
@@ -35,7 +35,6 @@ open scoped OracleSpec.PrimitiveQuery
 namespace OracleComp
 
 variable {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι}
-  [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
 
 /-! ## Collision Predicates -/
 
@@ -45,7 +44,7 @@ def LogHasCollision (log : QueryLog spec) : Prop :=
   ∃ (i j : Fin log.length), i ≠ j ∧
     log[i].1 ≠ log[j].1 ∧ HEq log[i].2 log[j].2
 
-omit [DecidableEq ι] [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
+omit [DecidableEq ι] in
 /-- Value-form constructor for `LogHasCollision`: any two distinct log entries with
 `HEq`-equal outputs (note: distinctness forces distinct inputs when outputs match) witness
 a collision. -/
@@ -70,7 +69,7 @@ lemma LogHasCollision.of_mem {log : QueryLog spec}
     exact congrArg _ (eq_of_heq hresp)
   · rw [hgi', hgj']; exact hresp
 
-omit [DecidableEq ι] [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
+omit [DecidableEq ι] in
 /-- `LogHasCollision` is monotone under log inclusion (member-wise). -/
 lemma LogHasCollision.mono {log₁ log₂ : QueryLog spec}
     (h_sub : ∀ q, q ∈ log₁ → q ∈ log₂) :
@@ -86,7 +85,7 @@ def CacheHasCollision (cache : QueryCache spec) : Prop :=
   ∃ (t₁ t₂ : spec.Domain) (u₁ : spec.Range t₁) (u₂ : spec.Range t₂),
     t₁ ≠ t₂ ∧ cache t₁ = some u₁ ∧ cache t₂ = some u₂ ∧ HEq u₁ u₂
 
-omit [DecidableEq ι] [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
+omit [DecidableEq ι] in
 /-- In a collision-free cache, a value determines at most one query input. -/
 lemma cache_lookup_eq_of_noCollision
     {cache : QueryCache spec}
@@ -101,7 +100,6 @@ lemma cache_lookup_eq_of_noCollision
 
 /-! ## Log entries are cached after logging inside caching -/
 
-omit [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
 /-- When running `loggingOracle` inside `cachingOracle`, every log entry ends up in the cache.
 
 We prove two properties simultaneously by induction:
@@ -211,7 +209,6 @@ theorem log_entry_in_cache_and_mono {α : Type}
       | tail _ hentry' => exact ih_entries entry hentry',
       le_trans hcache₀_le_mid ih_mono⟩
 
-omit [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] in
 /-- **Converse of `log_entry_in_cache_and_mono`**: when running `loggingOracle` inside
 `cachingOracle`, every cache entry that was not in the initial cache has a corresponding
 log entry. Combined with `log_entry_in_cache_and_mono`, this shows that (starting from `∅`)

--- a/VCVio/OracleComp/QueryTracking/CostModel.lean
+++ b/VCVio/OracleComp/QueryTracking/CostModel.lean
@@ -95,7 +95,7 @@ theorem fst_map_costDist [AddCommMonoid ω] (oa : OracleComp spec α) (cm : Cost
 
 namespace AddWriterT
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- For `OracleComp`, `AddWriterT.expectedCost` is the weakest-precondition expectation of the
 run semantics projected to the additive cost component. -/
@@ -115,7 +115,7 @@ end AddWriterT
 section ExpectedCost
 
 variable [AddCommMonoid ω]
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- The expected total cost of `oa` under cost model `cm`, valued by `val : ω → ℝ≥0∞`.
 Computed as `E[val(cost)] = ∑ (x, c), Pr[= (x, c) | costDist] * val(c)`.
@@ -168,7 +168,7 @@ theorem expectedCost_le_of_support_bound (oa : OracleComp spec α) (cm : CostMod
         · exact mul_le_mul_of_nonneg_left (h z hz) (zero_le _)
         · simp [probOutput_eq_zero_of_not_mem_support hz]
     _ = c := by
-        rw [ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+        rw [ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
 end ExpectedCost
 
@@ -177,12 +177,13 @@ end ExpectedCost
 /-- Every execution path of `oa` under `cm` has total cost at most `bound`.
 
 Currently unused outside this file; retained as scaffolding for future asymptotic analyses. -/
-def WorstCaseCostBound [AddCommMonoid ω] [Preorder ω]
+def WorstCaseCostBound [AddCommMonoid ω] [Preorder ω] [IsUniformSpec spec]
     (oa : OracleComp spec α) (cm : CostModel spec ω) (bound : ω) : Prop :=
   AddWriterT.PathwiseCostAtMost (instrumentedRun oa cm) bound
 
 /-- `WorstCaseCostBound` is equivalently a support bound over the old `costDist` view. -/
 theorem worstCaseCostBound_iff_support_bound [AddCommMonoid ω] [Preorder ω]
+    [IsUniformSpec spec]
     (oa : OracleComp spec α) (cm : CostModel spec ω) (bound : ω) :
     WorstCaseCostBound oa cm bound ↔
       ∀ z ∈ support (costDist oa cm), z.2 ≤ bound := by
@@ -194,7 +195,7 @@ theorem worstCaseCostBound_iff_support_bound [AddCommMonoid ω] [Preorder ω]
 section CostBounds
 
 variable [AddCommMonoid ω]
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- The expected cost of `oa` under `cm` (valued by `val`) is at most `bound`.
 
@@ -267,7 +268,7 @@ private lemma addCostOracle_unit_run_apply (t : spec.Domain) :
 
 section UnitCostBridge
 
-private lemma exists_mem_support [spec.Inhabited] (oa : OracleComp spec α) :
+private lemma exists_mem_support [IsUniformSpec spec] (oa : OracleComp spec α) :
     ∃ x, x ∈ support oa := by
   induction oa using OracleComp.inductionOn with
   | pure x =>
@@ -279,7 +280,8 @@ private lemma exists_mem_support [spec.Inhabited] (oa : OracleComp spec α) :
       exact ⟨u, mem_support_query t u, hx⟩
 
 private lemma exists_mem_support_costDist_of_mem_support
-    [AddCommMonoid ω] (oa : OracleComp spec α) (cm : CostModel spec ω) {x : α}
+    [AddCommMonoid ω] [IsUniformSpec spec]
+    (oa : OracleComp spec α) (cm : CostModel spec ω) {x : α}
     (hx : x ∈ support oa) :
     ∃ c, (x, c) ∈ support (costDist oa cm) := by
   have hx' : x ∈ support (Prod.fst <$> costDist oa cm) := by
@@ -291,6 +293,7 @@ private lemma exists_mem_support_costDist_of_mem_support
   exact ⟨c, hz⟩
 
 private lemma mem_support_costDist_unit_query_bind_of_mem_support
+    [IsUniformSpec spec]
     (t : spec.Domain) (mx : spec.Range t → OracleComp spec α) (u : spec.Range t)
     {z : α × Multiplicative ℕ} (hz : z ∈ support (costDist (mx u) CostModel.unit)) :
     (z.1, Multiplicative.ofAdd (Multiplicative.toAdd z.2 + 1)) ∈ support
@@ -307,7 +310,7 @@ private lemma mem_support_costDist_unit_query_bind_of_mem_support
     exact ⟨z, hz, by ext <;> simp [Nat.add_comm]⟩
 
 private theorem isPerIndexQueryBound_of_unit_support_bound
-    [DecidableEq ι] [spec.Inhabited]
+    [DecidableEq ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {bound : ℕ}
     (hSupport : ∀ z ∈ support (costDist oa CostModel.unit), z.2 ≤ bound) :
     IsPerIndexQueryBound oa (fun _ => bound) := by
@@ -345,7 +348,7 @@ private theorem isPerIndexQueryBound_of_unit_support_bound
 if every execution uses at most `bound` total unit-cost steps, then each oracle index
 is queried at most `bound` times. -/
 theorem WorstCaseCostBound.toIsPerIndexQueryBound_unit
-    [DecidableEq ι] [spec.Inhabited]
+    [DecidableEq ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {bound : ℕ}
     (h : WorstCaseCostBound oa CostModel.unit bound) :
     IsPerIndexQueryBound oa (fun _ => bound) := by
@@ -380,7 +383,7 @@ private lemma sum_update_pred_eq
 /-- If `main` makes at most `qb i` queries to each oracle `i`, then its total query count
 (under the unit cost model) is at most `∑ i, qb i` on every execution path. -/
 theorem IsPerIndexQueryBound.toWorstCaseCostBound_unit_sum
-    [DecidableEq ι] [Fintype ι] [spec.Inhabited]
+    [DecidableEq ι] [Fintype ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {qb : ι → ℕ}
     (h : IsPerIndexQueryBound oa qb) :
     WorstCaseCostBound oa CostModel.unit (∑ i, qb i) := by
@@ -440,7 +443,7 @@ theorem IsPerIndexQueryBound.toWorstCaseCostBound_unit_sum
 /-- Corollary: the expected total query count is also at most `∑ i, qb i`. Follows from the
 worst-case bound `toWorstCaseCostBound_unit_sum`. -/
 theorem IsPerIndexQueryBound.toExpectedCostBound_unit_sum
-    [DecidableEq ι] [Fintype ι] [spec.Fintype] [spec.Inhabited]
+    [DecidableEq ι] [Fintype ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {qb : ι → ℕ}
     (h : IsPerIndexQueryBound oa qb) :
     ExpectedCostBound oa CostModel.unit (fun n ↦ (n : ENNReal)) (∑ i, qb i) := by

--- a/VCVio/OracleComp/QueryTracking/CountingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/CountingOracle.lean
@@ -77,14 +77,16 @@ lemma fst_map_run_withCost [LawfulMonad m]
     Prod.fst <$> (simulateQ (so.withCost costFn) mx).run = simulateQ so mx :=
   fst_map_run_withTraceBefore so costFn mx
 
-/-- Cost-tracking preserves failure probability: for any base monad `m` with `HasEvalSPMF`,
+/-- Cost-tracking preserves failure probability: for any base monad `m` with `MonadLiftT m SPMF`,
 wrapping an oracle implementation with `withCost` does not change the probability of failure. -/
-lemma probFailure_run_simulateQ_withCost [LawfulMonad m] [HasEvalSPMF m]
+lemma probFailure_run_simulateQ_withCost [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
     Pr[⊥ | (simulateQ (so.withCost costFn) mx).run] = Pr[⊥ | simulateQ so mx] :=
   probFailure_run_simulateQ_withTraceBefore so costFn mx
 
-lemma NeverFail_run_simulateQ_withCost_iff [LawfulMonad m] [HasEvalSPMF m]
+lemma NeverFail_run_simulateQ_withCost_iff [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
     NeverFail (simulateQ (so.withCost costFn) mx).run ↔ NeverFail (simulateQ so mx) :=
   NeverFail_run_simulateQ_withTraceBefore_iff so costFn mx
@@ -104,19 +106,19 @@ These lemmas connect the result-marginal distribution of a `withCost`-instrument
 computation to the distribution of the uninstrumented computation, enabling direct
 probability-level reasoning about traced computations. -/
 
-lemma evalDist_fst_run_withCost [LawfulMonad m] [HasEvalSPMF m]
+lemma evalDist_fst_run_withCost [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
     𝒟[Prod.fst <$> (simulateQ (so.withCost costFn) mx).run] =
       𝒟[simulateQ so mx] :=
   evalDist_fst_run_withTraceBefore so costFn mx
 
-lemma probOutput_fst_run_withCost [LawfulMonad m] [HasEvalSPMF m]
+lemma probOutput_fst_run_withCost [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (so.withCost costFn) mx).run] =
       Pr[= x | simulateQ so mx] :=
   probOutput_fst_run_withTraceBefore so costFn mx x
 
-lemma support_fst_run_withCost [LawfulMonad m] [HasEvalSPMF m]
+lemma support_fst_run_withCost [LawfulMonad m] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (costFn : spec.Domain → ω) (mx : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (so.withCost costFn) mx).run) =
       support (simulateQ so mx) :=
@@ -170,19 +172,19 @@ lemma fst_map_run_simulateQ (costFn : spec.Domain → ω) (oa : OracleComp spec 
   rw [costOracle, QueryImpl.fst_map_run_withCost, simulateQ_ofLift_eq_self]
 
 @[simp]
-lemma evalDist_fst_run_simulateQ [spec.Fintype] [spec.Inhabited]
+lemma evalDist_fst_run_simulateQ [IsUniformSpec spec]
     (costFn : spec.Domain → ω) (oa : OracleComp spec α) :
     𝒟[Prod.fst <$> (simulateQ (costOracle costFn) oa).run] = 𝒟[oa] := by
   rw [fst_map_run_simulateQ]
 
 @[simp]
-lemma probOutput_fst_run_simulateQ [spec.Fintype] [spec.Inhabited]
+lemma probOutput_fst_run_simulateQ [IsUniformSpec spec]
     (costFn : spec.Domain → ω) (oa : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (costOracle costFn) oa).run] = Pr[= x | oa] := by
   rw [fst_map_run_simulateQ]
 
 @[simp]
-lemma support_run_simulateQ [spec.Fintype] [spec.Inhabited]
+lemma support_run_simulateQ [IsUniformSpec spec]
     (costFn : spec.Domain → ω) (oa : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (costOracle costFn) oa).run) = support oa := by
   rw [fst_map_run_simulateQ]
@@ -206,7 +208,7 @@ lemma run_simulateQ_bind_fst (oa : OracleComp spec α) (ob : α → OracleComp s
 /-- Specialization of `QueryImpl.probFailure_run_simulateQ_withCost` to `countingOracle`. -/
 @[simp]
 lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
-    [spec₀.Fintype] [spec₀.Inhabited] {α : Type} (oa : OracleComp spec₀ α) :
+    [IsUniformSpec spec₀] {α : Type} (oa : OracleComp spec₀ α) :
     Pr[⊥ | (simulateQ (spec₀.countingOracle) oa).run] = Pr[⊥ | oa] := by
   simp only [countingOracle, QueryImpl.withCounting_eq_withCost,
     QueryImpl.probFailure_run_simulateQ_withCost, simulateQ_ofLift_eq_self]
@@ -214,7 +216,7 @@ lemma probFailure_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι�
 /-- Specialization of `QueryImpl.NeverFail_run_simulateQ_withCost_iff` to `countingOracle`. -/
 @[simp]
 lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
-    [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
+    [IsUniformSpec spec₀] {α : Type}
     (oa : OracleComp spec₀ α) :
     NeverFail (simulateQ (spec₀.countingOracle) oa).run ↔ NeverFail oa := by
   simp only [countingOracle, QueryImpl.withCounting_eq_withCost,
@@ -222,7 +224,7 @@ lemma NeverFail_run_simulateQ_iff {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι
 
 @[simp]
 lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
-    [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
+    [IsUniformSpec spec₀] {α : Type}
     (oa : OracleComp spec₀ α) (p : α → Prop) :
     Pr[ fun z => p z.1 | (simulateQ (spec₀.countingOracle) oa).run] = Pr[ p | oa] := by
   rw [show (fun z : α × QueryCount ι₀ => p z.1) = p ∘ Prod.fst from rfl,
@@ -230,7 +232,7 @@ lemma probEvent_fst_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι
 
 @[simp]
 lemma probOutput_fst_map_run_simulateQ {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} [DecidableEq ι₀]
-    [spec₀.Fintype] [spec₀.Inhabited] {α : Type}
+    [IsUniformSpec spec₀] {α : Type}
     (oa : OracleComp spec₀ α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (spec₀.countingOracle) oa).run] =
       Pr[= x | oa] := by

--- a/VCVio/OracleComp/QueryTracking/Enforcement.lean
+++ b/VCVio/OracleComp/QueryTracking/Enforcement.lean
@@ -44,7 +44,7 @@ def OracleSpec.enforceOracle [DecidableEq ι] [spec.Inhabited] :
 
 namespace enforceOracle
 
-variable [DecidableEq ι] [spec.Inhabited]
+variable [DecidableEq ι] [IsUniformSpec spec]
 
 @[simp]
 lemma run_apply (t : ι) (budget : ι → ℕ) :
@@ -75,8 +75,6 @@ theorem fst_map_run_simulateQ
     exact ih u (hcont u)
 
 section Probability
-
-variable [spec.Fintype]
 
 /-- For a computation that is structurally within budget, the budget check in the
 counting semantics is redundant on the support. -/

--- a/VCVio/OracleComp/QueryTracking/Iter.lean
+++ b/VCVio/OracleComp/QueryTracking/Iter.lean
@@ -150,7 +150,7 @@ private lemma countingOracle.support_simulate_replicate_const [DecidableEq ι]
         · funext i; simp
       · funext i; simp [Pi.add_apply]; ring
 
-theorem isTotalQueryBound_replicate_iff [Finite ι] [spec.Inhabited]
+theorem isTotalQueryBound_replicate_iff [Finite ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {n k : ℕ} (hn : 0 < n) :
     IsTotalQueryBound (oa.replicate n) (n * k) ↔ IsTotalQueryBound oa k := by
   letI : DecidableEq ι := Classical.decEq ι
@@ -165,7 +165,7 @@ theorem isTotalQueryBound_replicate_iff [Finite ι] [spec.Inhabited]
   rw [hsum] at this
   exact Nat.le_of_mul_le_mul_left this hn
 
-theorem isQueryBoundP_replicate_iff [Finite ι] [spec.Inhabited]
+theorem isQueryBoundP_replicate_iff [Finite ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {p : ι → Prop} [DecidablePred p] {n k : ℕ} (hn : 0 < n) :
     IsQueryBoundP (oa.replicate n) p (n * k) ↔ IsQueryBoundP oa p k := by
   letI : DecidableEq ι := Classical.decEq ι
@@ -200,12 +200,12 @@ lemma isPerIndexQueryBound_replicateTR [DecidableEq ι]
     IsPerIndexQueryBound (oa.replicateTR n) (n • qb) := by
   rw [replicateTR_eq_replicate]; exact isPerIndexQueryBound_replicate h n
 
-theorem isTotalQueryBound_replicateTR_iff [Finite ι] [spec.Inhabited]
+theorem isTotalQueryBound_replicateTR_iff [Finite ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {n k : ℕ} (hn : 0 < n) :
     IsTotalQueryBound (oa.replicateTR n) (n * k) ↔ IsTotalQueryBound oa k := by
   rw [replicateTR_eq_replicate]; exact isTotalQueryBound_replicate_iff hn
 
-theorem isQueryBoundP_replicateTR_iff [Finite ι] [spec.Inhabited]
+theorem isQueryBoundP_replicateTR_iff [Finite ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {p : ι → Prop} [DecidablePred p] {n k : ℕ} (hn : 0 < n) :
     IsQueryBoundP (oa.replicateTR n) p (n * k) ↔ IsQueryBoundP oa p k := by
   rw [replicateTR_eq_replicate]; exact isQueryBoundP_replicate_iff hn

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -94,17 +94,19 @@ lemma fst_map_run_withLogging [LawfulMonad m] (so : QueryImpl spec m) (mx : Orac
     simulateQ so mx :=
   fst_map_run_withTraceAppend so (fun (t : spec.Domain) u => ([⟨t, u⟩] : QueryLog spec)) mx
 
-/-- Logging preserves failure probability: for any base monad `m` with `HasEvalSPMF`,
+/-- Logging preserves failure probability: for any base monad `m` with `MonadLiftT m SPMF`,
 wrapping an oracle implementation with `withLogging` does not change the probability of failure.
 When `m = OracleComp spec`, both sides are `0` (trivially true). When `m` can genuinely fail
 (e.g. `OptionT (OracleComp spec)`), this is a non-trivial faithfulness property. -/
-lemma probFailure_run_simulateQ_withLogging [LawfulMonad m] [HasEvalSPMF m]
+lemma probFailure_run_simulateQ_withLogging [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (mx : OracleComp spec α) :
     Pr[⊥ | (simulateQ (so.withLogging) mx).run] = Pr[⊥ | simulateQ so mx] :=
   probFailure_run_simulateQ_withTraceAppend so
     (fun (t : spec.Domain) u => ([⟨t, u⟩] : QueryLog spec)) mx
 
-lemma NeverFail_run_simulateQ_withLogging_iff [LawfulMonad m] [HasEvalSPMF m]
+lemma NeverFail_run_simulateQ_withLogging_iff [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (mx : OracleComp spec α) :
     NeverFail (simulateQ (so.withLogging) mx).run ↔ NeverFail (simulateQ so mx) :=
   NeverFail_run_simulateQ_withTraceAppend_iff so
@@ -231,7 +233,7 @@ namespace loggingOracle
 /-- Specialization of `QueryImpl.probFailure_run_simulateQ_withLogging` to `loggingOracle`. -/
 @[simp]
 lemma probFailure_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (oa : OracleComp spec α) :
     Pr[⊥ | (WriterT.run
         (simulateQ spec.loggingOracle oa) :
@@ -253,14 +255,14 @@ lemma run_simulateQ_bind_fst {spec : OracleSpec.{0, 0} ι} {α β : Type}
 /-- Specialization of `QueryImpl.NeverFail_run_simulateQ_withLogging_iff` to `loggingOracle`. -/
 @[simp]
 lemma NeverFail_run_simulateQ_iff {spec : OracleSpec.{0, 0} ι} {α : Type}
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (oa : OracleComp spec α) :
     NeverFail (simulateQ spec.loggingOracle oa).run ↔ NeverFail oa := by
   rw [loggingOracle, QueryImpl.NeverFail_run_simulateQ_withLogging_iff, simulateQ_ofLift_eq_self]
 
 @[simp]
 lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (oa : OracleComp spec α) (p : α → Prop) :
     Pr[ fun z => p z.1 | (simulateQ spec.loggingOracle oa).run] = Pr[ p | oa] := by
   rw [show (fun z : α × spec.QueryLog => p z.1) = p ∘ Prod.fst from rfl,
@@ -268,7 +270,7 @@ lemma probEvent_fst_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
 
 @[simp]
 lemma probOutput_fst_map_run_simulateQ {spec : OracleSpec.{0, 0} ι} {α : Type}
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     (oa : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ spec.loggingOracle oa).run] =
       Pr[= x | oa] := by
@@ -298,7 +300,7 @@ theorem isTotalQueryBound_run_simulateQ_loggingOracle_iff
   isQueryBound_iff_of_map_eq (loggingOracle.fst_map_run_simulateQ oa) _ _
 
 theorem isQueryBoundP_run_simulateQ_loggingOracle_iff
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} {α : Type}
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : ι → Prop) [DecidablePred p] (n : ℕ) :
     IsQueryBoundP ((simulateQ loggingOracle oa).run) p n ↔
     IsQueryBoundP oa p n :=
@@ -315,7 +317,7 @@ theorem isTotalQueryBound_run_simulateQ_withLogging_iff
 
 theorem isQueryBoundP_run_simulateQ_withLogging_iff
     {ι : Type} {spec : OracleSpec.{0, 0} ι}
-    {ι' : Type} {spec' : OracleSpec.{0, 0} ι'}
+    {ι' : Type} {spec' : OracleSpec.{0, 0} ι'} [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec'))
     {α : Type} (mx : OracleComp spec α)
     (q : ι' → Prop) [DecidablePred q] (n : ℕ) :
@@ -324,7 +326,8 @@ theorem isQueryBoundP_run_simulateQ_withLogging_iff
   isQueryBoundP_iff_of_map_eq (p := q) (QueryImpl.fst_map_run_withLogging so mx)
 
 theorem isPerIndexQueryBound_run_simulateQ_loggingOracle_iff
-    {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι} {α : Type}
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (qb : ι → ℕ) :
     IsPerIndexQueryBound ((simulateQ loggingOracle oa).run) qb ↔
     IsPerIndexQueryBound oa qb :=
@@ -333,6 +336,7 @@ theorem isPerIndexQueryBound_run_simulateQ_loggingOracle_iff
 theorem isPerIndexQueryBound_run_simulateQ_withLogging_iff
     {ι : Type} {spec : OracleSpec.{0, 0} ι}
     {ι' : Type} [DecidableEq ι'] {spec' : OracleSpec.{0, 0} ι'}
+    [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec'))
     {α : Type} (mx : OracleComp spec α) (qb : ι' → ℕ) :
     IsPerIndexQueryBound ((simulateQ (so.withLogging) mx).run) qb ↔
@@ -344,7 +348,7 @@ if `oa` makes at most `n` queries, then every support point of
 `(simulateQ loggingOracle oa).run` has log length at most `n`. -/
 theorem log_length_le_of_mem_support_run_simulateQ
     {ι : Type} {spec : OracleSpec.{0, 0} ι}
-    [spec.DecidableEq] [spec.Fintype] [spec.Inhabited] {α : Type}
+    [spec.DecidableEq] [IsUniformSpec spec] {α : Type}
     {oa : OracleComp spec α} {n : ℕ}
     (hbound : IsTotalQueryBound oa n)
     {z : α × QueryLog spec}
@@ -359,6 +363,8 @@ theorem log_length_le_of_mem_support_run_simulateQ
   | pure x =>
       intro z hz
       simp only [simulateQ_pure] at hz
+      change z ∈ support (pure (x, ([] : QueryLog spec)) : OracleComp spec _) at hz
+      rw [support_pure] at hz
       subst hz
       simp
   | query_bind t mx ih =>
@@ -429,7 +435,7 @@ lemma withQueryLog_query
 equals the probability of `p ∘ Prod.fst` holding on the output of `oa.withQueryLog`. -/
 @[simp, grind =]
 lemma probEvent_withQueryLog {ι : Type} {oSpec : OracleSpec ι}
-    [oSpec.Fintype] [oSpec.Inhabited] {α : Type}
+    [IsUniformSpec oSpec] {α : Type}
     (oa : OracleComp oSpec α) (p : α → Prop) :
     Pr[p ∘ Prod.fst | oa.withQueryLog] = Pr[p | oa] :=
   loggingOracle.probEvent_fst_run_simulateQ oa p

--- a/VCVio/OracleComp/QueryTracking/ObservationOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/ObservationOracle.lean
@@ -38,8 +38,8 @@ values. The definitions `eraseObs` and `runObs` are parameterized by a base orac
 ## Main Results
 
 * `fst_map_runObs`: erasure theorem — projecting away the trace recovers `eraseObs`.
-* `probFailure_runObs`: observations do not change failure probability (`[HasEvalSPMF m]`).
-* `NeverFail_runObs_iff`: `NeverFail` is preserved by observation (`[HasEvalSPMF m]`).
+* `probFailure_runObs`: observations do not change failure probability (`[MonadLiftT m SPMF]`).
+* `NeverFail_runObs_iff`: `NeverFail` is preserved by observation (`[MonadLiftT m SPMF]`).
 -/
 
 open OracleSpec OracleComp
@@ -154,7 +154,7 @@ theorem fst_map_runObs [LawfulMonad m] (base : QueryImpl spec m) (encode : Ev �
   exact QueryImpl.fst_map_run_withCost (eraseObsImpl base) (obsCostFn encode) oa
 
 /-- Failure preservation: observations do not change the probability of failure. -/
-theorem probFailure_runObs [LawfulMonad m] [HasEvalSPMF m]
+theorem probFailure_runObs [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (base : QueryImpl spec m) (encode : Ev → ω) (oa : OracleComp (spec + ObsSpec Ev) α) :
     Pr[⊥ | runObs base encode oa] = Pr[⊥ | eraseObs base oa] := by
   rw [show Pr[⊥ | runObs base encode oa] =
@@ -162,10 +162,10 @@ theorem probFailure_runObs [LawfulMonad m] [HasEvalSPMF m]
     (probFailure_map _ _).symm, fst_map_runObs]
 
 /-- `NeverFail` is preserved by observation. -/
-theorem NeverFail_runObs_iff [LawfulMonad m] [HasEvalSPMF m]
+theorem NeverFail_runObs_iff [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (base : QueryImpl spec m) (encode : Ev → ω) (oa : OracleComp (spec + ObsSpec Ev) α) :
     NeverFail (runObs base encode oa) ↔ NeverFail (eraseObs base oa) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_runObs]
+  simp only [neverFail_iff, probFailure_runObs]
 
 /-! ### EvalDist Bridge for `runObs`
 
@@ -173,21 +173,21 @@ These lemmas connect the result-marginal distribution of `runObs` to the distrib
 of `eraseObs`, enabling direct probability-level reasoning about traces without needing
 to manually simplify the traced computation into its concrete form. -/
 
-lemma evalDist_fst_runObs [LawfulMonad m] [HasEvalSPMF m]
+lemma evalDist_fst_runObs [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (base : QueryImpl spec m) (encode : Ev → ω)
     (oa : OracleComp (spec + ObsSpec Ev) α) :
     𝒟[(fun z : α × ω => z.1) <$> runObs base encode oa] =
       𝒟[eraseObs base oa] := by
   rw [fst_map_runObs]
 
-lemma probOutput_fst_runObs [LawfulMonad m] [HasEvalSPMF m]
+lemma probOutput_fst_runObs [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (base : QueryImpl spec m) (encode : Ev → ω)
     (oa : OracleComp (spec + ObsSpec Ev) α) (x : α) :
     Pr[= x | (fun z : α × ω => z.1) <$> runObs base encode oa] =
       Pr[= x | eraseObs base oa] := by
   rw [fst_map_runObs]
 
-lemma support_fst_runObs [LawfulMonad m] [HasEvalSPMF m]
+lemma support_fst_runObs [LawfulMonad m] [MonadLiftT m SetM]
     (base : QueryImpl spec m) (encode : Ev → ω)
     (oa : OracleComp (spec + ObsSpec Ev) α) :
     support ((fun z : α × ω => z.1) <$> runObs base encode oa) =

--- a/VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/ProgrammingOracle.lean
@@ -140,7 +140,7 @@ def withProgramming
 
 /-! ## Bad-flag monotonicity -/
 
-variable [LawfulMonad m] [HasEvalSet m]
+variable [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- The bad flag of `withProgramming` is monotone: once set, every query keeps it set. -/
 lemma withProgramming_bad_monotone
@@ -204,7 +204,7 @@ def withCachingTrackingPolicy
     (fun (t : spec.Domain) (_ : spec.QueryCache) (bad : Bool) =>
       (fun u => (u, if (policy t).isSome then true else bad)) <$> so t)
 
-omit [LawfulMonad m] [HasEvalSet m] in
+omit [LawfulMonad m] [MonadLiftT m SetM] in
 @[simp] lemma withCachingTrackingPolicy_apply
     (so : QueryImpl spec m) (policy : ProgrammingPolicy spec) (t : spec.Domain) :
     so.withCachingTrackingPolicy policy t =
@@ -256,7 +256,7 @@ end QueryImpl
 
 namespace OracleComp.ProgramLogic.Relational
 
-variable {α : Type}
+variable {α : Type} [IsUniformSpec spec]
 
 /-- Cache-side projection: running `withProgramming so empty` and projecting away the bad flag
 gives the same distribution as running `so.withCaching` directly.
@@ -352,6 +352,7 @@ and makes no underlying queries, so the `withCaching` bounds transfer directly. 
 
 theorem isTotalQueryBound_run_simulateQ_withCachingTrackingPolicy
     {ι ι' : Type} [DecidableEq ι] {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
     {oa : OracleComp spec α} {n : ℕ}
     (h : OracleComp.IsTotalQueryBound oa n)
@@ -366,6 +367,7 @@ theorem isTotalQueryBound_run_simulateQ_withCachingTrackingPolicy
 
 theorem isQueryBoundP_run_simulateQ_withCachingTrackingPolicy
     {ι ι' : Type} [DecidableEq ι] {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
     {oa : OracleComp spec α}
     {p : ι → Prop} [DecidablePred p] {q : ι' → Prop} [DecidablePred q] {n : ℕ}
@@ -380,7 +382,7 @@ theorem isQueryBoundP_run_simulateQ_withCachingTrackingPolicy
     (OracleComp.IsQueryBoundP.simulateQ_run_withCaching so h hstep_p hstep_np cache)
 
 theorem isPerIndexQueryBound_run_simulateQ_withCachingTrackingPolicy
-    {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec ι} [IsUniformSpec spec]
     (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
     {oa : OracleComp spec α} {qb : ι → ℕ}
     (h : OracleComp.IsPerIndexQueryBound oa qb)
@@ -402,7 +404,9 @@ projection. -/
 section WithProgrammingBounds
 
 variable {ι ι' : Type} [DecidableEq ι] {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+  [IsUniformSpec spec']
 
+omit [IsUniformSpec spec'] in
 private lemma isTotalQueryBound_run_withProgramming
     (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
     (t : spec.Domain) {n : ℕ}
@@ -420,6 +424,7 @@ private lemma isTotalQueryBound_run_withProgramming
           exact (OracleComp.isQueryBound_map_iff _ _ _ _ _).mpr
             ((OracleComp.isQueryBound_map_iff _ _ _ _ _).mpr h)
 
+omit [IsUniformSpec spec'] in
 private lemma isQueryBoundP_run_withProgramming
     (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
     (t : spec.Domain) {q : ι' → Prop} [DecidablePred q] {n : ℕ}
@@ -437,7 +442,7 @@ private lemma isQueryBoundP_run_withProgramming
           exact (OracleComp.isQueryBoundP_map_iff (p := q) _ _ _).mpr
             ((OracleComp.isQueryBoundP_map_iff (p := q) _ _ _).mpr h)
 
-private lemma isPerIndexQueryBound_run_withProgramming
+private lemma isPerIndexQueryBound_run_withProgramming [IsUniformSpec spec]
     (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
     (t : spec.Domain) {qb : ι → ℕ}
     (h : OracleComp.IsPerIndexQueryBound (so t) qb) (s : spec.QueryCache × Bool) :
@@ -480,7 +485,7 @@ theorem isQueryBoundP_run_simulateQ_withProgramming
     (fun t hnp s => isQueryBoundP_run_withProgramming so policy t (hstep_np t hnp) s)
     (cache, bad)
 
-theorem isPerIndexQueryBound_run_simulateQ_withProgramming
+theorem isPerIndexQueryBound_run_simulateQ_withProgramming [IsUniformSpec spec]
     (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
     {oa : OracleComp spec α} {qb : ι → ℕ}
     (h : OracleComp.IsPerIndexQueryBound oa qb)

--- a/VCVio/OracleComp/QueryTracking/QueryBound.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryBound.lean
@@ -320,7 +320,8 @@ theorem IsQueryBoundP.mono {oa : OracleComp spec α} {n m : ℕ}
 
 /-- `oa >>= ob` is `p`-bounded by `n + m` when `oa` is `p`-bounded by `n` and every reachable
 continuation `ob x` is `p`-bounded by `m`. -/
-lemma isQueryBoundP_bind {oa : OracleComp spec α} {ob : α → OracleComp spec β} {n m : ℕ}
+lemma isQueryBoundP_bind
+    {oa : OracleComp spec α} {ob : α → OracleComp spec β} {n m : ℕ}
     (h : IsQueryBoundP oa p n) (h' : ∀ x ∈ support oa, IsQueryBoundP (ob x) p m) :
     IsQueryBoundP (oa >>= ob) p (n + m) := by
   induction oa using OracleComp.inductionOn generalizing n with
@@ -785,7 +786,7 @@ lemma IsTotalQueryBound.of_bind_query_prefix [spec.Inhabited]
       exact ih u (n := n - 1) hu
 
 theorem IsTotalQueryBound.simulateQ_run_of_step {ι' : Type u} {spec' : OracleSpec ι'}
-    {σ : Type u}
+    [IsUniformSpec spec'] {σ : Type u}
     {impl : QueryImpl spec (StateT σ (OracleComp spec'))}
     {oa : OracleComp spec α} {n : ℕ}
     (h : IsTotalQueryBound oa n)
@@ -813,6 +814,7 @@ target monad is `OracleComp spec'` directly (no `StateT` layer), every per-step 
 applies without an external state argument. Captures the `liftComp` shape, where each
 source query becomes one query in the larger spec. -/
 theorem IsTotalQueryBound.simulateQ_of_step {ι' : Type u} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {impl : QueryImpl spec (OracleComp spec')}
     {oa : OracleComp spec α} {n : ℕ}
     (h : IsTotalQueryBound oa n)
@@ -834,6 +836,7 @@ theorem IsTotalQueryBound.simulateQ_of_step {ι' : Type u} {spec' : OracleSpec �
 makes at most `step` queries (rather than at most `1`). The bound on the simulation is
 `n * step`, where `n` is the bound on the source. -/
 theorem IsTotalQueryBound.simulateQ_of_step_le {ι' : Type u} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {impl : QueryImpl spec (OracleComp spec')}
     {oa : OracleComp spec α} {n step : ℕ}
     (h : IsTotalQueryBound oa n)
@@ -871,7 +874,7 @@ When `b_nx = 0` (the trace case), the formula collapses to `n * b_so`, recoverin
 biconditional trace transfer in one direction. -/
 
 theorem isTotalQueryBound_simulateQ_preInsert
-    {ι' : Type u} {spec' : OracleSpec ι'} {β : Type u}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec'] {β : Type u}
     {impl : QueryImpl spec (OracleComp spec')}
     {nx : spec.Domain → OracleComp spec' β}
     {oa : OracleComp spec α} {n b_so b_nx : ℕ}
@@ -886,7 +889,7 @@ theorem isTotalQueryBound_simulateQ_preInsert
   exact isTotalQueryBound_bind (h_nx t) (fun _ => h_so t)
 
 theorem isTotalQueryBound_simulateQ_postInsert
-    {ι' : Type u} {spec' : OracleSpec ι'} {β : Type u}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec'] {β : Type u}
     {impl : QueryImpl spec (OracleComp spec')}
     {nx : (t : spec.Domain) → spec.Range t → OracleComp spec' β}
     {oa : OracleComp spec α} {n b_so b_nx : ℕ}
@@ -905,7 +908,7 @@ theorem isTotalQueryBound_simulateQ_postInsert
 /-- Predicated version of `simulateQ_of_step_le`: a total bound on the source plus a
 predicated step bound transfers to a predicated bound on the simulation. -/
 theorem IsQueryBoundP.simulateQ_of_step_le_total
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {q : ι' → Prop} [DecidablePred q]
     {impl : QueryImpl spec (OracleComp spec')}
     {oa : OracleComp spec α} {n step : ℕ}
@@ -926,7 +929,7 @@ theorem IsQueryBoundP.simulateQ_of_step_le_total
       · simp [Nat.succ_mul]; ring_nf; rfl
 
 theorem isQueryBoundP_simulateQ_preInsert
-    {ι' : Type u} {spec' : OracleSpec ι'} {β : Type u}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec'] {β : Type u}
     {q : ι' → Prop} [DecidablePred q]
     {impl : QueryImpl spec (OracleComp spec')}
     {nx : spec.Domain → OracleComp spec' β}
@@ -942,7 +945,7 @@ theorem isQueryBoundP_simulateQ_preInsert
   exact isQueryBoundP_bind (h_nx t) (fun _ _ => h_so t)
 
 theorem isQueryBoundP_simulateQ_postInsert
-    {ι' : Type u} {spec' : OracleSpec ι'} {β : Type u}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec'] {β : Type u}
     {q : ι' → Prop} [DecidablePred q]
     {impl : QueryImpl spec (OracleComp spec')}
     {nx : (t : spec.Domain) → spec.Range t → OracleComp spec' β}
@@ -961,7 +964,7 @@ theorem isQueryBoundP_simulateQ_postInsert
 
 /-- Sanity check: instrumenting an oracle with a side-querying "monitor" computation
 fired before each query gives a clean multiplicative bound. -/
-example {ι : Type u} {spec : OracleSpec ι} {α β : Type u}
+example {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec] {α β : Type u}
     {impl : QueryImpl spec (OracleComp spec)} {monitor : OracleComp spec β}
     {oa : OracleComp spec α} {n b_so b_mon : ℕ}
     (hoa : IsTotalQueryBound oa n)
@@ -973,7 +976,8 @@ example {ι : Type u} {spec : OracleSpec ι} {α β : Type u}
 
 namespace countingOracle
 
-lemma add_single_mem_support_simulate_queryBind [DecidableEq ι] {t : spec.Domain}
+lemma add_single_mem_support_simulate_queryBind [DecidableEq ι]
+    [IsUniformSpec spec] {t : spec.Domain}
     {oa : spec.Range t → OracleComp spec α} {u : spec.Range t}
     {z : α × QueryCount ι}
     (hz : z ∈ support (countingOracle.simulate (spec := spec) (oa := oa u) 0)) :
@@ -991,9 +995,8 @@ lemma add_single_mem_support_simulate_queryBind [DecidableEq ι] {t : spec.Domai
 
 section CostSupport
 
-variable [DecidableEq ι] [spec.Fintype] [spec.Inhabited] [Fintype ι]
+variable [DecidableEq ι] [IsUniformSpec spec] [Fintype ι]
 
-omit [spec.Fintype] [spec.Inhabited] in
 lemma exists_mem_support_simulate_of_mem_support_run_simulateQ_le_cost
     {σ : Type u} {impl : QueryImpl spec (StateT σ (OracleComp spec))}
     (cost : σ → ℕ)
@@ -1113,7 +1116,7 @@ omit [Fintype ι] in
 /-- The counting-oracle simulation of any `OracleComp` has non-empty support whenever every
 oracle range is inhabited. Used by the converse direction of
 `isTotalQueryBound_iff_counting_total_le`. -/
-lemma countingOracle.support_simulate_nonempty [spec.Inhabited]
+lemma countingOracle.support_simulate_nonempty [IsUniformSpec spec]
     (oa : OracleComp spec α) :
     (support (countingOracle.simulate oa 0)).Nonempty := by
   induction oa using OracleComp.inductionOn with
@@ -1126,7 +1129,7 @@ lemma countingOracle.support_simulate_nonempty [spec.Inhabited]
 /-- Converse of `IsTotalQueryBound.counting_total_le`: a counting-oracle bound on every
 support path implies the structural total query bound. Together they characterize
 `IsTotalQueryBound` purely in terms of the counting-oracle support. -/
-theorem isTotalQueryBound_iff_counting_total_le [spec.Inhabited]
+theorem isTotalQueryBound_iff_counting_total_le [IsUniformSpec spec]
     {oa : OracleComp spec α} {n : ℕ} :
     IsTotalQueryBound oa n ↔
       ∀ z ∈ support (countingOracle.simulate oa 0), (∑ i, z.2 i) ≤ n := by
@@ -1166,7 +1169,7 @@ point of the simulated prefix leaves the continuation bounded by the residual bu
 by that cost. The cost may under-approximate the true query count, so the resulting residual
 budget is correspondingly weaker but still sound. -/
 theorem IsTotalQueryBound.residual_of_mem_support_run_simulateQ_le_cost
-    [spec.Fintype] [spec.Inhabited] [Finite ι]
+    [IsUniformSpec spec] [Finite ι]
     {σ : Type u} {impl : QueryImpl spec (StateT σ (OracleComp spec))}
     (cost : σ → ℕ)
     (hstep : ∀ t : spec.Domain, ∀ st : σ,
@@ -1193,7 +1196,8 @@ theorem IsTotalQueryBound.residual_of_mem_support_run_simulateQ_le_cost
 end CountingResidual
 
 /-- Per-index bound implies total bound (sum over indices). -/
-theorem IsTotalQueryBound.of_perIndex [DecidableEq ι] [Fintype ι] {oa : OracleComp spec α}
+theorem IsTotalQueryBound.of_perIndex [DecidableEq ι] [Fintype ι]
+    [IsUniformSpec spec] {oa : OracleComp spec α}
     {qb : ι → ℕ}
     (h : IsPerIndexQueryBound oa qb) :
     IsTotalQueryBound oa (∑ i, qb i) := by
@@ -1346,7 +1350,7 @@ theorem IsQueryBoundP.residual_of_mem_support_counting [DecidableEq ι] [Fintype
 /-- Predicate-targeted analogue of `isTotalQueryBound_iff_counting_total_le`: a
 counting-oracle filtered-sum bound characterizes the structural `IsQueryBoundP` bound. -/
 theorem isQueryBoundP_iff_counting_filter_le
-    [DecidableEq ι] [Fintype ι] [spec.Inhabited]
+    [DecidableEq ι] [Fintype ι] [IsUniformSpec spec]
     {oa : OracleComp spec α} {n : ℕ} :
     IsQueryBoundP oa p n ↔
       ∀ z ∈ support (countingOracle.simulate oa 0),
@@ -1407,7 +1411,8 @@ end IsQueryBoundPRelations
 /-- Transfer a predicate-targeted query bound through `simulateQ` into a stateful target
 semantics, provided each simulated source query step is itself `q`-bounded (by `1` on
 `p`-indices, by `0` on `¬ p`-indices). -/
-theorem IsQueryBoundP.simulateQ_run_of_step {ι' : Type u} {spec' : OracleSpec ι'} {σ : Type u}
+theorem IsQueryBoundP.simulateQ_run_of_step {ι' : Type u} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec'] {σ : Type u}
     {p : ι → Prop} [DecidablePred p] {q : ι' → Prop} [DecidablePred q]
     {impl : QueryImpl spec (StateT σ (OracleComp spec'))}
     {oa : OracleComp spec α} {n : ℕ}
@@ -1452,6 +1457,7 @@ monad is `OracleComp spec'` directly (no `StateT` layer), the per-step bounds ap
 an external state argument. Captures the `liftComp` shape, where each `p`-step becomes one
 `q`-query and each `¬ p`-step is `q`-free. -/
 theorem IsQueryBoundP.simulateQ_of_step {ι' : Type u} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {p : ι → Prop} [DecidablePred p] {q : ι' → Prop} [DecidablePred q]
     {impl : QueryImpl spec (OracleComp spec')}
     {oa : OracleComp spec α} {n : ℕ}
@@ -1485,7 +1491,8 @@ its `.inl` and `.inr` branches, with separate step hypotheses for each impl on i
 sub-predicate. -/
 theorem IsQueryBoundP.simulateQ_run_add_of_step
     {ι₁ ι₂ ι' : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    {spec' : OracleSpec ι'} {σ : Type u}
+    {spec' : OracleSpec ι'} [IsUniformSpec spec']
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited] {σ : Type u}
     {p : ι₁ ⊕ ι₂ → Prop} [DecidablePred p]
     {q : ι' → Prop} [DecidablePred q]
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp spec'))}
@@ -1511,7 +1518,8 @@ is vacuously false on `.inr _` queries: only `impl₁` interacts with the predic
 `impl₂` only needs a uniform 0-bound step. -/
 theorem IsQueryBoundP.simulateQ_run_add_inl_of_step
     {ι₁ ι₂ ι' : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    {spec' : OracleSpec ι'} {σ : Type u}
+    {spec' : OracleSpec ι'} [IsUniformSpec spec']
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited] {σ : Type u}
     {p : ι₁ ⊕ ι₂ → Prop} [DecidablePred p]
     {q : ι' → Prop} [DecidablePred q]
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp spec'))}
@@ -1533,7 +1541,8 @@ is vacuously false on `.inl _` queries: only `impl₂` interacts with the predic
 `impl₁` only needs a uniform 0-bound step. -/
 theorem IsQueryBoundP.simulateQ_run_add_inr_of_step
     {ι₁ ι₂ ι' : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    {spec' : OracleSpec ι'} {σ : Type u}
+    {spec' : OracleSpec ι'} [IsUniformSpec spec']
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited] {σ : Type u}
     {p : ι₁ ⊕ ι₂ → Prop} [DecidablePred p]
     {q : ι' → Prop} [DecidablePred q]
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp spec'))}
@@ -1560,7 +1569,8 @@ either side counts toward the same uniform budget. -/
 
 theorem IsTotalQueryBound.simulateQ_run_add_of_step
     {ι₁ ι₂ ι' : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    {spec' : OracleSpec ι'} {σ : Type u}
+    {spec' : OracleSpec ι'} [IsUniformSpec spec']
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited] {σ : Type u}
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp spec'))}
     {impl₂ : QueryImpl spec₂ (StateT σ (OracleComp spec'))}
     {oa : OracleComp (spec₁ + spec₂) α} {n : ℕ}
@@ -1578,7 +1588,8 @@ theorem IsTotalQueryBound.simulateQ_run_add_of_step
 interaction: `impl₂` only needs a uniform 0-bound step. -/
 theorem IsTotalQueryBound.simulateQ_run_add_inl_of_step
     {ι₁ ι₂ ι' : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    {spec' : OracleSpec ι'} {σ : Type u}
+    {spec' : OracleSpec ι'} [IsUniformSpec spec']
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited] {σ : Type u}
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp spec'))}
     {impl₂ : QueryImpl spec₂ (StateT σ (OracleComp spec'))}
     {oa : OracleComp (spec₁ + spec₂) α} {n : ℕ}
@@ -1594,7 +1605,8 @@ theorem IsTotalQueryBound.simulateQ_run_add_inl_of_step
 interaction: `impl₁` only needs a uniform 0-bound step. -/
 theorem IsTotalQueryBound.simulateQ_run_add_inr_of_step
     {ι₁ ι₂ ι' : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    {spec' : OracleSpec ι'} {σ : Type u}
+    {spec' : OracleSpec ι'} [IsUniformSpec spec']
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited] {σ : Type u}
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp spec'))}
     {impl₂ : QueryImpl spec₂ (StateT σ (OracleComp spec'))}
     {oa : OracleComp (spec₁ + spec₂) α} {n : ℕ}
@@ -1616,6 +1628,7 @@ spec, mirroring the single-spec `simulateQ_run_of_uniform_step`. -/
 theorem IsPerIndexQueryBound.simulateQ_run_add_of_uniform_step
     {ι₁ ι₂ : Type u} [DecidableEq ι₁] [DecidableEq ι₂]
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited]
     {σ : Type u}
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp (spec₁ + spec₂)))}
     {impl₂ : QueryImpl spec₂ (StateT σ (OracleComp (spec₁ + spec₂)))}
@@ -1637,6 +1650,7 @@ interaction: `impl₂` only needs a uniform 0-step. -/
 theorem IsPerIndexQueryBound.simulateQ_run_add_inl_of_uniform_step
     {ι₁ ι₂ : Type u} [DecidableEq ι₁] [DecidableEq ι₂]
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited]
     {σ : Type u}
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp (spec₁ + spec₂)))}
     {impl₂ : QueryImpl spec₂ (StateT σ (OracleComp (spec₁ + spec₂)))}
@@ -1655,6 +1669,7 @@ interaction: `impl₁` only needs a uniform 0-step. -/
 theorem IsPerIndexQueryBound.simulateQ_run_add_inr_of_uniform_step
     {ι₁ ι₂ : Type u} [DecidableEq ι₁] [DecidableEq ι₂]
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [(spec₁ + spec₂).Fintype] [(spec₁ + spec₂).Inhabited]
     {σ : Type u}
     {impl₁ : QueryImpl spec₁ (StateT σ (OracleComp (spec₁ + spec₂)))}
     {impl₂ : QueryImpl spec₂ (StateT σ (OracleComp (spec₁ + spec₂)))}
@@ -1687,7 +1702,8 @@ theorem isTotalQueryBound_run_simulateQ_countingOracle_iff
   isQueryBound_iff_of_map_eq (countingOracle.fst_map_run_simulateQ oa) _ _
 
 theorem isQueryBoundP_run_simulateQ_countingOracle_iff
-    {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι} {α : Type}
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : ι → Prop) [DecidablePred p] (n : ℕ) :
     IsQueryBoundP ((simulateQ countingOracle oa).run) p n ↔
     IsQueryBoundP oa p n :=
@@ -1695,7 +1711,7 @@ theorem isQueryBoundP_run_simulateQ_countingOracle_iff
 
 theorem isTotalQueryBound_run_simulateQ_withTraceBefore_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec')) (traceFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α) (n : ℕ) :
@@ -1705,7 +1721,7 @@ theorem isTotalQueryBound_run_simulateQ_withTraceBefore_iff
 
 theorem isQueryBoundP_run_simulateQ_withTraceBefore_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec')) (traceFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α)
@@ -1716,7 +1732,7 @@ theorem isQueryBoundP_run_simulateQ_withTraceBefore_iff
 
 theorem isTotalQueryBound_run_simulateQ_withTraceAppend_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [EmptyCollection ω] [Append ω] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
@@ -1727,7 +1743,7 @@ theorem isTotalQueryBound_run_simulateQ_withTraceAppend_iff
 
 theorem isQueryBoundP_run_simulateQ_withTraceAppend_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [EmptyCollection ω] [Append ω] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
@@ -1739,7 +1755,7 @@ theorem isQueryBoundP_run_simulateQ_withTraceAppend_iff
 
 theorem isTotalQueryBound_run_simulateQ_withTrace_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
@@ -1750,7 +1766,7 @@ theorem isTotalQueryBound_run_simulateQ_withTrace_iff
 
 theorem isQueryBoundP_run_simulateQ_withTrace_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
@@ -1762,7 +1778,7 @@ theorem isQueryBoundP_run_simulateQ_withTrace_iff
 
 theorem isTotalQueryBound_run_simulateQ_withTraceAppendBefore_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [EmptyCollection ω] [Append ω] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec')) (traceFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α) (n : ℕ) :
@@ -1773,7 +1789,7 @@ theorem isTotalQueryBound_run_simulateQ_withTraceAppendBefore_iff
 
 theorem isQueryBoundP_run_simulateQ_withTraceAppendBefore_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [EmptyCollection ω] [Append ω] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec')) (traceFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α)
@@ -1785,7 +1801,7 @@ theorem isQueryBoundP_run_simulateQ_withTraceAppendBefore_iff
 
 theorem isTotalQueryBound_run_simulateQ_withCost_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec')) (costFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α) (n : ℕ) :
@@ -1795,7 +1811,7 @@ theorem isTotalQueryBound_run_simulateQ_withCost_iff
 
 theorem isQueryBoundP_run_simulateQ_withCost_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec')) (costFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α)
@@ -1806,7 +1822,7 @@ theorem isQueryBoundP_run_simulateQ_withCost_iff
 
 theorem isTotalQueryBound_run_simulateQ_withCounting_iff
     {ι : Type u} [DecidableEq ι] {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec'))
     {α : Type u} (mx : OracleComp spec α) (n : ℕ) :
     IsTotalQueryBound ((simulateQ (so.withCounting) mx).run) n ↔
@@ -1815,7 +1831,7 @@ theorem isTotalQueryBound_run_simulateQ_withCounting_iff
 
 theorem isQueryBoundP_run_simulateQ_withCounting_iff
     {ι : Type u} [DecidableEq ι] {spec : OracleSpec ι}
-    {ι' : Type u} {spec' : OracleSpec ι'}
+    {ι' : Type u} {spec' : OracleSpec ι'} [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec'))
     {α : Type u} (mx : OracleComp spec α)
     (q : ι' → Prop) [DecidablePred q] (n : ℕ) :
@@ -1826,7 +1842,8 @@ theorem isQueryBoundP_run_simulateQ_withCounting_iff
 /-! ### Per-index analogues -/
 
 theorem isPerIndexQueryBound_run_simulateQ_countingOracle_iff
-    {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι} {α : Type}
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (qb : ι → ℕ) :
     IsPerIndexQueryBound ((simulateQ countingOracle oa).run) qb ↔
     IsPerIndexQueryBound oa qb :=
@@ -1834,7 +1851,7 @@ theorem isPerIndexQueryBound_run_simulateQ_countingOracle_iff
 
 theorem isPerIndexQueryBound_run_simulateQ_withTraceBefore_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'}
+    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec')) (traceFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α) (qb : ι' → ℕ) :
@@ -1844,7 +1861,7 @@ theorem isPerIndexQueryBound_run_simulateQ_withTraceBefore_iff
 
 theorem isPerIndexQueryBound_run_simulateQ_withTrace_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'}
+    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
@@ -1855,7 +1872,7 @@ theorem isPerIndexQueryBound_run_simulateQ_withTrace_iff
 
 theorem isPerIndexQueryBound_run_simulateQ_withTraceAppendBefore_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'}
+    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [EmptyCollection ω] [Append ω] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec')) (traceFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α) (qb : ι' → ℕ) :
@@ -1866,7 +1883,7 @@ theorem isPerIndexQueryBound_run_simulateQ_withTraceAppendBefore_iff
 
 theorem isPerIndexQueryBound_run_simulateQ_withTraceAppend_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'}
+    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [EmptyCollection ω] [Append ω] [LawfulAppend ω]
     (so : QueryImpl spec (OracleComp spec'))
     (traceFn : (t : spec.Domain) → spec.Range t → ω)
@@ -1877,7 +1894,7 @@ theorem isPerIndexQueryBound_run_simulateQ_withTraceAppend_iff
 
 theorem isPerIndexQueryBound_run_simulateQ_withCost_iff
     {ι : Type u} {spec : OracleSpec ι}
-    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'}
+    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'} [IsUniformSpec spec']
     {ω : Type u} [Monoid ω]
     (so : QueryImpl spec (OracleComp spec')) (costFn : spec.Domain → ω)
     {α : Type u} (mx : OracleComp spec α) (qb : ι' → ℕ) :
@@ -1887,7 +1904,7 @@ theorem isPerIndexQueryBound_run_simulateQ_withCost_iff
 
 theorem isPerIndexQueryBound_run_simulateQ_withCounting_iff
     {ι : Type u} [DecidableEq ι] {spec : OracleSpec ι}
-    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'}
+    {ι' : Type u} [DecidableEq ι'] {spec' : OracleSpec ι'} [IsUniformSpec spec']
     (so : QueryImpl spec (OracleComp spec'))
     {α : Type u} (mx : OracleComp spec α) (qb : ι' → ℕ) :
     IsPerIndexQueryBound ((simulateQ (so.withCounting) mx).run) qb ↔

--- a/VCVio/OracleComp/QueryTracking/QueryCost.lean
+++ b/VCVio/OracleComp/QueryTracking/QueryCost.lean
@@ -75,7 +75,7 @@ lemma hasCost_withAddCost_query {ω : Type} [AddMonoid ω]
   simp [AddWriterT.outputs, AddWriterT.costs, AddWriterT.addTell]
 
 lemma queryBoundedAboveBy_withUnitCost_query
-    [HasEvalSet m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl spec m) (t : spec.Domain) :
     AddWriterT.QueryBoundedAboveBy
       (HasQuery.Program.withUnitCost
@@ -91,7 +91,7 @@ lemma queryBoundedAboveBy_withUnitCost_query
     exact AddWriterT.queryBoundedAboveBy_monadLift (runtime t)
 
 lemma queryBoundedBelowBy_withUnitCost_query
-    [HasEvalSet m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl spec m) (t : spec.Domain) :
     AddWriterT.QueryBoundedBelowBy
       (HasQuery.Program.withUnitCost
@@ -107,7 +107,7 @@ lemma queryBoundedBelowBy_withUnitCost_query
     exact AddWriterT.queryBoundedBelowBy_monadLift (runtime t)
 
 lemma queryCostExactly_withUnitCost_query
-    [HasEvalSet m]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl spec m) (t : spec.Domain) :
     AddWriterT.QueryCostExactly
       (HasQuery.Program.withUnitCost
@@ -148,20 +148,22 @@ def UsesCostExactly {ω : Type} [AddMonoid ω]
 /-- Running `oa` in the additive-cost instrumentation of `runtime` incurs cost at most `w` on
 every execution path. This is a semantic support bound, not merely an output-indexed cost
 description. -/
-def UsesCostAtMost {ω : Type} [AddMonoid ω] [Preorder ω] [HasEvalSet m]
+def UsesCostAtMost {ω : Type} [AddMonoid ω] [Preorder ω] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     (oa : Computation spec (AddWriterT ω m) α) (runtime : QueryImpl spec m)
     (costFn : spec.Domain → ω) (w : ω) : Prop :=
   AddWriterT.PathwiseCostAtMost (HasQuery.Program.withAddCost oa runtime costFn) w
 
 /-- Running `oa` in the additive-cost instrumentation of `runtime` incurs cost at least `w` on
 every execution path. -/
-def UsesCostAtLeast {ω : Type} [AddMonoid ω] [Preorder ω] [HasEvalSet m]
+def UsesCostAtLeast {ω : Type} [AddMonoid ω] [Preorder ω] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     (oa : Computation spec (AddWriterT ω m) α) (runtime : QueryImpl spec m)
     (costFn : spec.Domain → ω) (w : ω) : Prop :=
   AddWriterT.PathwiseCostAtLeast (HasQuery.Program.withAddCost oa runtime costFn) w
 
 lemma usesCostAtMost_of_usesCostExactly {ω : Type} [AddMonoid ω] [Preorder ω]
-    [LawfulMonad m] [HasEvalSet m]
+    [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryImpl spec m}
     {costFn : spec.Domain → ω} {w b : ω}
     (h : HasQuery.UsesCostExactly oa runtime costFn w) (hwb : w ≤ b) :
@@ -169,7 +171,7 @@ lemma usesCostAtMost_of_usesCostExactly {ω : Type} [AddMonoid ω] [Preorder ω]
   AddWriterT.pathwiseCostAtMost_of_hasCost h hwb
 
 lemma usesCostAtLeast_of_usesCostExactly {ω : Type} [AddMonoid ω] [Preorder ω]
-    [LawfulMonad m] [HasEvalSet m]
+    [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryImpl spec m}
     {costFn : spec.Domain → ω} {w b : ω}
     (h : HasQuery.UsesCostExactly oa runtime costFn w) (hbw : b ≤ w) :
@@ -177,7 +179,7 @@ lemma usesCostAtLeast_of_usesCostExactly {ω : Type} [AddMonoid ω] [Preorder ω
   AddWriterT.pathwiseCostAtLeast_of_hasCost h hbw
 
 lemma usesCostAtMost_query_of_le {ω : Type} [AddMonoid ω] [Preorder ω]
-    [LawfulMonad m] [HasEvalSet m]
+    [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (runtime : QueryImpl spec m) (costFn : spec.Domain → ω) (t : spec.Domain) {b : ω}
     (ht : costFn t ≤ b) :
     HasQuery.UsesCostAtMost
@@ -194,26 +196,26 @@ def UsesExactlyQueries (oa : Computation spec (AddWriterT ℕ m) α)
   HasQuery.UsesCostExactly oa runtime (fun _ ↦ 1) n
 
 /-- Unit-cost specialization: every query contributes cost `1`, with an upper bound. -/
-def UsesAtMostQueries [HasEvalSet m]
+def UsesAtMostQueries [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (oa : Computation spec (AddWriterT ℕ m) α)
     (runtime : QueryImpl spec m) (n : ℕ) : Prop :=
   AddWriterT.QueryBoundedAboveBy (HasQuery.Program.withUnitCost oa runtime) n
 
 /-- Unit-cost specialization: every query contributes cost `1`, with a lower bound. -/
-def UsesAtLeastQueries [HasEvalSet m]
+def UsesAtLeastQueries [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (oa : Computation spec (AddWriterT ℕ m) α)
     (runtime : QueryImpl spec m) (n : ℕ) : Prop :=
   AddWriterT.QueryBoundedBelowBy (HasQuery.Program.withUnitCost oa runtime) n
 
 lemma usesAtMostQueries_of_usesExactlyQueries
-    [LawfulMonad m] [HasEvalSet m]
+    [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryImpl spec m}
     {n b : ℕ} (h : HasQuery.UsesExactlyQueries oa runtime n) (hnb : n ≤ b) :
     HasQuery.UsesAtMostQueries oa runtime b :=
   usesCostAtMost_of_usesCostExactly h hnb
 
 lemma usesAtLeastQueries_of_usesExactlyQueries
-    [LawfulMonad m] [HasEvalSet m]
+    [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryImpl spec m}
     {n b : ℕ} (h : HasQuery.UsesExactlyQueries oa runtime n) (hbn : b ≤ n) :
     HasQuery.UsesAtLeastQueries oa runtime b :=
@@ -223,7 +225,8 @@ end genericCost
 
 section expectedCost
 
-variable [Monad m] [HasEvalSPMF m]
+variable [Monad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 /-- The expected weighted query cost of `oa`, instantiated in `runtime` and instrumented by
 `costFn`.
@@ -256,6 +259,8 @@ noncomputable abbrev expectedQueries
     (oa : Computation spec (AddWriterT ℕ m) α) (runtime : QueryImpl spec m) : ENNReal :=
   HasQuery.expectedQueryCost oa runtime (fun _ ↦ 1) (fun n ↦ (n : ENNReal))
 
+omit [LawfulMonadLiftT m SPMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+    in
 /-- Tail-sum formula for the expected number of oracle queries made by `oa` in `runtime`:
 
 `E[number of queries] = ∑ i, Pr[i < number of queries]`.
@@ -268,6 +273,8 @@ lemma expectedQueries_eq_tsum_tail_probs
   simpa [HasQuery.expectedQueries, HasQuery.expectedQueryCost] using
     AddWriterT.expectedCostNat_eq_tsum_tail_probs (oa := HasQuery.Program.withUnitCost oa runtime)
 
+omit [LawfulMonadLiftT m SPMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+    in
 /-- Tail domination bounds expected query count.
 
 If `Pr[i < number of queries] ≤ a i` for every `i`, then
@@ -294,6 +301,7 @@ lemma expectedQueries_eq_sum_tail_probs_of_usesAtMostQueries [LawfulMonad m]
     (AddWriterT.expectedCostNat_eq_sum_tail_probs_of_pathwiseCostAtMost
       (oa := HasQuery.Program.withUnitCost oa runtime) h)
 
+omit [LawfulMonadLiftT m SPMF] in
 lemma expectedQueryCost_le_of_usesCostAtMost
     {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryImpl spec m}
@@ -302,6 +310,7 @@ lemma expectedQueryCost_le_of_usesCostAtMost
     HasQuery.expectedQueryCost oa runtime costFn val ≤ val w :=
   AddWriterT.expectedCost_le_of_pathwiseCostAtMost h hval
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m] in
 lemma expectedQueryCost_eq_tsum_outputs_of_usesCostAs
     {ω : Type} [AddMonoid ω] [LawfulMonad m]
     {oa : Computation spec (AddWriterT ω m) α} {runtime : QueryImpl spec m}
@@ -315,6 +324,7 @@ lemma expectedQueryCost_eq_tsum_outputs_of_usesCostAs
     (AddWriterT.expectedCost_eq_tsum_outputs_of_costsAs
       (oa := HasQuery.Program.withAddCost oa runtime costFn) (f := f) (val := val) h)
 
+omit [LawfulMonadLiftT m SPMF] in
 lemma expectedQueries_le_of_usesAtMostQueries [LawfulMonad m]
     {oa : Computation spec (AddWriterT ℕ m) α} {runtime : QueryImpl spec m} {n : ℕ}
     (h : HasQuery.UsesAtMostQueries oa runtime n) :
@@ -329,7 +339,8 @@ end expectedCost
 
 section expectedCostPMF
 
-variable [Monad m] [HasEvalPMF m]
+variable [Monad m] [MonadLiftT m PMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 lemma expectedQueryCost_ge_of_usesCostAtLeast
     {ω : Type} [AddMonoid ω] [Preorder ω] [LawfulMonad m]

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/Eager.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/Eager.lean
@@ -60,11 +60,11 @@ lemma apply_eq (t : spec₀.Domain) :
 /-- With an empty seed, the eager random oracle reduces to `uniformSampleImpl`:
 every query falls through to fresh uniform sampling with no state change.
 This is a faithful simulation (preserves `evalDist`). -/
-theorem evalDist_simulateQ_run'_empty [spec₀.Fintype] [spec₀.Inhabited]
+theorem evalDist_simulateQ_run'_empty [IsUniformSpec spec₀]
     {α : Type} (oa : OracleComp spec₀ α) :
     𝒟[(simulateQ (eagerRandomOracle (spec := spec₀)) oa).run' ∅] = 𝒟[oa] := by
   induction oa using OracleComp.inductionOn with
-  | pure a => simp [simulateQ_pure, evalDist_pure]
+  | pure a => simp [simulateQ_pure]
   | query_bind t f ih =>
     rw [simulateQ_bind,
       show simulateQ eagerRandomOracle (liftM (query t)) = eagerRandomOracle t by
@@ -133,7 +133,7 @@ but for `eagerRandomOracle` (which falls back to `ProbComp` rather than `OracleC
 theorem eagerRandomOracle_evalDist_generateSeed_bind {ι₀ : Type} [DecidableEq ι₀]
     {spec₀ : OracleSpec.{0, 0} ι₀}
     [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     {α : Type} (oa : OracleComp spec₀ α)
     (qc : ι₀ → ℕ) (js : List ι₀) :
     𝒟[do

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/Simulation.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/Simulation.lean
@@ -116,7 +116,7 @@ theorem neverFail_simulateQ_randomOracle_run
     [DecidableEq ι] [spec.Inhabited] [(t : spec.Domain) → SampleableType (spec.Range t)]
     (oa : OracleComp spec α) (cache : spec.QueryCache) :
     NeverFail ((simulateQ randomOracle oa).run cache) := by
-  grind only [= HasEvalSPMF.neverFail_iff, = HasEvalPMF.probFailure_eq_zero]
+  grind only [= neverFail_iff, = probFailure_of_liftM_PMF]
 
 /-- Support characterization for lazy random-oracle simulation.
 

--- a/VCVio/OracleComp/QueryTracking/SeededOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/SeededOracle.lean
@@ -119,7 +119,7 @@ namespace OracleComp
 
 variable {ι' : Type u} {spec' : OracleSpec ι'} {α : Type u}
 
-theorem IsQueryBoundP.simulateQ_run_withPregen
+theorem IsQueryBoundP.simulateQ_run_withPregen [IsUniformSpec spec']
     {p : ι → Prop} [DecidablePred p] {q : ι' → Prop} [DecidablePred q]
     (so : QueryImpl spec (OracleComp spec'))
     {oa : OracleComp spec α} {n : ℕ}
@@ -133,7 +133,7 @@ theorem IsQueryBoundP.simulateQ_run_withPregen
     (fun t hnp s' => QueryImpl.isQueryBoundP_run_withPregen so t (hstep_np t hnp) s')
     seed
 
-theorem IsTotalQueryBound.simulateQ_run_withPregen
+theorem IsTotalQueryBound.simulateQ_run_withPregen [IsUniformSpec spec]
     (so : QueryImpl spec (OracleComp spec))
     {oa : OracleComp spec α} {n : ℕ}
     (h : IsTotalQueryBound oa n)
@@ -186,7 +186,7 @@ lemma probEvent_liftComp_uniformSample_eq_of_eq
     {ι : Type} {spec : OracleSpec ι}
     [(i : ι) → SampleableType (spec.Range i)]
     [unifSpec ⊂ₒ spec] [unifSpec ˡ⊂ₒ spec]
-    [spec.Fintype] [spec.Inhabited]
+    [IsUniformSpec spec]
     {i : ι} (u₀ : spec.Range i) :
     probEvent (liftComp (uniformSample (spec.Range i)) spec)
       (fun u => u₀ = u) =
@@ -220,7 +220,7 @@ private lemma evalDist_liftComp_generateSeed_bind_simulateQ_run'
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ i, SampleableType (spec₀.Range i)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (qc : ι₀ → ℕ) (js : List ι₀)
     {α : Type} (oa : OracleComp spec₀ α) :
     𝒟[(do
@@ -363,7 +363,7 @@ lemma probOutput_generateSeed_bind_simulateQ_bind
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ i, SampleableType (spec₀.Range i)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (qc : ι₀ → ℕ) (js : List ι₀)
     {α β : Type} (oa : OracleComp spec₀ α) (ob : α → OracleComp spec₀ β) (y : β) :
     Pr[= y | do
@@ -387,7 +387,7 @@ lemma probOutput_generateSeed_bind_map_simulateQ
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ i, SampleableType (spec₀.Range i)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (qc : ι₀ → ℕ) (js : List ι₀)
     {α β : Type} (oa : OracleComp spec₀ α) (f : α → β) (y : β) :
     Pr[= y | (do
@@ -406,7 +406,7 @@ lemma evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ j, SampleableType (spec₀.Range j)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (σ : QuerySeed spec₀) (i : ι₀) {α : Type} (oa : OracleComp spec₀ α) :
     𝒟[(do
       let u ← liftComp ($ᵗ spec₀.Range i) spec₀
@@ -421,7 +421,7 @@ lemma evalDist_liftComp_uniformSample_bind_simulateQ_run'_addValue
     apply evalDist_ext; intro a
     simp_rw [hrun']
     rw [probOutput_bind_const]
-    simp [HasEvalPMF.probFailure_eq_zero]
+    simp [probFailure_of_liftM_PMF]
   | query_bind t mx ih =>
     intro σ
     simp only [simulateQ_bind, simulateQ_query, OracleQuery.cont_query,
@@ -520,7 +520,7 @@ lemma evalDist_liftComp_replicate_uniformSample_bind_simulateQ_run'_addValues
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ j, SampleableType (spec₀.Range j)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (i : ι₀) {α : Type} (oa : OracleComp spec₀ α) (n : ℕ) :
     ∀ (σ : QuerySeed spec₀),
     𝒟[(do
@@ -554,7 +554,7 @@ lemma evalDist_liftComp_generateSeed_bind_simulateQ_run'_takeAtIndex
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ i, SampleableType (spec₀.Range i)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (qc : ι₀ → ℕ) (js : List ι₀) (i₀ : ι₀) (k : ℕ)
     {α : Type} (oa : OracleComp spec₀ α) :
     𝒟[(do
@@ -746,7 +746,7 @@ lemma probOutput_generateSeed_bind_map_simulateQ_takeAtIndex
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ i, SampleableType (spec₀.Range i)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (qc : ι₀ → ℕ) (js : List ι₀) (i₀ : ι₀) (k : ℕ)
     {α β : Type} (oa : OracleComp spec₀ α) (f : α → β) (y : β) :
     Pr[= y | (do
@@ -773,7 +773,7 @@ lemma tsum_probOutput_generateSeed_weight_takeAtIndex
     {ι₀ : Type} {spec₀ : OracleSpec ι₀} [DecidableEq ι₀]
     [∀ i, SampleableType (spec₀.Range i)] [unifSpec ⊂ₒ spec₀]
     [unifSpec ˡ⊂ₒ spec₀]
-    [spec₀.Fintype] [spec₀.Inhabited]
+    [IsUniformSpec spec₀]
     (qc : ι₀ → ℕ) (js : List ι₀) (i₀ : ι₀) (k : ℕ)
     {α : Type} (oa : OracleComp spec₀ α) (x : α)
     (h : QuerySeed spec₀ → ENNReal) :
@@ -1172,6 +1172,7 @@ end queryBounds
 Forward only — the reverse fails because pregenerated values strictly reduce the count. -/
 
 theorem isTotalQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀}
+    [IsUniformSpec spec₀]
     {α : Type} {oa : OracleComp spec₀ α} {n : ℕ}
     (h : OracleComp.IsTotalQueryBound oa n) (seed : QuerySeed spec₀) :
     OracleComp.IsTotalQueryBound ((simulateQ spec₀.seededOracle oa).run seed) n := by
@@ -1180,6 +1181,7 @@ theorem isTotalQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀] {spec
     (fun t => (OracleComp.isQueryBound_query_iff t 1 _ _).mpr Nat.one_pos) seed
 
 theorem isQueryBoundP_run_simulateQ {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀}
+    [IsUniformSpec spec₀]
     {α : Type} {oa : OracleComp spec₀ α}
     {p : ι₀ → Prop} [DecidablePred p] {n : ℕ}
     (h : OracleComp.IsQueryBoundP oa p n) (seed : QuerySeed spec₀) :
@@ -1191,6 +1193,7 @@ theorem isQueryBoundP_run_simulateQ {ι₀ : Type} [DecidableEq ι₀] {spec₀ 
     seed
 
 theorem isPerIndexQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀}
+    [IsUniformSpec spec₀]
     {α : Type} {oa : OracleComp spec₀ α} {qb : ι₀ → ℕ}
     (h : OracleComp.IsPerIndexQueryBound oa qb) (seed : QuerySeed spec₀) :
     OracleComp.IsPerIndexQueryBound ((simulateQ spec₀.seededOracle oa).run seed) qb := by
@@ -1204,7 +1207,8 @@ theorem isPerIndexQueryBound_run_simulateQ {ι₀ : Type} [DecidableEq ι₀] {s
 /-- State-preserving variant of `isPerIndexQueryBound_run'_zero`: when the seed covers `qb`
 at every index, the simulation makes zero further queries even with the seed in scope. -/
 theorem isPerIndexQueryBound_run_simulateQ_zero
-    {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀} {α : Type}
+    {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀} [IsUniformSpec spec₀]
+    {α : Type}
     {oa : OracleComp spec₀ α} {qb : ι₀ → ℕ} {seed : QuerySeed spec₀}
     (hqb : OracleComp.IsPerIndexQueryBound oa qb)
     (hseed : ∀ t, qb t ≤ (seed t).length) :
@@ -1216,7 +1220,8 @@ theorem isPerIndexQueryBound_run_simulateQ_zero
 /-- State-preserving variant of `isPerIndexQueryBound_run'_of_seedCoverage`: any uncovered
 suffix of the seed becomes the residual budget in the result spec. -/
 theorem isPerIndexQueryBound_run_simulateQ_of_seedCoverage
-    {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀} {α : Type}
+    {ι₀ : Type} [DecidableEq ι₀] {spec₀ : OracleSpec ι₀} [IsUniformSpec spec₀]
+    {α : Type}
     {oa : OracleComp spec₀ α} {qb residual : ι₀ → ℕ} {seed : QuerySeed spec₀}
     (hqb : OracleComp.IsPerIndexQueryBound oa qb)
     (hcover : ∀ t, qb t - residual t ≤ (seed t).length) :

--- a/VCVio/OracleComp/QueryTracking/Tracing.lean
+++ b/VCVio/OracleComp/QueryTracking/Tracing.lean
@@ -94,19 +94,21 @@ lemma fst_map_run_withTraceBefore [LawfulMonad m]
     (fun t => by simp [WriterT.run_tell]) mx
 
 /-- A "before"-style trace preserves failure probability for any base monad with
-`HasEvalSPMF`: instrumenting with `withTraceBefore` does not change the
+`MonadLiftT m SPMF`: instrumenting with `withTraceBefore` does not change the
 probability of failure. -/
-lemma probFailure_run_simulateQ_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+lemma probFailure_run_simulateQ_withTraceBefore [LawfulMonad m]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     Pr[⊥ | (simulateQ (so.withTraceBefore traceFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
   rw [show Pr[⊥ | (simulateQ (so.withTraceBefore traceFn) mx).run] =
     Pr[⊥ | Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run] from
     (probFailure_map _ _).symm, fst_map_run_withTraceBefore]
 
-lemma NeverFail_run_simulateQ_withTraceBefore_iff [LawfulMonad m] [HasEvalSPMF m]
+lemma NeverFail_run_simulateQ_withTraceBefore_iff [LawfulMonad m]
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     NeverFail (simulateQ (so.withTraceBefore traceFn) mx).run ↔ NeverFail (simulateQ so mx) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTraceBefore]
+  simp only [neverFail_iff, probFailure_run_simulateQ_withTraceBefore]
 
 /-- When every query traces to the monoid identity `1`, `withTraceBefore` is a
 no-op up to pairing with `1`. -/
@@ -121,19 +123,20 @@ lemma run_simulateQ_withTraceBefore_const_one [LawfulMonad m]
 
 /-! #### `evalDist` / `probOutput` / `support` bridges for `withTraceBefore` -/
 
-lemma evalDist_fst_run_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+lemma evalDist_fst_run_withTraceBefore [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     𝒟[Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run] =
       𝒟[simulateQ so mx] :=
   congrArg evalDist (fst_map_run_withTraceBefore so traceFn mx)
 
-lemma probOutput_fst_run_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+lemma probOutput_fst_run_withTraceBefore [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run] =
       Pr[= x | simulateQ so mx] := by
   rw [fst_map_run_withTraceBefore]
 
-lemma support_fst_run_withTraceBefore [LawfulMonad m] [HasEvalSPMF m]
+lemma support_fst_run_withTraceBefore [LawfulMonad m] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (so.withTraceBefore traceFn) mx).run) =
       support (simulateQ so mx) := by
@@ -170,11 +173,12 @@ lemma fst_map_run_withTrace [LawfulMonad m]
     (fun t => by simp [WriterT.run_tell]) mx
 
 /-- An "after"-style trace preserves failure probability for any base monad with
-`HasEvalSPMF`: instrumenting with `withTrace` does not change the probability
+`MonadLiftT m SPMF`: instrumenting with `withTrace` does not change the probability
 of failure. When `m = OracleComp spec`, both sides are `0` (trivially true);
 when `m` can genuinely fail (e.g. `OptionT (OracleComp spec)`), this is a
 non-trivial faithfulness property. -/
-lemma probFailure_run_simulateQ_withTrace [LawfulMonad m] [HasEvalSPMF m]
+lemma probFailure_run_simulateQ_withTrace [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     Pr[⊥ | (simulateQ (so.withTrace traceFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
@@ -182,11 +186,12 @@ lemma probFailure_run_simulateQ_withTrace [LawfulMonad m] [HasEvalSPMF m]
     Pr[⊥ | Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run] from
     (probFailure_map _ _).symm, fst_map_run_withTrace]
 
-lemma NeverFail_run_simulateQ_withTrace_iff [LawfulMonad m] [HasEvalSPMF m]
+lemma NeverFail_run_simulateQ_withTrace_iff [LawfulMonad m] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     NeverFail (simulateQ (so.withTrace traceFn) mx).run ↔ NeverFail (simulateQ so mx) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTrace]
+  simp only [neverFail_iff, probFailure_run_simulateQ_withTrace]
 
 /-- When every query/response pair traces to the monoid identity `1`,
 `withTrace` is a no-op up to pairing with `1`. -/
@@ -201,21 +206,21 @@ lemma run_simulateQ_withTrace_const_one [LawfulMonad m]
 
 /-! #### `evalDist` / `probOutput` / `support` bridges for `withTrace` -/
 
-lemma evalDist_fst_run_withTrace [LawfulMonad m] [HasEvalSPMF m]
+lemma evalDist_fst_run_withTrace [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     𝒟[Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run] =
       𝒟[simulateQ so mx] :=
   congrArg evalDist (fst_map_run_withTrace so traceFn mx)
 
-lemma probOutput_fst_run_withTrace [LawfulMonad m] [HasEvalSPMF m]
+lemma probOutput_fst_run_withTrace [LawfulMonad m] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run] =
       Pr[= x | simulateQ so mx] := by
   rw [fst_map_run_withTrace]
 
-lemma support_fst_run_withTrace [LawfulMonad m] [HasEvalSPMF m]
+lemma support_fst_run_withTrace [LawfulMonad m] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (so.withTrace traceFn) mx).run) =
@@ -254,7 +259,7 @@ lemma fst_map_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω]
     (fun t => by simp [WriterT.run_tell]) mx
 
 lemma probFailure_run_simulateQ_withTraceAppendBefore [LawfulMonad m]
-    [LawfulAppend ω] [HasEvalSPMF m]
+    [LawfulAppend ω] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     Pr[⊥ | (simulateQ (so.withTraceAppendBefore traceFn) mx).run] =
       Pr[⊥ | simulateQ so mx] := by
@@ -263,27 +268,29 @@ lemma probFailure_run_simulateQ_withTraceAppendBefore [LawfulMonad m]
     (probFailure_map _ _).symm, fst_map_run_withTraceAppendBefore]
 
 lemma NeverFail_run_simulateQ_withTraceAppendBefore_iff [LawfulMonad m]
-    [LawfulAppend ω] [HasEvalSPMF m]
+    [LawfulAppend ω] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     NeverFail (simulateQ (so.withTraceAppendBefore traceFn) mx).run ↔
       NeverFail (simulateQ so mx) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTraceAppendBefore]
+  simp only [neverFail_iff, probFailure_run_simulateQ_withTraceAppendBefore]
 
 /-! #### `evalDist` / `probOutput` / `support` bridges for `withTraceAppendBefore` -/
 
-lemma evalDist_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+lemma evalDist_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     𝒟[Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run] =
       𝒟[simulateQ so mx] :=
   congrArg evalDist (fst_map_run_withTraceAppendBefore so traceFn mx)
 
-lemma probOutput_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+lemma probOutput_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run] =
       Pr[= x | simulateQ so mx] := by
   rw [fst_map_run_withTraceAppendBefore]
 
-lemma support_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+lemma support_fst_run_withTraceAppendBefore [LawfulMonad m] [LawfulAppend ω] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (traceFn : spec.Domain → ω) (mx : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (so.withTraceAppendBefore traceFn) mx).run) =
       support (simulateQ so mx) := by
@@ -322,7 +329,7 @@ lemma fst_map_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω]
     (fun t => by simp [WriterT.run_tell]) mx
 
 lemma probFailure_run_simulateQ_withTraceAppend [LawfulMonad m]
-    [LawfulAppend ω] [HasEvalSPMF m]
+    [LawfulAppend ω] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     Pr[⊥ | (simulateQ (so.withTraceAppend traceFn) mx).run] = Pr[⊥ | simulateQ so mx] := by
@@ -331,30 +338,32 @@ lemma probFailure_run_simulateQ_withTraceAppend [LawfulMonad m]
     (probFailure_map _ _).symm, fst_map_run_withTraceAppend]
 
 lemma NeverFail_run_simulateQ_withTraceAppend_iff [LawfulMonad m]
-    [LawfulAppend ω] [HasEvalSPMF m]
+    [LawfulAppend ω] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     NeverFail (simulateQ (so.withTraceAppend traceFn) mx).run ↔
       NeverFail (simulateQ so mx) := by
-  simp only [HasEvalSPMF.neverFail_iff, probFailure_run_simulateQ_withTraceAppend]
+  simp only [neverFail_iff, probFailure_run_simulateQ_withTraceAppend]
 
 /-! #### `evalDist` / `probOutput` / `support` bridges for `withTraceAppend` -/
 
-lemma evalDist_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+lemma evalDist_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     𝒟[Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run] =
       𝒟[simulateQ so mx] :=
   congrArg evalDist (fst_map_run_withTraceAppend so traceFn mx)
 
-lemma probOutput_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+lemma probOutput_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [MonadLiftT m SPMF]
+    [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) (x : α) :
     Pr[= x | Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run] =
       Pr[= x | simulateQ so mx] := by
   rw [fst_map_run_withTraceAppend]
 
-lemma support_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [HasEvalSPMF m]
+lemma support_fst_run_withTraceAppend [LawfulMonad m] [LawfulAppend ω] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (traceFn : (t : spec.Domain) → spec.Range t → ω)
     (mx : OracleComp spec α) :
     support (Prod.fst <$> (simulateQ (so.withTraceAppend traceFn) mx).run) =

--- a/VCVio/OracleComp/QueryTracking/Unpredictability.lean
+++ b/VCVio/OracleComp/QueryTracking/Unpredictability.lean
@@ -37,13 +37,13 @@ open scoped OracleSpec.PrimitiveQuery
 namespace OracleComp
 
 variable {ι : Type} [DecidableEq ι] {spec : OracleSpec.{0, 0} ι}
-  [spec.DecidableEq] [spec.Fintype] [spec.Inhabited]
+  [spec.DecidableEq] [IsUniformSpec spec]
 
 /-! ## Unpredictability -/
 
 section Unpredictability
 
-variable {spec' : OracleSpec.{0, 0} ι} [spec'.DecidableEq] [spec'.Fintype] [spec'.Inhabited]
+variable {spec' : OracleSpec.{0, 0} ι} [spec'.DecidableEq] [IsUniformSpec spec']
 
 omit [spec'.DecidableEq] in
 /-- **Fresh query uniformity**: querying `cachingOracle` at an uncached point
@@ -53,11 +53,14 @@ theorem probOutput_fresh_cachingOracle_query
     (cache₀ : QueryCache spec') (hfresh : cache₀ t = none) :
     Pr[= (u, cache₀.cacheQuery t u) | (cachingOracle t).run cache₀] =
       (Fintype.card (spec'.Range t) : ℝ≥0∞)⁻¹ := by
-  simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind, hfresh]
-  simp only [liftM, MonadLiftT.monadLift, MonadLift.monadLift, StateT.run_lift, monad_norm]
-  simp only [modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
-    StateT.modifyGet, StateT.run]
-  erw [probOutput_map_injective _ (fun a b hab => by exact Prod.ext_iff.mp hab |>.1)]
+  rw [show (cachingOracle t).run cache₀ =
+    (fun u' => (u', cache₀.cacheQuery t u')) <$> (liftM (query t) : OracleComp spec' _) by
+      simp only [cachingOracle.apply_eq, StateT.run_bind, StateT.run_get, pure_bind, hfresh]
+      simp only [liftM, MonadLiftT.monadLift, MonadLift.monadLift, StateT.run_lift, monad_norm]
+      simp only [modifyGet, MonadState.modifyGet, MonadStateOf.modifyGet,
+        StateT.modifyGet, StateT.run]
+      rfl]
+  rw [probOutput_map_injective _ (fun a b hab => Prod.ext_iff.mp hab |>.1)]
   exact probOutput_query t u
 
 omit [spec'.DecidableEq] in
@@ -116,7 +119,9 @@ theorem probEvent_cache_has_value_le_of_unique_preimage {α : Type}
         (simulateQ cachingOracle (pure x)).run cache₀] = 0 := by
       rw [simulateQ_pure]
       refine probEvent_eq_zero fun z hz h => ?_
-      simp only [StateT.run] at hz; obtain ⟨_, rfl⟩ := hz
+      change z ∈ support (pure (x, cache₀) : OracleComp _ _) at hz
+      rw [support_pure, Set.mem_singleton_iff] at hz
+      subst hz
       obtain ⟨t₀, v, hcache, hnone, _⟩ := h
       simp [hnone] at hcache
     rw [this]; exact zero_le _

--- a/VCVio/OracleComp/QueryTracking/WriterCost.lean
+++ b/VCVio/OracleComp/QueryTracking/WriterCost.lean
@@ -68,7 +68,7 @@ variable {α β : Type}
 
 section pathwiseCost
 
-variable [HasEvalSet m]
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- Pathwise upper bound for an `AddWriterT` computation: every reachable execution result carries
 additive cost at most `w`. -/
@@ -92,6 +92,7 @@ def PathwiseCostEqOnSupport {ω : Type} [AddMonoid ω] [Preorder ω]
     (oa : AddWriterT ω m α) (w : ω) : Prop :=
   PathwiseCostAtMost oa w ∧ PathwiseCostAtLeast oa w
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 @[simp] lemma pathwiseCostEqOnSupport_iff {ω : Type} [AddMonoid ω] [Preorder ω]
     (oa : AddWriterT ω m α) (w : ω) :
     PathwiseCostEqOnSupport oa w ↔ PathwiseCostAtMost oa w ∧ PathwiseCostAtLeast oa w :=
@@ -108,42 +109,50 @@ def PathwiseHasCost {ω : Type} [AddMonoid ω] [Preorder ω]
     (oa : AddWriterT ω m α) (w : ω) : Prop :=
   (support oa.run).Nonempty ∧ PathwiseCostEqOnSupport oa w
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 @[simp] lemma pathwiseHasCost_iff {ω : Type} [AddMonoid ω] [Preorder ω]
     (oa : AddWriterT ω m α) (w : ω) :
     PathwiseHasCost oa w ↔
       (support oa.run).Nonempty ∧ PathwiseCostEqOnSupport oa w :=
   Iff.rfl
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseHasCost.nonempty {ω : Type} [AddMonoid ω] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} (h : PathwiseHasCost oa w) :
     (support oa.run).Nonempty :=
   h.1
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseCostEqOnSupport.atMost {ω : Type} [AddMonoid ω] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} (h : PathwiseCostEqOnSupport oa w) :
     PathwiseCostAtMost oa w :=
   h.1
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseCostEqOnSupport.atLeast {ω : Type} [AddMonoid ω] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} (h : PathwiseCostEqOnSupport oa w) :
     PathwiseCostAtLeast oa w :=
   h.2
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseHasCost.eqOnSupport {ω : Type} [AddMonoid ω] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} (h : PathwiseHasCost oa w) :
     PathwiseCostEqOnSupport oa w :=
   h.2
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseHasCost.atMost {ω : Type} [AddMonoid ω] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} (h : PathwiseHasCost oa w) :
     PathwiseCostAtMost oa w :=
   h.2.1
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseHasCost.atLeast {ω : Type} [AddMonoid ω] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} (h : PathwiseHasCost oa w) :
     PathwiseCostAtLeast oa w :=
   h.2.2
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma PathwiseHasCost.unique {ω : Type} [AddMonoid ω] [PartialOrder ω]
     {oa : AddWriterT ω m α} {w₁ w₂ : ω}
     (h₁ : PathwiseHasCost oa w₁) (h₂ : PathwiseHasCost oa w₂) :
@@ -184,6 +193,8 @@ end pathwiseCost
 section expectedCost
 
 variable {ω : Type}
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m]
 
 /-- The expected additive cost of an `AddWriterT` computation, obtained by taking the expectation
 of its cost marginal.
@@ -191,20 +202,24 @@ of its cost marginal.
 This expectation is computed over the base monad's subdistribution semantics on `oa.costs`. In
 particular, if the underlying computation can fail, the missing mass contributes `0`, exactly as
 for other `wp`-style expectations in VCV-io. -/
-noncomputable def expectedCost [HasEvalSPMF m]
+noncomputable def expectedCost
     (oa : AddWriterT ω m α) (val : ω → ENNReal) : ENNReal :=
   ∑' w : ω, Pr[= w | oa.costs] * val w
 
 /-- Convenience specialization of [`AddWriterT.expectedCost`] to natural-valued additive costs. -/
-noncomputable abbrev expectedCostNat [HasEvalSPMF m] (oa : AddWriterT ℕ m α) : ENNReal :=
+noncomputable abbrev expectedCostNat
+    (oa : AddWriterT ℕ m α) : ENNReal :=
   expectedCost oa (fun n ↦ ↑n)
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m]
+    in
 /-- Tail-sum formula for the natural-valued expected cost of an `AddWriterT` computation:
 
 `E[cost] = ∑ i, Pr[i < cost]`.
 
 This is the standard discrete expectation identity specialized to the writer-cost marginal. -/
-lemma expectedCostNat_eq_tsum_tail_probs [HasEvalSPMF m] (oa : AddWriterT ℕ m α) :
+lemma expectedCostNat_eq_tsum_tail_probs
+    (oa : AddWriterT ℕ m α) :
     expectedCostNat oa = ∑' i : ℕ, Pr[ fun c ↦ i < c | oa.costs ] := by
   unfold expectedCostNat expectedCost
   calc
@@ -217,23 +232,27 @@ lemma expectedCostNat_eq_tsum_tail_probs [HasEvalSPMF m] (oa : AddWriterT ℕ m 
           refine tsum_congr fun n ↦ ?_
           by_cases h : i < n <;> simp [Set.indicator, h]
 
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [LawfulMonadLiftT m SPMF] [EvalDistCompatible m]
+    in
 /-- Tail domination bounds the expected natural-valued writer cost.
 
 If the tail probability `Pr[i < cost]` is bounded by `a i` for every `i`, then
 `E[cost] ≤ ∑ i, a i`. -/
-lemma expectedCostNat_le_tsum_of_tail_probs_le [HasEvalSPMF m]
+lemma expectedCostNat_le_tsum_of_tail_probs_le
     (oa : AddWriterT ℕ m α) {a : ℕ → ENNReal}
     (h : ∀ i : ℕ, Pr[ fun c ↦ i < c | oa.costs ] ≤ a i) :
     expectedCostNat oa ≤ ∑' i : ℕ, a i := by
   rw [expectedCostNat_eq_tsum_tail_probs]
   exact ENNReal.tsum_le_tsum h
 
+omit [LawfulMonadLiftT m SPMF] in
 /-- Finite tail-sum formula for natural-valued writer cost under a pathwise upper bound.
 
 If every execution path of `oa` incurs cost at most `n`, then the tail probabilities vanish above
 `n`, so the infinite tail sum truncates to `Finset.range n`. -/
 lemma expectedCostNat_eq_sum_tail_probs_of_pathwiseCostAtMost
-    [HasEvalSPMF m] [LawfulMonad m] {oa : AddWriterT ℕ m α} {n : ℕ}
+    [LawfulMonad m]
+    {oa : AddWriterT ℕ m α} {n : ℕ}
     (h : PathwiseCostAtMost oa n) :
     expectedCostNat oa = ∑ i ∈ Finset.range n, Pr[ fun c ↦ i < c | oa.costs ] := by
   rw [expectedCostNat_eq_tsum_tail_probs]
@@ -246,7 +265,8 @@ lemma expectedCostNat_eq_sum_tail_probs_of_pathwiseCostAtMost
     rcases hc with ⟨z, hz, rfl⟩
     exact not_lt_of_ge (le_trans (h z hz) hnb)
 
-lemma expectedCost_le_of_support_bound [HasEvalSPMF m]
+omit [LawfulMonadLiftT m SetM] [LawfulMonadLiftT m SPMF] in
+lemma expectedCost_le_of_support_bound
     (oa : AddWriterT ω m α) (val : ω → ENNReal) (c : ENNReal)
     (h : ∀ w ∈ support oa.costs, val w ≤ c) :
     expectedCost oa val ≤ c := by
@@ -273,8 +293,9 @@ lemma expectedCost_le_of_support_bound [HasEvalSPMF m]
           simpa [mul_comm] using (mul_le_mul_right hmass c)
     _ = c := by simp
 
-lemma expectedCost_le_of_pathwiseCostAtMost [AddMonoid ω] [HasEvalSPMF m] [LawfulMonad m]
-    [Preorder ω]
+omit [LawfulMonadLiftT m SPMF] in
+lemma expectedCost_le_of_pathwiseCostAtMost [AddMonoid ω]
+    [LawfulMonad m] [Preorder ω]
     {oa : AddWriterT ω m α} {w : ω} {val : ω → ENNReal}
     (h : PathwiseCostAtMost oa w) (hval : Monotone val) :
     expectedCost oa val ≤ val w := by
@@ -284,14 +305,16 @@ lemma expectedCost_le_of_pathwiseCostAtMost [AddMonoid ω] [HasEvalSPMF m] [Lawf
   rcases hc with ⟨z, hz, rfl⟩
   exact hval (h z hz)
 
+omit [LawfulMonadLiftT m SPMF] in
 lemma expectedCost_ge_of_pathwiseCostAtLeast [AddMonoid ω] [LawfulMonad m] [Preorder ω]
-    [HasEvalPMF m]
     {oa : AddWriterT ω m α} {w : ω} {val : ω → ENNReal}
-    (h : PathwiseCostAtLeast oa w) (hval : Monotone val) :
+    (h : PathwiseCostAtLeast oa w) (hval : Monotone val)
+    (hnf : Pr[⊥ | oa.costs] = 0) :
     val w ≤ expectedCost oa val := by
   unfold expectedCost
-  have hmass : ∑' c : ω, Pr[= c | oa.costs] = 1 :=
-    HasEvalPMF.tsum_probOutput_eq_one (mx := oa.costs)
+  have hmass : ∑' c : ω, Pr[= c | oa.costs] = 1 := by
+    have := tsum_probOutput_eq_sub (mx := oa.costs)
+    rw [this, hnf, tsub_zero]
   calc
     val w = 1 * val w := by simp
     _ = (∑' c : ω, Pr[= c | oa.costs]) * val w := by
@@ -313,7 +336,10 @@ lemma expectedCost_ge_of_pathwiseCostAtLeast [AddMonoid ω] [LawfulMonad m] [Pre
             rw [hp]
             simp
 
-lemma expectedCost_eq_tsum_outputs_of_costsAs [HasEvalSPMF m] [LawfulMonad m]
+omit [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+    [EvalDistCompatible m] in
+lemma expectedCost_eq_tsum_outputs_of_costsAs
+    [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [LawfulMonad m]
     {oa : AddWriterT ω m α} {f : α → ω} {val : ω → ENNReal}
     (h : oa.CostsAs f) :
     expectedCost oa val = ∑' a : α, Pr[= a | oa.outputs] * val (f a) := by
@@ -348,7 +374,7 @@ end expectedCost
 
 section weightedPathwiseBounds
 
-variable [HasEvalSet m]
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 variable {ω : Type} [AddCommMonoid ω] [PartialOrder ω]
 
 lemma pathwiseCostAtMost_pure [LawfulMonad m] (x : α) :
@@ -459,12 +485,14 @@ lemma pathwiseHasCost_probCompLift_of_supportNonempty [LawfulMonad m] [MonadLift
   change PathwiseHasCost (monadLift ((liftM x : m α)) : AddWriterT ω m α) 0
   exact pathwiseHasCost_monadLift_of_supportNonempty (m := m) (ω := ω) (x := (liftM x : m α)) hx
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma pathwiseCostAtMost_mono {oa : AddWriterT ω m α} {w₁ w₂ : ω}
     (h : PathwiseCostAtMost oa w₁) (hw : w₁ ≤ w₂) :
     PathwiseCostAtMost oa w₂ := by
   intro z hz
   exact le_trans (h z hz) hw
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma pathwiseCostAtLeast_mono {oa : AddWriterT ω m α} {w₁ w₂ : ω}
     (h : PathwiseCostAtLeast oa w₂) (hw : w₁ ≤ w₂) :
     PathwiseCostAtLeast oa w₁ := by
@@ -665,7 +693,7 @@ end weightedPathwiseBounds
 
 section unitCostBounds
 
-variable [HasEvalSet m]
+variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- Pathwise upper bound for a unit-cost `AddWriterT` computation. -/
 def QueryBoundedAboveBy (oa : AddWriterT ℕ m α) (n : ℕ) : Prop :=
@@ -691,11 +719,13 @@ lemma queryBoundedBelowBy_monadLift [LawfulMonad m] (x : m α) :
     QueryBoundedBelowBy (monadLift x : AddWriterT ℕ m α) 0 :=
   pathwiseCostAtLeast_monadLift x
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma queryBoundedAboveBy_mono {oa : AddWriterT ℕ m α} {n₁ n₂ : ℕ}
     (h : QueryBoundedAboveBy oa n₁) (hn : n₁ ≤ n₂) :
     QueryBoundedAboveBy oa n₂ :=
   pathwiseCostAtMost_mono h hn
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma queryBoundedBelowBy_mono {oa : AddWriterT ℕ m α} {n₁ n₂ : ℕ}
     (h : QueryBoundedBelowBy oa n₂) (hn : n₁ ≤ n₂) :
     QueryBoundedBelowBy oa n₁ :=
@@ -746,9 +776,11 @@ carries exactly `n` unit queries. -/
 def QueryCostExactly (oa : AddWriterT ℕ m α) (n : ℕ) : Prop :=
   PathwiseCostEqOnSupport oa n
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma QueryCostExactly.toAbove {oa : AddWriterT ℕ m α} {n : ℕ}
     (h : QueryCostExactly oa n) : QueryBoundedAboveBy oa n := h.atMost
 
+omit [Monad m] [LawfulMonadLiftT m SetM] in
 lemma QueryCostExactly.toBelow {oa : AddWriterT ℕ m α} {n : ℕ}
     (h : QueryCostExactly oa n) : QueryBoundedBelowBy oa n := h.atLeast
 
@@ -785,7 +817,8 @@ end unitCostBounds
 
 section expectedUnitCost
 
-variable [HasEvalSPMF m]
+variable [MonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 lemma expectedCostNat_le_of_queryBoundedAboveBy [LawfulMonad m]
     {oa : AddWriterT ℕ m α} {n : ℕ}
@@ -801,19 +834,20 @@ end expectedUnitCost
 
 section expectedUnitCostPMF
 
-variable [HasEvalPMF m]
+variable [MonadLiftT m PMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
-lemma expectedCostNat_ge_of_queryBoundedBelowBy [LawfulMonad m]
+lemma expectedCostNat_ge_of_queryBoundedBelowBy [LawfulMonad m] [EvalDistCompatible m]
     {oa : AddWriterT ℕ m α} {n : ℕ}
     (h : QueryBoundedBelowBy oa n) :
     (n : ENNReal) ≤ expectedCostNat oa := by
-  simpa [expectedCostNat, QueryBoundedBelowBy] using
-    (expectedCost_ge_of_pathwiseCostAtLeast
-      (oa := oa) (w := n) (val := fun k ↦ (k : ENNReal)) h
-      (fun a b hle ↦ by
-        simpa using (Nat.cast_le.mpr hle : (a : ENNReal) ≤ (b : ENNReal))))
+  refine expectedCost_ge_of_pathwiseCostAtLeast
+    (oa := oa) (w := n) (val := fun k ↦ (k : ENNReal)) h
+    (fun a b hle ↦ by
+      simpa using (Nat.cast_le.mpr hle : (a : ENNReal) ≤ (b : ENNReal)))
+    (probFailure_of_liftM_PMF _)
 
-lemma expectedCostNat_eq_of_queryCostExactly [LawfulMonad m]
+lemma expectedCostNat_eq_of_queryCostExactly [LawfulMonad m] [EvalDistCompatible m]
     {oa : AddWriterT ℕ m α} {n : ℕ}
     (h : QueryCostExactly oa n) :
     expectedCostNat oa = n :=
@@ -824,4 +858,3 @@ lemma expectedCostNat_eq_of_queryCostExactly [LawfulMonad m]
 end expectedUnitCostPMF
 
 end AddWriterT
-

--- a/VCVio/OracleComp/SimSemantics/QueryImpl/Constructions.lean
+++ b/VCVio/OracleComp/SimSemantics/QueryImpl/Constructions.lean
@@ -155,9 +155,10 @@ lemma proj_simulateQ_preInsert [Monad m] [LawfulMonad m] [LawfulMonad n]
       exact bind_congr ih
 
 /-- A `preInsert` instrumentation preserves failure probability for any base monad with
-`HasEvalSPMF`, given the projection bundle and its compatibility with failure probabilities. -/
+`[MonadLiftT m SPMF]`, given the projection bundle and its compatibility with failure
+probabilities. -/
 lemma probFailure_proj_simulateQ_preInsert [Monad m]
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : spec.Domain → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -170,7 +171,7 @@ lemma probFailure_proj_simulateQ_preInsert [Monad m]
 
 /-- `NeverFail` biconditional companion of `probFailure_proj_simulateQ_preInsert`. -/
 lemma neverFail_proj_simulateQ_preInsert_iff [Monad m]
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : spec.Domain → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -195,7 +196,7 @@ lemma simulateQ_preInsert_const_pure [Monad m]
 /-! #### `evalDist` / `probOutput` / `support` bridges for `preInsert` -/
 
 lemma evalDist_proj_simulateQ_preInsert [Monad m]
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : spec.Domain → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -207,7 +208,7 @@ lemma evalDist_proj_simulateQ_preInsert [Monad m]
   rw [proj_simulateQ_preInsert so nx proj hproj_pure hproj_bind hproj_apply]
 
 lemma probOutput_proj_simulateQ_preInsert [Monad m]
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : spec.Domain → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -219,7 +220,7 @@ lemma probOutput_proj_simulateQ_preInsert [Monad m]
   rw [proj_simulateQ_preInsert so nx proj hproj_pure hproj_bind hproj_apply]
 
 lemma support_proj_simulateQ_preInsert [Monad m]
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (nx : spec.Domain → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -231,7 +232,7 @@ lemma support_proj_simulateQ_preInsert [Monad m]
   rw [proj_simulateQ_preInsert so nx proj hproj_pure hproj_bind hproj_apply]
 
 lemma finSupport_proj_simulateQ_preInsert [Monad m]
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m] [HasEvalFinset m] [DecidableEq β]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq β]
     (so : QueryImpl spec m) (nx : spec.Domain → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -325,9 +326,10 @@ lemma proj_simulateQ_postInsert [LawfulMonad m] [LawfulMonad n]
       exact bind_congr ih
 
 /-- A `postInsert` instrumentation preserves failure probability for any base monad with
-`HasEvalSPMF`, given the projection bundle and its compatibility with failure probabilities. -/
+`[MonadLiftT m SPMF]`, given the projection bundle and its compatibility with failure
+probabilities. -/
 lemma probFailure_proj_simulateQ_postInsert
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : (t : spec.Domain) → spec.Range t → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -340,7 +342,7 @@ lemma probFailure_proj_simulateQ_postInsert
 
 /-- `NeverFail` biconditional companion of `probFailure_proj_simulateQ_postInsert`. -/
 lemma neverFail_proj_simulateQ_postInsert_iff
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : (t : spec.Domain) → spec.Range t → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -367,7 +369,7 @@ lemma simulateQ_postInsert_const_pure
 /-! #### `evalDist` / `probOutput` / `support` bridges for `postInsert` -/
 
 lemma evalDist_proj_simulateQ_postInsert
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : (t : spec.Domain) → spec.Range t → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -379,7 +381,7 @@ lemma evalDist_proj_simulateQ_postInsert
   rw [proj_simulateQ_postInsert so nx proj hproj_pure hproj_bind hproj_apply]
 
 lemma probOutput_proj_simulateQ_postInsert
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     (so : QueryImpl spec m) (nx : (t : spec.Domain) → spec.Range t → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -391,7 +393,7 @@ lemma probOutput_proj_simulateQ_postInsert
   rw [proj_simulateQ_postInsert so nx proj hproj_pure hproj_bind hproj_apply]
 
 lemma support_proj_simulateQ_postInsert
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SetM]
     (so : QueryImpl spec m) (nx : (t : spec.Domain) → spec.Range t → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)
@@ -403,7 +405,7 @@ lemma support_proj_simulateQ_postInsert
   rw [proj_simulateQ_postInsert so nx proj hproj_pure hproj_bind hproj_apply]
 
 lemma finSupport_proj_simulateQ_postInsert
-    [LawfulMonad m] [LawfulMonad n] [HasEvalSPMF m] [HasEvalFinset m] [DecidableEq β]
+    [LawfulMonad m] [LawfulMonad n] [MonadLiftT m SetM] [HasEvalFinset m] [DecidableEq β]
     (so : QueryImpl spec m) (nx : (t : spec.Domain) → spec.Range t → n α)
     (proj : ∀ {γ : Type u}, n γ → m γ)
     (hproj_pure : ∀ {γ : Type u} (x : γ), proj (pure x : n γ) = pure x)

--- a/VCVio/OracleComp/SimSemantics/StateT/Basic.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT/Basic.lean
@@ -240,7 +240,7 @@ open scoped OracleSpec.PrimitiveQuery
 
 section simulateQ_evalDist
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 /-- If a `StateT` oracle implementation preserves distributions (each oracle query produces a
 uniform distribution after discarding state), then `simulateQ` followed by `run'` preserves
@@ -327,14 +327,16 @@ end simulateQ_evalDist
 
 section support_simulateQ_StateT
 
-variable {α : Type w}
+variable {α : Type w} [IsUniformSpec spec]
 
+omit [IsUniformSpec spec] in
 /-- Simulating an `OracleComp` through a stateful implementation in monad `m` can only shrink the
 support: any output reachable after simulation was already reachable in the original computation
 (where oracle queries may return any value). This is the support-level analogue of
 `evalDist_simulateQ_run'_eq_evalDist`. -/
 theorem support_simulateQ_run'_subset
-    {n : Type w → Type _} [Monad n] [LawfulMonad n] [HasEvalSet n] {σ : Type w}
+    {n : Type w → Type _} [Monad n] [LawfulMonad n] [MonadLiftT n SetM] [LawfulMonadLiftT n SetM]
+    {σ : Type w}
     (impl : QueryImpl spec (StateT σ n))
     (oa : OracleComp spec α) (s : σ) :
     support ((simulateQ impl oa).run' s) ⊆ support oa := by

--- a/VCVio/OracleComp/SimSemantics/StateT/BundledSemantics.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT/BundledSemantics.lean
@@ -8,6 +8,7 @@ import VCVio.OracleComp.Coercions.Add
 import VCVio.OracleComp.SimSemantics.Append
 import VCVio.OracleComp.SimSemantics.StateT.Basic
 import VCVio.EvalDist.Defs.Semantics
+import ToMathlib.Control.StateT
 
 /-!
 # Bundled Subprobability Semantics for Oracle Simulations
@@ -40,7 +41,7 @@ noncomputable def withStateOracle
   instMonadSem := inferInstance
   interpret := simulateQ'
     ((QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp) + hashImpl)
-  observe := fun mx => HasEvalSPMF.toSPMF (StateT.run' mx s)
+  observe := fun mx => (liftM (StateT.run' mx s) : SPMF _)
 
 /-- `withStateOracle` commutes with `<$>`: mapping a function over the surface computation
 is the same as mapping it over the observed `SPMF`.
@@ -55,9 +56,11 @@ monad morphism: `<$>` does not thread state, so `Prod.fst <$> (f <$> mx).run s` 
     {α β : Type} (f : α → β) (mx : OracleComp (unifSpec + hashSpec) α) :
     (SPMFSemantics.withStateOracle hashImpl s).evalDist (f <$> mx) =
       f <$> (SPMFSemantics.withStateOracle hashImpl s).evalDist mx := by
-  unfold SPMFSemantics.evalDist SemanticsVia.denote
-  simp only [SPMFSemantics.withStateOracle, simulateQ_map, StateT.run'_eq, StateT.run_map,
-    Functor.map_map, MonadHom.mmap_map]
+  set impl :=
+    (QueryImpl.ofLift unifSpec ProbComp).liftTarget (StateT σ ProbComp) + hashImpl with himpl
+  change (liftM (StateT.run' (simulateQ impl (f <$> mx)) s) : SPMF _) =
+    f <$> (liftM (StateT.run' (simulateQ impl mx) s) : SPMF _)
+  rw [simulateQ_map, StateT.run'_map', liftM_map]
 
 /-- `withStateOracle` commutes with the specific `>>= pure ∘ f` pattern produced by
 a do-block returning a pure value at the end. A direct corollary of

--- a/VCVio/OracleComp/SimSemantics/StateT/PreservesInv.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT/PreservesInv.lean
@@ -207,55 +207,37 @@ lemma preservesInv_bind {σ α β : Type}
   rcases (mem_support_bind_iff _ _ _).1 hz' with ⟨us, hus, hcont⟩
   exact h₂ us.1 us.2 (h₁ σ0 hσ0 us hus) z hcont
 
-/-- If `mx` is output-independent on `Inv`, and `my` preserves `Inv` and never fails, then the
-output distribution of `mx` is unchanged by running `my` first and then running `mx` on the
-resulting state. -/
+/-- If `mx` is output-independent on `Inv`, and `my` preserves `Inv` and never fails under `Inv`,
+then the output distribution of `mx` is unchanged by running `my` first and then running `mx`
+on the resulting state. -/
 lemma outputIndependent_after_preservesInv {σ α β : Type}
     (mx : StateT σ ProbComp α) (my : StateT σ ProbComp β) (Inv : σ → Prop)
     (hmx : OutputIndependent mx Inv)
-    (hmyInv : PreservesInv my Inv) :
+    (hmyInv : PreservesInv my Inv)
+    (hmyNoFail : NeverFailsUnder my Inv) :
     ∀ σ0, Inv σ0 →
       𝒟[(my.run σ0) >>= fun us => mx.run' us.2] = 𝒟[mx.run' σ0] := by
-  classical
   intro σ0 hσ0
-  ext y
-  have hconst :
-      ∀ us : support (my.run σ0), Pr[= y | mx.run' us.1.2] = Pr[= y | mx.run' σ0] := by
-    intro us
-    have husInv : Inv us.1.2 := hmyInv σ0 hσ0 us.1 us.2
-    have hdist : 𝒟[mx.run' us.1.2] = 𝒟[mx.run' σ0] :=
-      hmx _ _ husInv hσ0
-    simpa [probOutput_def] using congrArg (fun d => d y) hdist
-  have hsum_support : (∑' us : support (my.run σ0), Pr[= us | my.run σ0]) = 1 := by
-    have hsum_all :
-        (∑' us : β × σ, Pr[= us | my.run σ0]) = 1 - Pr[⊥ | my.run σ0] := by
-      simpa [probOutput_def, probFailure, SPMF.apply_eq_toPMF_some] using
-        (SPMF.tsum_run_some_eq_one_sub (p := 𝒟[my.run σ0]))
-    have hsum_all' : (∑' us : β × σ, Pr[= us | my.run σ0]) = 1 := by
-      simp [hsum_all]
-    have hrestrict :
-        (∑' us : support (my.run σ0), Pr[= us | my.run σ0]) =
-          (∑' us : β × σ, Pr[= us | my.run σ0]) := by
-      rw [tsum_subtype (support (my.run σ0)) (fun us : β × σ => Pr[= us | my.run σ0])]
-      refine (tsum_congr fun us => ?_)
-      by_cases hus : us ∈ support (my.run σ0)
-      · simp [hus]
-      · simp [hus, probOutput_eq_zero_of_not_mem_support hus]
-    simp [hrestrict, hsum_all']
-  calc
-    Pr[= y | (my.run σ0 >>= fun us => mx.run' us.2)]
-        = ∑' us : support (my.run σ0),
-            Pr[= us | my.run σ0] * Pr[= y | mx.run' us.1.2] := by
-          simpa using (probOutput_bind_eq_tsum_subtype (mx := my.run σ0)
-            (my := fun us => mx.run' us.2) (y := y))
-    _ = ∑' us : support (my.run σ0),
-          Pr[= us | my.run σ0] * Pr[= y | mx.run' σ0] := by
-          refine tsum_congr fun us => ?_
-          simpa using congrArg (fun p => Pr[= us | my.run σ0] * p) (hconst us)
-    _ = (∑' us : support (my.run σ0), Pr[= us | my.run σ0]) * Pr[= y | mx.run' σ0] := by
-          simpa [mul_assoc] using
-            (ENNReal.tsum_mul_right (f := fun us : support (my.run σ0) => Pr[= us | my.run σ0])
-              (a := Pr[= y | mx.run' σ0]))
-    _ = Pr[= y | mx.run' σ0] := by simp [hsum_support]
+  refine SPMF.ext fun a => ?_
+  change Pr[= a | (my.run σ0) >>= fun us => mx.run' us.2] = Pr[= a | mx.run' σ0]
+  rw [probOutput_bind_eq_tsum]
+  have hbind_eq :
+      (∑' us : β × σ, Pr[= us | my.run σ0] * Pr[= a | mx.run' us.2]) =
+        (∑' us : β × σ, Pr[= us | my.run σ0]) * Pr[= a | mx.run' σ0] := by
+    rw [← ENNReal.tsum_mul_right]
+    refine tsum_congr fun us => ?_
+    rcases eq_or_ne (Pr[= us | my.run σ0]) 0 with hus | hus
+    · rw [hus, zero_mul, zero_mul]
+    · have hus' : us ∈ support (my.run σ0) := by
+        rw [mem_support_iff]; exact hus
+      have hInv : Inv us.2 := hmyInv σ0 hσ0 us hus'
+      simp only [probOutput_def, hmx us.2 σ0 hInv hσ0]
+  rw [hbind_eq]
+  have hsum : (∑' us : β × σ, Pr[= us | my.run σ0]) = 1 := by
+    have hnofail : Pr[⊥ | my.run σ0] = 0 := hmyNoFail σ0 hσ0
+    have htotal := tsum_probOutput_add_probFailure (my.run σ0)
+    rw [hnofail, add_zero] at htotal
+    exact htotal
+  rw [hsum, one_mul]
 
 end StateT

--- a/VCVio/OracleComp/SimSemantics/StateT/StateProjection.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT/StateProjection.lean
@@ -113,6 +113,7 @@ is the natural strengthening of `map_run_simulateQ_eq_of_query_map_eq` for
 projections that only agree on a reachable subset of states. -/
 theorem map_run_simulateQ_eq_of_query_map_eq_inv'
     {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {σ₁ σ₂ : Type _}
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec')))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec')))
@@ -163,6 +164,7 @@ support-preservation half of `map_run_simulateQ_eq_of_query_map_eq_inv'`,
 exposed separately for projected continuations after a simulated prefix. -/
 theorem simulateQ_run_preserves_inv_of_query
     {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {σ : Type _}
     (impl : QueryImpl spec (StateT σ (OracleComp spec')))
     (inv : σ → Prop)
@@ -186,6 +188,7 @@ theorem simulateQ_run_preserves_inv_of_query
 a stateful continuation. -/
 theorem map_run_simulateQ_bind_eq_of_query_map_eq_inv'
     {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {σ₁ σ₂ : Type _} {β : Type u}
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec')))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec')))
@@ -236,6 +239,7 @@ theorem map_run_simulateQ_bind_eq_of_query_map_eq_inv'
 /-- `run'` projection corollary of `map_run_simulateQ_eq_of_query_map_eq_inv'`. -/
 theorem run'_simulateQ_eq_of_query_map_eq_inv'
     {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {σ₁ σ₂ : Type _}
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec')))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec')))
@@ -263,6 +267,7 @@ only needs to commute with each query on states satisfying `inv`, and `inv` must
 be preserved by each query step. -/
 structure StateOrnament
     {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+    [IsUniformSpec spec']
     {σ τ : Type _}
     (decorated : QueryImpl spec (StateT σ (OracleComp spec')))
     (base : QueryImpl spec (StateT τ (OracleComp spec'))) where
@@ -278,6 +283,7 @@ structure StateOrnament
 namespace StateOrnament
 
 variable {ι ι' : Type} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
+variable [IsUniformSpec spec']
 variable {σ τ : Type _}
 variable {decorated : QueryImpl spec (StateT σ (OracleComp spec'))}
 variable {base : QueryImpl spec (StateT τ (OracleComp spec'))}

--- a/VCVio/OracleComp/SimSemantics/WriterT/Basic.lean
+++ b/VCVio/OracleComp/SimSemantics/WriterT/Basic.lean
@@ -85,14 +85,14 @@ lemma fst_map_writerT_run_simulateQ
     rw [this]
     exact ih a
 
-lemma probFailure_writerT_run_simulateQ [spec.Fintype] [spec.Inhabited]
+lemma probFailure_writerT_run_simulateQ [IsUniformSpec spec]
     {so : QueryImpl spec (WriterT ω (OracleComp spec))}
     (oa : OracleComp spec α) : Pr[⊥ | (simulateQ so oa).run] = Pr[⊥ | oa] := by
   induction oa using OracleComp.inductionOn with
   | pure x => simp
   | query_bind t oa h => simp
 
-lemma NeverFail_writerT_run_simulateQ_iff [spec.Fintype] [spec.Inhabited]
+lemma NeverFail_writerT_run_simulateQ_iff [IsUniformSpec spec]
     {so : QueryImpl spec (WriterT ω (OracleComp spec))}
     (oa : OracleComp spec α) :
     NeverFail ((simulateQ so oa).run : OracleComp spec _) ↔

--- a/VCVio/OracleComp/SimSemantics/WriterT/PreservesInv.lean
+++ b/VCVio/OracleComp/SimSemantics/WriterT/PreservesInv.lean
@@ -39,16 +39,19 @@ namespace QueryImpl
 /-- `WriterPreservesInv impl Inv` means every oracle query implementation step preserves
 `Inv` on the accumulated writer: starting from any `s₀` satisfying `Inv`, every reachable
 post-writer `s₀ * w` (for `(a, w)` in the support of `(impl t).run`) also satisfies `Inv`. -/
-def WriterPreservesInv {ι : Type} {spec : OracleSpec ι} {ω : Type} [Monoid ω]
+def WriterPreservesInv {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec]
+    {ω : Type} [Monoid ω]
     (impl : QueryImpl spec (WriterT ω (OracleComp spec))) (Inv : ω → Prop) : Prop :=
   ∀ t s₀, Inv s₀ → ∀ z ∈ support (impl t).run, Inv (s₀ * z.2)
 
-lemma WriterPreservesInv.trivial {ι : Type} {spec : OracleSpec ι} {ω : Type} [Monoid ω]
+lemma WriterPreservesInv.trivial {ι : Type} {spec : OracleSpec ι}
+    [IsUniformSpec spec] {ω : Type} [Monoid ω]
     (impl : QueryImpl spec (WriterT ω (OracleComp spec))) :
     WriterPreservesInv impl (fun _ => True) :=
   fun _ _ _ _ _ => True.intro
 
-lemma WriterPreservesInv.and {ι : Type} {spec : OracleSpec ι} {ω : Type} [Monoid ω]
+lemma WriterPreservesInv.and {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec] {ω
+    : Type} [Monoid ω]
     {impl : QueryImpl spec (WriterT ω (OracleComp spec))} {P Q : ω → Prop}
     (hP : WriterPreservesInv impl P) (hQ : WriterPreservesInv impl Q) :
     WriterPreservesInv impl (fun s => P s ∧ Q s) :=
@@ -59,7 +62,7 @@ to `PreservesInv.of_forall`: if every reachable increment `z.2` satisfies
 `Inv (s₀ * z.2)` for *any* starting `s₀` regardless of whether `Inv s₀`
 holds, then `Inv` is preserved. -/
 lemma WriterPreservesInv.of_forall
-    {ι : Type} {spec : OracleSpec ι} {ω : Type} [Monoid ω]
+    {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec] {ω : Type} [Monoid ω]
     {impl : QueryImpl spec (WriterT ω (OracleComp spec))} {Inv : ω → Prop}
     (h : ∀ t s₀ z, z ∈ support (impl t).run → Inv (s₀ * z.2)) :
     WriterPreservesInv impl Inv :=
@@ -72,7 +75,8 @@ If `Inv` holds on every writer increment `w` produced by a single query
 preserved across the whole simulation. This is the canonical builder for
 writer invariants: pick a submonoid-like predicate, show every per-query
 increment lands in it, and you're done. -/
-lemma WriterPreservesInv.of_mul_closed {ι : Type} {spec : OracleSpec ι} {ω : Type} [Monoid ω]
+lemma WriterPreservesInv.of_mul_closed {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec]
+    {ω : Type} [Monoid ω]
     {impl : QueryImpl spec (WriterT ω (OracleComp spec))} {Inv : ω → Prop}
     (hClosed : ∀ a b, Inv a → Inv b → Inv (a * b))
     (hPerQuery : ∀ t z, z ∈ support (impl t).run → Inv z.2) :
@@ -97,7 +101,7 @@ open QueryImpl
 /-- If `impl` preserves the writer invariant `Inv`, then simulating *any* oracle computation
 with `simulateQ impl` preserves `Inv` on the final accumulated writer (support-wise). -/
 theorem simulateQ_run_writerPreservesInv
-    {ι : Type} {spec : OracleSpec ι} {ω α : Type} [Monoid ω]
+    {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec] {ω α : Type} [Monoid ω]
     (impl : QueryImpl spec (WriterT ω (OracleComp spec))) (Inv : ω → Prop)
     (himpl : QueryImpl.WriterPreservesInv impl Inv) :
     ∀ oa : OracleComp spec α,

--- a/VCVio/ProgramLogic/Notation.lean
+++ b/VCVio/ProgramLogic/Notation.lean
@@ -22,7 +22,7 @@ namespace OracleComp.ProgramLogic
 
 variable {ι₁ : Type u}
 variable {spec₁ : OracleSpec ι₁}
-variable [spec₁.Fintype] [spec₁.Inhabited]
+variable [IsUniformSpec spec₁]
 variable {α : Type}
 
 /-- Game equivalence from exact pRHL equality coupling. -/

--- a/VCVio/ProgramLogic/NotationCore.lean
+++ b/VCVio/ProgramLogic/NotationCore.lean
@@ -50,7 +50,7 @@ namespace OracleComp.ProgramLogic
 
 variable {ι₁ : Type u}
 variable {spec₁ : OracleSpec ι₁}
-variable [spec₁.Fintype] [spec₁.Inhabited]
+variable [IsUniformSpec spec₁]
 variable {α β : Type}
 
 /-! ## Convenience predicates -/
@@ -181,7 +181,7 @@ macro_rules
 
 /-- `probEvent` equals WP of propInd postcondition. -/
 lemma probEvent_eq_wp_propInd {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) :
     Pr[ p | oa] = wp oa (fun x => 𝟙⟦p x⟧) := by
   classical
@@ -198,7 +198,7 @@ lemma Relational.RelPost.indicator_eq_propInd {α β : Type}
 /-- Almost-sure correctness: `Triple 𝟙⟦True⟧ c (fun x => 𝟙⟦p x⟧)` iff
 `Pr[ p | c] = 1`. -/
 lemma triple_propInd_iff_probEvent_eq_one {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) :
     Triple (𝟙⟦True⟧ : ℝ≥0∞) oa (fun x => 𝟙⟦p x⟧) ↔
       Pr[ p | oa] = 1 := by
@@ -207,7 +207,7 @@ lemma triple_propInd_iff_probEvent_eq_one {ι : Type u} {spec : OracleSpec ι}
 
 /-- Lower-bound event goals are exactly quantitative triples with indicator postconditions. -/
 lemma triple_propInd_iff_le_probEvent {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) (r : ℝ≥0∞) :
     Triple r oa (fun x => 𝟙⟦p x⟧) ↔ r ≤ Pr[ p | oa] := by
   rw [triple_iff_le_wp, ← probEvent_eq_wp_propInd]
@@ -216,7 +216,7 @@ lemma triple_propInd_iff_le_probEvent {ι : Type u} {spec : OracleSpec ι}
 
 /-- WP of a disjunction indicator is bounded by the sum of individual WP indicators. -/
 theorem wp_propInd_or_le {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p q : α → Prop) :
     wp oa (fun x => 𝟙⟦p x ∨ q x⟧) ≤
         wp oa (fun x => 𝟙⟦p x⟧) +
@@ -226,7 +226,7 @@ theorem wp_propInd_or_le {ι : Type u} {spec : OracleSpec ι}
 
 /-- Monotonicity for event probabilities, exposed through the program-logic namespace. -/
 theorem probEvent_mono {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) {p q : α → Prop}
     (h : ∀ x, p x → q x) :
     Pr[ p | oa] ≤ Pr[ q | oa] :=
@@ -234,7 +234,7 @@ theorem probEvent_mono {ι : Type u} {spec : OracleSpec ι}
 
 /-- Markov inequality: if `a ≤ f x` whenever `p x`, then `a * Pr[ p | oa] ≤ E[f | oa]`. -/
 theorem markov_bound {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (f : α → ℝ≥0∞) (a : ℝ≥0∞)
     (p : α → Prop) (hf : ∀ x, p x → a ≤ f x) :
     a * Pr[ p | oa] ≤ wp oa f := by
@@ -247,12 +247,12 @@ theorem markov_bound {ι : Type u} {spec : OracleSpec ι}
 
 /-- `Triple` with precondition `1` and indicator postcondition when the event is almost sure. -/
 theorem triple_propInd_of_support {ι : Type u} {spec : OracleSpec ι}
-    [spec.Fintype] [spec.Inhabited] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (p : α → Prop) (h : ∀ x ∈ support oa, p x) :
     Triple (1 : ℝ≥0∞) oa (fun x => 𝟙⟦p x⟧) := by
   rw [show (1 : ℝ≥0∞) = 𝟙⟦True⟧ from propInd_true.symm]
   exact (triple_propInd_iff_probEvent_eq_one oa p).mpr
-    (probEvent_eq_one ⟨HasEvalPMF.probFailure_eq_zero oa, h⟩)
+    (probEvent_eq_one ⟨probFailure_of_liftM_PMF oa, h⟩)
 
 /-! ## Bridge lemmas: game equivalence and advantage -/
 

--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -32,7 +32,7 @@ namespace OracleComp.ProgramLogic.Relational
 
 variable {ι₁ : Type u} {ι₂ : Type v}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β γ δ : Type}
 
 /-- Relational postconditions over two output spaces. -/
@@ -289,7 +289,7 @@ lemma relTriple_symm {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
 /-- Transport a relational triple across equality of the left output distribution. -/
 lemma relTriple_of_evalDist_eq_left
     {ι₃ : Type w} {spec₃ : OracleSpec ι₃}
-    [spec₃.Fintype] [spec₃.Inhabited]
+    [IsUniformSpec spec₃]
     {oa : OracleComp spec₁ α} {oa' : OracleComp spec₂ α}
     {ob : OracleComp spec₃ β} {R : RelPost α β}
     (heq : 𝒟[oa] = 𝒟[oa']) (h : RelTriple oa' ob R) :
@@ -306,7 +306,7 @@ lemma relTriple_of_evalDist_eq_left
 /-- Transport a relational triple across equality of the right output distribution. -/
 lemma relTriple_of_evalDist_eq_right
     {ι₃ : Type w} {spec₃ : OracleSpec ι₃}
-    [spec₃.Fintype] [spec₃.Inhabited]
+    [IsUniformSpec spec₃]
     {oa : OracleComp spec₁ α}
     {ob : OracleComp spec₂ β} {ob' : OracleComp spec₃ β}
     {R : RelPost α β}
@@ -411,7 +411,7 @@ lemma evalDist_eq_of_relTriple_eqRel {oa : OracleComp spec₁ α} {ob : OracleCo
 /-- Transitivity through an intermediate computation related to the left side by `EqRel`. -/
 lemma relTriple_trans_eqRel_left
     {ι₃ : Type w} {spec₃ : OracleSpec ι₃}
-    [spec₃.Fintype] [spec₃.Inhabited]
+    [IsUniformSpec spec₃]
     {oa : OracleComp spec₁ α} {mid : OracleComp spec₂ α}
     {ob : OracleComp spec₃ β} {R : RelPost α β}
     (hleft : RelTriple oa mid (EqRel α)) (hright : RelTriple mid ob R) :
@@ -424,7 +424,7 @@ lemma relTriple_trans_eqRel_left
 /-- Transitivity through an intermediate computation related to the right side by `EqRel`. -/
 lemma relTriple_trans_eqRel_right
     {ι₃ : Type w} {spec₃ : OracleSpec ι₃}
-    [spec₃.Fintype] [spec₃.Inhabited]
+    [IsUniformSpec spec₃]
     {oa : OracleComp spec₁ α}
     {mid : OracleComp spec₂ β} {ob : OracleComp spec₃ β}
     {R : RelPost α β}
@@ -438,7 +438,7 @@ lemma relTriple_trans_eqRel_right
 /-- Transitivity of equality-relation relational triples through an intermediate computation. -/
 lemma relTriple_trans_eqRel
     {ι₃ : Type w} {spec₃ : OracleSpec ι₃}
-    [spec₃.Fintype] [spec₃.Inhabited]
+    [IsUniformSpec spec₃]
     {oa : OracleComp spec₁ α} {mid : OracleComp spec₂ α}
     {ob : OracleComp spec₃ α}
     (hleft : RelTriple oa mid (EqRel α)) (hright : RelTriple mid ob (EqRel α)) :

--- a/VCVio/ProgramLogic/Relational/Examples.lean
+++ b/VCVio/ProgramLogic/Relational/Examples.lean
@@ -53,7 +53,7 @@ namespace OracleComp.ProgramLogic.Relational
 
 variable {ι₁ : Type u} {ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β γ δ : Type}
 
 /-! ### Term-mode examples (direct lemma application) -/

--- a/VCVio/ProgramLogic/Relational/FromUnary.lean
+++ b/VCVio/ProgramLogic/Relational/FromUnary.lean
@@ -12,7 +12,8 @@ import VCVio.ProgramLogic.Relational.Basic
 
 Two `OracleComp` computations that are independently correct (each satisfying a unary
 `Std.Do.Triple`) can always be paired via the product coupling, since every
-`OracleComp` distribution sums to probability `1` (`HasEvalPMF`).
+`OracleComp` distribution sums to probability `1` (the canonical
+`MonadLiftT (OracleComp spec) PMF` lift).
 
 This file provides the "unary → relational" bridge:
 
@@ -36,12 +37,13 @@ namespace OracleComp.ProgramLogic.Relational
 
 variable {ι₁ : Type u} {ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β : Type}
 
 /-- Core lift: two `support`-style unary postconditions combine into a relational
 coupling. The product coupling `evalDist oa ⊗ evalDist ob` witnesses the conjunction,
-using `HasEvalPMF` to ensure neither side has failure mass. -/
+using the canonical `MonadLiftT (OracleComp spec) PMF` to ensure neither side has
+failure mass. -/
 theorem relTriple_prod
     {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
     {P : α → Prop} {Q : β → Prop}

--- a/VCVio/ProgramLogic/Relational/HandlerFromUnary.lean
+++ b/VCVio/ProgramLogic/Relational/HandlerFromUnary.lean
@@ -58,7 +58,7 @@ open Std.Do
 namespace OracleComp.ProgramLogic.Relational
 
 variable {ι₁ ι₂ : Type} {spec₁ : OracleSpec.{0, 0} ι₁} {spec₂ : OracleSpec.{0, 0} ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {σ₁ σ₂ α β : Type}
 
 /-! ### Per-call lifts (one transformer layer) -/
@@ -178,7 +178,7 @@ extracts output equality and the state-relation invariant from a paired
 instance of the two unary postconditions, which is exactly the bridge
 needed by `relTriple_simulateQ_run`. -/
 theorem relTriple_simulateQ_run_of_triples
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
     (R_state : σ₁ → σ₂ → Prop)
@@ -229,7 +229,7 @@ are evaluated at the resulting step writer. Typical instantiations are
 `countingOracle_triple` and `costOracle_triple` with `qc₀ = 0` /
 `s₀ = 1`. -/
 theorem relTriple_simulateQ_run_writerT_of_triples
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     {ω₁ ω₂ : Type} [Monoid ω₁] [Monoid ω₂]
     (impl₁ : QueryImpl spec (WriterT ω₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (WriterT ω₂ (OracleComp spec₂)))
@@ -272,7 +272,7 @@ theorem relTriple_simulateQ_run_writerT_of_triples
 
 Drops the writer component, leaving only `EqRel α` on outputs. -/
 theorem relTriple_simulateQ_run_writerT'_of_triples
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     {ω₁ ω₂ : Type} [Monoid ω₁] [Monoid ω₂]
     (impl₁ : QueryImpl spec (WriterT ω₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (WriterT ω₂ (OracleComp spec₂)))
@@ -311,7 +311,7 @@ on the return values. This is the canonical shape needed for probability
 transport (via `probOutput_eq_of_relTriple_eqRel`), matching
 `relTriple_simulateQ_run'` at the handler-triple layer. -/
 theorem relTriple_simulateQ_run'_of_triples
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
     (R_state : σ₁ → σ₂ → Prop)
@@ -361,7 +361,7 @@ The `mvcgen` proof style produces invariant-preservation specs as
 relational infrastructure is phrased in terms of `support`. This lemma
 is the direct translator, lifting over `triple_stateT_iff_forall_support`. -/
 theorem support_preservesInv_of_triple
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     {σ : Type}
     (impl : QueryImpl spec (StateT σ (OracleComp spec₁)))
     (Inv : σ → Prop)
@@ -386,7 +386,7 @@ Use this whenever a writer-invariant-preservation proof is available as
 an `mvcgen`-style `Std.Do.Triple`, and the downstream consumer is a
 `support`-based whole-program lemma. -/
 theorem writerPreservesInv_of_triple
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     {ω : Type} [Monoid ω]
     (impl : QueryImpl spec (WriterT ω (OracleComp spec)))
     (Inv : ω → Prop)
@@ -407,7 +407,7 @@ an invariant `Inv` and the target handler preserves `Inv`. This is the
 hypothesis is supplied via `mvcgen`-style `Std.Do.Triple`s rather than a
 `support`-based quantifier. -/
 theorem relTriple_simulateQ_run_of_impl_eq_triple
-    {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+    {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
     {σ : Type}
     (impl₁ impl₂ : QueryImpl spec (StateT σ ProbComp))
     (Inv : σ → Prop)
@@ -432,7 +432,7 @@ theorem relTriple_simulateQ_run_of_impl_eq_triple
 
 section SmokeTests
 
-variable {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+variable {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
 variable [DecidableEq ι]
 
 /-- Smoke test: independent product coupling for two `cachingOracle` runs

--- a/VCVio/ProgramLogic/Relational/Leakage.lean
+++ b/VCVio/ProgramLogic/Relational/Leakage.lean
@@ -48,7 +48,7 @@ in every coupled output. This is the strongest leakage judgment, corresponding t
 constant-time execution for deterministic channels.
 
 Defined via `RelTriple'` (the pRHL indicator pattern from `QuantitativeDefs.lean`). -/
-def TraceNoninterference [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+def TraceNoninterference [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     (oa₁ : OracleComp spec₁ (α × ω))
     (oa₂ : OracleComp spec₂ (β × ω)) : Prop :=
   ProgramLogic.Relational.RelTriple' oa₁ oa₂ (fun z₁ z₂ => z₁.2 = z₂.2)
@@ -61,7 +61,7 @@ only the trace cannot distinguish between the two computations.
 
 The comparison is made at the `SPMF` level via `evalDist`, allowing computations over
 different oracle specs to be compared. -/
-def ProbLeakFree [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+def ProbLeakFree [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     (oa₁ : OracleComp spec₁ (α × ω))
     (oa₂ : OracleComp spec₂ (β × ω)) : Prop :=
   𝒟[Prod.snd <$> oa₁] = 𝒟[Prod.snd <$> oa₂]
@@ -71,7 +71,7 @@ def ProbLeakFree [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec�
 /-- Approximate trace independence: the trace distributions differ by at most `ε` in total
 variation distance. This enables game-hopping arguments where each hop introduces a small
 leakage discrepancy. -/
-def LeakageBound [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+def LeakageBound [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     (ε : ℝ) (oa₁ : OracleComp spec₁ (α × ω))
     (oa₂ : OracleComp spec₂ (β × ω)) : Prop :=
   SPMF.tvDist (𝒟[Prod.snd <$> oa₁]) (𝒟[Prod.snd <$> oa₂]) ≤ ε
@@ -81,7 +81,7 @@ def LeakageBound [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec�
 /-- Exact trace noninterference implies distributional trace independence:
 if traces always match in every coupling, their distributions must be equal. -/
 theorem traceNoninterference_implies_probLeakFree
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : TraceNoninterference oa₁ oa₂) :
     ProbLeakFree oa₁ oa₂ :=
@@ -89,7 +89,7 @@ theorem traceNoninterference_implies_probLeakFree
 
 /-- `ProbLeakFree` is equivalent to `LeakageBound 0`. -/
 theorem probLeakFree_iff_leakageBound_zero
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)} :
     ProbLeakFree oa₁ oa₂ ↔ LeakageBound 0 oa₁ oa₂ := by
   simp only [ProbLeakFree, LeakageBound]
@@ -104,8 +104,8 @@ theorem probLeakFree_iff_leakageBound_zero
 has leakage at most `ε₁` and the second pair at most `ε₂`, then the outer pair has
 leakage at most `ε₁ + ε₂`. -/
 theorem leakageBound_triangle
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
-    [spec₃.Fintype] [spec₃.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    [IsUniformSpec spec₃]
     {ε₁ ε₂ : ℝ}
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     {oa₃ : OracleComp spec₃ (γ × ω)}
@@ -120,20 +120,20 @@ theorem leakageBound_triangle
 
 /-- `ProbLeakFree` is reflexive. -/
 @[simp]
-theorem probLeakFree_refl [spec₁.Fintype] [spec₁.Inhabited]
+theorem probLeakFree_refl [IsUniformSpec spec₁]
     (oa : OracleComp spec₁ (α × ω)) :
     ProbLeakFree oa oa := rfl
 
 /-- `ProbLeakFree` is symmetric. -/
 theorem probLeakFree_symm
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : ProbLeakFree oa₁ oa₂) :
     ProbLeakFree oa₂ oa₁ := h.symm
 
 /-- `LeakageBound` with `ε = 0` implies `ProbLeakFree`. -/
 theorem probLeakFree_of_leakageBound_zero
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : LeakageBound 0 oa₁ oa₂) :
     ProbLeakFree oa₁ oa₂ :=
@@ -141,14 +141,14 @@ theorem probLeakFree_of_leakageBound_zero
 
 /-- `LeakageBound` is reflexive with bound `0`. -/
 @[simp]
-theorem leakageBound_refl [spec₁.Fintype] [spec₁.Inhabited]
+theorem leakageBound_refl [IsUniformSpec spec₁]
     (oa : OracleComp spec₁ (α × ω)) :
     LeakageBound 0 oa oa := by
   unfold LeakageBound; simp
 
 /-- `LeakageBound` is symmetric. -/
 theorem leakageBound_symm
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ε : ℝ} {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : LeakageBound ε oa₁ oa₂) :
     LeakageBound ε oa₂ oa₁ := by
@@ -157,7 +157,7 @@ theorem leakageBound_symm
 
 /-- Monotonicity: a smaller leakage bound implies a larger one. -/
 theorem leakageBound_mono
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ε₁ ε₂ : ℝ} (hε : ε₁ ≤ ε₂)
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : LeakageBound ε₁ oa₁ oa₂) :
@@ -167,7 +167,7 @@ theorem leakageBound_mono
 
 /-- Mapping the result component preserves distributional trace independence. -/
 theorem probLeakFree_map_fst
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : ProbLeakFree oa₁ oa₂) {δ : Type} (f₁ : α → γ) (f₂ : β → δ) :
     ProbLeakFree (Prod.map f₁ id <$> oa₁) (Prod.map f₂ id <$> oa₂) := by
@@ -176,7 +176,7 @@ theorem probLeakFree_map_fst
 
 /-- Mapping the result component preserves approximate trace independence. -/
 theorem leakageBound_map_fst
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ε : ℝ} {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : LeakageBound ε oa₁ oa₂) {δ : Type} (f₁ : α → γ) (f₂ : β → δ) :
     LeakageBound ε (Prod.map f₁ id <$> oa₁) (Prod.map f₂ id <$> oa₂) := by
@@ -185,7 +185,7 @@ theorem leakageBound_map_fst
 
 /-- Mapping the result component preserves trace noninterference. -/
 theorem traceNoninterference_map_fst
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : TraceNoninterference oa₁ oa₂) {δ : Type} (f₁ : α → γ) (f₂ : β → δ) :
     TraceNoninterference (Prod.map f₁ id <$> oa₁) (Prod.map f₂ id <$> oa₂) := by
@@ -196,7 +196,7 @@ theorem traceNoninterference_map_fst
 /-- Mapping the trace component with the same function preserves distributional trace
 independence. -/
 theorem probLeakFree_map_snd
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : ProbLeakFree oa₁ oa₂) {ω' : Type} (g : ω → ω') :
     ProbLeakFree (Prod.map id g <$> oa₁) (Prod.map id g <$> oa₂) := by
@@ -207,7 +207,7 @@ theorem probLeakFree_map_snd
 /-- Mapping the trace component with the same function preserves approximate trace
 independence. -/
 theorem leakageBound_map_snd
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ε : ℝ} {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : LeakageBound ε oa₁ oa₂) {ω' : Type} (g : ω → ω') :
     LeakageBound ε (Prod.map id g <$> oa₁) (Prod.map id g <$> oa₂) := by
@@ -217,7 +217,7 @@ theorem leakageBound_map_snd
 
 /-- Mapping the trace component with the same function preserves trace noninterference. -/
 theorem traceNoninterference_map_snd
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : TraceNoninterference oa₁ oa₂) {ω' : Type} (g : ω → ω') :
     TraceNoninterference (Prod.map id g <$> oa₁) (Prod.map id g <$> oa₂) := by
@@ -239,7 +239,7 @@ private lemma snd_map_bind_snd {m : Type → Type _} [Monad m] [LawfulMonad m]
 The continuations may depend on both the result and the trace, but whenever the
 traces match, the continuations must themselves be trace noninterfering. -/
 theorem traceNoninterference_bind
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {δ ω' : Type}
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     {f₁ : (α × ω) → OracleComp spec₁ (γ × ω')}
@@ -257,7 +257,7 @@ theorem traceNoninterference_bind
 /-- Distributional trace independence is preserved by bind when the continuation
 depends only on the trace (second component). -/
 theorem probLeakFree_bind_of_trace_only
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {δ ω' : Type}
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : ProbLeakFree oa₁ oa₂)
@@ -271,7 +271,7 @@ theorem probLeakFree_bind_of_trace_only
 /-- Approximate trace independence is preserved by bind when the continuation depends
 only on the trace and produces identical trace distributions. -/
 theorem leakageBound_bind_of_trace_only
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ε : ℝ} {δ ω' : Type}
     {oa₁ : OracleComp spec₁ (α × ω)} {oa₂ : OracleComp spec₂ (β × ω)}
     (h : LeakageBound ε oa₁ oa₂)

--- a/VCVio/ProgramLogic/Relational/Loom/Coherence.lean
+++ b/VCVio/ProgramLogic/Relational/Loom/Coherence.lean
@@ -59,7 +59,7 @@ namespace OracleComp.Rel.Loom.Coherence
 
 variable {ι₁ ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β : Type}
 
 /-! ## Bound: `eRelWP` on an indicator post is always `≤ 1`

--- a/VCVio/ProgramLogic/Relational/Loom/Probabilistic.lean
+++ b/VCVio/ProgramLogic/Relational/Loom/Probabilistic.lean
@@ -51,7 +51,7 @@ namespace OracleComp.Rel.Probabilistic
 
 variable {ι₁ ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β γ δ : Type}
 
 /-! ## Bound: `eRelWP` on a `Prob`-valued post is always `≤ 1`

--- a/VCVio/ProgramLogic/Relational/Loom/Qualitative.lean
+++ b/VCVio/ProgramLogic/Relational/Loom/Qualitative.lean
@@ -67,7 +67,7 @@ namespace OracleComp.Rel.Qualitative
 
 variable {ι₁ ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β : Type}
 
 /-- Qualitative `Std.Do'.RelWP` interpretation of pairs of `OracleComp`

--- a/VCVio/ProgramLogic/Relational/Loom/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Loom/Quantitative.lean
@@ -55,7 +55,7 @@ namespace OracleComp.ProgramLogic.Relational.Loom
 
 variable {ι₁ ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β γ δ : Type}
 
 /-- Quantitative `Std.Do'.RelWP` interpretation of pairs of `OracleComp`

--- a/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
+++ b/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
@@ -48,7 +48,7 @@ universe u
 
 namespace OracleComp.ProgramLogic.Relational
 
-variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι} [IsUniformSpec spec]
 variable {α : Type}
 
 /-! ## Per-step distributional agreement on non-bad outputs -/
@@ -107,7 +107,7 @@ private lemma probOutput_withProgramming_eq_withCachingTrackingPolicy_of_not_bad
 
 /-! ## Bad-input monotonicity wrappers (`σ × Bool` shape) -/
 
-omit [spec.Fintype] [spec.Inhabited] in
+omit [IsUniformSpec spec] in
 private lemma withProgramming_mono_pair
     (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
     (t : spec.Domain) (p : spec.QueryCache × Bool) (hp : p.2 = true)
@@ -116,7 +116,7 @@ private lemma withProgramming_mono_pair
   cases (show b = true from hp)
   exact QueryImpl.withProgramming_bad_monotone (so := so) (policy := policy) t cache z hz
 
-omit [spec.Fintype] [spec.Inhabited] in
+omit [IsUniformSpec spec] in
 private lemma withCachingTrackingPolicy_mono_pair
     (so : QueryImpl spec (OracleComp spec)) (policy : ProgrammingPolicy spec)
     (t : spec.Domain) (p : spec.QueryCache × Bool) (hp : p.2 = true)

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -48,7 +48,7 @@ namespace OracleComp.ProgramLogic.Relational
 
 variable {ι₁ : Type u} {ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β γ δ : Type}
 
 /-! ## Helpers for coupling mass -/
@@ -99,11 +99,10 @@ lemma spmf_bind_bind_const_of_no_failure {α' β' γ' : Type w}
     _ = r := spmf_bind_const_of_no_failure hp r
 
 lemma probFailure_evalDist_eq_zero
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α : Type u} (mx : m α) :
-    Pr[⊥ | 𝒟[mx]] = 0 := by
-  change (𝒟[evalDist mx]).run none = 0
-  simp [HasEvalPMF.evalDist_of_hasEvalPMF_def]
+    Pr[⊥ | 𝒟[mx]] = 0 :=
+  probFailure_eq_zero (mx := mx)
 
 private lemma nonempty_spmf_coupling
     {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β} :
@@ -296,15 +295,15 @@ lemma mapKernelWithFallback_eq_pure_of {α β γ : Type*}
 end PMF
 
 theorem ofReal_tvDist_map_private_right_bad_le
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α β γ : Type u}
     (oa : m α) (ob : m β)
     (pub : α → β) (fa : α → γ) (fb : β → γ) (bad : β → Prop)
     (h_eq : ∀ a b, pub a = b → ¬ bad b → fa a = fb b) :
     ENNReal.ofReal (tvDist (fa <$> oa) (fb <$> ob))
       ≤ ENNReal.ofReal (tvDist (pub <$> oa) ob) + Pr[bad | ob] := by
-  let p : PMF α := HasEvalPMF.toPMF oa
-  let q : PMF β := HasEvalPMF.toPMF ob
+  let p : PMF α := liftM oa
+  let q : PMF β := liftM ob
   let K : β → PMF γ := PMF.mapKernelWithFallback p pub fa fb
   have hstep : ∀ b, ¬ bad b → 𝒟[K b] = 𝒟[(pure (fb b) : PMF γ)] := by
     intro b hb
@@ -317,41 +316,47 @@ theorem ofReal_tvDist_map_private_right_bad_le
     PMF.map_bind_mapKernelWithFallback p pub fa fb
   have hq : q.bind (fun b => (pure (fb b) : PMF γ)) = PMF.map fb q := by
     simpa [Function.comp_def] using (PMF.bind_pure_comp fb q)
-  have hp_pub : HasEvalPMF.toPMF (pub <$> oa) = PMF.map pub p := by
-    change HasEvalPMF.toPMF (pub <$> oa) = pub <$> p
+  have hp_pub : (liftM (pub <$> oa) : PMF β) = PMF.map pub p := by
+    change (liftM (pub <$> oa) : PMF β) = pub <$> p
     simpa only [p] using
-      (MonadHom.mmap_map (F := HasEvalPMF.toPMF) (x := oa) (g := pub))
-  have hp_fa : HasEvalPMF.toPMF (fa <$> oa) = PMF.map fa p := by
-    change HasEvalPMF.toPMF (fa <$> oa) = fa <$> p
+      (MonadHom.mmap_map (F := MonadHom.ofLift _ PMF) (x := oa) (g := pub))
+  have hp_fa : (liftM (fa <$> oa) : PMF γ) = PMF.map fa p := by
+    change (liftM (fa <$> oa) : PMF γ) = fa <$> p
     simpa only [p] using
-      (MonadHom.mmap_map (F := HasEvalPMF.toPMF) (x := oa) (g := fa))
-  have hq_fb : HasEvalPMF.toPMF (fb <$> ob) = PMF.map fb q := by
-    change HasEvalPMF.toPMF (fb <$> ob) = fb <$> q
+      (MonadHom.mmap_map (F := MonadHom.ofLift _ PMF) (x := oa) (g := fa))
+  have hq_fb : (liftM (fb <$> ob) : PMF γ) = PMF.map fb q := by
+    change (liftM (fb <$> ob) : PMF γ) = fb <$> q
     simpa only [q] using
-      (MonadHom.mmap_map (F := HasEvalPMF.toPMF) (x := ob) (g := fb))
+      (MonadHom.mmap_map (F := MonadHom.ofLift _ PMF) (x := ob) (g := fb))
   have hleft :
       tvDist (fa <$> oa) (fb <$> ob) =
         tvDist ((PMF.map pub p).bind K) (q.bind fun b => (pure (fb b) : PMF γ)) := by
     unfold tvDist
-    rw [HasEvalPMF.evalDist_of_hasEvalPMF_def (fa <$> oa),
-      HasEvalPMF.evalDist_of_hasEvalPMF_def (fb <$> ob),
+    rw [evalDist_def (fa <$> oa),
+      evalDist_def (fb <$> ob),
       PMF.evalDist_eq ((PMF.map pub p).bind K),
       PMF.evalDist_eq (q.bind fun b => (pure (fb b) : PMF γ))]
-    rw [hp_fa, hq_fb, hK, hq]
+    rw [show (liftM (fa <$> oa) : SPMF γ) = liftM ((liftM (fa <$> oa) : PMF γ)) from rfl,
+      show (liftM (fb <$> ob) : SPMF γ) = liftM ((liftM (fb <$> ob) : PMF γ)) from rfl,
+      hp_fa, hq_fb, hK, hq]
   have hbase :
       tvDist (pub <$> oa) ob = tvDist (PMF.map pub p) q := by
     unfold tvDist
-    rw [HasEvalPMF.evalDist_of_hasEvalPMF_def (pub <$> oa),
-      HasEvalPMF.evalDist_of_hasEvalPMF_def ob,
+    rw [evalDist_def (pub <$> oa),
+      evalDist_def ob,
       PMF.evalDist_eq (PMF.map pub p),
       PMF.evalDist_eq q]
-    rw [hp_pub]
+    rw [show (liftM (pub <$> oa) : SPMF β) = liftM ((liftM (pub <$> oa) : PMF β)) from rfl,
+      show (liftM ob : SPMF β) = liftM ((liftM ob : PMF β)) from rfl,
+      hp_pub]
   have hbad : Pr[bad | ob] = Pr[bad | q] := by
-    simp [probEvent_def, HasEvalPMF.evalDist_of_hasEvalPMF_def, PMF.evalDist_eq, q]
+    change Pr[bad | ob] = Pr[bad | (liftM ob : PMF β)]
+    rfl
   simpa [hleft, hbase, hbad] using h
 
 theorem ofReal_tvDist_bind_left_le_const
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
     {α β : Type u}
     (mx : m α) (f g : α → m β) (ε : ℝ≥0∞)
     (hfg : ∀ a, a ∈ support mx → ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε) :
@@ -363,7 +368,7 @@ theorem ofReal_tvDist_bind_left_le_const
   · have hfg_real : ∀ a, a ∈ support mx → tvDist (f a) (g a) ≤ ε.toReal := fun a ha =>
       (ENNReal.ofReal_le_iff_le_toReal htop).mp (hfg a ha)
     have hp_sum_ne_top : (∑' a : α, Pr[= a | mx]) ≠ ⊤ := by
-      rw [HasEvalPMF.tsum_probOutput_eq_one]
+      rw [tsum_probOutput_of_liftM_PMF]
       exact one_ne_top
     have hp_summable : Summable (fun a : α => Pr[= a | mx].toReal) :=
       ENNReal.summable_toReal hp_sum_ne_top
@@ -371,7 +376,7 @@ theorem ofReal_tvDist_bind_left_le_const
       ne_top_of_le_ne_top one_ne_top (probOutput_le_one (mx := mx) (x := a))
     have hp_sum_toReal : (∑' a : α, Pr[= a | mx].toReal) = 1 := by
       rw [← ENNReal.tsum_toReal_eq hprob_ne_top,
-        HasEvalPMF.tsum_probOutput_eq_one, ENNReal.toReal_one]
+        tsum_probOutput_of_liftM_PMF, ENNReal.toReal_one]
     have hlhs_nonneg : ∀ a : α, 0 ≤ Pr[= a | mx].toReal * tvDist (f a) (g a) :=
       fun _ => mul_nonneg ENNReal.toReal_nonneg (tvDist_nonneg _ _)
     have hlhs_le_p : ∀ a : α,
@@ -403,7 +408,8 @@ theorem ofReal_tvDist_bind_left_le_const
     exact (ENNReal.ofReal_le_iff_le_toReal htop).mpr hreal
 
 theorem ofReal_tvDist_bind_left_le_const'
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
     {α β : Type u}
     (mx : m α) (f g : α → m β) (ε : ℝ≥0∞)
     (hfg : ∀ a, ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε) :
@@ -411,7 +417,7 @@ theorem ofReal_tvDist_bind_left_le_const'
   ofReal_tvDist_bind_left_le_const mx f g ε fun a _ => hfg a
 
 theorem evalDist_bind_ignore
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α β γ : Type u}
     (mx : m α) (noise : α → m β) (f : α → γ) :
     𝒟[mx >>= fun a => noise a >>= fun _ => pure (f a)] =
@@ -421,15 +427,15 @@ theorem evalDist_bind_ignore
   funext a
   rw [evalDist_bind, evalDist_pure]
   exact spmf_bind_const_of_no_failure
-    (HasEvalPMF.probFailure_eq_zero (noise a)) (pure (f a) : SPMF γ)
+    (probFailure_of_liftM_PMF (noise a)) (pure (f a) : SPMF γ)
 
 theorem evalDist_bind_const_of_no_failure
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α β : Type u}
     (mx : m α) (my : m β) :
     𝒟[mx >>= fun _ => my] = 𝒟[my] := by
   rw [evalDist_bind]
-  exact spmf_bind_const_of_no_failure (HasEvalPMF.probFailure_eq_zero mx) (𝒟[my])
+  exact spmf_bind_const_of_no_failure (probFailure_of_liftM_PMF mx) (𝒟[my])
 
 namespace SPMF
 
@@ -457,7 +463,7 @@ noncomputable def liftLeftMapCoupling
     (c : SPMF.Coupling (𝒟[f <$> oa]) (𝒟[ob])) : SPMF (α × β) :=
   c.1 >>= fun z =>
     (fun a => (a, z.2)) <$>
-      (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f z.1) : SPMF α)
+      (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f z.1) : SPMF α)
 
 theorem liftLeftMapCoupling_isCoupling
     {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
@@ -469,44 +475,45 @@ theorem liftLeftMapCoupling_isCoupling
     calc
       Prod.fst <$> (c.1 >>= fun z =>
           (fun a => (a, z.2)) <$>
-            (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f z.1) : SPMF α))
+            (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f z.1) : SPMF α))
           = c.1 >>= fun z =>
-              (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f z.1) : SPMF α) := by
+              (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f z.1) : SPMF α) := by
             simp only [map_bind, Functor.map_map]
             conv_lhs =>
               arg 2
               intro z
               change id <$>
-                (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f z.1) : SPMF α)
+                (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f z.1) : SPMF α)
               rw [LawfulFunctor.id_map]
       _ = (Prod.fst <$> c.1) >>= fun b =>
-            (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f b) : SPMF α) := by
+            (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f b) : SPMF α) := by
             rw [bind_map_left]
       _ = 𝒟[f <$> oa] >>= fun b =>
-            (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f b) : SPMF α) := by
+            (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f b) : SPMF α) := by
             rw [c.2.map_fst]
       _ = 𝒟[oa] := by
-            rw [HasEvalPMF.evalDist_of_hasEvalPMF_def (f <$> oa)]
-            rw [HasEvalPMF.evalDist_of_hasEvalPMF_def oa]
-            have hmap : HasEvalPMF.toPMF (f <$> oa) =
-                (f <$> HasEvalPMF.toPMF oa) := by
-              simp only [← MonadHom.mmap_map]
+            rw [evalDist_def (f <$> oa)]
+            rw [evalDist_def oa]
+            have hmap : (liftM (f <$> oa) : PMF β) =
+                (f <$> (liftM oa : PMF α)) :=
+              MonadHom.mmap_map (F := MonadHom.ofLift _ PMF) (x := oa) (g := f)
+            rw [show (liftM (f <$> oa) : SPMF β) = liftM ((liftM (f <$> oa) : PMF β)) from rfl]
             rw [hmap]
-            change ((liftM (PMF.map f (HasEvalPMF.toPMF oa)) : SPMF β) >>= fun b =>
-                (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f b) : SPMF α)) =
-              liftM (HasEvalPMF.toPMF oa)
+            change ((liftM (PMF.map f (MonadHom.ofLift _ PMF oa)) : SPMF β) >>= fun b =>
+                (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f b) : SPMF α)) =
+              liftM (MonadHom.ofLift _ PMF oa)
             rw [SPMF.bind_liftM]
             rw [PMF.map_bind_condOnMap]
   · unfold liftLeftMapCoupling
     calc
       Prod.snd <$> (c.1 >>= fun z =>
           (fun a => (a, z.2)) <$>
-            (liftM (PMF.condOnMap (HasEvalPMF.toPMF oa) f z.1) : SPMF α))
+            (liftM (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f z.1) : SPMF α))
           = c.1 >>= fun z => (pure z.2 : SPMF β) := by
             simp only [map_bind, Functor.map_map]
             refine bind_congr fun z => ?_
             exact SPMF.map_const_liftM
-              (PMF.condOnMap (HasEvalPMF.toPMF oa) f z.1) z.2
+              (PMF.condOnMap (MonadHom.ofLift _ PMF oa) f z.1) z.2
       _ = Prod.snd <$> c.1 := by
             rfl
       _ = 𝒟[ob] := c.2.map_snd
@@ -562,8 +569,8 @@ theorem relTriple'_iff_couplingPost
       letI : DecidableEq B := Classical.decEq B
       letI : Fintype A := inferInstance
       letI : Fintype B := inferInstance
-      have hA_nonempty : (finSupport oa).Nonempty := HasEvalPMF.finSupport_nonempty oa
-      have hB_nonempty : (finSupport ob).Nonempty := HasEvalPMF.finSupport_nonempty ob
+      have hA_nonempty : (finSupport oa).Nonempty := finSupport_nonempty_of_liftM_PMF oa
+      have hB_nonempty : (finSupport ob).Nonempty := finSupport_nonempty_of_liftM_PMF ob
       let a₀ : A := ⟨hA_nonempty.choose, hA_nonempty.choose_spec⟩
       let b₀ : B := ⟨hB_nonempty.choose, hB_nonempty.choose_spec⟩
       let packA : α → A := fun a => if ha : a ∈ finSupport oa then ⟨a, ha⟩ else a₀
@@ -1182,8 +1189,8 @@ private lemma tsum_min_le_eRelWP
   set rP := fun a => P a - min (P a) (Q a)
   set rQ := fun a => Q a - min (Q a) (P a)
   set δ := ∑' a, rP a
-  have hP_sum : ∑' a, P a = 1 := HasEvalPMF.tsum_probOutput_eq_one oa
-  have hQ_sum : ∑' a, Q a = 1 := HasEvalPMF.tsum_probOutput_eq_one ob
+  have hP_sum : ∑' a, P a = 1 := tsum_probOutput_of_liftM_PMF oa
+  have hQ_sum : ∑' a, Q a = 1 := tsum_probOutput_of_liftM_PMF ob
   have hδ_ne_top : δ ≠ ⊤ :=
     ne_top_of_le_ne_top one_ne_top (hP_sum ▸ ENNReal.tsum_le_tsum fun a => tsub_le_self)
   have hδ_eq_rQ : ∑' a, rQ a = δ := by

--- a/VCVio/ProgramLogic/Relational/QuantitativeDefs.lean
+++ b/VCVio/ProgramLogic/Relational/QuantitativeDefs.lean
@@ -22,7 +22,7 @@ namespace OracleComp.ProgramLogic.Relational
 
 variable {ι₁ : Type u} {ι₂ : Type u}
 variable {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+variable [IsUniformSpec spec₁] [IsUniformSpec spec₂]
 variable {α β : Type}
 
 /-- eRHL-style quantitative relational WP for `OracleComp`.

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -2263,10 +2263,8 @@ section HeterogeneousBadSlack
 
 variable {ι : Type} {spec : OracleSpec ι}
 variable {ι₁ ι₂ : Type} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-variable [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
 variable {σ₁ σ₂ : Type}
 
-omit [spec₁.Fintype] [spec₁.Inhabited] in
 /-- Bad propagation for a general (non-flag) bad predicate: starting the simulation from a
 bad state, every output state stays bad. The heterogeneous-state analogue of
 `mem_support_simulateQ_run_of_bad`. -/
@@ -2293,7 +2291,7 @@ private lemma mem_support_simulateQ_run_of_bad_general
 
 /-- A simulation started from a bad state has bad probability exactly `1`. The
 heterogeneous-state analogue of `probEvent_simulateQ_run_bad_eq_one_of_bad`. -/
-private lemma probEvent_bad_simulateQ_run_eq_one_of_bad
+private lemma probEvent_bad_simulateQ_run_eq_one_of_bad [IsUniformSpec spec₁]
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (bad : σ₁ → Prop)
     (hmono : ∀ (t : spec.Domain) (s₁ : σ₁), bad s₁ →
@@ -2308,6 +2306,7 @@ private lemma probEvent_bad_simulateQ_run_eq_one_of_bad
 /-- Inductive core of `probOutput_simulateQ_run'_le_add_bad_add_slack`, stated on the
 joint `run` distribution with the event `fun z => z.1 = true`. -/
 private theorem probEvent_fst_simulateQ_run_le_add_bad_add_slack
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
     (R : σ₁ → σ₂ → Prop)
@@ -2418,6 +2417,7 @@ the obligation a concrete cross-domain reduction must discharge for its oracle p
 Only `impl₁` requires bad monotonicity (`hmono`), since the bound is one-directional and
 mentions `Pr[bad]` only on side `1`. -/
 theorem probOutput_simulateQ_run'_le_add_bad_add_slack
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
     (R : σ₁ → σ₂ → Prop)

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -46,7 +46,7 @@ then the full simulation also preserves the invariant and output equality. -/
 theorem relTriple_simulateQ_run
     {ι₁ : Type u} {ι₂ : Type u}
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {σ₁ σ₂ : Type}
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
@@ -76,7 +76,7 @@ theorem relTriple_simulateQ_run
 theorem relTriple_simulateQ_run'
     {ι₁ : Type u} {ι₂ : Type u}
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {σ₁ σ₂ : Type}
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
@@ -108,7 +108,7 @@ invariant" into a single theorem. -/
 theorem relTriple_simulateQ_run'_of_impl_evalDist_eq
     {ι₁ : Type u} {ι₂ : Type u}
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {σ : Type}
     (impl₁ : QueryImpl spec (StateT σ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ (OracleComp spec₂)))
@@ -140,7 +140,7 @@ requirement for whole-program accumulation. -/
 theorem relTriple_simulateQ_run_writerT
     {ι₁ : Type u} {ι₂ : Type u}
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ω₁ ω₂ : Type} [Monoid ω₁] [Monoid ω₂]
     (impl₁ : QueryImpl spec (WriterT ω₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (WriterT ω₂ (OracleComp spec₂)))
@@ -187,7 +187,7 @@ hypothesis is a plain equality rather than an invariant-gated
 implication. The postcondition is strict equality on `α × ω`. -/
 theorem relTriple_simulateQ_run_writerT_of_impl_eq
     {ι₁ : Type u}
-    {spec₁ : OracleSpec ι₁} [spec₁.Fintype] [spec₁.Inhabited]
+    {spec₁ : OracleSpec ι₁} [IsUniformSpec spec₁]
     {ω : Type} [Monoid ω]
     (impl₁ impl₂ : QueryImpl spec (WriterT ω (OracleComp spec₁)))
     (himpl_eq : ∀ (t : spec.Domain), (impl₁ t).run = (impl₂ t).run)
@@ -228,7 +228,7 @@ pointwise-equal `.run` yield identical `(output, accumulator)` probability
 distributions. -/
 theorem probOutput_simulateQ_run_writerT_eq_of_impl_eq
     {ι₁ : Type u}
-    {spec₁ : OracleSpec ι₁} [spec₁.Fintype] [spec₁.Inhabited]
+    {spec₁ : OracleSpec ι₁} [IsUniformSpec spec₁]
     {ω : Type} [Monoid ω]
     (impl₁ impl₂ : QueryImpl spec (WriterT ω (OracleComp spec₁)))
     (himpl_eq : ∀ (t : spec.Domain), (impl₁ t).run = (impl₂ t).run)
@@ -242,7 +242,7 @@ theorem probOutput_simulateQ_run_writerT_eq_of_impl_eq
 `relTriple_simulateQ_run_writerT_of_impl_eq`. -/
 theorem evalDist_simulateQ_run_writerT_eq_of_impl_eq
     {ι₁ : Type u}
-    {spec₁ : OracleSpec ι₁} [spec₁.Fintype] [spec₁.Inhabited]
+    {spec₁ : OracleSpec ι₁} [IsUniformSpec spec₁]
     {ω : Type} [Monoid ω]
     (impl₁ impl₂ : QueryImpl spec (WriterT ω (OracleComp spec₁)))
     (himpl_eq : ∀ (t : spec.Domain), (impl₁ t).run = (impl₂ t).run)
@@ -256,7 +256,7 @@ theorem evalDist_simulateQ_run_writerT_eq_of_impl_eq
 theorem relTriple_simulateQ_run_writerT'
     {ι₁ : Type u} {ι₂ : Type u}
     {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    [spec₁.Fintype] [spec₁.Inhabited] [spec₂.Fintype] [spec₂.Inhabited]
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
     {ω₁ ω₂ : Type} [Monoid ω₁] [Monoid ω₂]
     (impl₁ : QueryImpl spec (WriterT ω₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (WriterT ω₂ (OracleComp spec₂)))
@@ -432,10 +432,10 @@ theorem relTriple_simulateQ_run'_of_query_map_eq
 
 /-! ## "Identical until bad" fundamental lemma -/
 
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 
 private lemma probOutput_simulateQ_run_eq_zero_of_bad
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl : QueryImpl spec (StateT σ (OracleComp spec)))
     (bad : σ → Prop)
     (h_mono : ∀ (t : spec.Domain) (s : σ), bad s →
@@ -460,7 +460,7 @@ private lemma probOutput_simulateQ_run_eq_zero_of_bad
     exact ih u s' (h_mono t s₀ h_bad (u, s') h_mem)
 
 private lemma probOutput_simulateQ_run_eq_of_not_bad
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec))) (bad : σ → Prop)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →
       (impl₁ t).run s = (impl₂ t).run s)
@@ -487,7 +487,7 @@ private lemma probOutput_simulateQ_run_eq_of_not_bad
       exact tsum_congr (fun ⟨u, s'⟩ => by congr 1; exact ih u s')
 
 private lemma probEvent_not_bad_eq
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
     (bad : σ → Prop)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →
@@ -508,7 +508,7 @@ private lemma probEvent_not_bad_eq
       a s h
 
 private lemma probEvent_bad_eq
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
     (bad : σ → Prop)
     (h_agree : ∀ (t : spec.Domain) (s : σ), ¬bad s →
@@ -595,7 +595,7 @@ output probabilities. -/
 
 open scoped Classical in
 private lemma probOutput_simulateQ_run_eq_of_not_bad_dist
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
     (bad : σ → Prop)
     (h_agree_dist : ∀ (t : spec.Domain) (s : σ), ¬bad s →
@@ -635,7 +635,7 @@ private lemma probOutput_simulateQ_run_eq_of_not_bad_dist
 
 open scoped Classical in
 private lemma probEvent_not_bad_eq_dist
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
     (bad : σ → Prop)
     (h_agree_dist : ∀ (t : spec.Domain) (s : σ), ¬bad s →
@@ -656,7 +656,7 @@ private lemma probEvent_not_bad_eq_dist
 
 open scoped Classical in
 private lemma probEvent_bad_eq_dist
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec)))
     (bad : σ → Prop)
     (h_agree_dist : ∀ (t : spec.Domain) (s : σ), ¬bad s →
@@ -737,7 +737,7 @@ steps) and the `programming_collision_bound` argument that builds on it. -/
 
 open scoped Classical in
 private lemma probOutput_simulateQ_run_eq_of_not_output_bad
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
     (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
       Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
@@ -772,7 +772,7 @@ private lemma probOutput_simulateQ_run_eq_of_not_output_bad
 
 open scoped Classical in
 private lemma probEvent_output_bad_eq
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
     (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
       Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
@@ -823,7 +823,7 @@ from non-bad input states. They may disagree arbitrarily on the very step that f
 Both implementations must satisfy bad-input monotonicity: once `b = true` in the input state of
 a step, every reachable output also has `b = true`. -/
 theorem tvDist_simulateQ_le_probEvent_output_bad
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
     (oa : OracleComp spec α) (s₀ : σ)
     (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
@@ -870,7 +870,7 @@ This is the exact shape consumed by the `QueryImpl.withProgramming` collision-bo
 the impls agree on `(s, false)` input *modulo* the rare programming-fired step, and the bound
 is the probability of any policy hit during the run. -/
 theorem identical_until_bad_with_flag
-    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [spec.Fintype] [spec.Inhabited]
+    {σ : Type} {ι : Type u} {spec : OracleSpec ι} [IsUniformSpec spec]
     (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec)))
     (oa : OracleComp spec α) (s₀ : σ)
     (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
@@ -903,10 +903,10 @@ entries). The total reduction loss is `qS·ε + Pr[collision]`. -/
 section IdenticalUntilBadEpsilon
 
 variable {ι : Type} {spec : OracleSpec ι}
-variable {ι' : Type} {spec' : OracleSpec ι'} [spec'.Fintype] [spec'.Inhabited]
+variable {ι' : Type} {spec' : OracleSpec ι'} [IsUniformSpec spec']
 variable {α : Type} {σ : Type}
 
-omit [spec'.Fintype] [spec'.Inhabited] in
+omit [IsUniformSpec spec'] in
 /-- "Bad propagation": starting from a bad state, every output of the simulation has the
 bad flag set. This generalizes the per-step `h_mono` hypothesis to the full simulation. -/
 private lemma mem_support_simulateQ_run_of_bad
@@ -931,7 +931,8 @@ private lemma mem_support_simulateQ_run_of_bad
       exact ih u p' hp' z h_z
 
 /-- Under bad-monotonicity, a simulation started from a bad state has bad output probability
-exactly `1` (using `OracleComp.HasEvalPMF` to ensure no failure mass). -/
+exactly `1` (using the canonical `MonadLiftT (OracleComp spec) PMF` to ensure no failure
+mass). -/
 private lemma probEvent_simulateQ_run_bad_eq_one_of_bad
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (h_mono : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
@@ -1019,7 +1020,7 @@ private theorem tsum_probOutput_mul_tvDist_le_const_plus_probEvent_bad
         (ENNReal.tsum_toReal_eq fun z => by
           have h := probOutput_le_one (mx := mx) (x := z)
           exact ne_top_of_le_ne_top one_ne_top h).symm]
-      rw [HasEvalPMF.tsum_probOutput_eq_one]
+      rw [tsum_probOutput_of_liftM_PMF]
       simp
     rw [h_one, one_mul]
   have h_second_sum :
@@ -1230,7 +1231,7 @@ give `(qS + qH) · ε`, but for tight bounds we want `q · ε`. -/
 section IdenticalUntilBadEpsilonSelective
 
 variable {ι : Type} {spec : OracleSpec ι}
-variable {ι' : Type} {spec' : OracleSpec ι'} [spec'.Fintype] [spec'.Inhabited]
+variable {ι' : Type} {spec' : OracleSpec ι'} [IsUniformSpec spec']
 variable {α : Type} {σ : Type}
 
 /-- The `query_bind` step for a "free" query (impls pointwise equal on the no-bad branch).
@@ -1438,7 +1439,7 @@ bridge lemma is stated in `ℝ≥0∞` via `ENNReal.ofReal (tvDist …)`. -/
 section IdenticalUntilBadEpsilonStateDep
 
 variable {ι : Type} {spec : OracleSpec ι}
-variable {ι' : Type} {spec' : OracleSpec ι'} [spec'.Fintype] [spec'.Inhabited]
+variable {ι' : Type} {spec' : OracleSpec ι'} [IsUniformSpec spec']
 variable {α : Type} {σ : Type}
 
 /-- Per-`query_bind` step of `expectedQuerySlack`. Given the impl, the charged-query

--- a/VCVio/ProgramLogic/SeededFork.lean
+++ b/VCVio/ProgramLogic/SeededFork.lean
@@ -25,7 +25,7 @@ variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
 
 variable (main : OracleComp spec α) (qb : ι → ℕ)
     (js : List ι) (i : ι) (cf : α → Option (Fin (qb i + 1)))
-    [spec.Fintype] [spec.Inhabited] [unifSpec ˡ⊂ₒ spec]
+    [IsUniformSpec spec] [unifSpec ˡ⊂ₒ spec]
 
 /-- Seeded forking lemma as a quantitative Hoare triple for the fork-success event. -/
 theorem triple_seededFork :

--- a/VCVio/ProgramLogic/Tactics/Common/Backward.lean
+++ b/VCVio/ProgramLogic/Tactics/Common/Backward.lean
@@ -241,21 +241,21 @@ private def mkUnaryPostLERfl (post postTy : Expr) : MetaM Expr := do
     let h ← mkAppOptM ``le_rfl #[none, none, some lhs]
     mkLambdaFVars #[a] h
 
-private def oracleSpecInstancesFrom (xs : Array Expr) : MetaM (Option Expr × Option Expr) := do
-  let mut fintype? := none
-  let mut inhabited? := none
+/-- Scan the theorem's binder mvars `xs` for an `IsUniformSpec ?spec` instance
+binder and return it, so `mkAppOptM` can forward the unresolved mvar into
+`triple_conseq`'s instance slot instead of trying to synthesize it eagerly
+(which fails while `?spec` is still a free metavariable). -/
+private def isUniformSpecInstanceFrom (xs : Array Expr) : MetaM (Option Expr) := do
   for x in xs do
     let ty ← whnfR (← inferType x)
-    if ty.getAppFn.isConstOf ``OracleSpec.Fintype then
-      fintype? := some x
-    else if ty.getAppFn.isConstOf ``OracleSpec.Inhabited then
-      inhabited? := some x
-  return (fintype?, inhabited?)
+    if ty.getAppFn.isConstOf ``OracleSpec.IsUniformSpec then
+      return some x
+  return none
 
-private def mkTripleConseqApp (fintype? inhabited? : Option Expr)
+private def mkTripleConseqApp (uniform? : Option Expr)
     (pre preAbstract prog postSpec postAbstract hpre hpost specProof : Expr) : MetaM Expr :=
   mkAppOptM ``OracleComp.ProgramLogic.triple_conseq
-    #[none, none, fintype?, inhabited?, none, some pre, some preAbstract, some prog,
+    #[none, none, uniform?, none, some pre, some preAbstract, some prog,
       some postSpec, some postAbstract, some hpre, some hpost, some specProof]
 
 /-- Generalize a folded unary `Triple pre prog post` proof into a reusable
@@ -264,7 +264,7 @@ backward-rule source by abstracting concrete `post` and always abstracting
 private def mkUnaryTripleBackwardProof (proofArgs : Array Expr)
     (pre _prog postSpec specProof : Expr) :
     MetaM Expr := do
-  let (fintype?, inhabited?) ← oracleSpecInstancesFrom proofArgs
+  let uniform? ← isUniformSpecInstanceFrom proofArgs
   let mut postAbstract := postSpec.consumeMData
   unless postAbstract.isMVar do
     let postTy ← inferType postSpec
@@ -275,7 +275,7 @@ private def mkUnaryTripleBackwardProof (proofArgs : Array Expr)
     let preAbstract ← mkFreshExprMVar (userName := `pre) preTy
     let hpreTy ← mkLE preAbstract pre
     let hpre ← mkFreshExprMVar (userName := `vc) hpreTy
-    return (← mkTripleConseqApp fintype? inhabited?
+    return (← mkTripleConseqApp uniform?
       pre preAbstract _prog postSpec postAbstract hpre hpost specProof)
   let preTy ← inferType pre
   let preAbstract ← mkFreshExprMVar (userName := `pre) preTy
@@ -283,7 +283,7 @@ private def mkUnaryTripleBackwardProof (proofArgs : Array Expr)
   let hpre ← mkFreshExprMVar (userName := `vc) hpreTy
   let postTy ← inferType postAbstract
   let hpost ← mkUnaryPostLERfl postAbstract postTy
-  mkTripleConseqApp fintype? inhabited?
+  mkTripleConseqApp uniform?
     pre preAbstract _prog postAbstract postAbstract hpre hpost specProof
 
 /-- Generalize a raw unary `pre ⊑ wp prog post epost` proof into a reusable

--- a/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
+++ b/VCVio/ProgramLogic/Tactics/Unary/Internals.lean
@@ -29,35 +29,35 @@ The equality theorem `wp_pure` remains the canonical rewrite rule.
 This lower-bound form lets raw `wp` goals use the cached `@[vcspec]`
 backward-rule path before falling back to `@[wpStep]`. -/
 theorem wp_pure_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α : Type} (x : α)
+    [IsUniformSpec spec] {α : Type} (x : α)
     (post : α → ENNReal) :
     post x ≤ wp (pure x : OracleComp spec α) post := by
   rw [OracleComp.ProgramLogic.wp_pure]
 
 /-- Cached raw-`wp` structural leaf for functorial map. -/
 theorem wp_map_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α β : Type}
+    [IsUniformSpec spec] {α β : Type}
     (f : α → β) (oa : OracleComp spec α) (post : β → ENNReal) :
     wp oa (post ∘ f) ≤ wp (f <$> oa) post := by
   rw [OracleComp.ProgramLogic.wp_map]
 
 /-- Cached raw-`wp` structural leaf for conditionals. -/
 theorem wp_ite_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α : Type} (c : Prop) [Decidable c]
+    [IsUniformSpec spec] {α : Type} (c : Prop) [Decidable c]
     (oa ob : OracleComp spec α) (post : α → ENNReal) :
     (if c then wp oa post else wp ob post) ≤ wp (if c then oa else ob) post := by
   rw [OracleComp.ProgramLogic.wp_ite]
 
 /-- Cached raw-`wp` structural leaf for dependent conditionals. -/
 theorem wp_dite_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α : Type} (c : Prop) [Decidable c]
+    [IsUniformSpec spec] {α : Type} (c : Prop) [Decidable c]
     (oa : c → OracleComp spec α) (ob : ¬c → OracleComp spec α) (post : α → ENNReal) :
     (if h : c then wp (oa h) post else wp (ob h) post) ≤ wp (dite c oa ob) post := by
   rw [OracleComp.ProgramLogic.wp_dite]
 
 /-- Cached raw-`wp` structural leaf for `replicate (n + 1)`. -/
 theorem wp_replicate_succ_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (n : Nat) (post : List α → ENNReal) :
     wp oa (fun x => wp (oa.replicate n) (fun xs => post (x :: xs))) ≤
       wp (oa.replicate (n + 1)) post := by
@@ -65,7 +65,7 @@ theorem wp_replicate_succ_le_vcspec {ι : Type u} {spec : OracleSpec ι}
 
 /-- Cached raw-`wp` structural leaf for `List.mapM` on `x :: xs`. -/
 theorem wp_list_mapM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α β : Type}
+    [IsUniformSpec spec] {α β : Type}
     (x : α) (xs : List α) (f : α → OracleComp spec β) (post : List β → ENNReal) :
     wp (f x) (fun y => wp (xs.mapM f) (fun ys => post (y :: ys))) ≤
       wp ((x :: xs).mapM f) post := by
@@ -73,7 +73,7 @@ theorem wp_list_mapM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
 
 /-- Cached raw-`wp` structural leaf for `List.foldlM` on `x :: xs`. -/
 theorem wp_list_foldlM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α σ : Type}
+    [IsUniformSpec spec] {α σ : Type}
     (x : α) (xs : List α) (f : σ → α → OracleComp spec σ)
     (init : σ) (post : σ → ENNReal) :
     wp (f init x) (fun s => wp (xs.foldlM f s) post) ≤
@@ -82,7 +82,7 @@ theorem wp_list_foldlM_cons_le_vcspec {ι : Type u} {spec : OracleSpec ι}
 
 /-- Cached raw-`wp` structural leaf for oracle queries. -/
 theorem wp_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec]
+    [IsUniformSpec spec]
     (t : spec.Domain) (post : spec.Range t → ENNReal) :
     (∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ENNReal) * post u) ≤
       wp (query t : OracleComp spec (spec.Range t)) post := by
@@ -90,7 +90,7 @@ theorem wp_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
 
 /-- Cached raw-`wp` structural leaf for `HasQuery.query`. -/
 theorem wp_HasQuery_query_le_vcspec {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec]
+    [IsUniformSpec spec]
     (t : spec.Domain) (post : spec.Range t → ENNReal) :
     (∑' u : spec.Range t, (1 / Fintype.card (spec.Range t) : ENNReal) * post u) ≤
       wp (spec := spec) (HasQuery.query t : OracleComp spec (spec.Range t)) post := by
@@ -274,7 +274,7 @@ theorem wp_ReaderT_run_read_layer' {m : Type u → Type v} {Pred EPred : Type u}
   rfl
 
 theorem mAlgOrdered_wp_OptionT_run_StateT_get {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {σ : Type} (s : σ)
+    [IsUniformSpec spec] {σ : Type} (s : σ)
     (post : σ → σ → ENNReal)
     (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
     MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
@@ -286,7 +286,7 @@ theorem mAlgOrdered_wp_OptionT_run_StateT_get {ι : Type u} {spec : OracleSpec �
   rw [MAlgOrdered.wp_pure]
 
 theorem mAlgOrdered_wp_OptionT_run_StateT_set {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {σ : Type} (s s' : σ)
+    [IsUniformSpec spec] {σ : Type} (s s' : σ)
     (post : PUnit → σ → ENNReal) (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
     MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
       (((StateT.set s' : StateT σ (OptionT (OracleComp spec)) PUnit).run s).run)
@@ -297,7 +297,7 @@ theorem mAlgOrdered_wp_OptionT_run_StateT_set {ι : Type u} {spec : OracleSpec �
   rw [MAlgOrdered.wp_pure]
 
 theorem mAlgOrdered_wp_OptionT_run_lift {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {α : Type}
+    [IsUniformSpec spec] {α : Type}
     (oa : OracleComp spec α) (post : α → ENNReal)
     (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
     MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal) (OptionT.lift oa).run
@@ -313,7 +313,7 @@ theorem mAlgOrdered_wp_OptionT_run_lift {ι : Type u} {spec : OracleSpec ι}
   rw [MAlgOrdered.wp_pure]
 
 theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift {ι : Type u}
-    {spec : OracleSpec ι} [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec]
+    {spec : OracleSpec ι} [IsUniformSpec spec]
     {σ α : Type} (oa : OracleComp spec α) (s : σ) (post : α → σ → ENNReal)
     (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
     MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)
@@ -325,7 +325,7 @@ theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift {ι : Type u}
     Std.Do'.EPost.cons.pushOption]
 
 theorem wp_StateT_OptionT_monadLift_lift {ι : Type u} {spec : OracleSpec ι}
-    [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec] {σ α : Type}
+    [IsUniformSpec spec] {σ α : Type}
     (oa : OracleComp spec α) (post : α → σ → ENNReal)
     (epost : Std.Do'.EPost.cons ENNReal Std.Do'.EPost.nil) :
     Std.Do'.wp
@@ -342,7 +342,7 @@ theorem wp_StateT_OptionT_monadLift_lift {ι : Type u} {spec : OracleSpec ι}
   exact mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift (spec := spec) oa s post epost
 
 theorem mAlgOrdered_wp_OptionT_run_StateT_monadLift_lift_map {ι : Type u}
-    {spec : OracleSpec ι} [OracleSpec.Fintype spec] [OracleSpec.Inhabited spec]
+    {spec : OracleSpec ι} [IsUniformSpec spec]
     {σ α β : Type} (oa : OracleComp spec α) (s : σ) (f : α × σ → β)
     (post : β → ENNReal) (nonePost : ENNReal) :
     MAlgOrdered.wp (m := OracleComp spec) (l := ENNReal)

--- a/VCVio/ProgramLogic/Unary/Examples.lean
+++ b/VCVio/ProgramLogic/Unary/Examples.lean
@@ -17,7 +17,7 @@ universe u
 namespace OracleComp.ProgramLogic
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 /-! ## OracleComp-focused API examples -/

--- a/VCVio/ProgramLogic/Unary/HandlerSpecs.lean
+++ b/VCVio/ProgramLogic/Unary/HandlerSpecs.lean
@@ -155,7 +155,7 @@ to a polymorphic universe would require polymorphising the entire
 `wpProp` bridge, which the whole `ProgramLogic.Unary.*` stack is not yet
 set up to support. -/
 variable {ι : Type}
-variable {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+variable {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
 
 /-! ## Generic invariant-preservation for `simulateQ` -/
 

--- a/VCVio/ProgramLogic/Unary/HoareTriple.lean
+++ b/VCVio/ProgramLogic/Unary/HoareTriple.lean
@@ -44,7 +44,7 @@ open scoped OracleSpec.PrimitiveQuery
 namespace OracleComp.ProgramLogic
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β σ : Type}
 
 /-! ## API contract
@@ -222,7 +222,7 @@ theorem wp_eq_tsum (oa : OracleComp spec α) (post : α → ℝ≥0∞) :
 
 @[simp] theorem wp_const (oa : OracleComp spec α) (c : ℝ≥0∞) :
     wp oa (fun _ => c) = c := by
-  rw [wp_eq_tsum, ENNReal.tsum_mul_right, HasEvalPMF.tsum_probOutput_eq_one, one_mul]
+  rw [wp_eq_tsum, ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
 
 @[game_rule] theorem wp_add (oa : OracleComp spec α) (f g : α → ℝ≥0∞) :
     wp oa (fun x => f x + g x) =
@@ -568,10 +568,10 @@ lemma wp_congr_evalDist {oa ob : OracleComp spec α}
   exact μ_congr_evalDist (by simp [h])
 
 lemma μ_cross_congr_evalDist {ι' : Type*} {spec' : OracleSpec ι'}
-    [spec'.Fintype] [spec'.Inhabited]
+    [IsUniformSpec spec']
     {oa : OracleComp spec' ℝ≥0∞} {ob : OracleComp spec ℝ≥0∞}
     (h : 𝒟[oa] = 𝒟[ob]) :
-    @μ _ spec' _ _ oa = μ ob := by
+    @μ _ spec' _ oa = μ ob := by
   simp only [μ]
   exact tsum_congr fun x => by
     change 𝒟[oa] x * x = 𝒟[ob] x * x

--- a/VCVio/ProgramLogic/Unary/Loom/Coherence.lean
+++ b/VCVio/ProgramLogic/Unary/Loom/Coherence.lean
@@ -56,7 +56,7 @@ open ENNReal OracleComp.ProgramLogic OracleComp.ProgramLogic.PropLogic
 namespace OracleComp.Loom.Coherence
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α : Type}
 
 /-! ## Probabilistic ↔ Quantitative
@@ -70,9 +70,9 @@ which then occludes the qualitative tier discussed below. -/
 
 /-! ## Qualitative ↔ Probabilistic (support-vs-expectation bridge)
 
-For an `OracleComp` (which has `HasEvalPMF`, so total probability is
-exactly `1`), the support-based `Prop`-valued `wp` agrees with "the
-probabilistic `wp` on the indicator post equals `1`". -/
+For an `OracleComp` (which has a canonical `MonadLiftT … PMF`, so total
+probability is exactly `1`), the support-based `Prop`-valued `wp` agrees
+with "the probabilistic `wp` on the indicator post equals `1`". -/
 
 /-- Qualitative ↔ Probabilistic coherence: a `Prop`-valued post is
 satisfied almost-surely iff its indicator post has probabilistic `wp`

--- a/VCVio/ProgramLogic/Unary/Loom/Probabilistic.lean
+++ b/VCVio/ProgramLogic/Unary/Loom/Probabilistic.lean
@@ -149,13 +149,13 @@ end Prob
 The probabilistic WP wraps the existing quantitative `MAlgOrdered.wp`
 post-composed with the `Prob` constructor. The `≤ 1` bound is witnessed
 by monotonicity of `MAlgOrdered.wp` against the constant-`1` post,
-which evaluates to `1` on `OracleComp` (since `OracleComp` has
-`HasEvalPMF`, a true probability monad). -/
+which evaluates to `1` on `OracleComp` (since `OracleComp` has a
+canonical `MonadLiftT … PMF` — a true probability monad). -/
 
 namespace OracleComp.Probabilistic
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 /-- The underlying `ℝ≥0∞`-valued WP, packaged for use inside the `Prob`

--- a/VCVio/ProgramLogic/Unary/Loom/Quantitative.lean
+++ b/VCVio/ProgramLogic/Unary/Loom/Quantitative.lean
@@ -77,7 +77,7 @@ universe u v
 namespace OracleComp.ProgramLogic
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 /-! ## Expectation algebra and the `MAlgOrdered` instance -/
@@ -183,7 +183,7 @@ namespace OracleComp.ProgramLogic.Loom
 /-! ## `Std.Do'.WP` instance for `OracleComp` -/
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 /-- Quantitative `Std.Do'.WP` interpretation of `OracleComp spec` valued in `ℝ≥0∞`.
@@ -618,7 +618,7 @@ end Std.Do'
 namespace OracleComp.ProgramLogic.Loom
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 namespace WriterT

--- a/VCVio/ProgramLogic/Unary/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Unary/SimulateQ.lean
@@ -30,7 +30,7 @@ open scoped OracleSpec.PrimitiveQuery
 namespace OracleComp.ProgramLogic
 
 variable {ι : Type*} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α : Type}
 
 
@@ -55,12 +55,12 @@ then `wp` of the simulated computation equals `wp` of the original. -/
 
 /-- Lifting a computation to a larger oracle spec via `liftComp` preserves `wp`. -/
 @[game_rule] theorem wp_liftComp {ι' : Type*} {superSpec : OracleSpec ι'}
-    [superSpec.Fintype] [superSpec.Inhabited]
+    [IsUniformSpec superSpec]
     [h : spec ⊂ₒ superSpec] [spec ˡ⊂ₒ superSpec]
     (mx : OracleComp spec α) (post : α → ℝ≥0∞) :
     wp (liftComp mx superSpec) post =
       wp mx post := by
-  change @μ _ superSpec _ _ (liftComp mx superSpec >>= fun a => pure (post a)) =
+  change @μ _ superSpec _ (liftComp mx superSpec >>= fun a => pure (post a)) =
        μ (mx >>= fun a => pure (post a))
   exact μ_cross_congr_evalDist
     (by simp only [evalDist_bind, evalDist_liftComp, evalDist_pure])

--- a/VCVio/ProgramLogic/Unary/StdDoBridge.lean
+++ b/VCVio/ProgramLogic/Unary/StdDoBridge.lean
@@ -24,7 +24,7 @@ universe u
 namespace OracleComp.ProgramLogic.StdDo
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α β : Type}
 
 /-- Proposition-level bridge from quantitative WP (`= 1` threshold). -/
@@ -54,7 +54,7 @@ theorem wpProp_iff_forall_support (oa : OracleComp spec α) (p : α → Prop) :
     exact (probEvent_eq_one_iff (mx := oa) (p := p)).1 h |>.2
   · intro h
     exact probEvent_eq_one (mx := oa) (p := p)
-      ⟨HasEvalPMF.probFailure_eq_zero oa, h⟩
+      ⟨probFailure_of_liftM_PMF oa, h⟩
 
 /-- `wpProp` rule for `pure`. -/
 theorem wpProp_pure (x : α) (p : α → Prop) :
@@ -117,7 +117,7 @@ handler proof needs to leave `mvcgen` (e.g. to perform a structural induction on
 
 section StatefulBridges
 
-variable {ι : Type} {spec : OracleSpec.{0, 0} ι} [spec.Fintype] [spec.Inhabited]
+variable {ι : Type} {spec : OracleSpec.{0, 0} ι} [IsUniformSpec spec]
 
 /-- Support characterization of `Std.Do.Triple` on `StateT σ (OracleComp spec)`.
 

--- a/VCVio/ProgramLogic/Unary/StdDoExamples.lean
+++ b/VCVio/ProgramLogic/Unary/StdDoExamples.lean
@@ -20,7 +20,7 @@ set_option mvcgen.warning false
 namespace OracleComp.ProgramLogic.StdDo
 
 variable {ι : Type u} {spec : OracleSpec ι}
-variable [spec.Fintype] [spec.Inhabited]
+variable [IsUniformSpec spec]
 variable {α : Type}
 
 example (x : α) :

--- a/VCVio/StateSeparating/CellRef.lean
+++ b/VCVio/StateSeparating/CellRef.lean
@@ -122,24 +122,28 @@ theorem writeM_run [DecidableEq Ident] (r : CellRef Ident) (x : r.Value)
 support-reachable final heap has the same value at that reference as the
 initial heap. This is the right generalization of `Preserves` beyond `Id`:
 for probabilistic/oracle computations there may be many possible final states. -/
-def SupportPreserves {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+def SupportPreserves {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (c : StateT (Heap Ident) m α) (r : CellRef Ident) : Prop :=
   ∀ h z, z ∈ support (c.run h) → r.get z.2 = r.get h
 
 /-- An effectful heap program writes only a set of identifiers when every cell
 outside the set is support-preserved. -/
-def SupportWritesOnly {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+def SupportWritesOnly {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (c : StateT (Heap Ident) m α) (writes : Set Ident) : Prop :=
   ∀ r : CellRef Ident, r.id ∉ writes → SupportPreserves c r
 
-theorem supportWritesOnly_mono {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportWritesOnly_mono {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} {c : StateT (Heap Ident) m α} {writes₁ writes₂ : Set Ident}
     (hc : SupportWritesOnly c writes₁) (hsubset : writes₁ ⊆ writes₂) :
     SupportWritesOnly c writes₂ := by
   intro r hr
   exact hc r (fun hmem => hr (hsubset hmem))
 
-theorem supportPreserves_pure {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportPreserves_pure {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (x : α) (r : CellRef Ident) :
     SupportPreserves (pure x : StateT (Heap Ident) m α) r := by
   intro h z hz
@@ -147,13 +151,15 @@ theorem supportPreserves_pure {m : Type (max u v) → Type*} [Monad m] [HasEvalS
     simpa using (mem_support_pure_iff z (x, h)).1 hz
   simp [hz_eq]
 
-theorem supportWritesOnly_pure_empty {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportWritesOnly_pure_empty {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (x : α) :
     SupportWritesOnly (pure x : StateT (Heap Ident) m α) (∅ : Set Ident) := by
   intro r hr
   exact supportPreserves_pure x r
 
-theorem supportPreserves_readM {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportPreserves_readM {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     (r s : CellRef Ident) :
     SupportPreserves (r.readM : StateT (Heap Ident) m r.Value) s := by
   intro h z hz
@@ -161,13 +167,15 @@ theorem supportPreserves_readM {m : Type (max u v) → Type*} [Monad m] [HasEval
     simpa using (mem_support_pure_iff z (r.get h, h)).1 hz
   simp [hz_eq]
 
-theorem readM_supportWritesOnly_empty {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem readM_supportWritesOnly_empty {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     (r : CellRef Ident) :
     SupportWritesOnly (r.readM : StateT (Heap Ident) m r.Value) (∅ : Set Ident) := by
   intro s hs
   exact supportPreserves_readM r s
 
-theorem supportPreserves_bind {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportPreserves_bind {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α β : Type (max u v)} {c : StateT (Heap Ident) m α}
     {k : α → StateT (Heap Ident) m β} {r : CellRef Ident}
     (hc : SupportPreserves c r) (hk : ∀ a, SupportPreserves (k a) r) :
@@ -180,7 +188,7 @@ theorem supportPreserves_bind {m : Type (max u v) → Type*} [Monad m] [HasEvalS
   exact (hk us.1 us.2 z hzcont).trans (hc h us hus)
 
 theorem writeM_supportWritesOnly_single [DecidableEq Ident]
-    {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+    {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     (r : CellRef Ident) (x : r.Value) :
     SupportWritesOnly
       (r.writeM x : StateT (Heap Ident) m PUnit) ({r.id} : Set Ident) := by
@@ -193,7 +201,8 @@ theorem writeM_supportWritesOnly_single [DecidableEq Ident]
       change s.id = r.id
       exact heq))
 
-theorem supportWritesOnly_bind {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportWritesOnly_bind {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α β : Type (max u v)} {c : StateT (Heap Ident) m α}
     {k : α → StateT (Heap Ident) m β} {writes₁ writes₂ : Set Ident}
     (hc : SupportWritesOnly c writes₁) (hk : ∀ a, SupportWritesOnly (k a) writes₂) :
@@ -204,7 +213,8 @@ theorem supportWritesOnly_bind {m : Type (max u v) → Type*} [Monad m] [HasEval
 
 /-- Dependent effectful bind form: the continuation's write set may depend on
 the first result. -/
-theorem supportWritesOnly_bind_dep {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+theorem supportWritesOnly_bind_dep {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α β : Type (max u v)} {c : StateT (Heap Ident) m α}
     {k : α → StateT (Heap Ident) m β} {writes₁ : Set Ident}
     {writes₂ : α → Set Ident}
@@ -216,7 +226,8 @@ theorem supportWritesOnly_bind_dep {m : Type (max u v) → Type*} [Monad m] [Has
 
 /-- A support-based write footprint packages a program with the set of cells it
 may write and the proof that every other cell is preserved. -/
-structure SupportWriteFootprint {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+structure SupportWriteFootprint {m : Type (max u v)
+    → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (c : StateT (Heap Ident) m α) where
   /-- Cells that the effectful program may write. -/
   writes : Set Ident
@@ -225,7 +236,7 @@ structure SupportWriteFootprint {m : Type (max u v) → Type*} [Monad m] [HasEva
 
 namespace SupportWriteFootprint
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 variable {α β : Type (max u v)}
 
 theorem preserves {c : StateT (Heap Ident) m α} (footprint : SupportWriteFootprint c)
@@ -259,7 +270,8 @@ end SupportWriteFootprint
 
 namespace SupportPreserves
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSPMF m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 variable {α : Type (max u v)} {c : StateT (Heap Ident) m α} {r : CellRef Ident}
 
 /-- A support-level frame implies that the cell-change event has probability
@@ -291,11 +303,13 @@ theorem prob_unchanged_eq_one_of_probFailure_eq_zero (hc : SupportPreserves c r)
 
 /-- If the ambient monad has total probability semantics, support preservation
 gives probability-one preservation directly. -/
-theorem prob_unchanged_eq_one {m : Type (max u v) → Type*} [Monad m] [HasEvalPMF m]
+theorem prob_unchanged_eq_one {m : Type (max u v) → Type*} [Monad m]
+    [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
     {α : Type (max u v)} {c : StateT (Heap Ident) m α} {r : CellRef Ident}
     (hc : SupportPreserves c r) (h : Heap Ident) :
     Pr[ fun z => r.get z.2 = r.get h | c.run h] = 1 :=
-  prob_unchanged_eq_one_of_probFailure_eq_zero hc h (HasEvalPMF.probFailure_eq_zero (c.run h))
+  prob_unchanged_eq_one_of_probFailure_eq_zero hc h (probFailure_of_liftM_PMF (c.run h))
 
 /-- If the initial cell value is not `x`, then a support-preserved cell has
 final value `x` with probability zero. -/
@@ -310,7 +324,8 @@ end SupportPreserves
 
 namespace SupportWritesOnly
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSPMF m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 variable {α : Type (max u v)} {c : StateT (Heap Ident) m α} {writes : Set Ident}
 
 theorem prob_changed_eq_zero (hc : SupportWritesOnly c writes)
@@ -336,7 +351,8 @@ end SupportWritesOnly
 /-- A computation preserves a cell except on an event when every
 support-reachable outcome outside that event has the initial cell value. The
 event may depend on the initial heap. -/
-def SupportPreservesExcept {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+def SupportPreservesExcept {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (c : StateT (Heap Ident) m α) (r : CellRef Ident)
     (event : Heap Ident → α × Heap Ident → Prop) : Prop :=
   ∀ h z, z ∈ support (c.run h) → ¬ event h z → r.get z.2 = r.get h
@@ -345,7 +361,7 @@ namespace SupportPreservesExcept
 
 section support
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 variable {α : Type (max u v)} {c : StateT (Heap Ident) m α} {r : CellRef Ident}
 variable {event : Heap Ident → α × Heap Ident → Prop}
 
@@ -371,7 +387,8 @@ end support
 
 section probability
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSPMF m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 variable {α : Type (max u v)} {c : StateT (Heap Ident) m α} {r : CellRef Ident}
 variable {event : Heap Ident → α × Heap Ident → Prop}
 
@@ -406,7 +423,8 @@ end SupportPreservesExcept
 /-- A support-level relation between the initial and final value of one cell.
 This is the general qualitative layer underneath preservation (`rel := Eq`) and
 monotonicity/growth assertions. -/
-def SupportCellRel {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+def SupportCellRel {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (c : StateT (Heap Ident) m α) (r : CellRef Ident)
     (rel : r.Value → r.Value → Prop) : Prop :=
   ∀ h z, z ∈ support (c.run h) → rel (r.get h) (r.get z.2)
@@ -415,7 +433,7 @@ namespace SupportCellRel
 
 section support
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 variable {α β : Type (max u v)} {c : StateT (Heap Ident) m α}
 variable {k : α → StateT (Heap Ident) m β} {r : CellRef Ident}
 variable {rel : r.Value → r.Value → Prop}
@@ -446,7 +464,8 @@ end support
 
 section probability
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSPMF m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 variable {α : Type (max u v)} {c : StateT (Heap Ident) m α} {r : CellRef Ident}
 variable {rel : r.Value → r.Value → Prop}
 
@@ -465,7 +484,8 @@ end SupportCellRel
 /-- A measured cell bound says a numeric measure of a cell can increase by at
 most `δ` on every support-reachable execution path. Binds compose by adding
 their deltas. -/
-def SupportMeasureBound {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+def SupportMeasureBound {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM]
+    [LawfulMonadLiftT m SetM]
     {α : Type (max u v)} (c : StateT (Heap Ident) m α) (r : CellRef Ident)
     (measure : r.Value → Nat) (δ : Nat) : Prop :=
   ∀ h z, z ∈ support (c.run h) → measure (r.get z.2) ≤ measure (r.get h) + δ
@@ -474,7 +494,7 @@ namespace SupportMeasureBound
 
 section support
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSet m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 variable {α β : Type (max u v)} {c : StateT (Heap Ident) m α}
 variable {k : α → StateT (Heap Ident) m β} {r : CellRef Ident}
 variable {measure : r.Value → Nat}
@@ -506,7 +526,8 @@ end support
 
 section probability
 
-variable {m : Type (max u v) → Type*} [Monad m] [HasEvalSPMF m]
+variable {m : Type (max u v) → Type*} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 variable {α : Type (max u v)} {c : StateT (Heap Ident) m α} {r : CellRef Ident}
 variable {measure : r.Value → Nat} {δ : Nat}
 
@@ -741,7 +762,7 @@ namespace QueryImpl
 
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [HasEvalSet m]
+variable {m : Type (max u₀ v) → Type*} [Monad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- A `QueryImpl` preserves a heap cell when each single query step leaves
 that cell unchanged on every support-reachable post-state. This is the
@@ -797,7 +818,8 @@ namespace OracleComp
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {α : Type (max u₀ v)}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [HasEvalSet m]
+variable {m : Type (max u₀ v)
+    → Type*} [Monad m] [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- If every handler query preserves a cell, then interpreting any
 `OracleComp` through that handler preserves the cell. -/
@@ -842,7 +864,8 @@ section probability
 
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [HasEvalSPMF m]
+variable {m : Type (max u₀ v) → Type*} [Monad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 theorem PreservesCell.prob_changed_eq_zero
     {impl : QueryImpl spec (StateT (Heap Ident₀) m)} {r : CellRef Ident₀}
@@ -885,7 +908,8 @@ section probability
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {α : Type (max u₀ v)}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
+variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 theorem simulateQ_run_cellChange_prob_eq_zero
     (impl : QueryImpl spec (StateT (Heap Ident₀) m))
@@ -922,7 +946,8 @@ section probability_total
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {α : Type (max u₀ v)}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [MonadLiftT m PMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 theorem simulateQ_run_cellUnchanged_prob_eq_one
     (impl : QueryImpl spec (StateT (Heap Ident₀) m))
@@ -930,7 +955,7 @@ theorem simulateQ_run_cellUnchanged_prob_eq_one
     (A : OracleComp spec α) (h : Heap Ident₀) :
     Pr[ fun z => r.get z.2 = r.get h | (simulateQ impl A).run h] = 1 :=
   simulateQ_run_cellUnchanged_prob_eq_one_of_probFailure_eq_zero impl r himpl A h
-    (HasEvalPMF.probFailure_eq_zero ((simulateQ impl A).run h))
+    (probFailure_of_liftM_PMF ((simulateQ impl A).run h))
 
 end probability_total
 
@@ -941,7 +966,8 @@ namespace QueryImpl
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {α : Type (max u₀ v)}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [HasEvalSet m]
+variable {m : Type (max u₀ v)
+    → Type*} [Monad m] [LawfulMonad m] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 
 /-- A query-implementation cell-write footprint lifts through interpretation: if a
 cell is outside every per-query footprint, the interpreted computation
@@ -959,7 +985,8 @@ section probability
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {α : Type (max u₀ v)}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [HasEvalSPMF m]
+variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [MonadLiftT m SPMF]
+    [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
 theorem CellWriteFootprint.simulateQ_run_cellChange_prob_eq_zero
     {impl : QueryImpl spec (StateT (Heap Ident₀) m)}
@@ -997,8 +1024,10 @@ section probability_total
 variable {ι : Type uι} {spec : OracleSpec.{uι, max u₀ v} ι}
 variable {α : Type (max u₀ v)}
 variable {Ident₀ : Type u₀} [CellSpec.{u₀, max u₀ v} Ident₀]
-variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [HasEvalPMF m]
+variable {m : Type (max u₀ v) → Type*} [Monad m] [LawfulMonad m] [MonadLiftT m PMF]
+    [LawfulMonadLiftT m PMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
 
+omit [LawfulMonadLiftT m PMF] in
 theorem CellWriteFootprint.simulateQ_run_cellUnchanged_prob_eq_one
     {impl : QueryImpl spec (StateT (Heap Ident₀) m)}
     (footprint : CellWriteFootprint impl) (r : CellRef Ident₀)
@@ -1130,14 +1159,17 @@ theorem demoClient_supportPreserves_flag :
   intro h z hz
   exact demoClient_preserves_flag h z hz
 
-/-- From the empty heap, the framed flag is never `true`. -/
+/-- From the empty heap, the framed flag is never `true`. The cell's
+`CellSpec.default` value is `false`, so support preservation collapses the event
+to one with no reachable witness. -/
 theorem demoClient_prob_flag_true_eq_zero :
     Pr[ fun z => flagRef.get z.2 = true |
       (simulateQ demoImpl demoClient).run (Heap.empty : Heap DemoCell)] = 0 :=
   CellRef.SupportPreserves.prob_final_eq_eq_zero_of_ne
     demoClient_supportPreserves_flag (Heap.empty : Heap DemoCell) (by decide)
 
-/-- Probability-one preservation for the framed flag. -/
+/-- Probability-one preservation for the framed flag: under the uniform-sampling
+semantics of `ProbComp`, the handler never changes the flag and never aborts. -/
 theorem demoClient_prob_flag_unchanged_eq_one (h : Heap DemoCell) :
     Pr[ fun z => flagRef.get z.2 = flagRef.get h |
       (simulateQ demoImpl demoClient).run h] = 1 :=

--- a/VCVio/StateSeparating/DistEquiv.lean
+++ b/VCVio/StateSeparating/DistEquiv.lean
@@ -24,7 +24,7 @@ variable {ιₑ : Type uₑ} {E : OracleSpec.{uₑ, 0} ιₑ}
 
 /-- Perfect distributional equivalence of two stateful handlers from explicit
 initial states. -/
-def DistEquiv [I.Fintype] [I.Inhabited] {σ₀ σ₁ : Type}
+def DistEquiv [IsUniformSpec I] {σ₀ σ₁ : Type}
     (h₀ : QueryImpl.Stateful I E σ₀) (s₀ : σ₀)
     (h₁ : QueryImpl.Stateful I E σ₁) (s₁ : σ₁) : Prop :=
   ∀ {α : Type} (A : OracleComp E α),
@@ -35,7 +35,7 @@ scoped notation:50 "(" h₀ ", " s₀ ")" " ≡ᵈ " "(" h₁ ", " s₁ ")" =>
   QueryImpl.Stateful.DistEquiv h₀ s₀ h₁ s₁
 
 /-- Perfect distributional equivalence from default initial states. -/
-def DistEquiv₀ [I.Fintype] [I.Inhabited] {σ₀ σ₁ : Type}
+def DistEquiv₀ [IsUniformSpec I] {σ₀ σ₁ : Type}
     [Inhabited σ₀] [Inhabited σ₁]
     (h₀ : QueryImpl.Stateful I E σ₀) (h₁ : QueryImpl.Stateful I E σ₁) : Prop :=
   QueryImpl.Stateful.DistEquiv h₀ default h₁ default
@@ -46,7 +46,7 @@ scoped infix:50 " ≡ᵈ₀ " => QueryImpl.Stateful.DistEquiv₀
 namespace DistEquiv
 
 variable {σ σ₀ σ₁ σ₂ : Type}
-variable [I.Fintype] [I.Inhabited]
+variable [IsUniformSpec I]
 
 private lemma simulateQ_StateT_evalDist_congr_import {α : Type}
     {h₀ h₁ : QueryImpl E (StateT σ (OracleComp I))}
@@ -204,7 +204,7 @@ section ParCongr
 
 variable {ιᵢ₁ : Type uₘ} {ιᵢ₂ : Type uₘ}
   {I₁ : OracleSpec.{uₘ, 0} ιᵢ₁} {I₂ : OracleSpec.{uₘ, 0} ιᵢ₂}
-  [I₁.Fintype] [I₁.Inhabited] [I₂.Fintype] [I₂.Inhabited]
+  [IsUniformSpec I₁] [IsUniformSpec I₂]
   {ιₑ₁ : Type uₑ} {ιₑ₂ : Type uₑ}
   {E₁ : OracleSpec.{uₑ, 0} ιₑ₁} {E₂ : OracleSpec.{uₑ, 0} ιₑ₂}
   {σ₁ σ₂ : Type}

--- a/docs/agents/gotchas.md
+++ b/docs/agents/gotchas.md
@@ -2,13 +2,13 @@
 
 ## Critical (Will Bite You Immediately)
 
-### 1. `[spec.Fintype]` and `[spec.Inhabited]` required for probability
+### 1. Probability semantics require the right spec class
 
-Any file using `evalDist`, `probOutput`, `probEvent`, or `Pr[...]` on `OracleComp spec` needs these instances on the spec. Without them, typeclass resolution silently fails with confusing errors.
+Any file using `evalDist`, `probOutput`, `probEvent`, or `Pr[...]` on `OracleComp spec` needs `[IsProbabilitySpec spec]`. Lemmas that use uniform cardinalities, `PMF.uniformOfFintype`, or connect `support` to nonzero probability need `[IsUniformSpec spec]`. Plain `support` works on arbitrary `OracleComp spec`.
 
-**Symptom**: "failed to synthesize instance" mentioning `Fintype` or `PFunctor.Fintype`.
+**Symptom**: "failed to synthesize instance" mentioning `MonadLiftT (OracleComp spec) SPMF`, `IsProbabilitySpec`, `IsUniformSpec`, or `EvalDistCompatible`.
 
-**Fix**: Add `[spec.Fintype] [spec.Inhabited]` to your variable/hypothesis list.
+**Fix**: Add `[IsProbabilitySpec spec]` for arbitrary per-query probability semantics, or `[IsUniformSpec spec]` for uniform oracle semantics. If you already have `[spec.Fintype] [spec.Inhabited]` and want uniform sampling, install a local instance with `IsUniformSpec.ofFintypeInhabited spec`.
 
 ### 2. `autoImplicit = false` is set globally in `lakefile.lean`
 
@@ -19,7 +19,7 @@ and do not add `set_option autoImplicit false` in individual files.
 
 ### 3. `evalDist` IS `simulateQ`
 
-They share the exact same code path: `evalDist` is `simulateQ` with `m = PMF` and uniform distributions as the oracle implementation. This identity is definitional (`rfl`).
+They share the exact same code path: `evalDist` is `simulateQ` with `m = PMF` and the `IsProbabilitySpec.toPMF` query implementation. Under `[IsUniformSpec spec]`, those query distributions are propositionally the uniform distributions. The `evalDist_eq_simulateQ` identity is definitional (`rfl`).
 
 ### 4. `++ₒ` is dead — use `+`
 

--- a/docs/agents/oracle-comp.md
+++ b/docs/agents/oracle-comp.md
@@ -124,7 +124,7 @@ When lifting `OracleComp spec α` to `OracleComp superSpec α` (e.g., a sub-comp
 | `liftComp_pure` | `liftComp (pure x) superSpec = pure x` |
 | `liftComp_bind` | `liftComp (mx >>= my) superSpec = liftComp mx superSpec >>= ...` |
 
-### Probability lemmas (additionally require `[spec ⊂ₒ superSpec] [LawfulSubSpec spec superSpec]` and `Fintype`/`Inhabited` on both specs)
+### Probability lemmas (additionally require `[spec ⊂ₒ superSpec] [LawfulSubSpec spec superSpec]` and uniform probability specs on both specs)
 
 | Lemma | Signature |
 |-------|-----------|
@@ -237,14 +237,17 @@ These are genuinely custom and stay as hand-written `QueryImpl` definitions. If 
 
 ### evalDist IS simulateQ
 
-`evalDist : OracleComp spec α → PMF α` is *definitionally* (`rfl`) `simulateQ` into `PMF`, with each query interpreted as the uniform distribution over its response type. The `HasEvalPMF` instance at `VCVio/OracleComp/EvalDist.lean:154-156` reads:
+For `OracleComp`, `support` is always available and is *definitionally* `simulateQ` into `SetM`, with each query interpreted by `Set.univ`.
+
+`evalDist : OracleComp spec α → SPMF α` is available under `[IsProbabilitySpec spec]` and is *definitionally* (`rfl`) `simulateQ` into `PMF`, then lifted to `SPMF`, with each query interpreted by `IsProbabilitySpec.toPMF`:
 
 ```lean
-noncomputable instance : HasEvalPMF (OracleComp spec) where
-  toPMF := simulateQ' fun t => PMF.uniformOfFintype (spec.Range t)
+noncomputable instance instMonadLiftTPMF [IsProbabilitySpec spec] :
+    MonadLiftT (OracleComp spec) PMF where
+  monadLift mx := simulateQ IsProbabilitySpec.toPMF mx
 ```
 
-(requires `[spec.Fintype] [spec.Inhabited]`). `support : OracleComp spec α → Set α` has the same shape but target `SetM` with `impl _ := Set.univ`. Both are instances of the same universal fold, not separate primitives.
+Uniform response semantics are supplied by `[IsUniformSpec spec]`, which bundles `[spec.Fintype]`, `[spec.Inhabited]`, `[IsProbabilitySpec spec]`, and a proof that `toPMF` is `PMF.uniformOfFintype`. The bridge from `support` to `SPMF.support 𝒟[...]` is `EvalDistCompatible (OracleComp spec)` and also requires `[IsUniformSpec spec]`.
 
 Distinct from the `PMF`-target `evalDist`, there is also a *syntactic* uniform-sampling handler that rewrites queries into `ProbComp` (i.e. target `OracleComp unifSpec`, not `PMF`):
 

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -118,10 +118,12 @@ Available for: `Bool`, `Fin n` (for `[NeZero n]`), `ZMod n`, `BitVec n`, `α × 
 
 ## Common Mistakes
 
-1. **Missing `[spec.Fintype]` and `[spec.Inhabited]`**: required for all `evalDist`/`probOutput`/`Pr[...]` usage. Check this first when debugging typeclass failures.
+1. **Missing probability spec classes**: on `OracleComp spec`, `evalDist`/`probOutput`/`Pr[...]` require `[IsProbabilitySpec spec]`. Uniform/cardinality lemmas and support-probability lemmas require `[IsUniformSpec spec]`, not just `[spec.Fintype] [spec.Inhabited]`. Use `IsUniformSpec.ofFintypeInhabited spec` when a concrete finite inhabited spec should use uniform sampling.
 
-2. **Using `support` when `finSupport` is needed**: `probOutput_bind_eq_sum_finSupport` requires `[DecidableEq α]` and `[HasEvalFinset m]`.
+2. **Carrying duplicate probability instances**: do not add a separate `[IsProbabilitySpec spec]` when `[IsUniformSpec spec]` is already in scope. `IsUniformSpec` extends `IsProbabilitySpec`; a second instance can make instance search ambiguous and may not describe the same distributions.
 
-3. **Forgetting `probOutput_eq_zero_of_not_mem_support`**: useful when restricting sums.
+3. **Using `support` when `finSupport` is needed**: `probOutput_bind_eq_sum_finSupport` requires `[DecidableEq α]` and `[HasEvalFinset m]`.
 
-4. **`evalDist` on bare `query t`**: works directly when the expected type pins `query t` to a monadic form, since `query` resolves to `HasQuery.query`. Write `evalDist (query t : OracleComp spec _)` (or hand the result to a context that provides the same ascription). If you need the primitive `OracleQuery spec _` (e.g. for `OracleQuery.cont`), use `spec.query t` instead.
+4. **Forgetting `probOutput_eq_zero_of_not_mem_support`**: useful when restricting sums.
+
+5. **`evalDist` on bare `query t`**: works directly when the expected type pins `query t` to a monadic form, since `query` resolves to `HasQuery.query`. Write `evalDist (query t : OracleComp spec _)` (or hand the result to a context that provides the same ascription). If you need the primitive `OracleQuery spec _` (e.g. for `OracleQuery.cont`), use `spec.query t` instead.

--- a/docs/agents/proof-workflows.md
+++ b/docs/agents/proof-workflows.md
@@ -410,8 +410,8 @@ before changing definitions or tactics for eRHL, pRHL, or apRHL.
 ### "typeclass instance problem ... HasQuery spec ?m" or "Monad (OracleQuery spec)"
 After the `HasQuery` cutover, the bare `query t` is `HasQuery.query t` and needs an expected type so Lean can pick the ambient monad. Either ascribe `(query t : OracleComp spec _)`, or use the primitive form `spec.query t : OracleQuery spec _` (e.g. when applying `liftM` or projecting `OracleQuery.cont`).
 
-### "failed to synthesize ... spec.Fintype"
-Add `[spec.Fintype]` and `[spec.Inhabited]` to your hypotheses. These are required for all probability reasoning.
+### "failed to synthesize ... MonadLiftT (OracleComp spec) SPMF"
+For `OracleComp spec`, add `[IsProbabilitySpec spec]` when you need `evalDist` or `Pr[...]`. Add `[IsUniformSpec spec]` when you need uniform/cardinality facts or lemmas relating `support` to nonzero probability. If you have `[spec.Fintype] [spec.Inhabited]` and intend uniform semantics, install a local instance with `IsUniformSpec.ofFintypeInhabited spec`.
 
 ### Universe mismatch around `SubSpec`
 `OracleComp` has 3 universe parameters, `SubSpec` has 6. Use `{ι : Type*}` instead of `{ι : Type u}` to let universes resolve independently.

--- a/docs/agents/query-tracking.md
+++ b/docs/agents/query-tracking.md
@@ -341,7 +341,8 @@ The query-tracking files now try to keep theorem signatures narrow.
 Preferred pattern:
 
 - put only genuinely shared assumptions in section variable blocks
-- localize `HasEvalSet`, `HasEvalSPMF`, `HasEvalPMF`, and `LawfulMonad` to the smallest section or
+- localize `MonadLiftT _ SetM`, `MonadLiftT _ SPMF`, `MonadLiftT _ PMF`,
+  `EvalDistCompatible`, `IsProbabilitySpec`, `IsUniformSpec`, and `LawfulMonad` to the smallest section or
   theorem that needs them
 - if a proof needs extra decidability or classical choice, install it locally with `classical` or
   a local instance


### PR DESCRIPTION
The motivation of this PR is to reduce the requirements needed to use the various definitions and notation in the library, making them more broadly applicable and hopefully leading to proofs that are easier to integrate with other work. Replaces the bespoke `HasEvalSPMF` / `HasEvalPMF` / `HasEvalSet` hierarchy with Lean's standard `MonadLiftT` lifts, plus one propositional bridge class `EvalDistCompatible`. Each probability notion now states exactly the assumption it needs:

| Notion | Notation | New assumption(s) |
|---|---|---|
| `evalDist` | `𝒟[mx]` | `[MonadLiftT m SPMF]` (`evalDist := liftM`) |
| `probOutput` | `Pr[= x \| mx]` | `[MonadLiftT m SPMF]` |
| `probEvent` | `Pr[p \| mx]` | `[MonadLiftT m SPMF]` |
| `probFailure` | `Pr[⊥ \| mx]` | `[MonadLiftT m SPMF]` |
| `support` | `support mx` | `[MonadLiftT m SetM]` alone — no probability structure |
| `finSupport` | `finSupport mx` | custom `[HasEvalFinset m]` (now built on `MonadLiftT m SetM`) |
| **support ↔ prob connection** | `mem_support_iff`, `probOutput_eq_zero_iff`, `probEvent_mono`, `probEvent_eq_one_iff`, `probFailure_eq_one_iff`, … | both lifts **plus** new `[EvalDistCompatible m]` |
| never-fails / total-mass | `probFailure_of_liftM_PMF`, `tsum_probOutput_of_liftM_PMF`, `NeverFail` instance | `[MonadLiftT m PMF]` |
| bind-distributivity | `probOutput_bind_eq_*`, `*_bind_eq_sum_fintype` | additionally `[LawfulMonadLiftT m SPMF]` |

The new `EvalDistCompatible m` (`[MonadLiftT m SetM] [MonadLiftT m SPMF] : Prop`) carries a single field `support_eq_SPMF_support` — `SetM.run (liftM mx) = SPMF.support (liftM mx)` — and is the *only* glue tying the qualitative (`support`) and quantitative (`Pr[…]`) views together.

### `OracleComp spec`

- **`support` is fixed to `OracleComp` via `simulateQ` and needs no `Fintype`/`Inhabited`.** The `MonadLiftT (OracleComp spec) SetM` instance folds queries to `Set.univ` through `simulateQ (r := SetM)`, working for arbitrary specs.
- **`evalDist` / `Pr[…]` require the new `[IsProbabilitySpec spec]`** — a per-query `toPMF (t) : PMF (spec t)`.
- **Uniform-content lemmas and `EvalDistCompatible (OracleComp spec)` require `[IsUniformSpec spec]`** — extends `IsProbabilitySpec` and bundles `spec.Fintype` + `spec.Inhabited` + a witness `toPMF t = PMF.uniformOfFintype (spec.Range t)`. This is the canonical replacement for the old `[spec.Fintype] [spec.Inhabited]` pair (`OracleSpec.IsProbSpec` deprecated → `IsUniformSpec`).

### Why `MonadLiftT` everywhere

All cross-monad lifts are declared `MonadLiftT` (never `MonadLift`) so Lean's `monadLiftTrans` cannot chain `OracleComp → SPMF → SetM`; each monad declares its `MonadLiftT m SetM` directly. This avoids a `support` diamond and instance-resolution stalls on parameterized, typeclass-gated lifts (`OracleComp spec`, `OptionT m`).

### Compositionality demo

`Examples/EvalDistCompatible/Basic.lean` shows `OptionT ProbComp` getting full `support` / `Pr[= _ | _]` / `Pr[⊥ | _]` reasoning purely by composing standard lifts, with no transformer-specific data class — and proves `Pr[= () | maybeHeads] = Pr[⊥ | maybeHeads] = 1/2`.

### Downstream churn

~150 files, almost entirely two mechanical substitutions: `[spec.Fintype] [spec.Inhabited]` → `[IsUniformSpec spec]`, `[Fintype A]` to `[Finite A]`. No new `sorry`s; `lake build VCVio Examples LatticeCrypto` is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)