### PR TITLE
feat(PRF): forwarding lemmas for prfReal/IdealQueryImpl

### DIFF
--- a/Examples/PRFTagReader.lean
+++ b/Examples/PRFTagReader.lean
@@ -561,26 +561,10 @@ private lemma simulateQ_prfReal_authToPRFTagImpl_run
     simulateQ (PRFScheme.prfRealQueryImpl prfs.multiplePRFScheme k)
         ((authToPRFTagImpl tag).run s) =
       (authTagQueryImpl (fun tag nonce => prfs.evalMultiple k tag nonce) tag).run s := by
-  let so : QueryImpl ((TagId × Nonce) →ₒ Digest) ProbComp :=
-    fun d => pure (prfs.multiplePRFScheme.eval k d)
-  let impl : QueryImpl (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp :=
-    HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp) + so
-  have hImplEq : impl = PRFScheme.prfRealQueryImpl prfs.multiplePRFScheme k := rfl
-  have hleft : ∀ {α : Type} (oa : ProbComp α),
-      simulateQ impl (liftComp oa (unifSpec + ((TagId × Nonce) →ₒ Digest))) = oa := by
-    intro α oa
-    trans simulateQ (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)) oa
-    · exact QueryImpl.simulateQ_add_liftComp_left
-        (impl₁' := HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp))
-        (impl₂' := so) oa
-    · exact simulateQ_ofLift_eq_self _
   unfold authToPRFTagImpl authTagQueryImpl authPRFQuery
   simp only [StateT.run_bind, StateT.run_get, StateT.run_monadLift,
-    bind_pure_comp, pure_bind]
-  rw [← hImplEq]
-  change @simulateQ _ (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp _ impl _ _ = _
-  simp only [simulateQ_bind, simulateQ_map, monadLift_eq_self,
-    hleft]
+    bind_pure_comp, pure_bind, simulateQ_bind, simulateQ_map, monadLift_eq_self,
+    PRFScheme.simulateQ_prfRealQueryImpl_liftComp]
   rfl
 
 omit [Nonempty TagId] [SampleableType Nonce] [SampleableType Digest] [NeZero sessionsPerTag] in
@@ -593,42 +577,21 @@ private lemma simulateQ_prfReal_authToPRFReaderImpl_run
     simulateQ (PRFScheme.prfRealQueryImpl prfs.multiplePRFScheme k)
         ((authToPRFReaderImpl transcript).run s) =
       (authReaderQueryImpl (fun tag nonce => prfs.evalMultiple k tag nonce) transcript).run s := by
-  let so : QueryImpl ((TagId × Nonce) →ₒ Digest) ProbComp :=
-    fun d => pure (prfs.multiplePRFScheme.eval k d)
-  let impl : QueryImpl (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp :=
-    HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp) + so
-  have hImplEq : impl = PRFScheme.prfRealQueryImpl prfs.multiplePRFScheme k := rfl
-  have hquery : ∀ (d : TagId × Nonce),
-      simulateQ impl
-        (liftM ((unifSpec + ((TagId × Nonce) →ₒ Digest)).query (Sum.inr d)) :
-          OracleComp (unifSpec + ((TagId × Nonce) →ₒ Digest)) _) =
-      (pure (prfs.evalMultiple k d.1 d.2) : ProbComp Digest) := by
-    intro d
-    rw [simulateQ_spec_query]
-    show impl (Sum.inr d) = _
-    simp [impl, so, QueryImpl.add_apply_inr, TagReaderPRFs.multiplePRFScheme]
   have hquery_pair : ∀ (tag : TagId),
-      simulateQ impl
+      simulateQ (PRFScheme.prfRealQueryImpl prfs.multiplePRFScheme k)
         (Prod.mk tag <$> authPRFQuery tag transcript.nonce :
           OracleComp (unifSpec + ((TagId × Nonce) →ₒ Digest)) (TagId × Digest)) =
         pure (tag, prfs.evalMultiple k tag transcript.nonce) := by
     intro tag
-    have step : simulateQ impl
-        (authPRFQuery tag transcript.nonce) =
-        (pure (prfs.evalMultiple k tag transcript.nonce) : ProbComp Digest) := by
-      show @simulateQ _ (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp _ impl _ _ = _
-      exact hquery (tag, transcript.nonce)
-    change @simulateQ _ (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp _ impl _ _ = _
-    rw [simulateQ_map, step]
-    rfl
+    simp only [authPRFQuery, simulateQ_map]
+    erw [PRFScheme.simulateQ_prfRealQueryImpl_inr, map_pure]; rfl
   have hmapM :
-      simulateQ impl
+      simulateQ (PRFScheme.prfRealQueryImpl prfs.multiplePRFScheme k)
         ((Finset.univ : Finset TagId).toList.mapM
           (m := OracleComp (unifSpec + ((TagId × Nonce) →ₒ Digest)))
           (fun tag => Prod.mk tag <$> authPRFQuery tag transcript.nonce)) =
       pure ((Finset.univ : Finset TagId).toList.map
         fun tag => (tag, prfs.evalMultiple k tag transcript.nonce)) := by
-    show @simulateQ _ (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp _ impl _ _ = _
     rw [simulateQ_list_mapM]
     induction (Finset.univ : Finset TagId).toList with
     | nil => rfl
@@ -657,10 +620,7 @@ private lemma simulateQ_prfReal_authToPRFReaderImpl_run
     aesop
   unfold authToPRFReaderImpl authReaderQueryImpl
   simp only [StateT.run_bind, StateT.run_get, StateT.run_monadLift,
-    bind_pure_comp, pure_bind]
-  rw [← hImplEq]
-  change @simulateQ _ (unifSpec + ((TagId × Nonce) →ₒ Digest)) ProbComp _ impl _ _ = _
-  simp only [simulateQ_bind, simulateQ_map, monadLift_eq_self,
+    bind_pure_comp, pure_bind, simulateQ_bind, simulateQ_map, monadLift_eq_self,
     hmapM, pure_bind, map_pure]
   rw [hForged, hAccept]
   rfl

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -138,19 +138,6 @@ private lemma simulateQ_prfReal_reduction (k : K) (n : ℕ)
         let outputs ← oracleOutputs n seed
         liftComp (adv outputs) (unifSpec + ofFn fun _ => S × O)) =
     (do let s ← $ᵗ S; adv (streamOutputs (prf.eval k) n s)) := by
-  let so : QueryImpl (S →ₒ S × O) ProbComp := fun d => pure (prf.eval k d)
-  have hleft :
-      ∀ {α : Type} (oa : ProbComp α),
-        simulateQ (prf.prfRealQueryImpl k)
-          (liftComp oa (unifSpec + ofFn fun _ => S × O)) = oa := by
-    intro α oa
-    trans simulateQ (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)) oa
-    · simpa [PRFScheme.prfRealQueryImpl, so] using
-        (QueryImpl.simulateQ_add_liftComp_left
-          (impl₁' := HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp))
-          (impl₂' := so)
-          oa)
-    · exact simulateQ_ofLift_eq_self _
   change simulateQ (prf.prfRealQueryImpl k)
       (do
         let seed ← liftComp ($ᵗ S) (unifSpec + ofFn fun _ => S × O)
@@ -159,10 +146,11 @@ private lemma simulateQ_prfReal_reduction (k : K) (n : ℕ)
     (do
       let s ← $ᵗ S
       adv (streamOutputs (prf.eval k) n s))
-  rw [simulateQ_bind, hleft]
+  rw [simulateQ_bind, simulateQ_prfRealQueryImpl_liftComp]
   refine bind_congr ?_
   intro s
-  rw [simulateQ_bind, simulateQ_prfReal_oracleOutputs, pure_bind, hleft]
+  rw [simulateQ_bind, simulateQ_prfReal_oracleOutputs, pure_bind,
+      simulateQ_prfRealQueryImpl_liftComp]
 
 omit [DecidableEq S] [Inhabited O] [Fintype O] [DecidableEq O] [SampleableType O] in
 /-- In the real world, the stream PRG experiment has the same output distribution as

--- a/VCVio/CryptoFoundations/MacFromPRF.lean
+++ b/VCVio/CryptoFoundations/MacFromPRF.lean
@@ -176,9 +176,7 @@ private theorem prfRealExp_macToPRFReduction_eq_body (prf : PRFScheme K D R)
   refine bind_congr fun k => ?_
   erw [simulateQ_bind, simulateQ_prfReal_macToPRFQueryImpl_run prf k]
   refine bind_congr fun x => ?_
-  erw [simulateQ_bind, simulateQ_spec_query]
-  simp only [prfRealQueryImpl, QueryImpl.add_apply_inr, pure_bind]
-  erw [simulateQ_pure]
+  erw [simulateQ_bind, simulateQ_prfRealQueryImpl_inr, pure_bind, simulateQ_pure]
 
 /-- In the real PRF experiment, the reduction reproduces exactly the UF-CMA game. -/
 theorem prfRealExp_macToPRFReduction_eq_UF_CMA_Exp (prf : PRFScheme K D R)
@@ -209,8 +207,8 @@ private theorem prfIdealExp_macToPRFReduction_eq_ideal_body [SampleableType R]
   refine bind_congr fun ⟨⟨⟨msg, τ⟩, log⟩, cache⟩ => ?_
   erw [simulateQ_bind]
   simp only [prfFuncQuery]
-  erw [simulateQ_spec_query]
-  simp only [prfIdealQueryImpl, QueryImpl.add_apply_inr, StateT.run'_bind']
+  erw [simulateQ_prfIdealQueryImpl_inr]
+  simp only [StateT.run'_bind']
   exact bind_congr fun ⟨t, _⟩ => StateT.run'_pure' _ _
 
 /-- Generalized log-cache invariant for arbitrary initial cache. Every domain point
@@ -293,8 +291,7 @@ private theorem log_cache_invariant_aux [SampleableType R]
         erw [QueryImpl.run_withLogging_apply] at hro
         erw [simulateQ_bind] at hro
         simp only [StateT.run_bind] at hro
-        erw [simulateQ_spec_query] at hro
-        simp only [prfIdealQueryImpl, QueryImpl.add_apply_inr] at hro
+        erw [simulateQ_prfIdealQueryImpl_inr] at hro
         rw [support_bind] at hro
         simp only [Set.mem_iUnion, exists_prop] at hro
         obtain ⟨⟨q_val, q_cache⟩, hro_q, hmem2⟩ := hro

--- a/VCVio/CryptoFoundations/PRF.lean
+++ b/VCVio/CryptoFoundations/PRF.lean
@@ -6,7 +6,6 @@ Authors: Quang Dao
 
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.EvalDist
-import VCVio.OracleComp.SimSemantics.QueryImpl.Basic
 import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
 import VCVio.OracleComp.SimSemantics.Append
@@ -87,5 +86,46 @@ noncomputable def prfAdvantage [DecidableEq D] [SampleableType R]
     (prf : PRFScheme K D R) (adversary : PRFAdversary D R) : ℝ :=
   |(Pr[= true | prf.prfRealExp adversary]).toReal -
     (Pr[= true | prfIdealExp adversary]).toReal|
+
+/-! ## Forwarding lemmas for the PRF query implementations
+
+How `prfRealQueryImpl`/`prfIdealQueryImpl` act on a computation lifted in from the ambient
+`unifSpec` (their identity-handled left summand) and on a function (`Sum.inr`) query. These are the
+facts a PRF distinguisher reduction needs when it forwards its own uniform sampling / oracle access
+through the PRF experiment: the `unifSpec` side is transparent, and an `inr` query is exactly the
+candidate function (real: `prf.eval k`; ideal: the lazy random oracle). -/
+
+/-- The real PRF handler is transparent on a computation lifted in from `unifSpec`: its
+`unifSpec` side is the identity handler and the function oracle is never consulted. -/
+@[simp] lemma simulateQ_prfRealQueryImpl_liftComp (prf : PRFScheme K D R) (k : K)
+    {β : Type} (ob : OracleComp unifSpec β) :
+    simulateQ (prf.prfRealQueryImpl k) (OracleComp.liftComp ob (PRFOracleSpec D R)) = ob := by
+  unfold prfRealQueryImpl
+  rw [QueryImpl.simulateQ_add_liftComp_left, HasQuery.toQueryImpl_eq_id', simulateQ_id']
+
+/-- The ideal (lazy random oracle) PRF handler is transparent on a computation lifted in from
+`unifSpec`, threading the cache: the result is just `ob` lifted into the cache state monad. -/
+@[simp] lemma simulateQ_prfIdealQueryImpl_liftComp [DecidableEq D] [SampleableType R]
+    {β : Type} (ob : OracleComp unifSpec β) :
+    simulateQ (prfIdealQueryImpl (D := D) (R := R)) (OracleComp.liftComp ob (PRFOracleSpec D R))
+      = (liftM ob : StateT ((D →ₒ R).QueryCache) ProbComp β) := by
+  unfold prfIdealQueryImpl
+  rw [QueryImpl.simulateQ_add_liftComp_left, HasQuery.toQueryImpl_eq_id',
+      simulateQ_liftTarget, simulateQ_id']
+
+/-- A function query (`Sum.inr`) under the real PRF handler evaluates the PRF. -/
+@[simp] lemma simulateQ_prfRealQueryImpl_inr (prf : PRFScheme K D R) (k : K) (d : D) :
+    simulateQ (prf.prfRealQueryImpl k)
+        (liftM (OracleSpec.query (Sum.inr d) : OracleQuery (PRFOracleSpec D R) R))
+      = pure (prf.eval k d) := by
+  simp only [prfRealQueryImpl, simulateQ_spec_query, QueryImpl.add_apply_inr]
+
+/-- A function query (`Sum.inr`) under the ideal PRF handler is the lazy random oracle at that
+point. -/
+@[simp] lemma simulateQ_prfIdealQueryImpl_inr [DecidableEq D] [SampleableType R] (q : D) :
+    simulateQ (prfIdealQueryImpl (D := D) (R := R))
+        (liftM (OracleSpec.query (Sum.inr q) : OracleQuery (PRFOracleSpec D R) R))
+      = (D →ₒ R).randomOracle q := by
+  simp only [prfIdealQueryImpl, simulateQ_spec_query, QueryImpl.add_apply_inr]
 
 end PRFScheme

--- a/VCVio/OracleComp/SimSemantics/QueryImpl/Basic.lean
+++ b/VCVio/OracleComp/SimSemantics/QueryImpl/Basic.lean
@@ -192,4 +192,12 @@ def toQueryImpl [HasQuery spec m] : QueryImpl spec m :=
 lemma toQueryImpl_apply [HasQuery spec m] (t : spec.Domain) :
     toQueryImpl (spec := spec) (m := m) t = HasQuery.query (spec := spec) (m := m) t := rfl
 
+/-- On `OracleComp spec`, `HasQuery.toQueryImpl` is the identity handler `QueryImpl.id'`.
+
+Not `@[simp]`: in `unifFwdImpl`-style definitions where `toQueryImpl.liftTarget` appears
+inside a `simp [unifFwdImpl]` call, the rewrite `toQueryImpl → id' = liftTarget _ (id _)`
+nests `liftTarget`s and triggers unbounded depth. Use via explicit `rw` instead. -/
+lemma toQueryImpl_eq_id' :
+    (toQueryImpl : QueryImpl spec (OracleComp spec)) = QueryImpl.id' spec := rfl
+
 end HasQuery


### PR DESCRIPTION
This PR adds four `@[simp]` forwarding lemmas to `VCVio/CryptoFoundations/PRF.lean` and a supporting named lemma `HasQuery.toQueryImpl_eq_id'` to `QueryImpl/Basic.lean`:

- **`simulateQ_prfRealQueryImpl_liftComp`** — the real handler `prfRealQueryImpl prf k` is transparent on a `unifSpec`-lifted computation: `simulateQ (prf.prfRealQueryImpl k) (liftComp ob _) = ob`.
- **`simulateQ_prfIdealQueryImpl_liftComp`** — the ideal handler is transparent on a `unifSpec`-lifted computation, threading the cache: `simulateQ prfIdealQueryImpl (liftComp ob _) = liftM ob`.
- **`simulateQ_prfRealQueryImpl_inr`** — a function query under the real handler evaluates the PRF: `simulateQ (prf.prfRealQueryImpl k) (liftM (query (Sum.inr d))) = pure (prf.eval k d)`.
- **`simulateQ_prfIdealQueryImpl_inr`** — a function query under the ideal handler is the lazy random oracle at that point: `simulateQ prfIdealQueryImpl (liftM (query (Sum.inr q))) = randomOracle q`.

The motivation for these lemmas is: they are the facts a PRF-distinguisher *reduction* needs when it forwards its own uniform sampling / oracle access through the PRF experiment. They were previously re-proven inline in downstream developments (`PRGfromPRF`, `PRFTagReader`, `MacFromPRF`); having them next to the `prfReal/IdealQueryImpl` definitions removes that duplication.

Additional changes:

- **`HasQuery.toQueryImpl_eq_id'`** (in `QueryImpl/Basic.lean`): named lemma establishing `HasQuery.toQueryImpl = QueryImpl.id'` on `OracleComp spec`. Deliberately *not* `@[simp]` — in `unifFwdImpl`-style definitions the rewrite nests `liftTarget`s and triggers unbounded depth. Used via explicit `rw` in the forwarding lemma proofs.
- **Hardened `_inr` proofs**: switched from `simp [...]` to `simp only [...]` for robustness.
- **Fixed CI failure**: qualified `simulateQ_prfRealQueryImpl_liftComp` with `PRFScheme.` in `PRFTagReader.lean` (the `PRFScheme` namespace is not opened there).
- **Downstream simplifications**: `PRGfromPRF.lean`, `PRFTagReader.lean`, and `MacFromPRF.lean` replace hand-rolled forwarding arguments (`impl`/`hImplEq`/`hquery` scaffolding) and two-step `erw [simulateQ_spec_query]; simp only [prfReal/IdealQueryImpl, add_apply_inr]` chains with the new lemmas.
- **Import cleanup**: dropped one redundant transitive import from `PRF.lean`.

Closes #423.

---
*Edited with Claude (Opus 4.6)*