### PR TITLE
feat(EvalDist/TVDist): add `tvDist_bind_left_le_const` as root of the const bound

### DIFF
--- a/VCVio/EvalDist/TVDist.lean
+++ b/VCVio/EvalDist/TVDist.lean
@@ -263,6 +263,87 @@ lemma tvDist_bind_left_le
             rfl
           rw [h1, h2]
 
+/-! ### TV distance for bind with a constant bound -/
+
+/-- Total-variation distance is convex over a shared `bind`: if `tvDist (f a) (g a) ≤ c` for every
+`a ∈ support mx`, then `tvDist (mx >>= f) (mx >>= g) ≤ c`. The real-valued root of the `const`
+bound, with `ℝ≥0∞` companion `ofReal_tvDist_bind_left_le_const`. -/
+theorem tvDist_bind_left_le_const
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
+    {α β : Type u} (mx : m α) (f g : α → m β) (c : ℝ)
+    (hfg : ∀ a, a ∈ support mx → tvDist (f a) (g a) ≤ c) :
+    tvDist (mx >>= f) (mx >>= g) ≤ c := by
+  classical
+  have hprob_ne_top : ∀ a : α, Pr[= a | mx] ≠ ⊤ := fun a =>
+    ne_top_of_le_ne_top one_ne_top (probOutput_le_one (mx := mx) (x := a))
+  have hp_sum_ne_top : (∑' a : α, Pr[= a | mx]) ≠ ⊤ := by
+    rw [tsum_probOutput_of_liftM_PMF]; exact one_ne_top
+  have hp_summable : Summable (fun a : α => Pr[= a | mx].toReal) :=
+    ENNReal.summable_toReal hp_sum_ne_top
+  have hp_sum_toReal : (∑' a : α, Pr[= a | mx].toReal) = 1 := by
+    rw [← ENNReal.tsum_toReal_eq hprob_ne_top, tsum_probOutput_of_liftM_PMF, ENNReal.toReal_one]
+  have hlhs_nonneg : ∀ a : α, 0 ≤ Pr[= a | mx].toReal * tvDist (f a) (g a) :=
+    fun _ => mul_nonneg ENNReal.toReal_nonneg (tvDist_nonneg _ _)
+  have hlhs_le_p : ∀ a : α,
+      Pr[= a | mx].toReal * tvDist (f a) (g a) ≤ Pr[= a | mx].toReal :=
+    fun _ => mul_le_of_le_one_right ENNReal.toReal_nonneg (tvDist_le_one _ _)
+  have hlhs_summable :
+      Summable (fun a : α => Pr[= a | mx].toReal * tvDist (f a) (g a)) :=
+    Summable.of_nonneg_of_le hlhs_nonneg hlhs_le_p hp_summable
+  have hrhs_summable : Summable (fun a : α => Pr[= a | mx].toReal * c) :=
+    Summable.mul_right _ hp_summable
+  refine (tvDist_bind_left_le mx f g).trans ?_
+  calc
+    (∑' a : α, Pr[= a | mx].toReal * tvDist (f a) (g a))
+        ≤ ∑' a : α, Pr[= a | mx].toReal * c :=
+          Summable.tsum_le_tsum
+            (fun a => by
+              by_cases ha : a ∈ support mx
+              · exact mul_le_mul_of_nonneg_left (hfg a ha) ENNReal.toReal_nonneg
+              · rw [probOutput_eq_zero_of_not_mem_support ha]; simp)
+            hlhs_summable hrhs_summable
+    _ = (∑' a : α, Pr[= a | mx].toReal) * c := Summable.tsum_mul_right _ hp_summable
+    _ = c := by rw [hp_sum_toReal, one_mul]
+
+/-- Unrestricted companion of `tvDist_bind_left_le_const`: a uniform per-`a` bound
+`tvDist (f a) (g a) ≤ c` lifts through the shared `mx` bind. -/
+theorem tvDist_bind_left_le_const'
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
+    {α β : Type u} (mx : m α) (f g : α → m β) (c : ℝ)
+    (hfg : ∀ a, tvDist (f a) (g a) ≤ c) :
+    tvDist (mx >>= f) (mx >>= g) ≤ c :=
+  tvDist_bind_left_le_const mx f g c fun a _ => hfg a
+
+/-- `ℝ≥0∞` form of `tvDist_bind_left_le_const`, matching the quantitative APIs: a per-`a` bound
+`ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε` on the support of `mx` lifts through the shared bind. -/
+theorem ofReal_tvDist_bind_left_le_const
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
+    {α β : Type u}
+    (mx : m α) (f g : α → m β) (ε : ℝ≥0∞)
+    (hfg : ∀ a, a ∈ support mx → ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε) :
+    ENNReal.ofReal (tvDist (mx >>= f) (mx >>= g)) ≤ ε := by
+  classical
+  by_cases htop : ε = (⊤ : ℝ≥0∞)
+  · simp [htop]
+  · have hreal : tvDist (mx >>= f) (mx >>= g) ≤ ε.toReal :=
+      tvDist_bind_left_le_const mx f g ε.toReal
+        (fun a ha => (ENNReal.ofReal_le_iff_le_toReal htop).mp (hfg a ha))
+    rw [← ENNReal.ofReal_toReal htop]
+    exact ENNReal.ofReal_le_ofReal hreal
+
+/-- Unrestricted companion of `ofReal_tvDist_bind_left_le_const`. -/
+theorem ofReal_tvDist_bind_left_le_const'
+    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
+    [MonadLiftT m SetM] [EvalDistCompatible m]
+    {α β : Type u}
+    (mx : m α) (f g : α → m β) (ε : ℝ≥0∞)
+    (hfg : ∀ a, ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε) :
+    ENNReal.ofReal (tvDist (mx >>= f) (mx >>= g)) ≤ ε :=
+  ofReal_tvDist_bind_left_le_const mx f g ε fun a _ => hfg a
+
 /-! ### TV distance for bind with a bad event -/
 
 /-- Bound the weighted TV sum from `tvDist_bind_left_le` by the probability of a bad event

--- a/VCVio/ProgramLogic/Relational/Quantitative.lean
+++ b/VCVio/ProgramLogic/Relational/Quantitative.lean
@@ -352,68 +352,6 @@ theorem ofReal_tvDist_map_private_right_bad_le
     rfl
   simpa [hleft, hbase, hbad] using h
 
-theorem ofReal_tvDist_bind_left_le_const
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
-    [MonadLiftT m SetM] [EvalDistCompatible m]
-    {α β : Type u}
-    (mx : m α) (f g : α → m β) (ε : ℝ≥0∞)
-    (hfg : ∀ a, a ∈ support mx → ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε) :
-    ENNReal.ofReal (tvDist (mx >>= f) (mx >>= g)) ≤ ε := by
-  classical
-  letI : DecidableEq ℝ≥0∞ := Classical.decEq _
-  by_cases htop : ε = (⊤ : ℝ≥0∞)
-  · simp [htop]
-  · have hfg_real : ∀ a, a ∈ support mx → tvDist (f a) (g a) ≤ ε.toReal := fun a ha =>
-      (ENNReal.ofReal_le_iff_le_toReal htop).mp (hfg a ha)
-    have hp_sum_ne_top : (∑' a : α, Pr[= a | mx]) ≠ ⊤ := by
-      rw [tsum_probOutput_of_liftM_PMF]
-      exact one_ne_top
-    have hp_summable : Summable (fun a : α => Pr[= a | mx].toReal) :=
-      ENNReal.summable_toReal hp_sum_ne_top
-    have hprob_ne_top : ∀ a : α, Pr[= a | mx] ≠ ⊤ := fun a =>
-      ne_top_of_le_ne_top one_ne_top (probOutput_le_one (mx := mx) (x := a))
-    have hp_sum_toReal : (∑' a : α, Pr[= a | mx].toReal) = 1 := by
-      rw [← ENNReal.tsum_toReal_eq hprob_ne_top,
-        tsum_probOutput_of_liftM_PMF, ENNReal.toReal_one]
-    have hlhs_nonneg : ∀ a : α, 0 ≤ Pr[= a | mx].toReal * tvDist (f a) (g a) :=
-      fun _ => mul_nonneg ENNReal.toReal_nonneg (tvDist_nonneg _ _)
-    have hlhs_le_p : ∀ a : α,
-        Pr[= a | mx].toReal * tvDist (f a) (g a) ≤ Pr[= a | mx].toReal :=
-      fun _ => mul_le_of_le_one_right ENNReal.toReal_nonneg (tvDist_le_one _ _)
-    have hlhs_summable :
-        Summable (fun a : α => Pr[= a | mx].toReal * tvDist (f a) (g a)) :=
-      Summable.of_nonneg_of_le hlhs_nonneg hlhs_le_p hp_summable
-    have hrhs_summable :
-        Summable (fun a : α => Pr[= a | mx].toReal * ε.toReal) :=
-      Summable.mul_right _ hp_summable
-    have hsum_le :
-        (∑' a : α, Pr[= a | mx].toReal * tvDist (f a) (g a)) ≤ ε.toReal := by
-      calc
-        (∑' a : α, Pr[= a | mx].toReal * tvDist (f a) (g a))
-            ≤ ∑' a : α, Pr[= a | mx].toReal * ε.toReal :=
-              Summable.tsum_le_tsum
-                (fun a => by
-                  by_cases ha : a ∈ support mx
-                  · exact mul_le_mul_of_nonneg_left (hfg_real a ha) ENNReal.toReal_nonneg
-                  · rw [probOutput_eq_zero_of_not_mem_support ha]
-                    simp)
-                hlhs_summable hrhs_summable
-        _ = (∑' a : α, Pr[= a | mx].toReal) * ε.toReal :=
-              Summable.tsum_mul_right _ hp_summable
-        _ = ε.toReal := by rw [hp_sum_toReal, one_mul]
-    have hreal : tvDist (mx >>= f) (mx >>= g) ≤ ε.toReal :=
-      (tvDist_bind_left_le mx f g).trans hsum_le
-    exact (ENNReal.ofReal_le_iff_le_toReal htop).mpr hreal
-
-theorem ofReal_tvDist_bind_left_le_const'
-    {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
-    [MonadLiftT m SetM] [EvalDistCompatible m]
-    {α β : Type u}
-    (mx : m α) (f g : α → m β) (ε : ℝ≥0∞)
-    (hfg : ∀ a, ENNReal.ofReal (tvDist (f a) (g a)) ≤ ε) :
-    ENNReal.ofReal (tvDist (mx >>= f) (mx >>= g)) ≤ ε :=
-  ofReal_tvDist_bind_left_le_const mx f g ε fun a _ => hfg a
-
 theorem evalDist_bind_ignore
     {m : Type u → Type v} [Monad m] [LawfulMonad m] [MonadLiftT m PMF] [LawfulMonadLiftT m PMF]
     {α β γ : Type u}


### PR DESCRIPTION
Closes #455.

Adds the real-valued convex-combination bound and makes it the root of the `const` family, in `VCVio/EvalDist/TVDist.lean` alongside the rest of the `tvDist_bind_*` family (the existing `ofReal_` const lemmas are relocated there from `ProgramLogic/Relational/Quantitative.lean`, where they had been the only members of the family living above the TVDist layer):

```lean
theorem tvDist_bind_left_le_const (mx : m α) (f g : α → m β) (c : ℝ)
    (hfg : ∀ a, a ∈ support mx → tvDist (f a) (g a) ≤ c) :
    tvDist (mx >>= f) (mx >>= g) ≤ c
```

- `tvDist_bind_left_le_const'` is the unrestricted `∀ a` companion (one-line derivation).
- `ofReal_tvDist_bind_left_le_const` now derives from it through the `ofReal`/`toReal` bridge; its ~40-line `tsum` body collapses to a 6-line `ε = ⊤` case split. The `'` companion and the sole call site (`VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean`) are unchanged — the `ofReal_` signatures are identical, and the consumer resolves the now-top-level names through its transitive `TVDist` import.
- No `0 ≤ c` hypothesis is needed: the weights `Pr[= a | mx].toReal` sum to `1` (unit mass), so `Summable.tsum_mul_right` factors `c` through the `tsum`, lifting a per-`a` bound by `c` to a bound by `c` for any real `c`.

Made with [Cursor](https://cursor.com)