### PR TITLE
feat(MLDSA/Scheme): prove keyGenFromSeed_wApprox_eq

### DIFF
--- a/LatticeCrypto/MLDSA/Scheme.lean
+++ b/LatticeCrypto/MLDSA/Scheme.lean
@@ -193,6 +193,60 @@ theorem keyGenFromSeed_wApprox_eq {pk : PublicKey p prims} {sk : SecretKey p}
     ∀ (c : Rq) (y : RqVec p.l),
       computeWApprox p prims (prims.expandA pk.rho) c (y + c • sk.s1) pk.t1 =
       (prims.expandA pk.rho) * y - c • sk.s2 + c • sk.t0 := by
-  sorry
+  intro c y
+  haveI := h_laws.transform
+  let laws := h_laws.transform
+  set aHat := prims.expandA pk.rho
+  simp only [computeWApprox]
+  refine Vector.ext fun i hi => ?_
+  simp only [Vector.getElem_add, Vector.getElem_sub,
+    nttOps.hatVec_add, nttOps.unhatVec_sub, nttOps.matVecMul_add, nttOps.unhatVec_add]
+  have h_kg : prims.power2RoundShiftVec pk.t1 + sk.t0 = aHat * sk.s1 + sk.s2 := by
+    simp only [keyGenFromSeed, Prod.mk.injEq] at hkeygen
+    obtain ⟨hpk, hsk⟩ := hkeygen
+    have hrho  := congr_arg PublicKey.rho hpk.symm
+    have hs1   := congr_arg SecretKey.s1 hsk.symm
+    have hs2   := congr_arg SecretKey.s2 hsk.symm
+    have haHat : aHat = prims.expandA (prims.expandSeed seed).1 := by simp [aHat, hrho]
+    rw [show pk.t1 = (prims.power2RoundVec (aHat * sk.s1 + sk.s2)).1 from by
+          rw [hs1, hs2, haHat]; exact congr_arg PublicKey.t1 hpk.symm,
+        show sk.t0 = (prims.power2RoundVec (aHat * sk.s1 + sk.s2)).2 from by
+          rw [hs1, hs2, haHat]; exact congr_arg SecretKey.t0 hsk.symm]
+    refine Vector.ext fun i hi => ?_
+    simp only [Vector.getElem_add, Primitives.power2RoundShiftVec, Primitives.power2RoundVec,
+      Vector.map_map, Vector.getElem_map, Function.comp]
+    exact h_laws.power2Round_decomp _
+  have hAs1_hat : nttOps.matVecMul aHat (nttOps.hatVec sk.s1) =
+      nttOps.hatVec (prims.power2RoundShiftVec pk.t1 + sk.t0 - sk.s2) := by
+    rw [h_kg]
+    refine Vector.ext fun j hj => ?_
+    simp only [hatVec, HMul.hMul, coeffMatVecMul, unhatVec, matVecMul,
+               Vector.getElem_map, Vector.getElem_sub, Vector.getElem_add]
+    have hcancel : (fromHat (dot nttOps aHat[j] (Vector.map toHat sk.s1)) : Rq) +
+        sk.s2[j] - sk.s2[j] = fromHat (dot nttOps aHat[j] (Vector.map toHat sk.s1)) := by
+      abel
+    rw [hcancel, laws.toHat_fromHat]
+  have hMatScalarComm : nttOps.matVecMul aHat (nttOps.hatVec (c • sk.s1)) =
+      nttOps.scalarVecMul (toHat c) (nttOps.matVecMul aHat (nttOps.hatVec sk.s1)) := by
+    have hNTTSmul : nttOps.hatVec (c • sk.s1) =
+        nttOps.scalarVecMul (toHat c) (nttOps.hatVec sk.s1) := by
+      refine Vector.ext fun j hj => ?_
+      simp only [hatVec, scalarVecMul, Vector.getElem_map]
+      change nttOps.toHat (nttOps.coeffScalarVecMul c sk.s1)[j] = _
+      simp only [coeffScalarVecMul, unhatVec, scalarVecMul, hatVec,
+                 Vector.map_map, Vector.getElem_map, Function.comp_apply, laws.toHat_fromHat]
+    rw [hNTTSmul]
+    refine Vector.ext fun j hj => ?_
+    simp only [matVecMul, scalarVecMul, Vector.getElem_map]
+    exact nttOps.dot_scalar_right (toHat c) _ _
+  simp only [hMatScalarComm, hAs1_hat]
+  change (aHat * y)[i] +
+      (nttOps.coeffScalarVecMul c (prims.power2RoundShiftVec pk.t1 + sk.t0 - sk.s2))[i] -
+      (nttOps.coeffScalarVecMul c (prims.power2RoundShiftVec pk.t1))[i] =
+      (aHat * y)[i] -
+      (nttOps.coeffScalarVecMul c sk.s2)[i] + (nttOps.coeffScalarVecMul c sk.t0)[i]
+  simp only [nttOps.coeffScalarVecMul_sub, nttOps.coeffScalarVecMul_add,
+             Vector.getElem_sub, Vector.getElem_add]
+  abel
 
 end MLDSA

--- a/LatticeCrypto/Ring/Norms.lean
+++ b/LatticeCrypto/Ring/Norms.lean
@@ -236,7 +236,7 @@ theorem cInfNorm_le_halfq (p : Poly (ZMod q) n) : cInfNorm p ≤ q / 2 :=
   simp only [cInfNorm, cInfNormOf, vectorBackend, zmodCenteredCoeffView]
   congr 1
   ext i
-  have hneg : (-f).get i = -(f.get i) := Vector.getElem_map (- ·) i.isLt
+  have hneg : (-f).get i = -(f.get i) := Poly.get_neg f i
   rw [hneg, centeredRepr_natAbs_neg]
 
 theorem l1Norm_le_of_cInfNorm_le {p : Poly (ZMod q) n} {b : ℕ}

--- a/LatticeCrypto/Ring/Transform.lean
+++ b/LatticeCrypto/Ring/Transform.lean
@@ -235,6 +235,151 @@ class Laws (ops : TransformOps ring Hat) : Prop where
   mul_comm : ∀ a b : Hat, ops.mulHat a b = ops.mulHat b a
   mul_assoc : ∀ a b c : Hat, ops.mulHat (ops.mulHat a b) c = ops.mulHat a (ops.mulHat b c)
 
+variable [laws : Laws ops]
+
+theorem hatVec_add {k} (u v : PolyVec ring.Poly k) :
+    ops.hatVec (u + v) = ops.hatVec u + ops.hatVec v := by
+  refine Vector.ext fun i _ => ?_
+  simp only [hatVec, Vector.getElem_map, Vector.getElem_add]
+  exact laws.toHat_add u[i] v[i]
+
+theorem hatVec_sub {k} (u v : PolyVec ring.Poly k) :
+    ops.hatVec (u - v) = ops.hatVec u - ops.hatVec v := by
+  refine Vector.ext fun i _ => ?_
+  simp only [hatVec, Vector.getElem_map, Vector.getElem_sub]
+  exact laws.toHat_sub u[i] v[i]
+
+private theorem addHat_eq (a b : Hat) :
+    a + b = ops.toHat (ops.fromHat a + ops.fromHat b) := by
+  rw [← laws.toHat_fromHat a, ← laws.toHat_fromHat b, ← laws.toHat_add]
+  congr 3
+  · rw[laws.toHat_fromHat]
+  · rw[laws.toHat_fromHat]
+
+theorem unhatVec_add {k} (uHat vHat : PolyVec Hat k) :
+    ops.unhatVec (uHat + vHat) = ops.unhatVec uHat + ops.unhatVec vHat := by
+  refine Vector.ext fun i _ => ?_
+  simp only [unhatVec, Vector.getElem_map, Vector.getElem_add]
+  rw [addHat_eq ops, laws.fromHat_toHat]
+
+private theorem subHat_eq (a b : Hat) :
+    a - b = ops.toHat (ops.fromHat a - ops.fromHat b) := by
+  rw [← laws.toHat_fromHat a, ← laws.toHat_fromHat b, ← laws.toHat_sub]
+  congr 3
+  · rw[laws.toHat_fromHat]
+  · rw[laws.toHat_fromHat]
+
+theorem unhatVec_sub {k} (uHat vHat : PolyVec Hat k) :
+    ops.unhatVec (uHat - vHat) = ops.unhatVec uHat - ops.unhatVec vHat := by
+  refine Vector.ext fun i _ => ?_
+  simp only [unhatVec, Vector.getElem_map, Vector.getElem_sub]
+  rw [subHat_eq ops, laws.fromHat_toHat]
+
+private theorem zipWith_push {β γ} {n : ℕ}
+  (f : α → β → γ) (a : Vector α n) (b : Vector β n) (x : α) (y : β) :
+    Vector.zipWith f (a.push x) (b.push y) = (Vector.zipWith f a b).push (f x y) := by
+  refine Vector.ext fun i _ => ?_
+  simp only [Vector.getElem_zipWith, Vector.getElem_push]
+  by_cases h : i < n <;> simp [h]
+
+private theorem foldl_distribute {k} (a b : PolyVec Hat k) :
+  (a + b).foldl (· + ·) 0 = (a.foldl (· + ·) 0) + (b.foldl (· + ·) 0) := by
+  induction k with
+  | zero =>
+    have : a = #v[] := Vector.eq_empty
+    have : b = #v[] := Vector.eq_empty
+    subst a b
+    simp only [Vector.eq_empty, Vector.foldl_empty, add_zero]
+  | succ n ih =>
+    haveI : NeZero (n + 1) := ⟨Nat.succ_ne_zero n⟩
+    rw [← Vector.push_pop_back a, ← Vector.push_pop_back b]
+    set sum_a := a.pop.foldl (· + ·) 0
+    set sum_b := b.pop.foldl (· + ·) 0
+    have : (a.pop.zipWith (· + ·) b.pop).foldl (· + ·) 0 = sum_a + sum_b := ih a.pop b.pop
+    change ((a.pop.push a.back).zipWith (· + ·) (b.pop.push b.back)).foldl (· + ·) 0  =
+      (a.pop.push a.back).foldl (· + ·) 0  + (b.pop.push b.back).foldl (· + ·) 0
+    rw [zipWith_push, Vector.foldl_push, Vector.foldl_push, Vector.foldl_push, this]
+    abel
+
+theorem dot_add_right {k} (row u v : PolyVec Hat k) :
+    ops.dot row (u + v) = (ops.dot row u) + ops.dot row v := by
+  have h_pt : Vector.zipWith ops.mulHat row (u + v) =
+    (row.zipWith ops.mulHat u) + (row.zipWith ops.mulHat v) := by
+    refine Vector.ext fun i _ => ?_
+    simp [Vector.getElem_zipWith, laws.mul_add]
+  simp only [dot]
+  rw [h_pt, foldl_distribute]
+
+theorem matVecMul_add {r c} (A : PolyMatrix Hat r c) (u v : PolyVec Hat c) :
+    ops.matVecMul A (u + v) = (ops.matVecMul A u) + ops.matVecMul A v := by
+  simp only [matVecMul]
+  refine Vector.ext fun i _ => ?_
+  simp only [Vector.getElem_map, Vector.getElem_add]
+  exact dot_add_right ops _ u v
+
+theorem mulHat_comm (a b : Hat) :
+    ops.mulHat a b = ops.mulHat b a := by
+  rw [show a = ops.toHat (ops.fromHat a) from (laws.toHat_fromHat a).symm,
+      show b = ops.toHat (ops.fromHat b) from (laws.toHat_fromHat b).symm,
+      ← laws.toHat_mul, laws.mul_comm, laws.toHat_mul]
+
+theorem mulHat_assoc (a b c : Hat) :
+    ops.mulHat (ops.mulHat a b) c = ops.mulHat a (ops.mulHat b c) :=
+  laws.mul_assoc a b c
+
+theorem fromHat_subHat (a b : Hat) :
+    ops.fromHat (a - b) = ops.fromHat a - ops.fromHat b := by
+  conv_lhs => rw [← laws.toHat_fromHat a, ← laws.toHat_fromHat b, ← laws.toHat_sub]
+  exact laws.fromHat_toHat _
+
+theorem fromHat_addHat (a b : Hat) :
+    ops.fromHat (a + b) = ops.fromHat a + ops.fromHat b := by
+  conv_lhs => rw [← laws.toHat_fromHat a, ← laws.toHat_fromHat b, ← laws.toHat_add]
+  exact laws.fromHat_toHat _
+
+theorem coeffScalarVecMul_sub {k} (c : ring.Poly)
+    (u v : PolyVec ring.Poly k) :
+    ops.coeffScalarVecMul c (u - v) =
+        ops.coeffScalarVecMul c u - ops.coeffScalarVecMul c v := by
+  refine Vector.ext fun i hi => ?_
+  simp only [coeffScalarVecMul, unhatVec, scalarVecMul, hatVec,
+             Vector.getElem_map, Vector.getElem_sub]
+  rw[laws.toHat_sub u[i] v[i], laws.mul_sub, fromHat_subHat ops]
+
+theorem coeffScalarVecMul_add {k} (c : ring.Poly)
+    (u v : PolyVec ring.Poly k) :
+    ops.coeffScalarVecMul c (u + v) =
+        ops.coeffScalarVecMul c u + ops.coeffScalarVecMul c v := by
+  refine Vector.ext fun i hi => ?_
+  simp only [coeffScalarVecMul, unhatVec, scalarVecMul, hatVec,
+             Vector.getElem_map, Vector.getElem_add]
+  rw [laws.toHat_add u[i] v[i], laws.mul_add, fromHat_addHat ops]
+
+theorem dot_scalar_right {k} (cHat : Hat)
+    (row v : PolyVec Hat k) :
+    ops.dot row (ops.scalarVecMul cHat v) = ops.mulHat cHat (ops.dot row v) := by
+  induction k with
+  | zero =>
+    have : row = #v[] := Vector.eq_empty; have : v = #v[] := Vector.eq_empty; subst_eqs
+    simp only [dot, scalarVecMul, Vector.map_mk, List.map_toArray, List.map_nil,
+      Vector.zipWith_self, Vector.foldl_mk, List.size_toArray, List.length_nil, List.foldl_toArray',
+      List.foldl_nil]
+    have h := laws.mul_sub cHat cHat cHat
+    simp only [sub_self] at h
+    rw[h]
+  | succ n ih =>
+    haveI : NeZero (n + 1) := ⟨Nat.succ_ne_zero n⟩
+    rw [← Vector.push_pop_back row, ← Vector.push_pop_back v]
+    change ops.dot (row.pop.push row.back) (ops.scalarVecMul cHat (v.pop.push v.back)) =
+      ops.mulHat cHat (ops.dot (row.pop.push row.back) (v.pop.push v.back))
+    simp only [dot, scalarVecMul, Vector.map_push, zipWith_push, Vector.foldl_push]
+    have ih_pop : ops.dot row.pop (ops.scalarVecMul cHat v.pop) =
+      ops.mulHat cHat (ops.dot row.pop v.pop) := ih row.pop v.pop
+    simp only [dot, scalarVecMul] at ih_pop
+    rw [ih_pop, laws.mul_add]
+    congr 1
+    rw[mulHat_comm ops, mulHat_assoc ops, mulHat_comm ops v.back]
+
 end TransformOps
 
 end LatticeCrypto


### PR DESCRIPTION
Fix #219

## Summary

Discharges the `sorry` in `keyGenFromSeed_wApprox_eq`, which states that
the approximate w value computed during verification equals the expected
linear combination `A·y − c·s₂ + c·t₀`.

**Depends on** #430 (ring refactor + CommRing instances) and #429 (Vec add already in Mathlib).

### New infrastructure (`Ring/Transform.lean`)

Adds a suite of theorems under `variable [laws : Laws ops]` that were
needed to carry the proof through:

- `hatVec_add/sub`, `unhatVec_add/sub` — lift `toHat_add/sub` to
  `PolyVec`
- `matVecMul_add`, `dot_add_right` — matrix-vector multiply distributes
  over vector addition
- `coeffScalarVecMul_add/sub`, `dot_scalar_right` — scalar-vector-mul
  linearity
- `mulHat_comm`, `mulHat_assoc`, `fromHat_addHat/subHat` — Hat
  arithmetic lemmas

🤖 Generated with [Claude Code](https://claude.com/claude-code)