### PR TITLE
refactor(ToMathlib): remove custom Vector Add/Zero instances superseded by Mathlib

### DIFF
--- a/LatticeCrypto/MLDSA/Signature.lean
+++ b/LatticeCrypto/MLDSA/Signature.lean
@@ -129,10 +129,6 @@ def fipsVerify (pk : PublicKey p prims) (msg : List Byte)
 
 /-! ### Vector Arithmetic Helpers -/
 
-private lemma rqvec_add_get {k : ℕ} (v u : RqVec k) (j : Fin k) :
-    (v + u).get j = v.get j + u.get j :=
-  congr_fun (Vector.vectorAdd_get v u) j
-
 private lemma rq_sub_add_cancel (a b : Rq) : a - b + b = a :=
   LatticeCrypto.Poly.ext_get_eq fun i => by
     change ((coeffRing.add (coeffRing.sub a b) b) : Rq).get i = a.get i
@@ -250,38 +246,28 @@ lemma useHintVec_makeHintVec_eq_highBitsVec
   unfold Primitives.useHintVec Primitives.makeHintVec Primitives.highBitsVec
   simp only [Vector.getElem_zipWith, Vector.getElem_neg, Vector.getElem_map]
   let jj : Fin p.k := ⟨j, hj⟩
-  let w_j := w.get jj
-  let r_j := (w - cs2).get jj
-  let ct0_j := ct0.get jj
-  let s_j := cs2.get jj
-  have h_ct0_lt : polyNorm ct0_j < p.gamma2 := by
+  let r_j := (w - cs2)[j]
+  have h_ct0_lt : polyNorm ct0[j] < p.gamma2 := by
       exact lt_of_le_of_lt
         (LatticeCrypto.PolyVec.component_cInfNorm_le normOps ct0 jj)
         h_norm_ct0
-  have h_r0_lt : polyNorm ((prims.lowBitsVec (w - cs2)).get jj) < p.gamma2 - p.beta := by
+  have h_r0_lt : polyNorm ((prims.lowBitsVec (w - cs2))[j]) < p.gamma2 - p.beta := by
       exact lt_of_le_of_lt
         (LatticeCrypto.PolyVec.component_cInfNorm_le normOps (prims.lowBitsVec (w - cs2)) jj)
         h_norm_r0
-  have h_hint : -ct0[j] = -ct0_j := by
-    change -(ct0.get jj) = -ct0_j
-    simp only [ct0_j]
-  have h_arg : (w - cs2 + ct0)[j] = r_j + ct0_j := by
-    change (w - cs2 + ct0).get jj = r_j + ct0_j
-    simp only [Vector.vectorAdd_get, Pi.add_apply, r_j, ct0_j]
-  have h_w : w[j] = w_j := by
-    change w.get jj = w_j
-    simp only [w_j]
-  rw [h_hint, h_arg, h_w]
+  have h_arg : (w - cs2 + ct0)[j] = r_j + ct0[j] := by
+    simp only [Vector.getElem_add, Vector.getElem_sub, r_j]
+  rw [h_arg]
   refine useHint_makeHint_eq_highBits (p := p) (prims := prims)
     h_useHint_makeHint h_hide_low
-    w_j r_j ct0_j s_j
+    w[j] (w - cs2)[j] ct0[j] cs2[j]
     ?_ ?_ ?_ ?_
   · change (w - cs2).get jj = w.get jj - cs2.get jj
     simp only [Vector.get_eq_getElem, Vector.getElem_sub]
   · exact Nat.le_of_lt h_ct0_lt
   · simpa [Primitives.lowBitsVec, r_j] using h_r0_lt
   · unfold polyNorm normOps
-    simpa [s_j, LatticeCrypto.zmodPolyNormOps, LatticeCrypto.normOpsOfCenteredView,
+    simpa [LatticeCrypto.zmodPolyNormOps, LatticeCrypto.normOpsOfCenteredView,
       LatticeCrypto.cInfNorm] using h_cs2_bound jj
 
 /-- Correctness of FIPS ML-DSA, conditional on the algebraic key identity (`h_wApprox_eq`)

--- a/ToMathlib/General.lean
+++ b/ToMathlib/General.lean
@@ -504,30 +504,6 @@ def induction₂ {α β} {motive : {n : ℕ} → Vector α n → Vector β n →
         v_insert hd ⟨⟨tl⟩, by simpa using hSize⟩ hd' ⟨⟨tl'⟩, by simpa using hSize'⟩
         (ih ⟨⟨tl⟩, by simpa using hSize⟩ ⟨⟨tl'⟩, by simpa using hSize'⟩)
 
-
-section add
--- Define vector addition more generally
-
-instance {α : Type} {n : ℕ} [Add α] : Add (Vector α n) where
-  add v1 v2 := Vector.ofFn (v1.get + v2.get)
-
-instance {α : Type} {n : ℕ} [Zero α] : Zero (Vector α n) where
-  zero := Vector.ofFn (0)
-
-@[simp]
-theorem vectorofFn_get {α : Type} {n : ℕ} (v : Fin n → α) : (Vector.ofFn v).get = v := by
-  ext i
-  apply Vector.getElem_ofFn
-
-@[simp]
-theorem vectorAdd_get {α : Type} {n : ℕ} [Add α] [Zero α]
- (vx : Vector α n) (vy : Vector α n)
- : (vx + vy).get = vx.get + vy.get := by
-  change (Vector.ofFn (vx.get + vy.get)).get = vx.get + vy.get
-  simp
-
-end add
-
 end Vector
 
 open Classical in


### PR DESCRIPTION
## Summary

- Remove custom `Add (Vector α n)` and `Zero (Vector α n)` instances from `ToMathlib/General.lean`, which are now superseded by Mathlib's built-in `Vector.zipWith`-based instances
- Remove the `@[simp]` bridge lemmas `vectorofFn_get` and `vectorAdd_get` that were only needed to reason about the old custom definition
- Update the downstream proof in `useHintVec_makeHintVec_eq_highBitsVec` (`LatticeCrypto/MLDSA/Signature.lean`) to use Mathlib's `Vector.getElem_add` / `Vector.getElem_sub` simp lemmas and `[j]` bracket notation throughout

The old custom `Add` instance (`Vector.ofFn (v1.get + v2.get)`) conflicted with Mathlib's instance (`Vector.zipWith (· + ·)`), causing downstream instance-resolution issues that block work in the upcoming MLDSA proofs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)