### PR TITLE
feat(simulateQ): commute simulateQ over list forIn

### DIFF
--- a/VCVio/OracleComp/SimSemantics/SimulateQ.lean
+++ b/VCVio/OracleComp/SimSemantics/SimulateQ.lean
@@ -210,6 +210,26 @@ lemma simulateQ_list_forM (f : α → OracleComp spec PUnit) (xs : List α) :
     have h : (x :: xs).forM f = f x >>= fun _ => xs.forM f := rfl
     rw [h, simulateQ_bind]; congr 1; funext; exact ih
 
+/-- `simulateQ` distributes over `forIn` on a list: a monad morphism commutes with `forIn`.
+
+This is the `forIn` (early-exit / accumulating loop) sibling of `simulateQ_list_mapM` and
+`simulateQ_list_forM`. It lets a `simulateQ` pushed in front of a verifier-style loop
+`forIn (List.finRange t) init (fun j acc => …)` be moved inside the loop body, after which the
+individual simulated query steps can be discharged. -/
+@[simp]
+lemma simulateQ_list_forIn {β : Type u} (xs : List α) (init : β)
+    (f : α → β → OracleComp spec (ForInStep β)) :
+    simulateQ impl (forIn xs init f) = forIn xs init (fun a b => simulateQ impl (f a b)) := by
+  induction xs generalizing init with
+  | nil => simp
+  | cons x xs ih =>
+    rw [List.forIn_cons, List.forIn_cons, simulateQ_bind]
+    congr 1
+    funext step
+    cases step with
+    | done b => simp
+    | yield b => exact ih b
+
 end List
 
 /-! ## Composition of simulations via a per-query bridge -/


### PR DESCRIPTION
## Summary
- add `simulateQ_list_forIn`, the `forIn` analogue of the existing list traversal simulation lemmas
- prove it by list induction using `List.forIn_cons` and `simulateQ_bind`
- mark it `[simp]` so simulated verifier loops can reduce under `forIn`

## Verification
- `lake build VCVio.OracleComp.SimSemantics.SimulateQ`
- `lake build VCVio`
- `#print axioms simulateQ_list_forIn` -> `[propext, Quot.sound]`

This lemma is needed downstream in ArkLib for verifier loops that use `forIn` / `ForInStep`.