### PR TITLE
chore(VCVio): improve computability of some `SampleableType` constructions

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -23,6 +23,7 @@ import ToMathlib.Data.ENNReal.AbsDiff
 import ToMathlib.Data.ENNReal.Gauss
 import ToMathlib.Data.ENNReal.SumSquares
 import ToMathlib.Data.ENNReal.TsumDistrib
+import ToMathlib.Data.FinEnum
 import ToMathlib.Data.Heap
 import ToMathlib.Data.IndexedBinaryTree.Basic
 import ToMathlib.Data.IndexedBinaryTree.Equiv

--- a/ToMathlib/Data/FinEnum.lean
+++ b/ToMathlib/Data/FinEnum.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import Mathlib.Data.FinEnum
+public import Mathlib.Data.Fintype.Perm
+public import Mathlib.Data.List.Sym
+public import Mathlib.Logic.Embedding.Basic
+public import Mathlib.Data.Fintype.Pi
+
+/-!
+# Computable `FinEnum` constructions for `Bool`, `Sym`, `Equiv.Perm`, and embeddings
+
+`FinEnum α` packages a finite type with a *canonical computable enumeration* (an exhaustive
+duplicate-free list, hence `DecidableEq` and `Fintype`). `Mathlib` provides `FinEnum` for the
+basic shape-formers (`Fin`, products, sums, `Finset`, subtypes, pi types, …) but not for `Bool`
+nor for the combinatorial type-formers `Sym`, `Equiv.Perm`, and function embeddings — even though
+each has a `Fintype` instance and an underlying list enumerator. This file fills those gaps.
+
+* `FinEnum Bool` is a small base instance.
+* `Sym.finEnum`, `Equiv.Perm.finEnum`, and `Function.Embedding.finEnum` are provided as plain
+  `def`s (not instances) on purpose: a global `FinEnum` instance for any of these would, through
+  the `priority 100` `FinEnum → Fintype` instance, synthesize a second `Fintype` competing with
+  `Mathlib`'s native one and not definitionally equal to it. Callers that want the enumeration
+  introduce it locally with `letI` so no competing `Fintype` ever enters global resolution.
+
+Each construction reuses an existing computable enumerator: `List.sym` for `Sym`, `permsOfList`
+for `Equiv.Perm`, and the equivalence with the injective-function subtype for embeddings (the
+latter is genuinely computable, unlike `Mathlib`'s noncomputable `Function.Embedding.fintype`).
+`List.mem_sym` supplies the completeness half that `Mathlib` is missing for `List.sym`.
+-/
+
+@[expose] public section
+
+universe u
+
+/-- Completeness of `List.sym`: every `z : Sym α n` whose members all lie in `xs` is enumerated by
+`xs.sym n`. This is the converse of `List.mem_of_mem_of_mem_sym`. -/
+theorem List.mem_sym {α : Type u} :
+    ∀ {n : ℕ} {xs : List α} {z : Sym α n}, (∀ a ∈ z, a ∈ xs) → z ∈ xs.sym n
+  | 0, _, z, _ => by rw [Sym.eq_nil_of_card_zero z]; simp [List.sym]
+  | n + 1, [], z, h => by
+      obtain ⟨a, z', rfl⟩ := z.exists_eq_cons_of_succ
+      exact absurd (h a (Sym.mem_cons_self a z')) (by simp)
+  | n + 1, x :: xs, z, h => by
+      classical
+      rw [List.sym, List.mem_append]
+      by_cases hx : x ∈ z
+      · refine Or.inl (List.mem_map.mpr ⟨z.erase x hx, ?_, Sym.cons_erase hx⟩)
+        exact List.mem_sym fun a ha =>
+          h a (by rw [← Sym.cons_erase hx]; exact Sym.mem_cons.mpr (Or.inr ha))
+      · refine Or.inr (List.mem_sym fun a ha => ?_)
+        rcases List.mem_cons.mp (h a ha) with rfl | ha'
+        · exact absurd ha hx
+        · exact ha'
+
+/-- `Bool` enumerated as `[true, false]`. -/
+instance : FinEnum Bool := .ofList [true, false] (by decide)
+
+/-- Computable enumeration of size-`n` multisets over a `FinEnum` type, drawn from `List.sym` of
+the canonical enumeration. Every `z : Sym α n` qualifies since all its members lie in
+`FinEnum.toList`. -/
+@[reducible] def Sym.finEnum {α : Type u} [FinEnum α] (n : ℕ) : FinEnum (Sym α n) :=
+  FinEnum.ofNodupList ((FinEnum.toList α).sym n)
+    (fun _ => List.mem_sym fun a _ => FinEnum.mem_toList a)
+    (List.Nodup.sym n FinEnum.nodup_toList)
+
+/-- Computable enumeration of permutations of a `FinEnum` type via `permsOfList` applied to the
+canonical enumeration. Completeness holds because every element a permutation can move lies in
+`FinEnum.toList`. -/
+@[reducible] def Equiv.Perm.finEnum {α : Type u} [FinEnum α] : FinEnum (Equiv.Perm α) :=
+  FinEnum.ofNodupList (permsOfList (FinEnum.toList α))
+    (fun _ => mem_permsOfList_of_mem fun x _ => FinEnum.mem_toList x)
+    (nodup_permsOfList FinEnum.nodup_toList)
+
+/-- Computable enumeration of embeddings `β ↪ α` between `FinEnum` types, transported from the
+`FinEnum` on the subtype of injective functions `{f : β → α // Function.Injective f}`. Injectivity
+is decidable for functions out of a finite domain, so this subtype is itself `FinEnum`. -/
+@[reducible] def Function.Embedding.finEnum {β α : Type u} [FinEnum β] [FinEnum α] :
+    FinEnum (β ↪ α) :=
+  FinEnum.ofEquiv { f : β → α // Function.Injective f }
+    (Equiv.subtypeInjectiveEquivEmbedding β α).symm

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -9,6 +9,7 @@ import VCVio.OracleComp.EvalDist
 import VCVio.EvalDist.Bool
 import VCVio.EvalDist.Prod
 import VCVio.EvalDist.Fintype
+import ToMathlib.Data.FinEnum
 import Init.Data.UInt.Lemmas
 import Mathlib.Data.FinEnum
 import Mathlib.Data.Fintype.Perm
@@ -276,10 +277,9 @@ instance (α : Type) [Unique α] : SampleableType α where
   mem_support_selectElem x := Unique.eq_default x ▸ (by simp)
   probOutput_selectElem_eq x y := by rw [Unique.eq_default x, Unique.eq_default y]
 
-instance : SampleableType Bool where
-  selectElem := $! #v[true, false]
-  mem_support_selectElem x := by simp
-  probOutput_selectElem_eq x y := by simp
+-- `SampleableType Bool` is derived from `FinEnum Bool` (see `ToMathlib.Data.FinEnum`) via
+-- `FinEnum.SampleableType`, keeping `FinEnum` as the canonical uniform-sampling pathway rather
+-- than carrying a bespoke `Bool` sampler.
 
 /-- A sum of oracle specs with sampleable ranges again has sampleable ranges. -/
 instance {ι ι'} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
@@ -420,40 +420,52 @@ inhabited by `∅`, so no `Nonempty` hypothesis is needed. -/
 instance instSampleableTypeFinset {α : Type} [FinEnum α] : SampleableType (Finset α) :=
   inferInstance
 
-/-- Uniform sampling of size-`n` multisets over `α`. `Sym α n` is the correct finite analogue
-of `Multiset α`: a plain `Multiset α` is unbounded in multiplicity and thus not `Fintype`,
-while `Sym α n` is a `Fintype` whenever `α` is. The `Mathlib` instance lives in
-`Mathlib.Data.Fintype.Vector`; we lift it through `SampleableType.ofFintype`. -/
-noncomputable instance instSampleableTypeSym {α : Type} {n : ℕ}
-    [Fintype α] [DecidableEq α] [Nonempty α] : SampleableType (Sym α n) :=
-  haveI : Nonempty (Sym α n) := ⟨.replicate n (Classical.arbitrary α)⟩
-  SampleableType.ofFintype _
+/-- Uniform sampling of size-`n` multisets over a `FinEnum` type. `Sym α n` is the correct finite
+analogue of `Multiset α`: a plain `Multiset α` is unbounded in multiplicity and thus not finite,
+while `Sym α n` is finite whenever `α` is. We obtain a *computable* uniform sampler from the
+canonical enumeration `Sym.finEnum`; for a base type with only a `Fintype` instance use
+`SampleableType.ofFintype` instead.
 
-/-- Uniform sampling of permutations of a finite type. `Equiv.Perm α` has `n!` elements when
-`Fintype.card α = n`. Mathlib provides `Fintype (Equiv.Perm α)` via
-`Mathlib.Data.Fintype.Perm`; we lift through `SampleableType.ofFintype`. Useful for
-shuffle-based protocols and oblivious-permutation games. -/
-noncomputable instance instSampleableTypePerm {α : Type} [Fintype α] [DecidableEq α] :
+Note this is genuinely uniform on multisets: mapping a uniform `List.Vector α n` through
+`Sym.ofVector` is *not* (it weights each multiset by its number of orderings), so we enumerate
+`Sym α n` canonically rather than pushing forward from vectors. -/
+instance instSampleableTypeSym {α : Type} {n : ℕ} [FinEnum α] [Nonempty α] :
+    SampleableType (Sym α n) :=
+  letI : FinEnum (Sym α n) := Sym.finEnum n
+  haveI : Nonempty (Sym α n) := ⟨Sym.replicate n (Classical.arbitrary α)⟩
+  FinEnum.SampleableType _
+
+/-- Uniform sampling of permutations of a `FinEnum` type. `Equiv.Perm α` has `n!` elements when
+`Fintype.card α = n`. We obtain a *computable* uniform sampler from the canonical enumeration
+`Equiv.Perm.finEnum`. Useful for shuffle-based protocols and oblivious-permutation games. -/
+instance instSampleableTypePerm {α : Type} [FinEnum α] :
     SampleableType (Equiv.Perm α) :=
+  letI : FinEnum (Equiv.Perm α) := Equiv.Perm.finEnum
   haveI : Nonempty (Equiv.Perm α) := ⟨Equiv.refl α⟩
-  SampleableType.ofFintype _
+  FinEnum.SampleableType _
 
-/-- Uniform sampling of injections `β ↪ α` for finite types. The number of such embeddings is
+/-- Uniform sampling of injections `β ↪ α` for `FinEnum` types. The number of such embeddings is
 `α.card! / (α.card - β.card)!` when `β.card ≤ α.card`, else `0`; the `Nonempty (β ↪ α)`
-hypothesis rules out the latter case. Mathlib provides `Fintype (β ↪ α)` via
-`Mathlib.Data.Fintype.Pi`; we lift through `SampleableType.ofFintype`. -/
-noncomputable instance instSampleableTypeEmbedding {β α : Type}
-    [Fintype β] [Fintype α] [DecidableEq β] [DecidableEq α] [Nonempty (β ↪ α)] :
+hypothesis rules out the latter case. We obtain a *computable* uniform sampler from the canonical
+enumeration `Function.Embedding.finEnum` (itself computable, unlike Mathlib's `Fintype (β ↪ α)`). -/
+instance instSampleableTypeEmbedding {β α : Type}
+    [FinEnum β] [FinEnum α] [Nonempty (β ↪ α)] :
     SampleableType (β ↪ α) :=
-  SampleableType.ofFintype _
+  letI : FinEnum (β ↪ α) := Function.Embedding.finEnum
+  FinEnum.SampleableType _
 
-/-- A function from a finite type `D` with decidable equality to a `SampleableType` is itself
-`SampleableType`: transport the `Fin (Fintype.card D) → α` instance across the canonical
-equivalence `(D → α) ≃ (Fin (Fintype.card D) → α)`. This is the general Pi instance over an
-arbitrary finite domain presented by `Fintype` + `DecidableEq`, complementing the `FinEnum`-domain
-instance `instSampleableTypeFunc`. -/
-noncomputable instance instSampleableTypePiFintype {D : Type} [Fintype D] [DecidableEq D]
-    {α : Type} [SampleableType α] : SampleableType (D → α) :=
+/-- A function from a finite type `D` with `Fintype` + `DecidableEq` (not necessarily `FinEnum`)
+to a `SampleableType` is itself `SampleableType`, transporting the `Fin (Fintype.card D) → α`
+sampler across the canonical equivalence `(D → α) ≃ (Fin (Fintype.card D) → α)`.
+
+This is the *noncomputable* counterpart to the computable `FinEnum`-domain instance
+`instSampleableTypeFunc`, and is given **lower priority** so that for a `FinEnum` domain the
+computable instance is preferred; it is the fallback for `Fintype` + `DecidableEq`-only domains. -/
+noncomputable instance (priority := 100) instSampleableTypePiFintype {D : Type}
+    [Fintype D] [DecidableEq D] {α : Type} [SampleableType α] : SampleableType (D → α) :=
+  -- Provide the `Fin (card D) → α` sampler explicitly: synthesizing it could loop, since for the
+  -- abstract `Fintype.card D` the overlapping `instSampleableTypeFunc` descends without converging.
+  letI : SampleableType (Fin (Fintype.card D) → α) := instSampleableTypeFinFunc
   SampleableType.ofEquiv
     (α := Fin (Fintype.card D) → α)
     (Equiv.arrowCongr (Fintype.equivFin D).symm (Equiv.refl α))
@@ -632,7 +644,7 @@ patched first and the head point `d` is then overwritten with a fresh uniform dr
 
 This is the iterated form of `Function.update` used by `evalDist_uniformSample_patchList`: the
 outermost update is at the head, so the list is consumed head-first. -/
-noncomputable def patchTable {D R : Type} [DecidableEq D] [SampleableType R] :
+def patchTable {D R : Type} [DecidableEq D] [SampleableType R] :
     List D → (D → R) → ProbComp (D → R)
   | [], g => pure g
   | d :: ds, g => do

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -9,6 +9,7 @@ import VCVio.OracleComp.EvalDist
 import VCVio.EvalDist.Bool
 import VCVio.EvalDist.Prod
 import VCVio.EvalDist.Fintype
+import ToMathlib.Data.FinEnum
 import Init.Data.UInt.Lemmas
 import Mathlib.Data.FinEnum
 import Mathlib.Data.Fintype.Perm
@@ -276,7 +277,9 @@ instance (α : Type) [Unique α] : SampleableType α where
   mem_support_selectElem x := Unique.eq_default x ▸ (by simp)
   probOutput_selectElem_eq x y := by rw [Unique.eq_default x, Unique.eq_default y]
 
-instance : SampleableType Bool where
+/-- Higher priority than the `FinEnum.SampleableType` path (`FinEnum Bool` exists) so that
+`$ᵗ Bool` always reduces to this canonical `#v[true, false]` sampler. -/
+instance (priority := 1100) : SampleableType Bool where
   selectElem := $! #v[true, false]
   mem_support_selectElem x := by simp
   probOutput_selectElem_eq x y := by simp
@@ -420,40 +423,52 @@ inhabited by `∅`, so no `Nonempty` hypothesis is needed. -/
 instance instSampleableTypeFinset {α : Type} [FinEnum α] : SampleableType (Finset α) :=
   inferInstance
 
-/-- Uniform sampling of size-`n` multisets over `α`. `Sym α n` is the correct finite analogue
-of `Multiset α`: a plain `Multiset α` is unbounded in multiplicity and thus not `Fintype`,
-while `Sym α n` is a `Fintype` whenever `α` is. The `Mathlib` instance lives in
-`Mathlib.Data.Fintype.Vector`; we lift it through `SampleableType.ofFintype`. -/
-noncomputable instance instSampleableTypeSym {α : Type} {n : ℕ}
-    [Fintype α] [DecidableEq α] [Nonempty α] : SampleableType (Sym α n) :=
-  haveI : Nonempty (Sym α n) := ⟨.replicate n (Classical.arbitrary α)⟩
-  SampleableType.ofFintype _
+/-- Uniform sampling of size-`n` multisets over a `FinEnum` type. `Sym α n` is the correct finite
+analogue of `Multiset α`: a plain `Multiset α` is unbounded in multiplicity and thus not finite,
+while `Sym α n` is finite whenever `α` is. We obtain a *computable* uniform sampler from the
+canonical enumeration `Sym.finEnum`; for a base type with only a `Fintype` instance use
+`SampleableType.ofFintype` instead.
 
-/-- Uniform sampling of permutations of a finite type. `Equiv.Perm α` has `n!` elements when
-`Fintype.card α = n`. Mathlib provides `Fintype (Equiv.Perm α)` via
-`Mathlib.Data.Fintype.Perm`; we lift through `SampleableType.ofFintype`. Useful for
-shuffle-based protocols and oblivious-permutation games. -/
-noncomputable instance instSampleableTypePerm {α : Type} [Fintype α] [DecidableEq α] :
+Note this is genuinely uniform on multisets: mapping a uniform `List.Vector α n` through
+`Sym.ofVector` is *not* (it weights each multiset by its number of orderings), so we enumerate
+`Sym α n` canonically rather than pushing forward from vectors. -/
+instance instSampleableTypeSym {α : Type} {n : ℕ} [FinEnum α] [Nonempty α] :
+    SampleableType (Sym α n) :=
+  letI : FinEnum (Sym α n) := Sym.finEnum n
+  haveI : Nonempty (Sym α n) := ⟨Sym.replicate n (Classical.arbitrary α)⟩
+  FinEnum.SampleableType _
+
+/-- Uniform sampling of permutations of a `FinEnum` type. `Equiv.Perm α` has `n!` elements when
+`Fintype.card α = n`. We obtain a *computable* uniform sampler from the canonical enumeration
+`Equiv.Perm.finEnum`. Useful for shuffle-based protocols and oblivious-permutation games. -/
+instance instSampleableTypePerm {α : Type} [FinEnum α] :
     SampleableType (Equiv.Perm α) :=
+  letI : FinEnum (Equiv.Perm α) := Equiv.Perm.finEnum
   haveI : Nonempty (Equiv.Perm α) := ⟨Equiv.refl α⟩
-  SampleableType.ofFintype _
+  FinEnum.SampleableType _
 
-/-- Uniform sampling of injections `β ↪ α` for finite types. The number of such embeddings is
+/-- Uniform sampling of injections `β ↪ α` for `FinEnum` types. The number of such embeddings is
 `α.card! / (α.card - β.card)!` when `β.card ≤ α.card`, else `0`; the `Nonempty (β ↪ α)`
-hypothesis rules out the latter case. Mathlib provides `Fintype (β ↪ α)` via
-`Mathlib.Data.Fintype.Pi`; we lift through `SampleableType.ofFintype`. -/
-noncomputable instance instSampleableTypeEmbedding {β α : Type}
-    [Fintype β] [Fintype α] [DecidableEq β] [DecidableEq α] [Nonempty (β ↪ α)] :
+hypothesis rules out the latter case. We obtain a *computable* uniform sampler from the canonical
+enumeration `Function.Embedding.finEnum` (itself computable, unlike Mathlib's `Fintype (β ↪ α)`). -/
+instance instSampleableTypeEmbedding {β α : Type}
+    [FinEnum β] [FinEnum α] [Nonempty (β ↪ α)] :
     SampleableType (β ↪ α) :=
-  SampleableType.ofFintype _
+  letI : FinEnum (β ↪ α) := Function.Embedding.finEnum
+  FinEnum.SampleableType _
 
-/-- A function from a finite type `D` with decidable equality to a `SampleableType` is itself
-`SampleableType`: transport the `Fin (Fintype.card D) → α` instance across the canonical
-equivalence `(D → α) ≃ (Fin (Fintype.card D) → α)`. This is the general Pi instance over an
-arbitrary finite domain presented by `Fintype` + `DecidableEq`, complementing the `FinEnum`-domain
-instance `instSampleableTypeFunc`. -/
-noncomputable instance instSampleableTypePiFintype {D : Type} [Fintype D] [DecidableEq D]
-    {α : Type} [SampleableType α] : SampleableType (D → α) :=
+/-- A function from a finite type `D` with `Fintype` + `DecidableEq` (not necessarily `FinEnum`)
+to a `SampleableType` is itself `SampleableType`, transporting the `Fin (Fintype.card D) → α`
+sampler across the canonical equivalence `(D → α) ≃ (Fin (Fintype.card D) → α)`.
+
+This is the *noncomputable* counterpart to the computable `FinEnum`-domain instance
+`instSampleableTypeFunc`, and is given **lower priority** so that for a `FinEnum` domain the
+computable instance is preferred; it is the fallback for `Fintype` + `DecidableEq`-only domains. -/
+noncomputable instance (priority := 100) instSampleableTypePiFintype {D : Type}
+    [Fintype D] [DecidableEq D] {α : Type} [SampleableType α] : SampleableType (D → α) :=
+  -- Provide the `Fin (card D) → α` sampler explicitly: synthesizing it could loop, since for the
+  -- abstract `Fintype.card D` the overlapping `instSampleableTypeFunc` descends without converging.
+  letI : SampleableType (Fin (Fintype.card D) → α) := instSampleableTypeFinFunc
   SampleableType.ofEquiv
     (α := Fin (Fintype.card D) → α)
     (Equiv.arrowCongr (Fintype.equivFin D).symm (Equiv.refl α))
@@ -632,7 +647,7 @@ patched first and the head point `d` is then overwritten with a fresh uniform dr
 
 This is the iterated form of `Function.update` used by `evalDist_uniformSample_patchList`: the
 outermost update is at the head, so the list is consumed head-first. -/
-noncomputable def patchTable {D R : Type} [DecidableEq D] [SampleableType R] :
+def patchTable {D R : Type} [DecidableEq D] [SampleableType R] :
     List D → (D → R) → ProbComp (D → R)
   | [], g => pure g
   | d :: ds, g => do

--- a/VCVioTest/SampleableType.lean
+++ b/VCVioTest/SampleableType.lean
@@ -43,23 +43,30 @@ example : SampleableType (Fin 2 ⊕ Fin 3) := inferInstance
 example : SampleableType (Finset (Fin 3)) := inferInstance
 example : SampleableType (Finset (Fin 4 ⊕ Fin 2)) := inferInstance
 
-/-- Size-`n` multisets over a nonempty `Fintype`. -/
-noncomputable example : SampleableType (Sym Bool 3) := inferInstance
-noncomputable example : SampleableType (Sym (Fin 3) 2) := inferInstance
+/-- Size-`n` multisets over a nonempty `FinEnum` type, sampled uniformly and *computably*. -/
+example : SampleableType (Sym Bool 3) := inferInstance
+example : SampleableType (Sym (Fin 3) 2) := inferInstance
 
-/-- Permutations of a finite type: `n!` outcomes. -/
-noncomputable example : SampleableType (Equiv.Perm (Fin 3)) := inferInstance
-noncomputable example : SampleableType (Equiv.Perm Bool) := inferInstance
+/-- Permutations of a `FinEnum` type: `n!` outcomes, sampled uniformly and *computably*. -/
+example : SampleableType (Equiv.Perm (Fin 3)) := inferInstance
+example : SampleableType (Equiv.Perm Bool) := inferInstance
 
-/-- Function embeddings (injections) between finite types. The `Nonempty (β ↪ α)`
-hypothesis amounts to `card β ≤ card α`, which is supplied at use-site. -/
-noncomputable example : SampleableType (Fin 2 ↪ Fin 3) :=
+/-- Function embeddings (injections) between `FinEnum` types, sampled uniformly and *computably*.
+The `Nonempty (β ↪ α)` hypothesis amounts to `card β ≤ card α`, which is supplied at use-site. -/
+example : SampleableType (Fin 2 ↪ Fin 3) :=
   haveI : Nonempty (Fin 2 ↪ Fin 3) :=
     ⟨⟨Fin.castLE (by omega), Fin.castLE_injective _⟩⟩
   inferInstance
-noncomputable example : SampleableType (Fin 3 ↪ Fin 3) :=
+example : SampleableType (Fin 3 ↪ Fin 3) :=
   haveI : Nonempty (Fin 3 ↪ Fin 3) := ⟨.refl _⟩
   inferInstance
+
+/-- The underlying `FinEnum` enumerations are computable and have the expected cardinalities:
+`Sym (Fin 2) 2` has `multichoose 2 2 = 3` multisets, `Equiv.Perm (Fin 3)` has `3! = 6`
+permutations, and `Fin 2 ↪ Fin 3` has `3 · 2 = 6` injections. -/
+example : (Sym.finEnum (α := Fin 2) 2).card = 3 := by native_decide
+example : (Equiv.Perm.finEnum (α := Fin 3)).card = 6 := by native_decide
+example : (Function.Embedding.finEnum (β := Fin 2) (α := Fin 3)).card = 6 := by native_decide
 
 end SampleableType
 


### PR DESCRIPTION
Some definitions for `SampleableType` have been added that aren't actually computable due to their use of AoC in their definitions. This PR redirects those through computable versions.

## Overview of Changes

The noncomputability came from routing finite-type samplers through `SampleableType.ofFintype`, which depends on the noncomputable `Fintype.equivFin`. This PR instead routes them through canonical `FinEnum` enumerations, making the samplers genuinely computable and simultaneously reducing their typeclass assumptions.

### New `ToMathlib/Data/FinEnum.lean`

- `instance : FinEnum Bool` — absent from Mathlib.
- `Sym.finEnum`, `Equiv.Perm.finEnum`, `Function.Embedding.finEnum` — canonical computable enumerations, provided as reducible `def`s (not instances) to avoid a `Fintype` diamond against Mathlib's native instances through the `priority 100` `FinEnum → Fintype` instance. Callers introduce them locally via `letI` so no competing `Fintype` enters global resolution.
- `List.mem_sym` — the completeness half of `List.sym` that Mathlib lacks, used to show the `Sym` enumeration is exhaustive.

### `VCVio/OracleComp/Constructions/SampleableType.lean`

| Instance | Before | After |
| --- | --- | --- |
| `instSampleableTypeSym` | `[Fintype α] [DecidableEq α] [Nonempty α]`, noncomputable | `[FinEnum α] [Nonempty α]`, computable |
| `instSampleableTypePerm` | `[Fintype α] [DecidableEq α]`, noncomputable | `[FinEnum α]`, computable |
| `instSampleableTypeEmbedding` | `[Fintype β] [Fintype α] [DecidableEq β] [DecidableEq α] [Nonempty (β ↪ α)]`, noncomputable | `[FinEnum β] [FinEnum α] [Nonempty (β ↪ α)]`, computable |

- The bespoke `SampleableType Bool` instance is removed; `Bool` now derives from the new `FinEnum Bool` via the canonical `FinEnum.SampleableType` pathway.
- `instSampleableTypePiFintype` (the `Fintype`-domain Pi instance) is kept but demoted to `priority 100`, so the computable `FinEnum`-domain `instSampleableTypeFunc` wins when available while the `Fintype` + `DecidableEq` version remains a fallback (e.g. for `Examples/PRFTagReader`). Its body now supplies the `Fin (card D)` sampler explicitly to avoid a resolution loop on abstract cardinalities.
- `patchTable` drops a spurious `noncomputable`.

### Note on uniformity

An earlier `Sym` experiment mapping a uniform `List.Vector α n` through `Sym.ofVector` was discarded: it is **not** uniform on multisets, since `Sym.ofVector` forgets order and so weights each multiset by its number of orderings (e.g. `⟦[T,F]⟧` gets `1/2` vs `1/4` in `Sym Bool 2`), which would falsify `probOutput_selectElem_eq`. Enumerating `Sym α n` canonically samples multisets uniformly.

### `VCVioTest/SampleableType.lean`

The `Sym`/`Perm`/`Embedding` smoke examples drop `noncomputable`, plus new `native_decide` checks confirm the enumerations execute with the expected cardinalities: `Sym (Fin 2) 2 = 3`, `Equiv.Perm (Fin 3) = 6`, and `Fin 2 ↪ Fin 3 = 6`.
