### PR TITLE
feat(Relational): probEvent monotonicity from couplings / relational triples

### DIFF
--- a/VCVio/ProgramLogic/Relational/Basic.lean
+++ b/VCVio/ProgramLogic/Relational/Basic.lean
@@ -408,6 +408,23 @@ lemma evalDist_eq_of_relTriple_eqRel {oa : OracleComp spec₁ α} {ob : OracleCo
     𝒟[oa] = 𝒟[ob] :=
   evalDist_ext (fun x => probOutput_eq_of_relTriple_eqRel (spec₁ := spec₁) (spec₂ := spec₂) h x)
 
+/-- `probEvent` monotonicity from a relational triple: if `RelTriple oa ob R` and `R a b` forces
+`p a → q b`, then `Pr[p | oa] ≤ Pr[q | ob]`. Routing both events through the coupling's marginals
+(`c.2.map_fst`/`map_snd`) reduces the bound to `probEvent_mono` on the joint distribution. The
+inequality-from-implication, event-level companion of `probOutput_eq_of_relTriple_eqRel`, for events
+tracked over different output spaces. -/
+lemma probEvent_le_of_relTriple {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
+    {R : RelPost α β} (h : RelTriple oa ob R)
+    {p : α → Prop} {q : β → Prop} (himp : ∀ a b, R a b → p a → q b) :
+    Pr[p | oa] ≤ Pr[q | ob] := by
+  obtain ⟨c, hc⟩ := (relTriple_iff_relWP).1 h
+  have hfst : Pr[p | oa] = Pr[(p ∘ Prod.fst) | c.1] := by
+    rw [show Pr[p | oa] = Pr[p | (𝒟[oa] : SPMF α)] from rfl, ← probEvent_map, c.2.map_fst]
+  have hsnd : Pr[q | ob] = Pr[(q ∘ Prod.snd) | c.1] := by
+    rw [show Pr[q | ob] = Pr[q | (𝒟[ob] : SPMF β)] from rfl, ← probEvent_map, c.2.map_snd]
+  rw [hfst, hsnd]
+  exact probEvent_mono fun z hz hpz => himp z.1 z.2 (hc z hz) hpz
+
 /-- Transitivity through an intermediate computation related to the left side by `EqRel`. -/
 lemma relTriple_trans_eqRel_left
     {ι₃ : Type w} {spec₃ : OracleSpec ι₃}

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -100,9 +100,9 @@ theorem relTriple_simulateQ_run'
   exact relTriple_map h_weak
 
 /-- `probEvent` monotonicity between two relational `simulateQ` runs. Simulating the same adversary
-`oa` under two `StateT` implementations related per query by `R_state` (via
+`oa` under two `StateT` implementations related per query by `rState` (via
 `relTriple_simulateQ_run`), any event implication that holds along the run postcondition
-`z₁.1 = z₂.1 ∧ R_state z₁.2 z₂.2` transports to `Pr[p | run impl₁] ≤ Pr[q | run impl₂]`. The
+`z₁.1 = z₂.1 ∧ rState z₁.2 z₂.2` transports to `Pr[p | run impl₁] ≤ Pr[q | run impl₂]`. The
 `simulateQ` form of `probEvent_le_of_relTriple`; the events range over the full `(output, state)`
 pair, so it covers output events, state events, and their conjunctions over the two
 `(output, state)` spaces (the output type is shared; the state spaces `σ₁`/`σ₂` differ). -/
@@ -112,18 +112,18 @@ theorem probEvent_le_of_relTriple_simulateQ_run
     {σ₁ σ₂ : Type}
     (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
     (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
-    (R_state : σ₁ → σ₂ → Prop)
+    (rState : σ₁ → σ₂ → Prop)
     (oa : OracleComp spec α)
     (himpl : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂),
-      R_state s₁ s₂ →
+      rState s₁ s₂ →
       RelTriple ((impl₁ t).run s₁) ((impl₂ t).run s₂)
-        (fun p₁ p₂ => p₁.1 = p₂.1 ∧ R_state p₁.2 p₂.2))
-    (s₁ : σ₁) (s₂ : σ₂) (hs : R_state s₁ s₂)
+        (fun p₁ p₂ => p₁.1 = p₂.1 ∧ rState p₁.2 p₂.2))
+    (s₁ : σ₁) (s₂ : σ₂) (hs : rState s₁ s₂)
     {p : α × σ₁ → Prop} {q : α × σ₂ → Prop}
-    (himp : ∀ z₁ z₂, z₁.1 = z₂.1 → R_state z₁.2 z₂.2 → p z₁ → q z₂) :
+    (himp : ∀ z₁ z₂, z₁.1 = z₂.1 → rState z₁.2 z₂.2 → p z₁ → q z₂) :
     Pr[p | (simulateQ impl₁ oa).run s₁] ≤ Pr[q | (simulateQ impl₂ oa).run s₂] :=
   probEvent_le_of_relTriple
-    (relTriple_simulateQ_run impl₁ impl₂ R_state oa himpl s₁ s₂ hs)
+    (relTriple_simulateQ_run impl₁ impl₂ rState oa himpl s₁ s₂ hs)
     (fun z₁ z₂ h => himp z₁ z₂ h.1 h.2)
 
 /-- Exact-distribution specialization of `relTriple_simulateQ_run'`.

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -99,6 +99,33 @@ theorem relTriple_simulateQ_run'
     exact hp.1
   exact relTriple_map h_weak
 
+/-- `probEvent` monotonicity between two relational `simulateQ` runs. Simulating the same adversary
+`oa` under two `StateT` implementations related per query by `R_state` (via
+`relTriple_simulateQ_run`), any event implication that holds along the run postcondition
+`z₁.1 = z₂.1 ∧ R_state z₁.2 z₂.2` transports to `Pr[p | run impl₁] ≤ Pr[q | run impl₂]`. The
+`simulateQ` form of `probEvent_le_of_relTriple`; the events range over the full `(output, state)`
+pair, so it covers output events, state events, and their conjunctions over the two
+`(output, state)` spaces (the output type is shared; the state spaces `σ₁`/`σ₂` differ). -/
+theorem probEvent_le_of_relTriple_simulateQ_run
+    {ι₁ ι₂ : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    {σ₁ σ₂ : Type}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (R_state : σ₁ → σ₂ → Prop)
+    (oa : OracleComp spec α)
+    (himpl : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂),
+      R_state s₁ s₂ →
+      RelTriple ((impl₁ t).run s₁) ((impl₂ t).run s₂)
+        (fun p₁ p₂ => p₁.1 = p₂.1 ∧ R_state p₁.2 p₂.2))
+    (s₁ : σ₁) (s₂ : σ₂) (hs : R_state s₁ s₂)
+    {p : α × σ₁ → Prop} {q : α × σ₂ → Prop}
+    (himp : ∀ z₁ z₂, z₁.1 = z₂.1 → R_state z₁.2 z₂.2 → p z₁ → q z₂) :
+    Pr[p | (simulateQ impl₁ oa).run s₁] ≤ Pr[q | (simulateQ impl₂ oa).run s₂] :=
+  probEvent_le_of_relTriple
+    (relTriple_simulateQ_run impl₁ impl₂ R_state oa himpl s₁ s₂ hs)
+    (fun z₁ z₂ h => himp z₁ z₂ h.1 h.2)
+
 /-- Exact-distribution specialization of `relTriple_simulateQ_run'`.
 
 If corresponding oracle calls have identical full `(output, state)` distributions whenever the


### PR DESCRIPTION
Adds the missing event-level `probEvent`-monotonicity API to the relational program logic, as the inequality-from-implication companion of `probOutput_eq_of_relTriple_eqRel`. This is the bound wanted when two experiments track related events over different output/state spaces, so they cannot be linked by a distribution equality, only by an implication on the support of a coupling. The existing `probOutput_eq_of_relTriple_eqRel` covers only the equality case (same output type, `EqRel`).

Also adds `probEvent_le_of_relTriple_simulateQ_run` (`VCVio/ProgramLogic/Relational/SimulateQ.lean`, beside `relTriple_simulateQ_run'`): the `simulateQ` form for the coupling produced by `relTriple_simulateQ_run`. Simulating the same adversary with two `StateT` implementations over different base/state spaces, it transports an event implication along the run postcondition `z₁.1 = z₂.1 ∧ R_state z₁.2 z₂.2` into a `probEvent ≤ probEvent` bound. Events range over the full `(output, state)` pair, so it covers output events, state events, and their conjunctions.

Closes https://github.com/Verified-zkEVM/VCV-io/issues/458

Made with [Cursor](https://cursor.com)