### PR TITLE
chore(PRFTagReader): correct new-file authorship to creating author

### DIFF
--- a/Examples/PRFTagReader/Auth.lean
+++ b/Examples/PRFTagReader/Auth.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Defs

--- a/Examples/PRFTagReader/BadEvent.lean
+++ b/Examples/PRFTagReader/BadEvent.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Collision

--- a/Examples/PRFTagReader/Collision.lean
+++ b/Examples/PRFTagReader/Collision.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Collision.ForgeStep

--- a/Examples/PRFTagReader/Collision/ForgeStep.lean
+++ b/Examples/PRFTagReader/Collision/ForgeStep.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Auth

--- a/Examples/PRFTagReader/Defs.lean
+++ b/Examples/PRFTagReader/Defs.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import VCVio.CryptoFoundations.PRF

--- a/Examples/PRFTagReader/DirectCoupling.lean
+++ b/Examples/PRFTagReader/DirectCoupling.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Table

--- a/Examples/PRFTagReader/DirectCoupling/Compose.lean
+++ b/Examples/PRFTagReader/DirectCoupling/Compose.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.DirectCoupling

--- a/Examples/PRFTagReader/DirectCoupling/ReaderCase.lean
+++ b/Examples/PRFTagReader/DirectCoupling/ReaderCase.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.DirectCoupling

--- a/Examples/PRFTagReader/DirectCoupling/StepLemmas.lean
+++ b/Examples/PRFTagReader/DirectCoupling/StepLemmas.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.DirectCoupling

--- a/Examples/PRFTagReader/DirectCoupling/Swap.lean
+++ b/Examples/PRFTagReader/DirectCoupling/Swap.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Table

--- a/Examples/PRFTagReader/DirectCoupling/TagSlotPositive.lean
+++ b/Examples/PRFTagReader/DirectCoupling/TagSlotPositive.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.DirectCoupling

--- a/Examples/PRFTagReader/DirectCoupling/TagSlotZero.lean
+++ b/Examples/PRFTagReader/DirectCoupling/TagSlotZero.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.DirectCoupling

--- a/Examples/PRFTagReader/MultipleBadCollision.lean
+++ b/Examples/PRFTagReader/MultipleBadCollision.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.DirectCoupling.Compose

--- a/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
+++ b/Examples/PRFTagReader/MultipleToHybrid/EagerSetup.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.MultipleToHybrid.Setup

--- a/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
+++ b/Examples/PRFTagReader/MultipleToHybrid/Setup.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.Table

--- a/Examples/PRFTagReader/PRFReductions.lean
+++ b/Examples/PRFTagReader/PRFReductions.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.PRFReductions.Reductions

--- a/Examples/PRFTagReader/PRFReductions/IdealHandlers.lean
+++ b/Examples/PRFTagReader/PRFReductions/IdealHandlers.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.PRFReductions.Reductions

--- a/Examples/PRFTagReader/PRFReductions/Reductions.lean
+++ b/Examples/PRFTagReader/PRFReductions/Reductions.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader

--- a/Examples/PRFTagReader/PRFReductions/Structural.lean
+++ b/Examples/PRFTagReader/PRFReductions/Structural.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.PRFReductions.IdealHandlers

--- a/Examples/PRFTagReader/Table.lean
+++ b/Examples/PRFTagReader/Table.lean
@@ -1,7 +1,7 @@
 /-
-Copyright (c) 2026 Quang Dao. All rights reserved.
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Quang Dao
+Authors: Oleksandr Vovkotrub
 -/
 
 import Examples.PRFTagReader.PRFReductions


### PR DESCRIPTION
## What

The 20 new files added under `Examples/PRFTagReader/` in #433 carried a file header copied verbatim from sibling files:

```
Copyright (c) 2026 Quang Dao. All rights reserved.
Authors: Quang Dao
```

Git history shows every one of these files was created by **Oleksandr Vovkotrub** (`alik@vovkotrub.com`). This PR updates the copyright holder and `Authors:` line on those 20 files to match the actual creating author, bringing them in line with the two files in the same directory that were already correct (`Asymptotic.lean`, `UnlinkReduction.lean`).

Per `CONTRIBUTING.md` §Attribution, new files should credit the author(s) who created them.

## Scope

- **Header-only**: each file changes exactly two lines (copyright + authors). No code, proofs, or imports are touched.
- 20 files, 40 insertions / 40 deletions.

## Files

`Auth`, `BadEvent`, `Collision`, `Collision/ForgeStep`, `Defs`, `DirectCoupling`, `DirectCoupling/{Compose,ReaderCase,StepLemmas,Swap,TagSlotPositive,TagSlotZero}`, `MultipleBadCollision`, `MultipleToHybrid/{EagerSetup,Setup}`, `PRFReductions`, `PRFReductions/{IdealHandlers,Reductions,Structural}`, `Table`.