### PR TITLE
feat(SimSemantics): liftM/simulateQ compatibility lemmas for handler lifts (#428)

### DIFF
--- a/Examples/PRFTagReader/Auth.lean
+++ b/Examples/PRFTagReader/Auth.lean
@@ -132,11 +132,7 @@ private lemma simulateQ_prfReal_authToPRFTagImpl_run
   have hleft : ∀ {α : Type} (oa : ProbComp α),
       simulateQ impl (liftComp oa (unifSpec + ((TagId × Nonce) →ₒ Digest))) = oa := by
     intro α oa
-    trans simulateQ (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)) oa
-    · exact QueryImpl.simulateQ_add_liftComp_left
-        (impl₁' := HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp))
-        (impl₂' := so) oa
-    · exact simulateQ_ofLift_eq_self _
+    simp [impl, QueryImpl.simulateQ_add_liftM_left, QueryImpl.simulateQ_toQueryImpl]
   unfold authToPRFTagImpl authTagQueryImpl authPRFQuery
   simp only [StateT.run_bind, StateT.run_get, StateT.run_monadLift,
     bind_pure_comp, pure_bind]
@@ -451,15 +447,7 @@ private lemma simulateQ_prfIdeal_authToPRFTagImpl_run
       simulateQ impl (liftComp oa (unifSpec + ((TagId × Nonce) →ₒ Digest))) =
         (liftM oa : StateT ((TagId × Nonce) →ₒ Digest).QueryCache ProbComp α) := by
     intro α oa
-    trans simulateQ ((HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
-        (StateT ((TagId × Nonce) →ₒ Digest).QueryCache ProbComp)) oa
-    · exact QueryImpl.simulateQ_add_liftComp_left
-        (impl₁' := (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
-          (StateT ((TagId × Nonce) →ₒ Digest).QueryCache ProbComp))
-        (impl₂' := ((TagId × Nonce) →ₒ Digest).randomOracle) oa
-    · rw [simulateQ_liftTarget]
-      congr 1
-      exact simulateQ_ofLift_eq_self _
+    simp [impl, QueryImpl.simulateQ_add_liftM_left, QueryImpl.simulateQ_toQueryImpl]
   have hquery : ∀ (d : TagId × Nonce),
       simulateQ impl
         (liftM ((unifSpec + ((TagId × Nonce) →ₒ Digest)).query (Sum.inr d)) :

--- a/Examples/PRFTagReader/PRFReductions/IdealHandlers.lean
+++ b/Examples/PRFTagReader/PRFReductions/IdealHandlers.lean
@@ -185,11 +185,8 @@ lemma simulateQ_prfIdeal_liftComp {D : Type} [DecidableEq D] {α : Type}
     (simulateQ (PRFScheme.prfIdealQueryImpl (D := D) (R := Digest))
         (OracleComp.liftComp oa (unifSpec + (D →ₒ Digest)))).run c =
       oa >>= fun a => pure (a, c) := by
-  have h := QueryImpl.simulateQ_add_liftComp_left
-    ((HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
-      (StateT (D →ₒ Digest).QueryCache ProbComp)) randomOracle oa
-  exact (congrArg (StateT.run · c) (h.trans ((simulateQ_liftTarget _ oa).trans
-    (congrArg liftM (simulateQ_ofLift_eq_self oa))))).trans (StateT.run_monadLift oa c)
+  simp [PRFScheme.prfIdealQueryImpl, QueryImpl.simulateQ_add_liftM_left,
+    QueryImpl.simulateQ_toQueryImpl, StateT.run_monadLift]
 
 omit [DecidableEq TagId] [Fintype TagId] [Nonempty TagId] [SampleableType Nonce]
   [DecidableEq Digest] [NeZero sessionsPerTag] in

--- a/VCVio/CryptoFoundations/PRF.lean
+++ b/VCVio/CryptoFoundations/PRF.lean
@@ -100,8 +100,7 @@ candidate function (real: `prf.eval k`; ideal: the lazy random oracle). -/
 @[simp] lemma simulateQ_prfRealQueryImpl_liftComp (prf : PRFScheme K D R) (k : K)
     {β : Type} (ob : OracleComp unifSpec β) :
     simulateQ (prf.prfRealQueryImpl k) (OracleComp.liftComp ob (PRFOracleSpec D R)) = ob := by
-  unfold prfRealQueryImpl
-  rw [QueryImpl.simulateQ_add_liftComp_left, HasQuery.toQueryImpl_eq_id', simulateQ_id']
+  simp [prfRealQueryImpl, QueryImpl.simulateQ_add_liftM_left, QueryImpl.simulateQ_toQueryImpl]
 
 /-- The ideal (lazy random oracle) PRF handler is transparent on a computation lifted in from
 `unifSpec`, threading the cache: the result is just `ob` lifted into the cache state monad. -/
@@ -109,9 +108,7 @@ candidate function (real: `prf.eval k`; ideal: the lazy random oracle). -/
     {β : Type} (ob : OracleComp unifSpec β) :
     simulateQ (prfIdealQueryImpl (D := D) (R := R)) (OracleComp.liftComp ob (PRFOracleSpec D R))
       = (liftM ob : StateT ((D →ₒ R).QueryCache) ProbComp β) := by
-  unfold prfIdealQueryImpl
-  rw [QueryImpl.simulateQ_add_liftComp_left, HasQuery.toQueryImpl_eq_id',
-      simulateQ_liftTarget, simulateQ_id']
+  simp [prfIdealQueryImpl, QueryImpl.simulateQ_add_liftM_left, QueryImpl.simulateQ_toQueryImpl]
 
 /-- A function query (`Sum.inr`) under the real PRF handler evaluates the PRF. -/
 @[simp] lemma simulateQ_prfRealQueryImpl_inr (prf : PRFScheme K D R) (k : K) (d : D) :

--- a/VCVio/OracleComp/SimSemantics/Append.lean
+++ b/VCVio/OracleComp/SimSemantics/Append.lean
@@ -55,7 +55,7 @@ variable {ι₁' : Type} {ι₂' : Type}
   {α : Type} {m' : Type → Type v} [Monad m'] [LawfulMonad m']
   (impl₁' : QueryImpl spec₁' m') (impl₂' : QueryImpl spec₂' m')
 
-private lemma simulateQ_add_liftM_left (t : spec₁'.Domain) :
+private lemma simulateQ_add_liftM_query_left (t : spec₁'.Domain) :
     simulateQ (impl₁' + impl₂')
       (liftM (spec₁'.query t) : OracleComp (spec₁' + spec₂') _) =
     impl₁' t := by
@@ -63,7 +63,7 @@ private lemma simulateQ_add_liftM_left (t : spec₁'.Domain) :
     (liftM (liftM (spec₁'.query t) : OracleQuery (spec₁' + spec₂') _)) = _
   simp [simulateQ_query]
 
-private lemma simulateQ_add_liftM_right (t : spec₂'.Domain) :
+private lemma simulateQ_add_liftM_query_right (t : spec₂'.Domain) :
     simulateQ (impl₁' + impl₂')
       (liftM (spec₂'.query t) : OracleComp (spec₁' + spec₂') _) =
     impl₂' t := by
@@ -78,7 +78,7 @@ lemma simulateQ_add_liftComp_left (oa : OracleComp spec₁' α) :
   rw [OracleComp.liftComp_def, ← simulateQ_compose]
   congr 1
   funext t
-  exact simulateQ_add_liftM_left impl₁' impl₂' t
+  exact simulateQ_add_liftM_query_left impl₁' impl₂' t
 
 @[simp]
 lemma simulateQ_add_liftComp_right (ob : OracleComp spec₂' α) :
@@ -87,7 +87,29 @@ lemma simulateQ_add_liftComp_right (ob : OracleComp spec₂' α) :
   rw [OracleComp.liftComp_def, ← simulateQ_compose]
   congr 1
   funext t
-  exact simulateQ_add_liftM_right impl₁' impl₂' t
+  exact simulateQ_add_liftM_query_right impl₁' impl₂' t
+
+/-- `liftM`-normal-form companion of `simulateQ_add_liftComp_left`. Because `liftComp_eq_liftM`
+normalizes `liftComp → liftM` under `simp`, the `liftComp`-keyed lemma never fires inside `simp`;
+this `liftM`-keyed form is what `simp` actually needs.
+
+Deliberately **not** `@[simp]`: as a global rule it shifts the normal form of `simulateQ` over an
+added handler applied to a lifted-in computation, which pre-empts and breaks existing proofs that
+manage that reduction themselves. Pass it explicitly, e.g.
+`simp [myHandler, simulateQ_add_liftM_left, simulateQ_toQueryImpl]`. -/
+lemma simulateQ_add_liftM_left (oa : OracleComp spec₁' α) :
+    simulateQ (impl₁' + impl₂') (liftM oa : OracleComp (spec₁' + spec₂') α) =
+      simulateQ impl₁' oa := by
+  rw [← OracleComp.liftComp_eq_liftM]
+  exact simulateQ_add_liftComp_left impl₁' impl₂' oa
+
+/-- `liftM`-normal-form companion of `simulateQ_add_liftComp_right`; opt-in, see
+`simulateQ_add_liftM_left`. -/
+lemma simulateQ_add_liftM_right (ob : OracleComp spec₂' α) :
+    simulateQ (impl₁' + impl₂') (liftM ob : OracleComp (spec₁' + spec₂') α) =
+      simulateQ impl₂' ob := by
+  rw [← OracleComp.liftComp_eq_liftM]
+  exact simulateQ_add_liftComp_right impl₁' impl₂' ob
 
 lemma simulateQ_liftComp_left_eq_of_apply
     (impl : QueryImpl (spec₁' + spec₂') m') (impl₁ : QueryImpl spec₁' m')
@@ -134,6 +156,20 @@ lemma simulateQ_liftComp_right_eq_of_apply
       exact bind_congr fun u => ih u
 
 end simulateQ_add_liftComp
+
+/-- Simulating the trivial `HasQuery.toQueryImpl` handler back into `OracleComp spec` is the
+identity (the composite of `HasQuery.toQueryImpl_eq_id'` and `simulateQ_id'`).
+
+Like `toQueryImpl_eq_id'`, this is deliberately **not** `@[simp]`: globally it lets `simulateQ`
+of a `unifFwdImpl`-style `toQueryImpl.liftTarget` handler fully reduce, which can re-enable a
+backward induction-hypothesis rewrite and diverge. Pass it explicitly to `simp` (alongside the
+opaque handler definition) to discharge a lifted-in computation, e.g.
+`simp [myHandler, simulateQ_toQueryImpl]`; the `simulateQ_add_liftM_left`/`_right` and
+`simulateQ_liftTarget` rungs are `@[simp]` and fire on their own. -/
+lemma simulateQ_toQueryImpl {ι : Type*} {spec : OracleSpec ι} {α : Type u}
+    (mx : OracleComp spec α) :
+    simulateQ (HasQuery.toQueryImpl : QueryImpl spec (OracleComp spec)) mx = mx := by
+  rw [HasQuery.toQueryImpl_eq_id', simulateQ_id']
 
 section simulateQ_liftM
 


### PR DESCRIPTION
Addresses #428.

## Problem
`simulateQ` over a sum-spec handler applied to a lifted-in computation could not be discharged in one step. The compositional lemmas `QueryImpl.simulateQ_add_liftComp_left/right` exist and are `@[simp]`, but they are **dead under `simp`**: `OracleComp.liftComp_eq_liftM` is `@[simp, aesop safe norm]`, so `simp` rewrites `liftComp → liftM` first and the `liftComp`-keyed lemmas can never match. That is why consumers fall back to manual `rw` chains like
```lean
rw [QueryImpl.simulateQ_add_liftComp_left, HasQuery.toQueryImpl_eq_id',
    simulateQ_liftTarget, simulateQ_id']
```

## Change
Add the `liftM`-keyed companions `simulateQ_add_liftM_left/right` (the form `simp` actually needs) and the composite `simulateQ_toQueryImpl`. The pre-existing private single-query helpers are renamed to `simulateQ_add_liftM_query_*`.

**These three lemmas are deliberately NOT `@[simp]`.** Making the `liftM`-add lemmas global shifts the normal form of `simulateQ` over a lifted-in computation and breaks existing proofs that manage that reduction themselves (verified: it broke `FiatShamir/Sigma/Stateful/Compatibility.lean` and `Chain.lean`). The `simulateQ_toQueryImpl` rung diverges globally for the same reason `HasQuery.toQueryImpl_eq_id'` is kept off `@[simp]` (see its docstring). They are meant to be passed explicitly, collapsing a 3–4 step `rw`/term chain to one `simp` call.

## Consumers simplified
- `PRF.lean`: both transparency lemmas now close by one `simp`.
- `Examples/PRFTagReader/Auth.lean`: both `hleft` blocks.
- `Examples/PRFTagReader/PRFReductions/IdealHandlers.lean`: `simulateQ_prfIdeal_liftComp`.

(`Reductions.lean` left as-is — its `hleft` already uses the minimal term idiom `simulateQ_add_liftComp_left.trans simulateQ_ofLift_eq_self`.)

## Validation
Full `VCVio + Examples` build is green; no new warnings; no statement changes.