### PR TITLE
fix(OracleComp): whole-computation lift coercions defeq to a single `liftComp` (#439)

### DIFF
--- a/Examples/BR93.lean
+++ b/Examples/BR93.lean
@@ -227,7 +227,8 @@ theorem game1_eq_game2 (adv : CPA_Adv (PK := PK) (Rand := Rand) (M := M)) :
     𝒟[game1 tdp adv] = 𝒟[game2 tdp adv] := by
   sorry
 
-omit [Fintype Rand] [Inhabited M] [Fintype M] [DecidableEq M] [AddCommGroup M] in
+omit [Inhabited Rand] [Fintype Rand] [Inhabited M] [Fintype M] [DecidableEq M]
+  [AddCommGroup M] in
 /-- In the all-random game, the challenge ciphertext is independent of the hidden bit, so the
 adversary succeeds with probability exactly `1/2`. -/
 theorem game2_eq_half (adv : CPA_Adv (PK := PK) (Rand := Rand) (M := M)) :

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -126,7 +126,7 @@ private lemma simulateQ_prfReal_oracleOutputs (k : K) (n : ℕ) (s : S) :
         rw [simulateQ_bind, ih']
         simp [h, so]
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [Fintype S] [DecidableEq S]
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [DecidableEq S]
   [Inhabited O] [Fintype O] [DecidableEq O] [SampleableType O] in
 /-- Applying the real PRF query implementation to the full reduction body simplifies to
 sampling a seed and running the adversary on deterministic output. -/

--- a/VCVio/OracleComp/Coercions/Add.lean
+++ b/VCVio/OracleComp/Coercions/Add.lean
@@ -96,7 +96,15 @@ end add_right
 
 section left_add_left_add
 
-instance subSpec_left_add_left_add_of_subSpec [h : spec₁ ⊂ₒ spec₃] :
+/-- Congruence on the left summand: an inclusion `spec₁ ⊂ₒ spec₃` extends to
+`spec₁ + spec₂ ⊂ₒ spec₃ + spec₂`.
+
+Low priority so that searches whose source spec is a metavariable (notably the
+`MonadLiftT (OracleComp spec) (OracleComp superSpec)` chain behind whole-computation
+coercions) prefer the direct embeddings `subSpec_add_left` / `subSpec_add_right`. This keeps
+such coercions a single `liftComp`, definitionally, instead of a stack of lifts through an
+intermediate spec. -/
+instance (priority := low) subSpec_left_add_left_add_of_subSpec [h : spec₁ ⊂ₒ spec₃] :
     spec₁ + spec₂ ⊂ₒ spec₃ + spec₂ where
   monadLift
     | ⟨.inl t, f⟩ => ⟨.inl (h.onQuery t), f ∘ h.onResponse t⟩
@@ -144,7 +152,13 @@ end left_add_left_add
 
 section right_add_right_add
 
-instance subSpec_right_add_right_add_of_subSpec [h : spec₂ ⊂ₒ spec₃] :
+/-- Congruence on the right summand: an inclusion `spec₂ ⊂ₒ spec₃` extends to
+`spec₁ + spec₂ ⊂ₒ spec₁ + spec₃`.
+
+Low priority for the same reason as `subSpec_left_add_left_add_of_subSpec`: the direct
+embeddings must win metavariable-headed searches so that whole-computation coercions stay a
+single `liftComp`. -/
+instance (priority := low) subSpec_right_add_right_add_of_subSpec [h : spec₂ ⊂ₒ spec₃] :
     spec₁ + spec₂ ⊂ₒ spec₁ + spec₃ where
   monadLift
     | ⟨.inl t, f⟩ => ⟨.inl t, f⟩
@@ -371,5 +385,15 @@ example (q : OracleQuery spec₁ α) :
       OracleQuery (spec₁ + spec₂ + spec₃) α) =
     (liftM (liftM q : OracleQuery (spec₁ + spec₃) α) :
       OracleQuery (spec₁ + spec₂ + spec₃) α) := by simp
+
+-- Whole-computation coercions into a sum spec are *definitionally* a single `liftComp`,
+-- with no intermediate hop through another spec. In particular lifting out of `ProbComp`
+-- (e.g. into a random-oracle spec `unifSpec + (T →ₒ U)`) is `liftComp` by `rfl`.
+example (oa : OracleComp spec₁ α) :
+    (oa : OracleComp (spec₁ + spec₂) α) = OracleComp.liftComp oa (spec₁ + spec₂) := rfl
+example (oa : OracleComp spec₂ α) :
+    (oa : OracleComp (spec₁ + spec₂) α) = OracleComp.liftComp oa (spec₁ + spec₂) := rfl
+example (px : ProbComp α) :
+    (px : OracleComp (unifSpec + spec₁) α) = OracleComp.liftComp px (unifSpec + spec₁) := rfl
 
 end tests


### PR DESCRIPTION
## Summary

Lands the highest-ROI fix from the #439 discussion: whole-computation lift coercions `ProbComp α → OracleComp (unifSpec + spec) α` (the "`liftProbComp`" of the BR93 report) are now **definitionally equal to a single `liftComp`** — `rfl`, no bridging lemma, no per-proof induction tax.

## Root cause

The `MonadLiftT ProbComp (OracleComp (unifSpec + spec))` instance search resolved through the summand-congruence instance `subSpec_right_add_right_add_of_subSpec` together with the `emptySpec ⊂ₒ spec` `Inhabited` escape hatch, producing **two stacked `liftComp`s through a spurious `unifSpec + emptySpec` intermediate** — equal to the direct single `liftComp` only propositionally (by induction). Every `ProbComp`-base proof that needed the two to line up re-paid that induction (e.g. BR93's local `liftProbComp_eq_liftComp`).

## Fix

Lower the priority (`priority := low`) of the two summand-congruence `SubSpec` instances in `VCVio/OracleComp/Coercions/Add.lean` (`subSpec_left_add_left_add_of_subSpec`, `subSpec_right_add_right_add_of_subSpec`) so that metavariable-headed searches prefer the direct embeddings `subSpec_add_left` / `subSpec_add_right`. Whole-computation coercions now elaborate to a single `liftComp`, and the existing core `@[simp] liftComp_eq_liftM` (itself `rfl`) covers the rest — no new definitions needed.

Three `rfl` regression examples are added to the file's coercion test section, including the exact `ProbComp → OracleComp (unifSpec + spec)` shape from the BR93 report.

**Bonus:** the old path smuggled an `Inhabited` requirement into lifts via the `emptySpec` hatch; the direct path doesn't. Two `Examples` files accordingly gain `omit`s for now-unused `Inhabited` instances.

## Verification

- `lake build ToMathlib VCVio FFI LatticeCrypto Examples VCVioWidgets Interop` → exit 0 (8976 jobs); zero errors, zero non-sorry warnings in repo files.
- `lake env lean VCVioTest/Smoke.lean` → exit 0.
- Per-file `-Dweak.linter.mathlibStandardSet=true` gates on all touched files → clean.

## Scope

`VCVio/OracleComp/Coercions/Add.lean` (+26/−2: two priority annotations, docstrings, regression examples) and `Examples/BR93.lean` / `Examples/PRGfromPRF.lean` (+3/−2: `omit` additions). Part of the #439 cleanup; the remaining items there (direct `HasQuery (OracleComp spec)` instance, `QueryImpl.ofHasQuery`) can follow separately.
