### PR TITLE
feat: fix grind to fail quickly on probability goals

### DIFF
--- a/Examples/CommitmentScheme/Hiding/CountBounds.lean
+++ b/Examples/CommitmentScheme/Hiding/CountBounds.lean
@@ -259,7 +259,6 @@ lemma self_mem_cache_of_mem_support_step_hidingImplCountAll (ms : M × S)
       simp [hcache]
   | none =>
       simp only [hcache, StateT.run_bind] at hx
-
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
       simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,

--- a/Examples/CommitmentScheme/Hiding/CountBounds.lean
+++ b/Examples/CommitmentScheme/Hiding/CountBounds.lean
@@ -259,12 +259,12 @@ lemma self_mem_cache_of_mem_support_step_hidingImplCountAll (ms : M × S)
       simp [hcache]
   | none =>
       simp only [hcache, StateT.run_bind] at hx
+
       rw [mem_support_bind_iff] at hx
       obtain ⟨u, _, hx⟩ := hx
       simp only [StateT.run_set, StateT.run_pure, monad_norm, support_pure,
         Set.mem_singleton_iff] at hx
-      subst hx
-      simp
+      simp only [hx, QueryCache.cacheQuery_self]
 
 /-- The counted hiding invariant: every cached salt has a positive counter. -/
 def HidingCountInv (st : QueryCache (CMOracle M S C) × (S → ℕ)) : Prop :=
@@ -1369,4 +1369,3 @@ abbrev hidingAvgRightImpl :
       OracleComp.liftComp
         ((hidingImplCountAll (M := M) (S := S) (C := C) t).run st)
         (HidingAvgSpec M S C)
-

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -154,7 +154,8 @@ private lemma simulateQ_prfReal_reduction (k : K) (n : ℕ)
   rw [simulateQ_bind, simulateQ_prfReal_oracleOutputs, pure_bind,
       simulateQ_prfRealQueryImpl_liftComp]
 
-omit [DecidableEq S] [Inhabited O] [Fintype O] [DecidableEq O] [SampleableType O] in
+omit [Inhabited K] [Fintype K] [Inhabited S] [Fintype S] [DecidableEq S] [Inhabited O] [Fintype O]
+  [DecidableEq O] [SampleableType O] in
 /-- In the real world, the stream PRG experiment has the same output distribution as
 the real PRF experiment for the reduction adversary, provided the PRF key
 distribution is uniform. -/
@@ -205,7 +206,7 @@ lemma prgIdealExp_eq_bind (adv : PRGAdversary (List.Vector O n)) :
     PRGScheme.prgIdealExp adv = (($ᵗ (List.Vector O n)) >>= adv) :=
   rfl
 
-omit [DecidableEq O] in
+omit [Inhabited S] [Fintype S] [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- The ideal PRF experiment, applied to the stream reduction, factors as sampling the
 adversary's input via the lazy-random-oracle chain (`idealOutputs`) and then running the
 adversary. -/
@@ -234,12 +235,14 @@ noncomputable def seedCollisionExp (n : ℕ) (seed : S) : ProbComp Bool := do
       (oracleVisitedStates n seed)).run' ∅
   return decide (¬ states.toList.Nodup)
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- `idealOutputs` averages the per-seed chain outputs over a uniform initial state. -/
 lemma idealOutputs_eq_bind :
     idealOutputs (S := S) (O := O) n = (($ᵗ S) >>= seedOutputs (S := S) (O := O) n) := rfl
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- `idealCollisionExp` averages the per-seed collision test over a uniform initial state. -/
 lemma idealCollisionExp_eq_bind :
     idealCollisionExp (S := S) (O := O) n = (($ᵗ S) >>= seedCollisionExp (S := S) (O := O) n) :=
@@ -256,7 +259,8 @@ noncomputable def genCollisionExp (N : ℕ) (s : S) (c : (S →ₒ S × O).Query
     (simulateQ (prfIdealQueryImpl (D := S) (R := S × O)) (oracleVisitedStates N s)).run' c
   return decide (¬ states.toList.Nodup ∨ ∃ x ∈ states.toList, c.isCached x = true)
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- One lazy-random-oracle step of the output chain: sample/recall the answer at `s`, then
 recurse on the returned next-state with the updated cache, prepending the output block. -/
 private lemma simulateQ_oracleOutputs_succ_run' (N : ℕ) (s : S)
@@ -275,7 +279,8 @@ private lemma simulateQ_oracleOutputs_succ_run' (N : ℕ) (s : S)
   simp only [simulateQ_bind, simulateQ_pure, StateT.run_bind, StateT.run_pure, map_bind, map_pure,
     bind_map_left]
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- One lazy-random-oracle step of the visited-state chain: sample/recall the answer at `s`, then
 recurse on the returned next-state with the updated cache, prepending the just-visited state `s`. -/
 private lemma simulateQ_oracleVisitedStates_succ_run' (N : ℕ) (s : S)
@@ -295,7 +300,8 @@ private lemma simulateQ_oracleVisitedStates_succ_run' (N : ℕ) (s : S)
   simp only [simulateQ_bind, simulateQ_pure, StateT.run_bind, StateT.run_pure, map_bind, map_pure,
     bind_map_left]
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- Cache-miss form of the lazy random oracle on input `s`: a fresh uniform draw `u : S × O`,
 returned together with the cache extended by `s ↦ u`. -/
 private lemma randomOracle_run_of_none (s : S) (c : (S →ₒ S × O).QueryCache) (hc : c s = none) :
@@ -303,7 +309,8 @@ private lemma randomOracle_run_of_none (s : S) (c : (S →ₒ S × O).QueryCache
       = (fun u => (u, c.cacheQuery s u)) <$> ($ᵗ (S × O)) := by
   rw [OracleSpec.randomOracle, QueryImpl.withCaching_run_none _ hc]; rfl
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq S] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [DecidableEq S]
+  [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- Sampling a pair uniformly is the same as sampling each coordinate independently. -/
 private lemma uniformSample_prod_eq_bind :
     ($ᵗ (S × O)) = (do let a ← $ᵗ S; let b ← $ᵗ O; pure (a, b)) := by
@@ -312,7 +319,7 @@ private lemma uniformSample_prod_eq_bind :
   simp [seq_eq_bind_map, map_eq_bind_pure_comp, bind_assoc]
 
 omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [DecidableEq S]
-  [SampleableType S] [Fintype O] [DecidableEq O] in
+  [SampleableType S] [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- A uniform output vector of length `N + 1` decomposes as a uniform head block prepended to a
 uniform vector of length `N`. -/
 private lemma evalDist_uniformSample_vector_succ (N : ℕ) :
@@ -346,7 +353,8 @@ private lemma evalDist_uniformSample_vector_succ (N : ℕ) :
     simp [card_vector, pow_succ, Nat.mul_comm]
   rw [hL, hR]
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq S] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [DecidableEq S]
+  [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- The reference uniform output vector of length `N + 1`, written as a bind over a uniformly
 sampled pair `p : S × O` whose first coordinate is discarded and whose second coordinate is the
 prepended head block. This is the shared-base form used for the identical-until-bad coupling. -/
@@ -358,7 +366,8 @@ private lemma evalDist_uniformSample_vector_succ_pair (N : ℕ) :
   refine (evalDist_ext fun v => ?_).symm
   rw [probOutput_bind_const, probFailure_uniformSample, tsub_zero, one_mul]
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- Cache-miss recursion for the generalized collision experiment. When `s` is uncached, the bad
 event on the length-`N + 1` visited chain splits into the fresh draw at `s` (extending the cache by
 `s`) followed by the bad event on the length-`N` sub-chain run against the extended cache. The
@@ -406,7 +415,8 @@ private lemma genCollisionExp_succ_of_none (N : ℕ) (s : S) (c : (S →ₒ S ×
   rw [hrest, List.nodup_cons, hhead]
   tauto
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- Cache-hit determinism for the generalized collision experiment. When `s` is already cached, the
 visited chain of length `N + 1` starts at `s`, which lies in the chain and is cached, so the bad
 event always fires and the experiment returns `true` with probability one. -/
@@ -423,7 +433,7 @@ private lemma probOutput_genCollisionExp_succ_of_isCached (N : ℕ) (s : S)
     subst hpeq
     rw [List.Vector.toList_cons, decide_eq_true (Or.inr ⟨s, List.mem_cons_self, hc⟩)]
 
-omit [DecidableEq O] in
+omit [Inhabited S] [Fintype S] [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- **Generalized per-seed core coupling.** For an arbitrary starting cache `c`, the total
 variation distance between the lazy-random-oracle output chain (run from cache `c`) and a
 uniformly random output vector is bounded by the generalized collision probability. Proved by
@@ -435,6 +445,7 @@ lemma tvDist_seedOutputs_le_collision_gen (N : ℕ) (s : S)
     tvDist ((simulateQ (prfIdealQueryImpl (D := S) (R := S × O))
           (oracleOutputs N s)).run' c) ($ᵗ (List.Vector O N)) ≤
       (Pr[= true | genCollisionExp N s c]).toReal := by
+  haveI : Fintype O := Fintype.ofFinite O
   induction N generalizing s c with
   | zero =>
     refine le_trans (le_of_eq ?_) ENNReal.toReal_nonneg
@@ -495,7 +506,7 @@ lemma tvDist_seedOutputs_le_collision_gen (N : ℕ) (s : S)
       rw [probOutput_genCollisionExp_succ_of_isCached N s c hc, ENNReal.toReal_one]
       exact tvDist_le_one _ _
 
-omit [DecidableEq O] in
+omit [Inhabited S] [Fintype S] [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- **Per-seed core coupling.** For a fixed initial state, the total variation distance between
 the lazy-random-oracle output chain and a uniformly random output vector is bounded by the
 probability that the state chain revisits a state. This is the fundamental "identical until
@@ -513,7 +524,7 @@ lemma tvDist_seedOutputs_le_collision (seed : S) :
   rw [heq] at h
   exact h
 
-omit [DecidableEq O] in
+omit [Inhabited S] [Fintype S] [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- **Core coupling.** The total variation distance between the lazy-random-oracle output
 chain and a uniformly random output vector is bounded by the state-collision probability.
 This is the fundamental "identical until bad" step: until the state chain repeats, the lazy
@@ -547,7 +558,7 @@ lemma tvDist_idealOutputs_le_collisionProb :
       (ENNReal.summable_toReal tsum_probOutput_ne_top)
   · exact ENNReal.summable_toReal (by rw [← probOutput_bind_eq_tsum]; exact probOutput_ne_top)
 
-omit [DecidableEq O] in
+omit [Inhabited S] [Fintype S] [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- The gap between the ideal PRF and ideal PRG experiments is bounded by the
 collision probability. This follows from the fundamental lemma of game playing:
 when a lazy random function never receives the same input twice, its outputs are
@@ -579,7 +590,8 @@ theorem prfIdealGap_le_collisionProb (adv : PRGAdversary (List.Vector O n)) :
     _ ≤ tvDist (idealOutputs n) ($ᵗ (List.Vector O n)) := tvDist_bind_right_le _ _ _
     _ ≤ collisionProb (S := S) (O := O) n := tvDist_idealOutputs_le_collisionProb
 
-omit [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [Inhabited S] [Fintype S] [Inhabited O] [Fintype O]
+  [DecidableEq O] in
 /-- Security of the stream PRG obtained from a PRF: PRG distinguishing advantage is
 bounded by the PRF advantage of the reduction plus the collision probability in the
 ideal random-function world. -/
@@ -662,7 +674,8 @@ private lemma enncard_eq_sum_isCached (c : (S →ₒ S × O).QueryCache) :
   rw [Set.toFinset_setOf]
   norm_cast
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [Inhabited O]
+  [Fintype O] [DecidableEq O] in
 /-- **Domain-invariance of the collision probability.** The generalized collision experiment reads
 the starting cache only through its domain (`isCached`): on the good path cached values are never
 inspected, and on a hit the bad event has already fired. Hence two caches with the same domain give
@@ -693,7 +706,8 @@ private lemma probOutput_genCollisionExp_eq_of_isCached_agree (N : ℕ) (s : S)
           QueryCache.isCached_cacheQuery_of_ne c' p hx]
         exact h x
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq S] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Inhabited S] [Fintype S] [DecidableEq S]
+  [Inhabited O] [Fintype O] [DecidableEq O] in
 /-- Sampling a pair uniformly and discarding the second coordinate is the same as sampling the
 first coordinate uniformly. -/
 private lemma probOutput_bind_uniformSample_prod_fst (f : S → ProbComp Bool) (b : Bool) :
@@ -706,7 +720,7 @@ private lemma probOutput_bind_uniformSample_prod_fst (f : S → ProbComp Bool) (
   congr 1
   rw [probOutput_bind_const, probFailure_uniformSample, tsub_zero, one_mul]
 
-omit [Inhabited K] [Fintype K] [SampleableType K] [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [SampleableType K] [Fintype O] [DecidableEq O] in
 /-- **Generalized averaged birthday bound.** Averaging over the uniform initial state, the
 generalized collision probability of the length-`N` chain starting from cache `c` is bounded by
 `∑_{j < N} (|c| + j) / |S|`. Proved by induction on `N` (generalizing `c`): a cache miss draws a
@@ -782,7 +796,7 @@ private lemma probOutput_genCollisionExp_bind_le (N : ℕ) (c : (S →ₒ S × O
           push_cast
           ring_nf
 
-omit [DecidableEq O] in
+omit [Fintype O] [DecidableEq O] in
 /-- **Birthday bound for the state-collision probability.** Over `n` rounds of the lazy random
 oracle chain, each freshly sampled state is uniform over `S`, so the probability that the chain
 revisits a state is at most `n·(n-1) / (2·|S|)` by a union bound over the at most `C(n,2)` pairs. -/
@@ -816,7 +830,7 @@ theorem collisionProb_le_birthday (n : ℕ) :
     ENNReal.toReal_natCast]
   norm_num
 
-omit [DecidableEq O] in
+omit [Inhabited K] [Fintype K] [Fintype O] [DecidableEq O] in
 /-- **Concrete security of the stream PRG.** The PRG distinguishing advantage is bounded by the
 PRF advantage of the reduction plus the birthday term `n·(n-1) / (2·|S|)`, obtained by combining
 `security` with `collisionProb_le_birthday`. -/

--- a/Examples/Schnorr/Signature.lean
+++ b/Examples/Schnorr/Signature.lean
@@ -128,7 +128,7 @@ def signature (g : G) (M : Type) [DecidableEq M] :
       (M := M) (PK := G) (SK := F) (S := G × F) :=
   FiatShamir (Schnorr.sigma F G g) (dlogGenerable (F := F) g) M
 
-omit [Fintype F] in
+omit [Fintype F] [DecidableEq F] in
 /-- Completeness of the Schnorr signature follows from completeness of the
 underlying Schnorr Σ-protocol via the generic Fiat-Shamir completeness theorem. -/
 theorem signature_complete (g : G) (M : Type) [DecidableEq M] :

--- a/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
@@ -306,13 +306,8 @@ private lemma getPutativeRoot_step_withQueryLog_decompose
       (prog >>= fun a => let (l, r') := mkPair a; singleHash l r').withQueryLog) :
     ∃ a log_a, (a, log_a) ∈ support prog.withQueryLog
       ∧ log_v = log_a ++ [⟨mkPair a, r⟩] := by
-  rw [OracleComp.withQueryLog_bind, mem_support_bind_iff] at hmem
-  obtain ⟨⟨a, log_a⟩, h_rec, hmem⟩ := hmem
-  rw [singleHash_withQueryLog, support_map, Set.mem_image] at hmem
-  obtain ⟨⟨_, _⟩, h_q, rfl, rfl⟩ := hmem
-  rw [mem_support_bind_iff] at h_q
-  obtain ⟨_, _, rfl, rfl⟩ := h_q
-  exact ⟨a, log_a, h_rec, rfl⟩
+  simp only [OracleComp.withQueryLog_bind, singleHash_withQueryLog] at hmem
+  grind
 
 /--
 Predicate stating that `log` contains a hash chain from `leaf` (combined with the
@@ -384,18 +379,7 @@ private lemma chainInLog_of_mem_support_verifyProof
     (hmem : (true, log_v) ∈ support
         (verifyProof (m := OracleComp (spec α)) idx leaf root proof).withQueryLog) :
     ChainInLog log_v leaf root idx proof := by
-  rw [show verifyProof (m := OracleComp (spec α)) idx leaf root proof =
-      (do let r ← getPutativeRoot (m := OracleComp (spec α)) idx leaf proof
-          pure (r == root)) from rfl,
-    OracleComp.withQueryLog_bind, mem_support_bind_iff] at hmem
-  obtain ⟨⟨r, log_g⟩, h_g, hmem⟩ := hmem
-  rw [support_map, Set.mem_image] at hmem
-  obtain ⟨⟨b, log_x⟩, h_x, h_eq⟩ := hmem
-  obtain ⟨rfl, rfl⟩ := Prod.mk.inj h_eq
-  obtain ⟨h_b_eq, rfl⟩ := Prod.mk.inj h_x
-  obtain rfl : r = root := by grind
-  have := chainInLog_of_mem_support_getPutativeRoot idx leaf proof r log_g h_g
-  grind
+  grind [ChainInLog, OracleComp.withQueryLog_bind, chainInLog_of_mem_support_getPutativeRoot]
 
 /-- **Log-level binding (Collision Lemma at the log level).** Log-formalized
 analog of `getPutativeRootWithHash_binding_collision`: two distinct openings

--- a/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
@@ -384,8 +384,18 @@ private lemma chainInLog_of_mem_support_verifyProof
     (hmem : (true, log_v) ∈ support
         (verifyProof (m := OracleComp (spec α)) idx leaf root proof).withQueryLog) :
     ChainInLog log_v leaf root idx proof := by
-  grind [verifyProof, OracleComp.withQueryLog_bind, OracleComp.withQueryLog_pure,
-    chainInLog_of_mem_support_getPutativeRoot]
+  rw [show verifyProof (m := OracleComp (spec α)) idx leaf root proof =
+      (do let r ← getPutativeRoot (m := OracleComp (spec α)) idx leaf proof
+          pure (r == root)) from rfl,
+    OracleComp.withQueryLog_bind, mem_support_bind_iff] at hmem
+  obtain ⟨⟨r, log_g⟩, h_g, hmem⟩ := hmem
+  rw [support_map, Set.mem_image] at hmem
+  obtain ⟨⟨b, log_x⟩, h_x, h_eq⟩ := hmem
+  obtain ⟨rfl, rfl⟩ := Prod.mk.inj h_eq
+  obtain ⟨h_b_eq, rfl⟩ := Prod.mk.inj h_x
+  obtain rfl : r = root := by grind
+  have := chainInLog_of_mem_support_getPutativeRoot idx leaf proof r log_g h_g
+  grind
 
 /-- **Log-level binding (Collision Lemma at the log level).** Log-formalized
 analog of `getPutativeRootWithHash_binding_collision`: two distinct openings

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -348,12 +348,7 @@ lemma advantage_eq_zero_iff (exp : SecExp m) :
 @[simp]
 lemma advantage_eq_one_iff (exp : SecExp m) :
     exp.advantage = 1 ↔ Pr[⊥ | exp.toSPMFSemantics.evalDist exp.main] = 0 := by
-  constructor
-  · intro h; by_contra hne
-    have : exp.advantage < 1 := by
-      unfold advantage; exact ENNReal.sub_lt_self one_ne_top one_ne_zero hne
-    exact absurd h (ne_of_lt this)
-  · intro h; simp [advantage, h]
+  grind [advantage, probEvent_eq_one_iff]
 
 end advantage
 

--- a/VCVio/CryptoFoundations/SecExp.lean
+++ b/VCVio/CryptoFoundations/SecExp.lean
@@ -348,8 +348,12 @@ lemma advantage_eq_zero_iff (exp : SecExp m) :
 @[simp]
 lemma advantage_eq_one_iff (exp : SecExp m) :
     exp.advantage = 1 ↔ Pr[⊥ | exp.toSPMFSemantics.evalDist exp.main] = 0 := by
-  rw [advantage]
-  grind
+  constructor
+  · intro h; by_contra hne
+    have : exp.advantage < 1 := by
+      unfold advantage; exact ENNReal.sub_lt_self one_ne_top one_ne_zero hne
+    exact absurd h (ne_of_lt this)
+  · intro h; simp [advantage, h]
 
 end advantage
 

--- a/VCVio/CryptoFoundations/SeededFork.lean
+++ b/VCVio/CryptoFoundations/SeededFork.lean
@@ -334,7 +334,20 @@ theorem cf_eq_of_mem_support_seededFork (x₁ x₂ : α)
     (h : some (x₁, x₂) ∈ support (seededFork main qb js i cf)) :
       ∃ s, cf x₁ = some s ∧ cf x₂ = some s := by
   simp only [seededFork] at h
-  grind
+  rw [mem_support_bind_iff] at h; obtain ⟨seed, -, h⟩ := h
+  rw [mem_support_bind_iff] at h; obtain ⟨y₁, -, h⟩ := h
+  rcases hcf : cf y₁ with _ | s
+  · simp_all
+  · simp only [hcf] at h
+    rw [mem_support_bind_iff] at h; obtain ⟨u, -, h⟩ := h
+    split_ifs at h with heq
+    · simp_all
+    · rw [mem_support_bind_iff] at h; obtain ⟨y₂, -, h⟩ := h
+      split_ifs at h with hcf₂
+      · rw [mem_support_pure_iff] at h
+        obtain ⟨rfl, rfl⟩ := Prod.mk.inj (Option.some.inj h)
+        exact ⟨s, hcf, hcf₂⟩
+      · simp_all
 
 omit [unifSpec ˡ⊂ₒ spec] in
 /-- On `seededFork` support, first-projection success equals old pair-style success event. -/

--- a/VCVio/CryptoFoundations/SeededFork.lean
+++ b/VCVio/CryptoFoundations/SeededFork.lean
@@ -334,20 +334,7 @@ theorem cf_eq_of_mem_support_seededFork (x₁ x₂ : α)
     (h : some (x₁, x₂) ∈ support (seededFork main qb js i cf)) :
       ∃ s, cf x₁ = some s ∧ cf x₂ = some s := by
   simp only [seededFork] at h
-  rw [mem_support_bind_iff] at h; obtain ⟨seed, -, h⟩ := h
-  rw [mem_support_bind_iff] at h; obtain ⟨y₁, -, h⟩ := h
-  rcases hcf : cf y₁ with _ | s
-  · simp_all
-  · simp only [hcf] at h
-    rw [mem_support_bind_iff] at h; obtain ⟨u, -, h⟩ := h
-    split_ifs at h with heq
-    · simp_all
-    · rw [mem_support_bind_iff] at h; obtain ⟨y₂, -, h⟩ := h
-      split_ifs at h with hcf₂
-      · rw [mem_support_pure_iff] at h
-        obtain ⟨rfl, rfl⟩ := Prod.mk.inj (Option.some.inj h)
-        exact ⟨s, hcf, hcf₂⟩
-      · simp_all
+  grind
 
 omit [unifSpec ˡ⊂ₒ spec] in
 /-- On `seededFork` support, first-projection success equals old pair-style success event. -/
@@ -358,9 +345,7 @@ theorem probEvent_seededFork_fst_eq_probEvent_pair (s : Fin (qb i + 1)) :
   refine probEvent_ext fun r hr ↦ ?_
   rcases r with _ | ⟨x₁, x₂⟩
   · simp
-  · obtain ⟨t, h₁, h₂⟩ := cf_eq_of_mem_support_seededFork (main := main) (qb := qb)
-      (js := js) (i := i) (cf := cf) x₁ x₂ (by simpa using hr)
-    simp [h₁, h₂]
+  · grind [cf_eq_of_mem_support_seededFork]
 
 omit [spec.DecidableEq] [DecidableEq ι] in
 private lemma probEvent_uniform_eq_seedSlot_le_inv (s : Fin (qb i + 1))

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -235,34 +235,41 @@ section zero
 
 variable [MonadLiftT m SetM] [EvalDistCompatible m] {mx : m α} {p : α → Prop}
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probEvent_eq_zero_iff :
     Pr[ p | mx] = 0 ↔ ∀ x ∈ support mx, ¬ p x := by
   rw [probEvent_eq_tsum_indicator]; aesop
 alias ⟨_, probEvent_eq_zero⟩ := probEvent_eq_zero_iff
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probEvent_eq_zero_iff' [HasEvalFinset m] [DecidableEq α] :
-    Pr[ p | mx] = 0 ↔ ∀ x ∈ finSupport mx, ¬ p x := by grind
+    Pr[ p | mx] = 0 ↔ ∀ x ∈ finSupport mx, ¬ p x := by grind [probEvent_eq_zero_iff]
 alias ⟨_, probEvent_eq_zero'⟩ := probEvent_eq_zero_iff'
 
-@[simp, grind =]
-lemma probEvent_ne_zero_iff : Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ support mx, p x := by  grind
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
+lemma probEvent_ne_zero_iff : Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ support mx, p x := by
+  grind [probEvent_eq_zero_iff]
 alias ⟨_, probEvent_ne_zero⟩ := probEvent_ne_zero_iff
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probEvent_ne_zero_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ finSupport mx, p x := by aesop
 alias ⟨_, probEvent_ne_zero'⟩ := probEvent_ne_zero_iff'
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probEvent_pos_iff : 0 < Pr[ p | mx] ↔ ∃ x ∈ support mx, p x := by
   simp [pos_iff_ne_zero]
 alias ⟨_, probEvent_pos⟩ := probEvent_pos_iff
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probEvent_pos_iff' [HasEvalFinset m] [DecidableEq α] :
-    0 < Pr[ p | mx] ↔ ∃ x ∈ finSupport mx, p x := by grind
+    0 < Pr[ p | mx] ↔ ∃ x ∈ finSupport mx, p x := by grind [probEvent_pos_iff]
 alias ⟨_, probEvent_pos'⟩ := probEvent_pos_iff'
 
 end zero
@@ -528,7 +535,8 @@ lemma one_le_probEvent_iff [MonadLiftT m SPMF] : 1 ≤ Pr[ p | mx] ↔ Pr[ p | m
 lemma one_le_probFailure_iff [MonadLiftT m SPMF] : 1 ≤ Pr[⊥ | mx] ↔ Pr[⊥ | mx] = 1 := by
   simp only [le_iff_eq_or_lt, not_one_lt_probFailure, or_false, eq_comm]
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probOutput_eq_one_iff [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m] :
     Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by
   rw [← probEvent_eq_eq_probOutput]
@@ -536,13 +544,15 @@ lemma probOutput_eq_one_iff [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCom
     Set.ext_iff, Option.forall, mem_support_iff_evalDist_apply_ne_zero]
 alias ⟨_, probOutput_eq_one⟩ := probOutput_eq_one_iff
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma one_eq_probOutput_iff [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m] :
     1 = Pr[= x | mx] ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by
   rw [eq_comm, probOutput_eq_one_iff]
 alias ⟨_, one_eq_probOutput⟩ := one_eq_probOutput_iff
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probOutput_eq_one_iff' [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
     [HasEvalFinset m] [DecidableEq α] :
     Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ finSupport mx = {x} := by
@@ -677,14 +687,23 @@ lemma probFailure_eq_one_iff_probEvent_true (mx : m α) :
   rw [ENNReal.toReal_sub_of_le (by grind) (by simp)]
   simp [tsub_eq_zero_iff_le, ENNReal.toReal_eq_one_iff]
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probFailure_eq_one_iff [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) :
     Pr[⊥ | mx] = 1 ↔ support mx = ∅ := by
   simp [probFailure_eq_one_iff_probEvent_true, probEvent_eq_tsum_subtype_mem_support, Set.ext_iff]
 
 @[aesop unsafe forward]
 lemma probFailure_eq_one [MonadLiftT m SetM] [EvalDistCompatible m]
-    {mx : m α} (h : support mx = ∅) : Pr[⊥ | mx] = 1 := by grind
+    {mx : m α} (h : support mx = ∅) : Pr[⊥ | mx] = 1 := (probFailure_eq_one_iff mx).mpr h
+
+/-- `grind`-friendly companion to `probFailure_eq_one_iff`: phrasing "fails with probability one"
+via `Set.Nonempty` — which `grind` keeps atomic — avoids the support quantifier that makes the
+`support = ∅` form saturate, so this stays in the default `grind` set. -/
+@[grind =]
+lemma probFailure_eq_one_iff_not_nonempty [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) :
+    Pr[⊥ | mx] = 1 ↔ ¬ (support mx).Nonempty := by
+  simp only [probFailure_eq_one_iff, Set.not_nonempty_iff_eq_empty]
 
 @[simp, aesop norm]
 lemma probEvent_const (mx : m α) (p : Prop) [Decidable p] :
@@ -786,7 +805,8 @@ specialisation of `probEvent_mono` that drops the support hypothesis. -/
 lemma probEvent_mono'' (h : ∀ x, p x → q x) : Pr[ p | mx] ≤ Pr[ q | mx] :=
   probEvent_mono (fun x _ => h x)
 
-@[simp low, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp low]
 lemma probEvent_eq_one_iff :
     Pr[ p | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, p x := by
   rw [show (∀ x ∈ support mx, p x) ↔ Pr[ fun x => ¬p x | mx] = 0 by
@@ -808,21 +828,24 @@ lemma probOutput_eq_one_iff_forall (mx : m α) (x : α) :
     Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ y ∈ support mx, y = x := by
   rw [← probEvent_eq_eq_probOutput, probEvent_eq_one_iff]
 
-@[simp low, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp low]
 lemma one_eq_probEvent_iff :
     1 = Pr[ p | mx] ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, p x := by
   rw [eq_comm, probEvent_eq_one_iff]
 
 alias ⟨_, one_eq_probEvent⟩ := one_eq_probEvent_iff
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probEvent_eq_one_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ finSupport mx, p x := by
   simp_rw [probEvent_eq_one_iff, mem_finSupport_iff_mem_support]
 
 alias ⟨_, probEvent_eq_one'⟩ := probEvent_eq_one_iff'
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma one_eq_probEvent_iff' [HasEvalFinset m] [DecidableEq α] :
     1 = Pr[ p | mx] ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ finSupport mx, p x := by
   rw [eq_comm, probEvent_eq_one_iff']

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -260,17 +260,36 @@ lemma probEvent_ne_zero_iff' [HasEvalFinset m] [DecidableEq α] :
     Pr[ p | mx] ≠ 0 ↔ ∃ x ∈ finSupport mx, p x := by aesop
 alias ⟨_, probEvent_ne_zero'⟩ := probEvent_ne_zero_iff'
 
--- `simp`-only: `grind` saturates on this support-quantifier characterization.
-@[simp]
+-- `grind`-safe in isolation: this support-quantifier characterization saturates `grind` only in
+-- combination with the `probEvent_eq_one_iff` family (kept `simp`-only). See `probability.md`.
+@[simp, grind =]
 lemma probEvent_pos_iff : 0 < Pr[ p | mx] ↔ ∃ x ∈ support mx, p x := by
   simp [pos_iff_ne_zero]
 alias ⟨_, probEvent_pos⟩ := probEvent_pos_iff
 
--- `simp`-only: `grind` saturates on this support-quantifier characterization.
-@[simp]
+-- `grind`-safe in isolation; see `probEvent_pos_iff`.
+@[simp, grind =]
 lemma probEvent_pos_iff' [HasEvalFinset m] [DecidableEq α] :
     0 < Pr[ p | mx] ↔ ∃ x ∈ finSupport mx, p x := by grind [probEvent_pos_iff]
 alias ⟨_, probEvent_pos'⟩ := probEvent_pos_iff'
+
+/-- `grind`-friendly companion to the `simp`-only `probEvent_ne_zero_iff`: the event has positive
+probability iff some reachable output satisfies `p`. The `Set.Nonempty` witness stays atomic under
+`grind` (unlike the saturating `∃ x ∈ support mx, p x` form). Mirrors
+`probFailure_eq_one_iff_not_nonempty`. -/
+@[grind =]
+lemma probEvent_ne_zero_iff_nonempty :
+    Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty := by
+  rw [probEvent_ne_zero_iff]; simp [Set.nonempty_def]
+
+/-- `grind`-friendly companion to the `simp`-only `probEvent_eq_zero_iff`: the event has probability
+zero iff no reachable output satisfies `p`, phrased via `Set.Nonempty` rather than the saturating
+`∀ x ∈ support mx, ¬ p x`. The negation of `probEvent_ne_zero_iff_nonempty`. -/
+@[grind =]
+lemma probEvent_eq_zero_iff_not_nonempty :
+    Pr[ p | mx] = 0 ↔ ¬ {x ∈ support mx | p x}.Nonempty := by
+  rw [probEvent_eq_zero_iff]
+  simp [Set.not_nonempty_iff_eq_empty, Set.eq_empty_iff_forall_notMem]
 
 end zero
 
@@ -551,8 +570,9 @@ lemma one_eq_probOutput_iff [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCom
   rw [eq_comm, probOutput_eq_one_iff]
 alias ⟨_, one_eq_probOutput⟩ := one_eq_probOutput_iff
 
--- `simp`-only: `grind` saturates on this support-quantifier characterization.
-@[simp]
+-- `grind`-safe in isolation, and the natural mirror of `one_eq_probOutput_iff'` (which kept its
+-- `grind` tag): both are the `finSupport`-singleton characterization. See `probability.md`.
+@[simp, grind =]
 lemma probOutput_eq_one_iff' [MonadLiftT m SPMF] [MonadLiftT m SetM] [EvalDistCompatible m]
     [HasEvalFinset m] [DecidableEq α] :
     Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ finSupport mx = {x} := by

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -273,11 +273,17 @@ lemma probEvent_pos_iff' [HasEvalFinset m] [DecidableEq α] :
     0 < Pr[ p | mx] ↔ ∃ x ∈ finSupport mx, p x := by grind [probEvent_pos_iff]
 alias ⟨_, probEvent_pos'⟩ := probEvent_pos_iff'
 
-/-- `grind`-friendly companion to the `simp`-only `probEvent_ne_zero_iff`: the event has positive
+/-- `Set.Nonempty` companion to the `simp`-only `probEvent_ne_zero_iff`: the event has positive
 probability iff some reachable output satisfies `p`. The `Set.Nonempty` witness stays atomic under
 `grind` (unlike the saturating `∃ x ∈ support mx, p x` form). Mirrors
-`probFailure_eq_one_iff_not_nonempty`. -/
-@[grind =]
+`probFailure_eq_one_iff_not_nonempty`.
+
+Deliberately NOT in the default `grind` set: together with `probEvent_eq_zero_iff_not_nonempty`
+and `probFailure_eq_one_iff_not_nonempty` it re-forms a saturation cycle in the generic-monad
+context (`grind` times out on the `probEvent_eq_one_iff` statement shape with all three tagged;
+dropping any one of the trio restores fail-fast, and dropping this one is free: `grind` recovers
+`≠ 0 ↔ Nonempty` from the kept `= 0 ↔ ¬ Nonempty` sibling by classical negation). Gated by
+`VCVioTest/GrindFailFast.lean`. -/
 lemma probEvent_ne_zero_iff_nonempty :
     Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty := by
   rw [probEvent_ne_zero_iff]; simp [Set.nonempty_def]
@@ -679,12 +685,14 @@ section bool
 
 variable [MonadLiftT m SPMF]
 
-@[simp]
+-- also `@[grind =]`: without the tag `grind` routes the impossible event through the support
+-- machinery and fails on `Pr[ fun _ => False | mx] = 0`
+@[simp, grind =]
 lemma probEvent_False (mx : m α) :
     Pr[ fun _ => False | mx] = 0 := by
   simp [probEvent_eq_tsum_indicator]
 
-@[simp]
+@[simp, grind =]
 lemma probEvent_false (mx : m α) :
     Pr[ fun _ => false | mx] = 0 := by aesop
 

--- a/VCVio/EvalDist/Defs/NeverFails.lean
+++ b/VCVio/EvalDist/Defs/NeverFails.lean
@@ -73,7 +73,7 @@ lemma neverFail_iff (mx : m α) : NeverFail mx ↔ Pr[⊥ | mx] = 0 :=
 lemma neverFail_bind_iff [MonadLiftT m SetM] [EvalDistCompatible m]
     (mx : m α) (my : α → m β) :
     NeverFail (mx >>= my) ↔ NeverFail mx ∧ ∀ x ∈ support mx, NeverFail (my x) := by
-  grind
+  simp [neverFail_iff, probFailure_bind_eq_add_tsum_support, add_eq_zero]
 
 @[simp, grind =]
 lemma neverFail_map_iff [LawfulMonad m] (mx : m α) (f : α → β) :
@@ -132,7 +132,7 @@ lemma bind_of_mem_support [MonadLiftT m SetM] [EvalDistCompatible m]
     {mx : m α} {my : α → m β}
     [hx : NeverFail mx] (hy : ∀ x ∈ support mx, NeverFail (my x)) :
     NeverFail (mx >>= my) where
-  probFailure_eq_zero := by grind
+  probFailure_eq_zero := ((neverFail_bind_iff mx my).mpr ⟨hx, hy⟩).probFailure_eq_zero
 
 /--
 Weak bind lemma: if the right-hand side never fails for every possible input (`∀ x`),

--- a/VCVio/EvalDist/Instances/OptionT.lean
+++ b/VCVio/EvalDist/Instances/OptionT.lean
@@ -66,11 +66,11 @@ lemma mem_support_iff (mx : OptionT m α) (x : α) :
 
 @[simp]
 lemma support_liftM (mx : m α) :
-    support (liftM mx : OptionT m α) = support mx := by grind
+    support (liftM mx : OptionT m α) = support mx := by grind [mem_support_bind_iff]
 
 @[simp]
 lemma support_lift (mx : m α) :
-    support (OptionT.lift mx) = support mx := by grind
+    support (OptionT.lift mx) = support mx := by grind [mem_support_bind_iff]
 
 end EvalSet
 

--- a/VCVio/EvalDist/Instances/OptionT.lean
+++ b/VCVio/EvalDist/Instances/OptionT.lean
@@ -66,11 +66,11 @@ lemma mem_support_iff (mx : OptionT m α) (x : α) :
 
 @[simp]
 lemma support_liftM (mx : m α) :
-    support (liftM mx : OptionT m α) = support mx := by grind [mem_support_bind_iff]
+    support (liftM mx : OptionT m α) = support mx := by grind
 
 @[simp]
 lemma support_lift (mx : m α) :
-    support (OptionT.lift mx) = support mx := by grind [mem_support_bind_iff]
+    support (OptionT.lift mx) = support mx := by grind
 
 end EvalSet
 

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -18,6 +18,14 @@ variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
 
 open ENNReal
 
+/- The monad/functor laws are confluent (terminating) rewrites. Tagging them for `grind` lets it
+normalize a computation's structure (`mx >>= pure = mx`, `pure a >>= f = f a`, reassociation,
+`f <$> pure a = pure (f a)`) *before* it falls into `probOutput`/`tsum` expansion — turning what
+would otherwise be a `grind` explosion on a structured-computation equality into a quick solve. (The
+analogous `bind_pure_comp`/`map_eq_bind` laws are deliberately omitted: their function argument sits
+under a binder that `grind`'s pattern compiler cannot index.) -/
+attribute [grind =] bind_pure pure_bind bind_assoc map_pure
+
 /-! ## Probabilities of `pure` -/
 
 section pure
@@ -115,7 +123,7 @@ lemma support_bind [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (mx : m α) (my
     support (mx >>= my) = ⋃ x ∈ support mx, support (my x) :=
   monadLift_bind mx my
 
-@[grind =]
+-- untagged: the `∃ x ∈ support` RHS saturates `grind`; `support_bind` is the `simp` form.
 lemma mem_support_bind_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (mx : m α)
     (my : α → m β) (y : β) :
     y ∈ support (mx >>= my) ↔ ∃ x ∈ support mx, y ∈ support (my x) := by simp
@@ -125,7 +133,7 @@ lemma finSupport_bind [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFins
     [DecidableEq α] [DecidableEq β] (mx : m α) (my : α → m β) : finSupport (mx >>= my) =
       Finset.biUnion (finSupport mx) fun x => finSupport (my x) := by aesop
 
-@[grind =]
+-- untagged: the `∃ x ∈ finSupport` RHS saturates `grind`; `finSupport_bind` is the `simp` form.
 lemma mem_finSupport_bind_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
     [DecidableEq α] [DecidableEq β] (mx : m α) (my : α → m β) (y : β) : y ∈ finSupport (mx >>= my) ↔
       ∃ x ∈ finSupport mx, y ∈ finSupport (my x) := by aesop
@@ -172,7 +180,8 @@ lemma probFailure_bind_eq_add_tsum_support [MonadLiftT m SPMF] [LawfulMonadLiftT
   refine tsum_congr fun x => ?_
   aesop (add simp Set.indicator)
 
-@[simp, grind =]
+-- `simp`-only: `grind` saturates on this support-quantifier characterization.
+@[simp]
 lemma probFailure_bind_eq_zero_iff [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = 0 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, Pr[⊥ | my x] = 0 := by
@@ -235,7 +244,7 @@ variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 @[simp]
 lemma support_bind_const (mx : m α) (my : m β) :
     support (mx >>= fun _ => my) = {y ∈ support my | (support mx).Nonempty} := by
-  grind [= Set.Nonempty]
+  grind [= Set.Nonempty, mem_support_bind_iff]
 
 @[simp]
 lemma finSupport_bind_const [HasEvalFinset m]

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -123,7 +123,7 @@ lemma support_bind [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (mx : m α) (my
     support (mx >>= my) = ⋃ x ∈ support mx, support (my x) :=
   monadLift_bind mx my
 
--- untagged: the `∃ x ∈ support` RHS saturates `grind`; `support_bind` is the `simp` form.
+@[grind =]
 lemma mem_support_bind_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] (mx : m α)
     (my : α → m β) (y : β) :
     y ∈ support (mx >>= my) ↔ ∃ x ∈ support mx, y ∈ support (my x) := by simp
@@ -133,7 +133,7 @@ lemma finSupport_bind [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFins
     [DecidableEq α] [DecidableEq β] (mx : m α) (my : α → m β) : finSupport (mx >>= my) =
       Finset.biUnion (finSupport mx) fun x => finSupport (my x) := by aesop
 
--- untagged: the `∃ x ∈ finSupport` RHS saturates `grind`; `finSupport_bind` is the `simp` form.
+@[grind =]
 lemma mem_finSupport_bind_iff [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [HasEvalFinset m]
     [DecidableEq α] [DecidableEq β] (mx : m α) (my : α → m β) (y : β) : y ∈ finSupport (mx >>= my) ↔
       ∃ x ∈ finSupport mx, y ∈ finSupport (my x) := by aesop
@@ -244,7 +244,7 @@ variable [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
 @[simp]
 lemma support_bind_const (mx : m α) (my : m β) :
     support (mx >>= fun _ => my) = {y ∈ support my | (support mx).Nonempty} := by
-  grind [= Set.Nonempty, mem_support_bind_iff]
+  grind [= Set.Nonempty]
 
 @[simp]
 lemma finSupport_bind_const [HasEvalFinset m]

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -180,8 +180,9 @@ lemma probFailure_bind_eq_add_tsum_support [MonadLiftT m SPMF] [LawfulMonadLiftT
   refine tsum_congr fun x => ?_
   aesop (add simp Set.indicator)
 
--- `simp`-only: `grind` saturates on this support-quantifier characterization.
-@[simp]
+-- `grind`-safe in isolation: this support-quantifier characterization saturates `grind` only in
+-- combination with the `probEvent_eq_one_iff` family (kept `simp`-only). See `probability.md`.
+@[simp, grind =]
 lemma probFailure_bind_eq_zero_iff [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
     [MonadLiftT m SetM] [EvalDistCompatible m] (mx : m α) (my : α → m β) :
     Pr[⊥ | mx >>= my] = 0 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, Pr[⊥ | my x] = 0 := by

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -19,12 +19,16 @@ variable {α β γ : Type u} {m : Type u → Type v} [Monad m]
 open ENNReal
 
 /- The monad/functor laws are confluent (terminating) rewrites. Tagging them for `grind` lets it
-normalize a computation's structure (`mx >>= pure = mx`, `pure a >>= f = f a`, reassociation,
-`f <$> pure a = pure (f a)`) *before* it falls into `probOutput`/`tsum` expansion — turning what
-would otherwise be a `grind` explosion on a structured-computation equality into a quick solve. (The
-analogous `bind_pure_comp`/`map_eq_bind` laws are deliberately omitted: their function argument sits
-under a binder that `grind`'s pattern compiler cannot index.) -/
-attribute [grind =] bind_pure pure_bind bind_assoc map_pure
+normalize a computation's structure (`mx >>= pure = mx`, reassociation, `f <$> pure a = pure (f a)`)
+*before* it falls into `probOutput`/`tsum` expansion — turning what would otherwise be a `grind`
+explosion on a structured-computation equality into a quick solve. `pure_bind` is not listed: core
+already ships it in the default set (`attribute [grind <=] pure_bind` in `Init.Control.Lawful`),
+and re-tagging it would add a redundant E-match entry. (The analogous
+`bind_pure_comp`/`map_eq_bind` laws are deliberately omitted: their function argument sits under a
+binder that `grind`'s pattern compiler cannot index; so do `pure_seq`/`seq_pure`, whose `Seq.seq`
+thunk argument makes even their LHS an invalid pattern. `Functor.map_map` is binder-free and joins
+the set.) -/
+attribute [grind =] bind_pure bind_assoc map_pure Functor.map_map
 
 /-! ## Probabilities of `pure` -/
 

--- a/VCVio/EvalDist/Monad/Map.lean
+++ b/VCVio/EvalDist/Monad/Map.lean
@@ -125,6 +125,15 @@ lemma probFailure_map : Pr[⊥ | f <$> mx] = Pr[⊥ | mx] := by
 lemma probEvent_map (q : β → Prop) : Pr[ q | f <$> mx] = Pr[ q ∘ f | mx] := by
   grind [= map_eq_bind_pure_comp]
 
+/-- Outcome probability of a `map`, as a pulled-back event: `Pr[= y | f <$> mx]` is the probability
+that the source lands in the `f`-preimage of `y`. The `probOutput` companion to `probEvent_map`.
+Tagged `@[grind =]` only (not `@[simp]`): `simp` keeps its injective/equiv-map normal forms
+(`probOutput_map_equiv`, `…_eq_probOutput_inverse`), which this pulled-back-event form would clash
+with. -/
+@[grind =]
+lemma probOutput_map (y : β) : Pr[= y | f <$> mx] = Pr[ fun x => f x = y | mx] := by
+  rw [← probEvent_eq_eq_probOutput, probEvent_map]; rfl
+
 lemma probEvent_comp (q : β → Prop) : Pr[ q ∘ f | mx] = Pr[ q | f <$> mx] :=
   symm <| probEvent_map mx f q
 

--- a/VCVio/EvalDist/Prod.lean
+++ b/VCVio/EvalDist/Prod.lean
@@ -78,7 +78,11 @@ section prod_mk
 
 variable (mx : m α) (my : m β) (f : α → γ) (g : β → δ)
 
-@[simp high]
+/- `@[grind norm]` (not `@[grind =]`): `Seq.seq`'s thunk argument makes the LHS an invalid
+E-matching pattern, but `grind`'s simp-based normalization phase needs no pattern indexing. This
+lets bare `grind` factor an independent applicative product (and e.g. close equiprobability of a
+uniform product), which E-matching alone cannot. -/
+@[simp high, grind norm]
 lemma probOutput_seq_map_prod_mk_eq_mul (z : α × β) :
     Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] :=
   probOutput_seq_map_eq_mul_of_injective2 mx my Prod.mk Prod.mk.injective2 z.1 z.2

--- a/VCVio/OracleComp/Constructions/Replicate.lean
+++ b/VCVio/OracleComp/Constructions/Replicate.lean
@@ -43,14 +43,14 @@ def replicateTR {ι} {spec : OracleSpec ι} {α : Type v}
 variable {ι} {spec : OracleSpec ι} {α β : Type v}
   (oa : OracleComp spec α) (n : ℕ)
 
-@[simp]
+@[simp, grind =]
 lemma replicate_zero : replicate 0 oa = return [] := rfl
 
-@[simp]
+@[simp, grind =]
 lemma replicateTR_zero : replicateTR 0 oa = return [] := rfl
 
 /-- Bind-style unfolding of `replicate`, convenient for program-logic proofs. -/
-@[simp]
+@[simp, grind =]
 lemma replicate_succ_bind :
     replicate (n + 1) oa = (do
       let x ← oa
@@ -60,7 +60,7 @@ lemma replicate_succ_bind :
 /-- The tail-recursive `replicateTR` agrees with the recursive `replicate`. The
 `@[simp]` annotation lets every later proof about `replicateTR` reduce to the
 recursive form automatically. -/
-@[simp]
+@[simp, grind =]
 lemma replicateTR_eq_replicate : replicateTR n oa = replicate n oa := by
   simp only [replicateTR, ← List.replicate_eq_replicateTR]
   induction n with
@@ -70,7 +70,7 @@ lemma replicateTR_eq_replicate : replicateTR n oa = replicate n oa := by
 lemma replicate_succ : replicate (n + 1) oa = List.cons <$> oa <*> replicate n oa := by
   simp [replicate_succ_bind, monad_norm, Function.comp]
 
-@[simp]
+@[simp, grind =]
 lemma replicate_pure (x : α) :
     (pure x : OracleComp spec α).replicate n = pure (List.replicate n x) := by
   induction n with

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -206,7 +206,7 @@ lemma mem_support_uniformSample {x : α} : x ∈ support ($ᵗ α) := by grind
 /-- Uniform sampling never fails, so its support is nonempty (which in turn witnesses `Nonempty α`).
 Tagged `@[grind]` rather than `@[simp]` because `simp` rewrites `support ($ᵗ α)` to `Set.univ`
 first, after which it would need a separate `Nonempty α` fact. -/
-@[grind]
+@[grind .]
 lemma support_uniformSample_nonempty : (support ($ᵗ α)).Nonempty := by
   rw [Set.nonempty_iff_ne_empty]
   intro h
@@ -247,8 +247,7 @@ instance {ι ι'} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
   | .inr t => h' t
 
 /-- Select a uniform element from `α × β` by independently selecting from `α` and `β`. -/
-instance (α β : Type)
-    [SampleableType α] [SampleableType β] : SampleableType (α × β) where
+instance (α β : Type) [SampleableType α] [SampleableType β] : SampleableType (α × β) where
   selectElem := (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)
   mem_support_selectElem x := by simp
   probOutput_selectElem_eq x y := by
@@ -275,6 +274,10 @@ than an `instance` to avoid overlap with `FinEnum.SampleableType`. -/
     [Fintype α] [Nonempty α] : SampleableType α :=
   haveI : NeZero (Fintype.card α) := ⟨Fintype.card_ne_zero⟩
   SampleableType.ofEquiv (Fintype.equivFin α).symm
+
+/-- This typeclass shouldn't cause diamonds since `Nonempty` is propositional. -/
+instance SampleableType.Nonempty (α : Type) [h : SampleableType α] : Nonempty α :=
+  ⟨OracleComp.defaultResult h.selectElem⟩
 
 /-- This typeclass shouldn't cause diamonds since `Finite` is propositional. -/
 instance SampleableType.Finite (α : Type) [SampleableType α] : Finite α :=

--- a/VCVio/OracleComp/Constructions/SampleableType.lean
+++ b/VCVio/OracleComp/Constructions/SampleableType.lean
@@ -203,6 +203,16 @@ lemma support_uniformSample : support ($ᵗ α) = Set.univ :=
 
 lemma mem_support_uniformSample {x : α} : x ∈ support ($ᵗ α) := by grind
 
+/-- Uniform sampling never fails, so its support is nonempty (which in turn witnesses `Nonempty α`).
+Tagged `@[grind]` rather than `@[simp]` because `simp` rewrites `support ($ᵗ α)` to `Set.univ`
+first, after which it would need a separate `Nonempty α` fact. -/
+@[grind]
+lemma support_uniformSample_nonempty : (support ($ᵗ α)).Nonempty := by
+  rw [Set.nonempty_iff_ne_empty]
+  intro h
+  rw [← probFailure_eq_one_iff, probFailure_uniformSample] at h
+  exact zero_ne_one h
+
 @[simp, grind =]
 lemma finSupport_uniformSample [Fintype α] [DecidableEq α] :
     finSupport ($ᵗ α) = Finset.univ := by aesop
@@ -237,11 +247,12 @@ instance {ι ι'} {spec : OracleSpec ι} {spec' : OracleSpec ι'}
   | .inr t => h' t
 
 /-- Select a uniform element from `α × β` by independently selecting from `α` and `β`. -/
-instance (α β : Type) [Fintype α] [Fintype β] [Inhabited α] [Inhabited β]
+instance (α β : Type)
     [SampleableType α] [SampleableType β] : SampleableType (α × β) where
   selectElem := (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)
   mem_support_selectElem x := by simp
-  probOutput_selectElem_eq x y := by simp
+  probOutput_selectElem_eq x y := by
+    simp only [probOutput_seq_map_prod_mk_eq_mul]; grind
 
 /-- A type equivalent to a `SampleableType` is also `SampleableType`. -/
 @[reducible] def SampleableType.ofEquiv {α β : Type} [SampleableType α] (e : α ≃ β) :

--- a/VCVio/OracleComp/EvalDist.lean
+++ b/VCVio/OracleComp/EvalDist.lean
@@ -380,6 +380,10 @@ variable [IsProbabilitySpec spec]
   · -- See note above.
     simp [OptionT.probFailure_eq, OptionT.run_failure]
 
+@[simp] lemma support_guard {p : Prop} [Decidable p] :
+    support (guard p : OptionT (OracleComp spec) Unit) = if p then {()} else ∅ := by
+  rw [OracleComp.guard_eq]; split_ifs <;> simp
+
 lemma probOutput_eq_sub_probFailure_of_unit {oa : OracleComp spec PUnit} :
     Pr[= () | oa] = 1 - Pr[⊥ | oa] := by
   have h := tsum_probOutput_add_probFailure oa
@@ -404,6 +408,46 @@ lemma probOutput_guard_eq_sub_probOutput_guard_not {α : Type} {oa : OracleComp 
     (by simpa only [probFailure_of_liftM_PMF, tsub_zero] using probEvent_compl oa p)
 
 end guard
+
+/-! ## Probabilities of `orElse` (`<|>`)
+
+`oa <|> oa'` runs `oa`, falling back to `oa'` only when `oa` returns `none`. The base `OracleComp`
+never fails, so the two failure events are independent: `oa <|> oa'` fails exactly when both do, and
+an output comes either from `oa` or — on `oa`'s failure mass — from `oa'`. (`support_orElse` is left
+as a future addition; it follows from `probOutput_orElse` via the support↔probability bridge.) -/
+
+section orElse
+
+variable [IsProbabilitySpec spec] {α : Type}
+
+@[simp]
+lemma probFailure_orElse (oa oa' : OptionT (OracleComp spec) α) :
+    Pr[⊥ | oa <|> oa'] = Pr[⊥ | oa] * Pr[⊥ | oa'] := by
+  classical
+  rw [OracleComp.orElse_def, OptionT.probFailure_eq, OptionT.probFailure_eq, OptionT.probFailure_eq,
+    OptionT.run_mk, probFailure_of_liftM_PMF, probFailure_of_liftM_PMF, probFailure_of_liftM_PMF,
+    zero_add, zero_add, zero_add, probOutput_bind_eq_tsum, tsum_option _ ENNReal.summable]
+  simp [probOutput_pure]
+
+@[simp]
+lemma probOutput_orElse (oa oa' : OptionT (OracleComp spec) α) (x : α) :
+    Pr[= x | oa <|> oa'] = Pr[= x | oa] + Pr[⊥ | oa] * Pr[= x | oa'] := by
+  classical
+  rw [OracleComp.orElse_def, OptionT.probOutput_eq, OptionT.probOutput_eq, OptionT.probFailure_eq,
+    OptionT.probOutput_eq, OptionT.run_mk, probFailure_of_liftM_PMF, zero_add,
+    probOutput_bind_eq_tsum, tsum_option _ ENNReal.summable,
+    tsum_eq_single x (fun b hb => by simp [probOutput_pure, Ne.symm hb])]
+  simp [probOutput_pure, add_comm]
+
+@[simp]
+lemma probEvent_orElse (oa oa' : OptionT (OracleComp spec) α) (p : α → Prop) :
+    Pr[ p | oa <|> oa'] = Pr[ p | oa] + Pr[⊥ | oa] * Pr[ p | oa'] := by
+  classical
+  simp only [probEvent_eq_tsum_ite, probOutput_orElse]
+  conv_rhs => rw [← ENNReal.tsum_mul_left, ← ENNReal.tsum_add]
+  refine tsum_congr fun b => ?_; split_ifs <;> ring
+
+end orElse
 
 section simulateQ_evalDist
 

--- a/VCVio/OracleComp/QueryTracking/Structures.lean
+++ b/VCVio/OracleComp/QueryTracking/Structures.lean
@@ -41,6 +41,7 @@ protected lemma ext {c₁ c₂ : QueryCache spec} (h : ∀ t, c₁ t = c₂ t) :
 /-! ### Agreement with answer functions -/
 
 /-- A total answer function agrees with a cache if it returns every cached response. -/
+@[grind]
 def AgreesWithFn (f : QueryImpl spec Id) (cache : QueryCache spec) : Prop :=
   ∀ ⦃t : spec.Domain⦄ ⦃r : spec.Range t⦄, cache t = some r → f t = r
 
@@ -69,6 +70,7 @@ instance : OrderBot (QueryCache spec) where
 @[simp]
 lemma bot_eq_empty : (⊥ : QueryCache spec) = ∅ := rfl
 
+@[grind =]
 lemma le_def {c₁ c₂ : QueryCache spec} :
     c₁ ≤ c₂ ↔ ∀ ⦃t⦄ ⦃u : spec.Range t⦄, c₁ t = some u → c₂ t = some u :=
   ⟨fun h => h, fun h => h⟩
@@ -110,57 +112,48 @@ lemma enncard_empty : enncard (∅ : QueryCache spec) = 0 := by
 
 /-! ### Cache update -/
 
-variable [spec.DecidableEq] [DecidableEq ι] (cache : QueryCache spec)
+variable [DecidableEq ι] (cache : QueryCache spec)
 
 /-- Add an index + input pair to the cache by updating the function
 (wrapper around `Function.update`). -/
 def cacheQuery (t : spec.Domain) (u : spec.Range t) : QueryCache spec :=
   Function.update cache t u
 
-omit [spec.DecidableEq] in
-@[simp]
+@[simp, grind =]
 lemma cacheQuery_self (t : spec.Domain) (u : spec.Range t) :
     (cache.cacheQuery t u) t = some u := by
   simp [cacheQuery]
 
-omit [spec.DecidableEq] in
-@[simp]
+@[simp, grind =]
 lemma cacheQuery_of_ne {t' t : spec.Domain} (u : spec.Range t) (h : t' ≠ t) :
     (cache.cacheQuery t u) t' = cache t' := by
   simp [cacheQuery, h]
 
-omit [spec.DecidableEq] in
 /-- An answer function agrees with `cache.cacheQuery t u` iff it agrees with `cache` and returns
 `u` on `t`, provided `t` was not already cached. -/
 lemma agreesWithFn_cacheQuery_iff (t : spec.Domain) (u : spec.Range t) (f : QueryImpl spec Id)
     (hcache : cache t = none) :
     (cache.cacheQuery t u).AgreesWithFn f ↔ cache.AgreesWithFn f ∧ f t = u := by
-  grind [AgreesWithFn, cacheQuery_self, cacheQuery_of_ne, cacheQuery]
+  grind [cacheQuery]
 
-omit [spec.DecidableEq] in
 lemma toSet_cacheQuery_subset_insert (t : spec.Domain) (u : spec.Range t) :
     (cache.cacheQuery t u).toSet ⊆ insert ⟨t, u⟩ cache.toSet := by
   rintro ⟨t', u'⟩ hmem
   rcases eq_or_ne t' t with rfl | ht <;> simp_all [cacheQuery]
 
-omit [spec.DecidableEq] in
 lemma toSet_encard_cacheQuery_le (t : spec.Domain) (u : spec.Range t) :
     (cache.cacheQuery t u).toSet.encard ≤ cache.toSet.encard + 1 :=
   le_trans (Set.encard_le_encard (toSet_cacheQuery_subset_insert cache t u))
     (Set.encard_insert_le cache.toSet ⟨t, u⟩)
 
-omit [spec.DecidableEq] in
 lemma enncard_cacheQuery_le (t : spec.Domain) (u : spec.Range t) :
     enncard (cache.cacheQuery t u) ≤ enncard cache + 1 := by
   simp only [enncard]
   exact_mod_cast toSet_encard_cacheQuery_le cache t u
 
-omit [spec.DecidableEq] in
 lemma le_cacheQuery {t : spec.Domain} {u : spec.Range t} (h : cache t = none) :
-    cache ≤ cache.cacheQuery t u := by
-  grind [cacheQuery_self, cacheQuery_of_ne, le_def]
+    cache ≤ cache.cacheQuery t u := by grind
 
-omit [spec.DecidableEq] in
 lemma cacheQuery_mono {c₁ c₂ : QueryCache spec} (h : c₁ ≤ c₂) (t : spec.Domain)
     (u : spec.Range t) : c₁.cacheQuery t u ≤ c₂.cacheQuery t u := by
   intro t' u' ht'
@@ -168,13 +161,11 @@ lemma cacheQuery_mono {c₁ c₂ : QueryCache spec} (h : c₁ ≤ c₂) (t : spe
   · simpa only [cacheQuery_self] using ht'
   · exact cacheQuery_of_ne c₂ u heq ▸ h (cacheQuery_of_ne c₁ u heq ▸ ht')
 
-omit [spec.DecidableEq] in
 @[simp]
 lemma isCached_cacheQuery_self (t : spec.Domain) (u : spec.Range t) :
     (cache.cacheQuery t u).isCached t = true := by
   simp [isCached]
 
-omit [spec.DecidableEq] in
 @[simp]
 lemma isCached_cacheQuery_of_ne {t' t : spec.Domain} (u : spec.Range t) (h : t' ≠ t) :
     (cache.cacheQuery t u).isCached t' = cache.isCached t' := by

--- a/VCVio/OracleComp/SimSemantics/Append.lean
+++ b/VCVio/OracleComp/SimSemantics/Append.lean
@@ -30,10 +30,10 @@ lemma add_apply (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m)
     (t : OracleSpec.Domain (spec₁ + spec₂)) : (impl₁ + impl₂) t =
       match t with | .inl t => impl₁ t | .inr t => impl₂ t := rfl
 
-@[simp] lemma add_apply_inl (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m)
+@[simp, grind =] lemma add_apply_inl (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m)
     (t : spec₁.Domain) : (impl₁ + impl₂) (.inl t) = impl₁ t := rfl
 
-@[simp] lemma add_apply_inr (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m)
+@[simp, grind =] lemma add_apply_inr (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m)
     (t : spec₂.Domain) : (impl₁ + impl₂) (.inr t) = impl₂ t := rfl
 
 /-- Version of `QueryImpl.add` that also lifts the two implementations to a shared lift monad. -/
@@ -42,7 +42,7 @@ def addLift {ι₁ ι₂} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι�
     (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ n) : QueryImpl (spec₁ + spec₂) r :=
   (impl₁.liftTarget r) + (impl₂.liftTarget r)
 
-@[simp] lemma addLift_def {ι₁ ι₂} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+@[simp, grind =] lemma addLift_def {ι₁ ι₂} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
     {m n r : Type u → Type*} [MonadLiftT m r] [MonadLiftT n r]
     (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ n) :
     (impl₁.addLift impl₂ : QueryImpl (spec₁ + spec₂) r) =
@@ -69,7 +69,9 @@ private lemma simulateQ_add_liftM_query_right (t : spec₂'.Domain) :
   change simulateQ (impl₁' + impl₂') (liftM ((spec₁' + spec₂').query (Sum.inr t))) = _
   simp
 
-@[simp]
+/- Also `@[grind =]`: without it, bare `grind` on a routed `simulateQ (impl₁ + impl₂)` goal over a
+lifted computation saturates (times out) instead of failing fast; with it, the shape closes. -/
+@[simp, grind =]
 lemma simulateQ_add_liftComp_left (oa : OracleComp spec₁' α) :
     simulateQ (impl₁' + impl₂') (OracleComp.liftComp oa (spec₁' + spec₂')) =
       simulateQ impl₁' oa := by
@@ -77,7 +79,7 @@ lemma simulateQ_add_liftComp_left (oa : OracleComp spec₁' α) :
   congr 1 with t
   exact simulateQ_add_liftM_query_left impl₁' impl₂' t
 
-@[simp]
+@[simp, grind =]
 lemma simulateQ_add_liftComp_right (ob : OracleComp spec₂' α) :
     simulateQ (impl₁' + impl₂') (OracleComp.liftComp ob (spec₁' + spec₂')) =
       simulateQ impl₂' ob := by

--- a/VCVio/OracleComp/SimSemantics/OptionT/Basic.lean
+++ b/VCVio/OracleComp/SimSemantics/OptionT/Basic.lean
@@ -28,12 +28,12 @@ variable {ι} {spec : OracleSpec ι} {r n : Type u → Type*}
     [Monad n] [LawfulMonad n] (impl : QueryImpl spec n)
 
 omit [LawfulMonad n] in
-@[simp] lemma simulateQ_option_elim (x : Option α) (my : OracleComp spec β)
+@[simp, grind =] lemma simulateQ_option_elim (x : Option α) (my : OracleComp spec β)
     (my' : α → OracleComp spec β) : simulateQ impl (x.elim my my') =
     x.elim (simulateQ impl my) (fun x => simulateQ impl (my' x)) := by
   cases x <;> simp
 
-@[simp] lemma simulateQ_option_elimM (mx : OracleComp spec (Option α))
+@[simp, grind =] lemma simulateQ_option_elimM (mx : OracleComp spec (Option α))
     (my : OracleComp spec β) (my' : α → OracleComp spec β) :
     simulateQ impl (Option.elimM mx my my') =
     Option.elimM (simulateQ impl mx) (simulateQ impl my) (fun x => simulateQ impl (my' x)) := by

--- a/VCVio/OracleComp/SimSemantics/StateT/Basic.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT/Basic.lean
@@ -79,7 +79,7 @@ def flattenStateT {ι : Type _} {spec : OracleSpec ι}
   StateT.mk fun (s, q) =>
     (fun ((u, s'), q') => (u, (s', q'))) <$> ((impl t).run s |>.run q)
 
-@[simp] theorem flattenStateT_liftTarget_apply_run {ι : Type _} {spec : OracleSpec ι}
+@[simp, grind =] theorem flattenStateT_liftTarget_apply_run {ι : Type _} {spec : OracleSpec ι}
     {m : Type u → Type v} [Monad m] [LawfulMonad m] {σ τ : Type u}
     (impl : QueryImpl spec (StateT τ m)) (t : spec.Domain) (s : σ) (q : τ) :
     ((impl.liftTarget (StateT σ (StateT τ m))).flattenStateT t).run (s, q) =
@@ -116,7 +116,7 @@ def withBadUpdate {ι : Type _} {spec : OracleSpec ι}
 
 /-- Run-shape of `withBadFlag`: the lifted implementation maps the underlying run by tagging
 each `(value, state)` pair with the unchanged bad flag `b`. -/
-@[simp] lemma withBadFlag_apply_run {ι : Type _} {spec : OracleSpec ι}
+@[simp, grind =] lemma withBadFlag_apply_run {ι : Type _} {spec : OracleSpec ι}
     {m : Type _ → Type _} [Functor m] {σ : Type _}
     (impl : QueryImpl spec (StateT σ m)) (t : spec.Domain) (s : σ) (b : Bool) :
     (impl.withBadFlag t).run (s, b) =
@@ -124,7 +124,7 @@ each `(value, state)` pair with the unchanged bad flag `b`. -/
 
 /-- Run-shape of `withBadUpdate`: the lifted implementation maps the underlying run by
 appending the OR-updated bad flag `b || f t s vs.1`. -/
-@[simp] lemma withBadUpdate_apply_run {ι : Type _} {spec : OracleSpec ι}
+@[simp, grind =] lemma withBadUpdate_apply_run {ι : Type _} {spec : OracleSpec ι}
     {m : Type _ → Type _} [Functor m] {σ : Type _}
     (impl : QueryImpl spec (StateT σ m))
     (f : (t : spec.Domain) → σ → spec.Range t → Bool)

--- a/VCVio/ProgramLogic/Unary/StdDoBridge.lean
+++ b/VCVio/ProgramLogic/Unary/StdDoBridge.lean
@@ -55,7 +55,15 @@ theorem wpProp_pure (x : α) (p : α → Prop) :
 /-- `wpProp` rule for bind. -/
 theorem wpProp_bind (oa : OracleComp spec α) (ob : α → OracleComp spec β) (p : β → Prop) :
     wpProp (spec := spec) (oa >>= ob) p ↔ wpProp oa (fun a => wpProp (ob a) p) := by
-  grind [wpProp_iff_forall_support]
+  rw [wpProp_iff_forall_support, wpProp_iff_forall_support]
+  constructor
+  · intro h a ha
+    rw [wpProp_iff_forall_support (spec := spec) (oa := ob a) (p := p)]
+    intro b hb
+    exact h b ((mem_support_bind_iff oa ob b).2 ⟨a, ha, hb⟩)
+  · intro h b hb
+    rcases (mem_support_bind_iff oa ob b).1 hb with ⟨a, ha, hb'⟩
+    exact ((wpProp_iff_forall_support (spec := spec) (oa := ob a) (p := p)).1 (h a ha)) b hb'
 
 private theorem wpProp_and (oa : OracleComp spec α) (p q : α → Prop) :
     wpProp (spec := spec) oa (fun a => p a ∧ q a) ↔

--- a/VCVio/ProgramLogic/Unary/StdDoBridge.lean
+++ b/VCVio/ProgramLogic/Unary/StdDoBridge.lean
@@ -55,15 +55,7 @@ theorem wpProp_pure (x : α) (p : α → Prop) :
 /-- `wpProp` rule for bind. -/
 theorem wpProp_bind (oa : OracleComp spec α) (ob : α → OracleComp spec β) (p : β → Prop) :
     wpProp (spec := spec) (oa >>= ob) p ↔ wpProp oa (fun a => wpProp (ob a) p) := by
-  rw [wpProp_iff_forall_support, wpProp_iff_forall_support]
-  constructor
-  · intro h a ha
-    rw [wpProp_iff_forall_support (spec := spec) (oa := ob a) (p := p)]
-    intro b hb
-    exact h b ((mem_support_bind_iff oa ob b).2 ⟨a, ha, hb⟩)
-  · intro h b hb
-    rcases (mem_support_bind_iff oa ob b).1 hb with ⟨a, ha, hb'⟩
-    exact ((wpProp_iff_forall_support (spec := spec) (oa := ob a) (p := p)).1 (h a ha)) b hb'
+  grind [wpProp_iff_forall_support]
 
 private theorem wpProp_and (oa : OracleComp spec α) (p q : α → Prop) :
     wpProp (spec := spec) oa (fun a => p a ∧ q a) ↔

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,3 +1,4 @@
+import VCVioTest.LongChainPrograms
 import VCVioTest.MonadProbability
 import VCVioTest.ProbabilityTactics
 import VCVioTest.SampleableType

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,2 +1,4 @@
+import VCVioTest.MonadProbability
+import VCVioTest.ProbabilityTactics
 import VCVioTest.SampleableType
 import VCVioTest.Smoke

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,3 +1,4 @@
+import VCVioTest.GrindFailFast
 import VCVioTest.LongChainPrograms
 import VCVioTest.MonadProbability
 import VCVioTest.ProbabilityTactics

--- a/VCVioTest/GrindFailFast.lean
+++ b/VCVioTest/GrindFailFast.lean
@@ -1,0 +1,177 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio
+
+/-!
+# Fail-fast and opt-in gates for `grind` on probability goals
+
+Companion to the three probability benchmarks (`VCVioTest/ProbabilityTactics.lean`,
+`VCVioTest/MonadProbability.lean`, `VCVioTest/LongChainPrograms.lean`), which gate what `grind`
+*solves*. This file gates the other half of the design: what `grind` deliberately does **not**
+solve, and that it fails **fast** when it doesn't.
+
+Each support-characterization lemma dropped from the default `grind` set gets one example of the
+form
+
+```
+example : <the lemma's own statement> := by
+  fail_if_success grind   -- the lemma is really out of the default set
+  grind [<the lemma>]     -- and the documented opt-in really closes the goal
+```
+
+stated over a generic monad `m`, where the drop actually bites (over `ProbComp` the kept
+`finSupport`-singleton route lets bare `grind` reach several of these shapes — those are recorded
+as mirrors at the end). The gate is loud in both failure directions:
+
+* If someone re-tags a dropped lemma `@[grind]`, bare `grind` starts *succeeding* on its statement
+  and `fail_if_success` fails the build.
+* If a change to the default set makes bare `grind` *saturate* instead of failing fast on one of
+  these statements, the resulting `(deterministic) timeout` is a runtime exception that escapes
+  `fail_if_success` and fails the build. (This is exactly how the saturation cycle among the three
+  `Set.Nonempty` companions was caught: with all three tagged, the `probEvent_eq_one_iff`-shaped
+  gate below times out rather than failing fast, which is why `probEvent_ne_zero_iff_nonempty` is
+  not in the default set.)
+-/
+
+open OracleComp ProbComp ENNReal
+
+namespace VCVioTest.GrindFailFast
+
+/-! ## Dropped-lemma gates over a generic monad
+
+Bare `grind` must fail (fast); the documented opt-in `grind [<lemma>]` must close the goal. -/
+
+section generic
+
+variable {α : Type} {m : Type → Type} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+  (p : α → Prop) (mx : m α) (x : α)
+
+example : Pr[ p | mx] = 0 ↔ ∀ y ∈ support mx, ¬ p y := by
+  fail_if_success grind
+  grind [probEvent_eq_zero_iff]
+
+example : Pr[ p | mx] ≠ 0 ↔ ∃ y ∈ support mx, p y := by
+  fail_if_success grind
+  grind [probEvent_ne_zero_iff]
+
+example : Pr[ p | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ y ∈ support mx, p y := by
+  fail_if_success grind
+  grind [probEvent_eq_one_iff]
+
+example : 1 = Pr[ p | mx] ↔ Pr[⊥ | mx] = 0 ∧ ∀ y ∈ support mx, p y := by
+  fail_if_success grind
+  grind [one_eq_probEvent_iff]
+
+example : Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by
+  fail_if_success grind
+  grind [probOutput_eq_one_iff]
+
+example : 1 = Pr[= x | mx] ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by
+  fail_if_success grind
+  grind [one_eq_probOutput_iff]
+
+example : Pr[⊥ | mx] = 1 ↔ support mx = ∅ := by
+  fail_if_success grind
+  grind [probFailure_eq_one_iff]
+
+/-! ## The `Set.Nonempty` companions
+
+`probEvent_ne_zero_iff_nonempty` is deliberately out of the default set (the trio of companions
+saturates the `probEvent_eq_one_iff`-shaped gate above; see its docstring). Nothing is lost: bare
+`grind` recovers its content from the kept `probEvent_eq_zero_iff_not_nonempty` sibling by
+classical negation, so all three companion statements are bare-`grind` mirrors. -/
+
+example : Pr[ p | mx] ≠ 0 ↔ {y ∈ support mx | p y}.Nonempty := by grind
+example : Pr[ p | mx] = 0 ↔ ¬ {y ∈ support mx | p y}.Nonempty := by grind
+example : Pr[⊥ | mx] = 1 ↔ ¬ (support mx).Nonempty := by grind
+
+-- `mem_support_bind_iff` is untagged, but bare `grind` reaches the shape through `support_bind`.
+example (my : α → m α) (y : α) :
+    y ∈ support (mx >>= my) ↔ ∃ z ∈ support mx, y ∈ support (my z) := by grind
+
+end generic
+
+/-! ## `finSupport` gates and `ProbComp` mirrors -/
+
+section probComp
+
+variable (p : Bool → Prop) [DecidablePred p] (mx : ProbComp Bool) (x : Bool)
+
+example : Pr[ p | mx] = 0 ↔ ∀ y ∈ finSupport mx, ¬ p y := by
+  fail_if_success grind
+  grind [probEvent_eq_zero_iff']
+
+example : Pr[ p | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ y ∈ finSupport mx, p y := by
+  fail_if_success grind
+  grind [probEvent_eq_one_iff']
+
+-- mirrors: over `ProbComp` the kept `finSupport`-singleton route closes these under bare `grind`
+example : Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x} := by grind
+example (my : Bool → ProbComp Bool) (y : Bool) :
+    y ∈ finSupport (mx >>= my) ↔ ∃ z ∈ finSupport mx, y ∈ finSupport (my z) := by grind
+
+end probComp
+
+/-! ## Structural additions to the default `grind` set
+
+Capability gates for the confluent structural rewrites tagged `@[grind =]` beyond the original
+monad-law block: `replicate` unfolds, `Functor.map_map`, and the `simulateQ` routing layer
+(`QueryImpl.add` / instrumentation wrappers). Each example is a shape bare `grind` could not close
+before the corresponding tag (the routing example previously *saturated* — it is also a fail-fast
+gate). -/
+
+section structural
+
+variable (oa : ProbComp Bool)
+
+example : oa.replicate 1 = (do let x ← oa; pure [x]) := by grind
+example (x : Bool) : (pure x : ProbComp Bool).replicate 3 = pure [x, x, x] := by grind
+example (xs : List Bool) : xs ∈ support (oa.replicate 0) ↔ xs = [] := by grind
+example : oa.replicateTR 1 = (do let x ← oa; pure [x]) := by grind
+
+section mapMap
+
+variable {α : Type} {m : Type → Type} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+
+example (mx : m α) (f g : α → α) : g <$> (f <$> mx) = (fun x => g (f x)) <$> mx := by grind
+example (mx : m α) (f g : α → α) : Pr[⊥ | g <$> (f <$> mx)] = Pr[⊥ | mx] := by grind
+
+end mapMap
+
+section routing
+
+variable {ι₁ ι₂ : Type} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂} {α β σ : Type}
+  {m : Type → Type} [Monad m] [LawfulMonad m]
+  (impl₁ : QueryImpl spec₁ m) (impl₂ : QueryImpl spec₂ m)
+
+-- formerly a saturating shape: bare `grind` timed out here before
+-- `simulateQ_add_liftComp_left` was tagged `@[grind =]`
+example (oa : OracleComp spec₁ α) :
+    simulateQ (impl₁ + impl₂) (do let x ← liftComp oa (spec₁ + spec₂); pure x) =
+      simulateQ impl₁ oa := by grind
+
+example (ob : OracleComp spec₂ α) :
+    simulateQ (impl₁ + impl₂) (liftComp ob (spec₁ + spec₂) >>= pure) =
+      simulateQ impl₂ ob := by grind
+
+example (impl : QueryImpl spec₁ (StateT σ m)) (t : spec₁.Domain) (s : σ) (b : Bool) :
+    (impl.withBadFlag t).run (s, b) =
+      (fun (vs : spec₁.Range t × σ) => (vs.1, vs.2, b)) <$> (impl t).run s := by grind
+
+example (impl : QueryImpl spec₁ m) (x : Option α) (my : OracleComp spec₁ β)
+    (my' : α → OracleComp spec₁ β) :
+    simulateQ impl (x.elim my my' >>= pure) =
+      x.elim (simulateQ impl my) (fun a => simulateQ impl (my' a)) := by grind
+
+end routing
+
+end structural
+
+end VCVioTest.GrindFailFast

--- a/VCVioTest/LongChainPrograms.lean
+++ b/VCVioTest/LongChainPrograms.lean
@@ -1,0 +1,156 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio
+
+/-!
+# Long-chain probability tactic benchmark
+
+A third probability benchmark (companion to `VCVioTest/ProbabilityTactics.lean` and
+`VCVioTest/MonadProbability.lean`) that exercises `simp` and `grind` over programs with **ten or
+more sequential binds**, rather than the one/two-step shapes of the other two files. The point is to
+pin down *where* on a long chain each tactic is strong: a regression in either surfaces here in
+isolation.
+
+The headline finding — the one this file gates — is that **`grind` keeps pace with `simp` on the
+deep failure-probability telescope** (`Pr[⊥ | _] = 0` for a twelve-step `ProbComp`, where the chain
+collapses through `probFailure_bind_eq_add_tsum` + each step never failing) and on **abstract
+monad-law normalization** (redundant-`pure` chain over an opaque `m`, collapsed by the `@[grind =]`
+laws `bind_pure`/`pure_bind`/`bind_assoc`/`map_pure`). These are genuinely long chains whose work is
+all *structural*, away from the final arithmetic — exactly `grind`'s wheelhouse.
+
+The complementary finding is that once a long chain bottoms out in a **concrete** distribution,
+support set, or outcome-probability *value*, `grind` is the wrong tool: it dives into the
+`PMF`/`SPMF` representation and either loses to `simp` or (for a numeric outcome) never closes it.
+Those are recorded as `target(grind)` / `target(simp+grind)` notes, matching the convention of the
+sibling files.
+
+Conventions (as in the sibling files):
+* **Mirrors.** Where both `simp` and `grind` close a goal, both are kept.
+* **Single tactic + target.** Where only one closes it, that tactic is used and the gap is recorded
+  with a `target(...)` note.
+* **Only stable tactics.** No example hangs or explodes.
+-/
+
+open OracleComp ProbComp ENNReal
+
+namespace VCVioTest.LongChainPrograms
+
+/-! ## Programs
+
+The named computations the benchmark reasons about. `chain12` / `chain12Opt` are twelve-step uniform
+chains (over `ProbComp` and the failing carrier `OptionT ProbComp`); `coinPadded` a ten-deep tower
+of redundant `pure` binds that is secretly just `$ᵗ Bool`; `longAbort` is a ten-step `OptionT` chain
+with a single guard, so it fails with probability one half. -/
+
+/-- A twelve-step chain of independent uniform draws. -/
+def chain12 : ProbComp Bool := do
+  let a ← $ᵗ Bool; let b ← $ᵗ Bool; let c ← $ᵗ Bool; let d ← $ᵗ Bool
+  let e ← $ᵗ Bool; let f ← $ᵗ Bool; let g ← $ᵗ Bool; let h ← $ᵗ Bool
+  let i ← $ᵗ Bool; let j ← $ᵗ Bool; let k ← $ᵗ Bool; let l ← $ᵗ Bool
+  pure (a && b && c && d && e && f && g && h && i && j && k && l)
+
+/-- The same twelve-step chain over the failing carrier `OptionT ProbComp`; it still never fails. -/
+def chain12Opt : OptionT ProbComp Bool := do
+  let a ← $ᵗ Bool; let b ← $ᵗ Bool; let c ← $ᵗ Bool; let d ← $ᵗ Bool
+  let e ← $ᵗ Bool; let f ← $ᵗ Bool; let g ← $ᵗ Bool; let h ← $ᵗ Bool
+  let i ← $ᵗ Bool; let j ← $ᵗ Bool; let k ← $ᵗ Bool; let l ← $ᵗ Bool
+  pure (a && b && c && d && e && f && g && h && i && j && k && l)
+
+/-- A ten-deep tower of redundant `pure` binds: `bind_pure`/`pure_bind` collapse it to `$ᵗ Bool`. -/
+def coinPadded : ProbComp Bool := do
+  let a ← $ᵗ Bool
+  let b ← pure a; let c ← pure b; let d ← pure c; let e ← pure d
+  let f ← pure e; let g ← pure f; let h ← pure g; let i ← pure h
+  let j ← pure i; let k ← pure j
+  pure k
+
+/-- A ten-step `OptionT` chain with a single guard at the fifth step: fails with probability one
+half, regardless of the nine surrounding uniform draws. -/
+def longAbort : OptionT ProbComp Bool := do
+  let a ← $ᵗ Bool; let b ← $ᵗ Bool; let c ← $ᵗ Bool; let d ← $ᵗ Bool
+  let e ← $ᵗ Bool; guard e
+  let f ← $ᵗ Bool; let g ← $ᵗ Bool; let h ← $ᵗ Bool; let i ← $ᵗ Bool; let j ← $ᵗ Bool
+  pure (a && b && c && d && f && g && h && i && j)
+
+/-! ## 1. The deep failure-probability telescope — `grind` keeps pace with `simp`
+
+`Pr[⊥ | chain12] = 0` is a twelve-deep `probFailure_bind_eq_add_tsum` telescope bottoming out in
+`Pr[⊥ | $ᵗ Bool] = 0` at each step. Both tactics drive it to `0`; this is the chain where `grind`
+matches `simp`, and the main regression gate of the file. -/
+
+example : Pr[⊥ | chain12] = 0 := by simp [chain12]
+example : Pr[⊥ | chain12] = 0 := by grind [chain12]
+
+/-! ## 2. The same chain over a failing carrier
+
+Over `OptionT ProbComp` the telescope is `simp`'s: `grind` descends into the `OptionT`/`PMF`
+plumbing instead of staying in the `probFailure` algebra.
+
+Both the "never fails" and "can fail" *symbolic* facts close by `simp` at chain depth; the exact
+failure *value* does not (the ten-deep `probFailure_bind_eq_add_tsum` telescope leaves a nested
+`ℝ≥0∞` sum that `simp` does not normalise to a number — a `target(simp+grind)` like §5, `2⁻¹` for
+`longAbort`).
+
+target(grind): both close by `simp`, not `grind` (which descends into the `OptionT`/`PMF`
+plumbing). -/
+
+example : Pr[⊥ | chain12Opt] = 0 := by simp [chain12Opt]
+example : Pr[⊥ | longAbort] ≠ 0 := by simp [longAbort, probFailure_bind_eq_add_tsum]
+
+/-! ## 3. Structural normalization — abstract chain vs concrete head
+
+A redundant-`pure` chain is pure monad-law rewriting. Over an **opaque** monad `m` (and over a free
+`ProbComp` head that `grind` keeps atomic) `grind` collapses it just like `simp`. Once the head is
+the **concrete** `$ᵗ Bool` of `coinPadded`, `grind` unfolds `𝒟` into `PMF.uniformOfFintype` and
+loses the structural view, so the deep concrete normalization is `simp`'s. -/
+
+section abstractHead
+variable {α : Type} {m : Type → Type} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+
+example (mx : m α) : 𝒟[do let a ← mx; pure a] = 𝒟[mx] := by simp
+example (mx : m α) : 𝒟[do let a ← mx; pure a] = 𝒟[mx] := by grind
+
+-- target(grind): a deeper opaque-`m` tower normalises by `simp`; `grind`'s collapse is unstable.
+example (mx : m α) :
+    𝒟[do let a ← mx; let b ← pure a; let c ← pure b; pure c] = 𝒟[mx] := by simp
+
+end abstractHead
+
+example (mx : ProbComp Bool) : 𝒟[do let a ← mx; pure a] = 𝒟[mx] := by simp
+example (mx : ProbComp Bool) : 𝒟[do let a ← mx; pure a] = 𝒟[mx] := by grind
+
+-- target(grind): with the concrete `$ᵗ Bool` head, the ten-deep `coinPadded` collapses by `simp`;
+-- `grind` descends into the `PMF` representation and does not close these.
+example : 𝒟[coinPadded] = 𝒟[($ᵗ Bool)] := by simp [coinPadded]
+example : Pr[= true | coinPadded] = Pr[= true | $ᵗ Bool] := by simp [coinPadded]
+example : support coinPadded = support ($ᵗ Bool) := by simp [coinPadded]
+
+/-! ## 4. Support of a deep chain
+
+A specific reachable point of `chain12`'s support is decided by `simp`.
+
+target(grind): membership in / equality of a deep chain's support is `simp`'s; `grind` does not
+close these. The full `support chain12 = Set.univ` is a `target(simp+grind)`: neither closes it in
+one terminal step (it needs that the twelve-fold `&&` realises both booleans and the union
+telescopes to the universe). -/
+
+example : (false : Bool) ∈ support chain12 := by simp [chain12]
+
+/-! ## 5. Outcome value of a multi-step chain — `target(simp+grind)`
+
+Computing a concrete outcome probability of a multi-step bind chain is the one shape **neither**
+terminal tactic closes: `simp` normalises the chain step by step but stops before collapsing the
+nested `tsum` to a number, and `grind` does no `ℝ≥0∞` arithmetic. The canonical proof threads
+`probOutput_bind_eq_tsum` and `tsum_eq_single` by hand. The benchmark records the gap rather than
+carrying a multi-step proof; `chain12` returns `true` only when all twelve coins do, so
+
+  `Pr[= true | chain12] = (2 ^ 12)⁻¹`   -- target(simp+grind)
+
+is the representative outcome-value target. -/
+
+end VCVioTest.LongChainPrograms

--- a/VCVioTest/MonadProbability.lean
+++ b/VCVioTest/MonadProbability.lean
@@ -1,0 +1,212 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio
+
+/-!
+# Generic-monad probability tactic benchmark
+
+A companion to `VCVioTest/ProbabilityTactics.lean`. That file gates `simp`/`grind` over concrete
+`ProbComp`; this one gates them over a **generic monad `m`** with the EvalDist instance stack
+(`[MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF] [MonadLiftT m SetM] [LawfulMonadLiftT m SetM]
+[EvalDistCompatible m]`), where the probability / support / distribution lemmas are actually stated,
+plus over the concrete transformer instances (`OptionT`, `ExceptT`, `ReaderT`, `SPMF`, `Id`).
+
+Testing generically exercises facts `ProbComp` masks. The headline is the **failure
+factor**: over a failing monad, `Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my]`, while
+`Pr[⊥ | mx *> my]` is inclusion–exclusion `Pr[⊥|mx] + Pr[⊥|my] - Pr[⊥|mx]*Pr[⊥|my]`; both collapse
+only when `Pr[⊥] = 0` (as in `ProbComp`).
+
+As in the concrete battery: where a fact closes by both `simp` and `grind`, both are kept (the
+mirror); otherwise a single terminal tactic + a `target(...)` note. Operations with no probability
+API yet are recorded as `target` gaps at the end.
+-/
+
+open OracleComp ProbComp ENNReal
+
+namespace VCVioTest.MonadProbability
+
+/-! # Generic monad `m` -/
+
+section generic
+
+variable {α β : Type} {m : Type → Type} [Monad m] [LawfulMonad m]
+  [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+  [MonadLiftT m SetM] [LawfulMonadLiftT m SetM] [EvalDistCompatible m]
+
+/-! ## `pure` — all heads close by both `simp` and `grind`. -/
+
+example (x : α) : Pr[= x | (pure x : m α)] = 1 := by simp
+example (x : α) : Pr[= x | (pure x : m α)] = 1 := by grind
+
+example (p : α → Prop) [DecidablePred p] (x : α) :
+    Pr[ p | (pure x : m α)] = if p x then 1 else 0 := by simp
+example (p : α → Prop) [DecidablePred p] (x : α) :
+    Pr[ p | (pure x : m α)] = if p x then 1 else 0 := by grind
+
+example (x : α) : Pr[⊥ | (pure x : m α)] = 0 := by simp
+example (x : α) : Pr[⊥ | (pure x : m α)] = 0 := by grind
+
+example (x : α) : support (pure x : m α) = {x} := by simp
+example (x : α) : support (pure x : m α) = {x} := by grind
+
+example (x : α) : 𝒟[(pure x : m α)] = pure x := by simp
+example (x : α) : 𝒟[(pure x : m α)] = pure x := by grind
+
+/-! ## `bind`
+
+The support is a union; the distribution is a `bind`; the outcome/event/failure probabilities are
+`tsum`s (`grind`-only — they are `@[grind =]`, not `@[simp]`). -/
+
+example (mx : m α) (my : α → m β) :
+    support (mx >>= my) = ⋃ x ∈ support mx, support (my x) := by simp
+example (mx : m α) (my : α → m β) :
+    support (mx >>= my) = ⋃ x ∈ support mx, support (my x) := by grind
+
+example (mx : m α) (my : α → m β) : 𝒟[mx >>= my] = 𝒟[mx] >>= fun x => 𝒟[my x] := by simp
+example (mx : m α) (my : α → m β) : 𝒟[mx >>= my] = 𝒟[mx] >>= fun x => 𝒟[my x] := by grind
+
+-- target(simp): the `tsum` bind expansions are `@[grind =]` only.
+example (mx : m α) (my : α → m β) (y : β) :
+    Pr[= y | mx >>= my] = ∑' x : α, Pr[= x | mx] * Pr[= y | my x] := by grind
+example (mx : m α) (my : α → m β) :
+    Pr[⊥ | mx >>= my] = Pr[⊥ | mx] + ∑' x : α, Pr[= x | mx] * Pr[⊥ | my x] := by grind
+
+/-! ## `bind` with a constant continuation — the failure factor
+
+`Pr[= y | mx >>= fun _ => my] = (1 - Pr[⊥ | mx]) * Pr[= y | my]`: the factor `(1 - Pr[⊥ | mx])` is
+the probability `mx` succeeds at all. -/
+
+example (mx : m α) (my : m β) (y : β) :
+    Pr[= y | mx >>= fun _ => my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by simp
+example (mx : m α) (my : m β) (y : β) :
+    Pr[= y | mx >>= fun _ => my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by grind
+
+example (mx : m α) (my : m β) :
+    Pr[⊥ | mx >>= fun _ => my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by simp
+example (mx : m α) (my : m β) :
+    Pr[⊥ | mx >>= fun _ => my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by grind
+
+/-! ## `map` (`<$>`)
+
+`probFailure`/`probEvent` are invariant / pulled back; `support` is the image; the new
+`probOutput_map` is the `grind`-only pulled-back outcome. -/
+
+example (f : α → β) (mx : m α) : Pr[⊥ | f <$> mx] = Pr[⊥ | mx] := by simp
+example (f : α → β) (mx : m α) : Pr[⊥ | f <$> mx] = Pr[⊥ | mx] := by grind
+
+example (f : α → β) (mx : m α) (q : β → Prop) : Pr[ q | f <$> mx] = Pr[ q ∘ f | mx] := by simp
+example (f : α → β) (mx : m α) (q : β → Prop) : Pr[ q | f <$> mx] = Pr[ q ∘ f | mx] := by grind
+
+example (f : α → β) (mx : m α) : support (f <$> mx) = f '' support mx := by simp
+example (f : α → β) (mx : m α) : support (f <$> mx) = f '' support mx := by grind
+
+example (f : α → β) (mx : m α) : 𝒟[f <$> mx] = f <$> 𝒟[mx] := by simp
+example (f : α → β) (mx : m α) : 𝒟[f <$> mx] = f <$> 𝒟[mx] := by grind
+
+-- target(simp): `probOutput_map` is `@[grind =]` only (`simp` keeps its injective/equiv map forms).
+example (f : α → β) (mx : m α) (y : β) :
+    Pr[= y | f <$> mx] = Pr[ fun x => f x = y | mx] := by grind
+
+/-! ## `seqLeft` (`<*`) / `seqRight` (`*>`) — the headline failure factors
+
+The discarded computation contributes only its *success* mass `(1 - Pr[⊥])`; the combined failure is
+inclusion–exclusion. Over `ProbComp` (`Pr[⊥] = 0`) these collapse to `Pr[= _ | _]` and `0`. -/
+
+example (mx my : m α) (x : α) : Pr[= x | mx <* my] = (1 - Pr[⊥ | my]) * Pr[= x | mx] := by simp
+example (mx my : m α) (x : α) : Pr[= x | mx <* my] = (1 - Pr[⊥ | my]) * Pr[= x | mx] := by grind
+
+example (mx my : m α) (y : α) : Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by simp
+example (mx my : m α) (y : α) : Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by grind
+
+example (mx my : m α) (p : α → Prop) :
+    Pr[ p | mx <* my] = (1 - Pr[⊥ | my]) * Pr[ p | mx] := by simp
+example (mx my : m α) (p : α → Prop) :
+    Pr[ p | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[ p | my] := by simp
+
+example (mx my : m α) :
+    Pr[⊥ | mx <* my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by simp
+example (mx my : m α) :
+    Pr[⊥ | mx *> my] = Pr[⊥ | mx] + Pr[⊥ | my] - Pr[⊥ | mx] * Pr[⊥ | my] := by simp
+
+example (mx my : m α) : 𝒟[mx *> my] = 𝒟[mx] *> 𝒟[my] := by simp
+example (mx my : m α) : 𝒟[mx <* my] = 𝒟[mx] <* 𝒟[my] := by simp
+
+/-! ## `seq` (`<*>`)
+
+Failure is inclusion–exclusion; the `Prod.mk` product factors (`simp`-only — `grind` cannot
+factor an applicative product). -/
+
+example (mf : m (α → β)) (mx : m α) :
+    Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by simp
+example (mf : m (α → β)) (mx : m α) :
+    Pr[⊥ | mf <*> mx] = Pr[⊥ | mf] + Pr[⊥ | mx] - Pr[⊥ | mf] * Pr[⊥ | mx] := by grind
+
+example (mf : m (α → β)) (mx : m α) : 𝒟[mf <*> mx] = 𝒟[mf] <*> 𝒟[mx] := by simp
+
+-- target(grind): the applicative product's second factor sits under a binder, unindexable by grind.
+example (mx my : m α) (z : α × α) :
+    Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] := by simp
+
+end generic
+
+/-! # Concrete transformer instantiations
+
+The generic lemmas specialise to each monad transformer that instantiates the framework. For
+never-failing carriers (`Id`, `OptionT ProbComp`'s base) the failure factor collapses; for genuinely
+failing ones it does not — that contrast is the point. -/
+
+/-! ## `Id` -/
+example (x : Bool) : Pr[= x | (pure x : Id Bool)] = 1 := by simp
+example (x : Bool) : Pr[= x | (pure x : Id Bool)] = 1 := by grind
+example (mx my : Id Bool) (y : Bool) : Pr[= y | mx *> my] = Pr[= y | my] := by simp
+
+/-! ## `OptionT ProbComp` (the failing case used in cryptography) -/
+example (x : Bool) : Pr[= x | (pure x : OptionT ProbComp Bool)] = 1 := by simp
+example (x : Bool) : Pr[= x | (pure x : OptionT ProbComp Bool)] = 1 := by grind
+example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by simp
+example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by grind
+
+-- the failure factor is visible here (the discarded draw can fail):
+example (mx my : OptionT ProbComp Bool) (y : Bool) :
+    Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my] := by simp
+
+/-! ## `ExceptT` over `ProbComp` (a failing carrier — failure factor visible) -/
+example (x : Bool) : Pr[= x | (pure x : ExceptT String ProbComp Bool)] = 1 := by simp
+example (x : Bool) : Pr[= x | (pure x : ExceptT String ProbComp Bool)] = 1 := by grind
+
+/-! ## `SPMF` itself -/
+example (x : Bool) : Pr[= x | (pure x : SPMF Bool)] = 1 := by simp
+example (x : Bool) : Pr[= x | (pure x : SPMF Bool)] = 1 := by grind
+
+/-! ## `orElse` (`<|>`) and `guard` over `OptionT ProbComp`
+
+The freshly-added API (`probFailure_orElse` / `probOutput_orElse` / `support_guard`). -/
+
+example (oa oa' : OptionT ProbComp Bool) :
+    Pr[⊥ | oa <|> oa'] = Pr[⊥ | oa] * Pr[⊥ | oa'] := by simp
+
+example (oa oa' : OptionT ProbComp Bool) (x : Bool) :
+    Pr[= x | oa <|> oa'] = Pr[= x | oa] + Pr[⊥ | oa] * Pr[= x | oa'] := by simp
+
+example (p : Prop) [Decidable p] :
+    support (guard p : OptionT ProbComp Unit) = if p then {()} else ∅ := by simp
+
+example (p : Prop) [Decidable p] :
+    Pr[⊥ | (guard p : OptionT ProbComp Unit)] = if p then 0 else 1 := by simp
+
+/-! # Remaining API gaps (`target`)
+
+These common monad operations have no probability lemmas yet; each is a future API addition:
+
+* `support_orElse` — `support (oa <|> oa') = support oa ∪ {x | Pr[⊥ | oa] ≠ 0 ∧ x ∈ support oa'}`;
+  follows from `probOutput_orElse` via the support↔probability bridge.
+* `finSupport_guard` / `probEvent_guard` / `evalDist_guard` — blocked on the
+  `LawfulFailure (OptionT (OracleComp spec))` universe quirk (see `OracleComp/EvalDist.lean`).
+* `forM` / `sequence` / `traverse` / `List.foldlM` — no generic probability lemmas (only `mapM` is
+  covered, via `probFailure_list_mapM` / `probOutput_list_mapM`).
+-/
+
+end VCVioTest.MonadProbability

--- a/VCVioTest/MonadProbability.lean
+++ b/VCVioTest/MonadProbability.lean
@@ -146,9 +146,13 @@ example (mf : m (α → β)) (mx : m α) :
 
 example (mf : m (α → β)) (mx : m α) : 𝒟[mf <*> mx] = 𝒟[mf] <*> 𝒟[mx] := by simp
 
--- target(grind): the applicative product's second factor sits under a binder, unindexable by grind.
+-- the applicative product factors under both: `simp` by the `@[simp high]` rule, `grind` by the
+-- same lemma as a `@[grind norm]` rule (the `Seq.seq` thunk is unindexable for E-matching, but
+-- `grind`'s normalization phase needs no pattern)
 example (mx my : m α) (z : α × α) :
     Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] := by simp
+example (mx my : m α) (z : α × α) :
+    Pr[= z | Prod.mk <$> mx <*> my] = Pr[= z.1 | mx] * Pr[= z.2 | my] := by grind
 
 end generic
 

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -1,0 +1,366 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio
+
+/-!
+# Probability tactic benchmark
+
+A curated, deliberately broad corpus of "high-school / intro-crypto-prerequisite" facts about
+**outcome probabilities, event probabilities, failure probabilities, support, and evaluation
+distributions**, each discharged by a single *terminal* tactic — `simp` or `grind`. The file
+**gates `simp` and `grind` as stable terminal tactics** over this surface, so a regression in
+either surfaces here in isolation rather than deep inside a downstream proof.
+
+Conventions:
+* **Mirrors.** Where a fact is closed by *both* `simp` and `grind`, both are kept, so each tactic
+  stays exercised on that shape. This is the bulk of the file.
+* **Single tactic + target.** Where only one tactic closes a goal, that tactic is used and the gap
+  is recorded with a `target(grind)` / `target(simp)` note — a concrete goal for future tactic work.
+* **Only stable tactics.** No example hangs or explodes. `grind` reasons well about symbolic /
+  atomic / membership / equiprobability / `pure`+`bind`-normalised goals; computing a concrete value
+  or factoring a structured computation (`<*>`, a non-trivial `<$>`/`if`) is `simp`'s job, so those
+  are `simp`-terminal with a `target(grind)` note.
+
+`grind` normalises monadic structure (`bind_pure`, `pure_bind`, `bind_assoc`, `map_pure` are
+`@[grind =]`), so `bind`-`pure`-shaped goals close by `grind`; `Set.Nonempty` bridges
+(`probFailure_eq_one_iff_not_nonempty`, `support_uniformSample_nonempty`) keep `Pr[⊥]=1` reasoning
+reachable. `ProbComp` itself never fails — interesting `Pr[⊥ | _]` lives in `OptionT ProbComp`.
+-/
+
+open OracleComp ProbComp ENNReal
+
+namespace VCVioTest.ProbabilityTactics
+
+/-! # 1. Outcome probability — `Pr[= x | _]` -/
+
+/-! ## Deterministic outcomes
+A `pure` computation puts all of its mass on its value. -/
+
+example (x : Bool) : Pr[= x | (pure x : ProbComp Bool)] = 1 := by simp
+example (x : Bool) : Pr[= x | (pure x : ProbComp Bool)] = 1 := by grind
+
+example (x y : Bool) : Pr[= x | (pure y : ProbComp Bool)] = if x = y then 1 else 0 := by simp
+example (x y : Bool) : Pr[= x | (pure y : ProbComp Bool)] = if x = y then 1 else 0 := by grind
+
+example (x : Bool) : Pr[= x | (pure x : ProbComp Bool)] ≠ 0 := by simp
+example (x : Bool) : Pr[= x | (pure x : ProbComp Bool)] ≠ 0 := by grind
+
+/-! ## Uniform draws
+Every outcome of a uniform draw over an `n`-element type has probability `1 / n`.
+
+target(grind): computing a concrete value needs `Fintype.card`/`ℝ≥0∞` arithmetic `grind` does not do
+(it fails fast); `simp` evaluates it. Symbolic facts (`≠ 0`, equiprobability) close by both. -/
+
+example : Pr[= true | $ᵗ Bool] = 2⁻¹ := by simp
+example : Pr[= (0 : Fin 6) | $ᵗ (Fin 6)] = 6⁻¹ := by simp
+
+example : Pr[= true | $ᵗ Bool] ≠ 0 := by simp
+example : Pr[= true | $ᵗ Bool] ≠ 0 := by grind
+
+example (x y : Fin 6) : Pr[= x | $ᵗ (Fin 6)] = Pr[= y | $ᵗ (Fin 6)] := by simp
+example (x y : Fin 6) : Pr[= x | $ᵗ (Fin 6)] = Pr[= y | $ᵗ (Fin 6)] := by grind
+
+example : Pr[= true | $ᵗ Bool] = Pr[= false | $ᵗ Bool] := by simp
+example : Pr[= true | $ᵗ Bool] = Pr[= false | $ᵗ Bool] := by grind
+
+example : Pr[= (3 : ZMod 5) | $ᵗ (ZMod 5)] = 5⁻¹ := by simp
+example : Pr[= (0 : BitVec 4) | $ᵗ (BitVec 4)] = 16⁻¹ := by simp
+
+example : Pr[= (0 : Fin 3) | $ᵗ (Fin 3)] ≠ 0 := by grind
+
+example (x : Bool ⊕ Bool) : Pr[= x | $ᵗ (Bool ⊕ Bool)] ≠ 0 := by grind
+
+/-! ## Bounds
+An outcome probability lies in `[0, 1]` and is never `⊤`.
+
+target(grind): `0 ≤ _` in `ℝ≥0∞` is just `zero_le`, but `grind` routes through the support machinery
+and fails; `simp` closes it. -/
+
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≤ 1 := by simp
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≤ 1 := by grind
+
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≠ ⊤ := by simp
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] ≠ ⊤ := by grind
+
+example (mx : ProbComp Bool) (x : Bool) : 0 ≤ Pr[= x | mx] := by simp
+
+/-! ## `bind`/`pure`-normalised computations
+`grind` normalises monadic structure, so a redundant `bind`/`pure` collapses and the outcome
+probability matches the underlying draw. -/
+
+example : Pr[= true | do let b ← $ᵗ Bool; pure b] = Pr[= true | $ᵗ Bool] := by simp
+example : Pr[= true | do let b ← $ᵗ Bool; pure b] = Pr[= true | $ᵗ Bool] := by grind
+
+example (mx : ProbComp Bool) (x : Bool) :
+    Pr[= x | do let y ← mx; pure y] = Pr[= x | mx] := by simp
+example (mx : ProbComp Bool) (x : Bool) :
+    Pr[= x | do let y ← mx; pure y] = Pr[= x | mx] := by grind
+
+example (x : Bool) : Pr[= x | (do let _ ← $ᵗ Bool; pure x : ProbComp Bool)] = 1 := by simp
+example (x : Bool) : Pr[= x | (do let _ ← $ᵗ Bool; pure x : ProbComp Bool)] = 1 := by grind
+
+/-! ## Independence and the multiplication rule
+Two independent uniform draws factor: the joint mass is the product of the marginals.
+
+target(grind): `grind` cannot factor an independent product — the second factor sits under a binder
+(`<*>`'s thunk or `bind`'s continuation), unindexable by `grind`; `simp` factors it. -/
+
+example (a b : Bool) :
+    Pr[= (a, b) | do let x ← $ᵗ Bool; let y ← $ᵗ Bool; pure (x, y)]
+      = Pr[= a | $ᵗ Bool] * Pr[= b | $ᵗ Bool] := by simp
+
+example :
+    Pr[= ((5 : Fin 6), (5 : Fin 6)) | do let x ← $ᵗ (Fin 6); let y ← $ᵗ (Fin 6); pure (x, y)]
+      = 6⁻¹ * 6⁻¹ := by simp
+
+example (z : Bool × Bool) :
+    Pr[= z | (·, ·) <$> ($ᵗ Bool) <*> ($ᵗ Bool)]
+      = Pr[= z.1 | $ᵗ Bool] * Pr[= z.2 | $ᵗ Bool] := by simp
+
+/-! # 2. Event probability — `Pr[ p | _]` -/
+
+/-! ## Bounds
+A probability is at most one and never `⊤`. -/
+
+example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≤ 1 := by simp
+example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≤ 1 := by grind
+
+example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≠ ⊤ := by simp
+example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≠ ⊤ := by grind
+
+-- The impossible event has probability zero; a single fair outcome has probability one half.
+-- target(grind): `grind` routes `Pr[fun _ => False]` through the support machinery and fails.
+example (mx : ProbComp Bool) : Pr[fun _ => False | mx] = 0 := by simp
+example : Pr[fun b => b = true | $ᵗ Bool] = 2⁻¹ := by simp
+example : Pr[fun n => n < 3 | $ᵗ (Fin 6)] = 3 / 6 := by simp; congr 1
+
+/-! ## Monotonicity and complement
+An event implies a wider event; the complement subtracts from one. -/
+
+example (mx : ProbComp Bool) (p q : Bool → Prop) (h : ∀ x, p x → q x) :
+    Pr[p | mx] ≤ Pr[q | mx] := probEvent_mono'' h
+
+example : Pr[fun b => b ≠ true | $ᵗ Bool] = 2⁻¹ := by simp
+
+/-! ## Counting (favourable / total)
+target(grind): the finite count needs `congr 1` after the `probEvent_uniformSample` rewrite; ideally
+`grind` evaluates the count itself. -/
+
+example : Pr[fun n => n = 0 ∨ n = 1 | $ᵗ (Fin 6)] = 2 / 6 := by simp; congr 1
+example : Pr[fun p => p.1 = true ∨ p.2 = true | $ᵗ (Bool × Bool)] = 3 / 4 := by simp; congr 1
+
+/-! ## Map pushforward
+The event-probability of a map is the pulled-back event. -/
+
+example (mx : ProbComp Bool) (q : Fin 6 → Prop) (f : Bool → Fin 6) :
+    Pr[q | f <$> mx] = Pr[q ∘ f | mx] := by simp
+
+/-! # 3. Failure probability — `Pr[⊥ | _]` -/
+
+/-! ## `ProbComp` never fails
+A bare `ProbComp` computation — `pure`, a uniform draw, or any `bind` of them — fails with
+probability zero. -/
+
+example (x : Bool) : Pr[⊥ | (pure x : ProbComp Bool)] = 0 := by simp
+example (x : Bool) : Pr[⊥ | (pure x : ProbComp Bool)] = 0 := by grind
+
+example : Pr[⊥ | $ᵗ Bool] = 0 := by simp
+example : Pr[⊥ | $ᵗ Bool] = 0 := by grind
+
+example : Pr[⊥ | do let x ← $ᵗ Bool; let y ← $ᵗ Bool; pure (x && y)] = 0 := by simp
+example : Pr[⊥ | do let x ← $ᵗ Bool; let y ← $ᵗ Bool; pure (x && y)] = 0 := by grind
+
+example (α : Type) [SampleableType α] : Pr[⊥ | $ᵗ α] = 0 := by simp
+example (α : Type) [SampleableType α] : Pr[⊥ | $ᵗ α] = 0 := by grind
+
+/-! ## Selection and abort (`OptionT ProbComp`)
+Selecting from the empty list fails with probability one; from a nonempty list it never fails. A
+nonempty support means the computation does not certainly fail (`grind` via the `Set.Nonempty`
+bridge). -/
+
+example : Pr[⊥ | ($ ([] : List Bool) : OptionT ProbComp Bool)] = 1 := by simp
+example : Pr[⊥ | ($ ([] : List Bool) : OptionT ProbComp Bool)] = 1 := by grind
+
+example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by simp
+example : Pr[⊥ | (failure : OptionT ProbComp Bool)] = 1 := by grind
+
+example : Pr[⊥ | ($ ([true, false] : List Bool) : OptionT ProbComp Bool)] = 0 := by simp
+
+example (mx : OptionT ProbComp Bool) (h : (support mx).Nonempty) : Pr[⊥ | mx] ≠ 1 := by grind
+example (mx : ProbComp Bool) (h : (support mx).Nonempty) : Pr[⊥ | mx] ≠ 1 := by grind
+
+example (α : Type) [SampleableType α] : Pr[⊥ | $ᵗ α] ≠ 1 := by grind
+
+/-! # 4. Support and finite support -/
+
+/-! ## Singletons and universes
+A `pure` computation is supported on its value; a uniform draw is supported everywhere. -/
+
+example (x : Bool) : support (pure x : ProbComp Bool) = {x} := by simp
+example (x : Bool) : support (pure x : ProbComp Bool) = {x} := by grind
+
+example : support ($ᵗ Bool) = Set.univ := by simp
+example : support ($ᵗ Bool) = Set.univ := by grind
+
+example : finSupport ($ᵗ (Fin 6)) = Finset.univ := by simp
+example : finSupport ($ᵗ (Fin 6)) = Finset.univ := by grind
+
+example : finSupport (pure true : ProbComp Bool) = {true} := by simp
+example : finSupport (pure true : ProbComp Bool) = {true} := by grind
+
+example : support ($ᵗ (Bool × Bool)) = Set.univ := by simp
+example : support ($ᵗ (Bool × Bool)) = Set.univ := by grind
+
+example : support ($ᵗ (Vector Bool 2)) = Set.univ := by simp
+example : support ($ᵗ (Vector Bool 2)) = Set.univ := by grind
+
+example : support (do let b ← $ᵗ Bool; pure b) = Set.univ := by simp
+example : support (do let b ← $ᵗ Bool; pure b) = Set.univ := by grind
+
+/-! ## Membership
+Every value is a possible outcome of a uniform draw. -/
+
+example (x : Bool) : x ∈ support ($ᵗ Bool) := by simp
+example (x : Bool) : x ∈ support ($ᵗ Bool) := by grind
+
+example (x : Bool) : x ∈ finSupport ($ᵗ Bool) := by simp
+example (x : Bool) : x ∈ finSupport ($ᵗ Bool) := by grind
+
+example (x : Bool) : x ∈ support (pure x : ProbComp Bool) := by simp
+example (x : Bool) : x ∈ support (pure x : ProbComp Bool) := by grind
+
+example (α : Type) [SampleableType α] (x : α) : x ∈ support ($ᵗ α) := by grind
+
+example (α : Type) [SampleableType α] : (support ($ᵗ α)).Nonempty := by grind
+
+/-! ## The support ↔ probability bridge
+A value has zero probability exactly when it is outside the support.
+
+target(simp): `simp` rewrites the `= 0` side but cannot close the `Iff`; `grind` discharges it. -/
+
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] = 0 ↔ x ∉ support mx := by grind
+
+example (mx : ProbComp Bool) (x : Bool) : 0 < Pr[= x | mx] ↔ x ∈ support mx := by simp
+example (mx : ProbComp Bool) (x : Bool) : 0 < Pr[= x | mx] ↔ x ∈ support mx := by grind
+
+/-! ## Structured supports
+target(grind): a non-trivial `<$>`/`do` support equality needs `simp`'s computation normalisation
+(and a set extensionality); `grind` would expand it instead. -/
+
+example : support (do let b ← $ᵗ Bool; pure (!b)) = Set.univ := by
+  ext b; cases b <;> simp
+
+/-! # 5. Evaluation distribution — `𝒟[_]` -/
+
+/-! ## `bind`/`pure` normalisation
+A redundant `bind`/`pure` does not change the distribution. -/
+
+example (mx : ProbComp Bool) : 𝒟[do let x ← mx; pure x] = 𝒟[mx] := by simp
+example (mx : ProbComp Bool) : 𝒟[do let x ← mx; pure x] = 𝒟[mx] := by grind
+
+example (mx : ProbComp Bool) : 𝒟[mx >>= pure] = 𝒟[mx] := by simp
+example (mx : ProbComp Bool) : 𝒟[mx >>= pure] = 𝒟[mx] := by grind
+
+/-! ## One-time-pad secrecy
+Adding a uniform key makes the ciphertext distribution independent of the message (`ZMod 2` — a
+one-bit XOR pad).
+
+target(grind): this needs the translation-invariance lemma to fire before `evalDist_uniformSample`
+unfolds the uniform draw, so it is `simp only`-terminal. -/
+
+example (msg : ZMod 2) : 𝒟[(msg + ·) <$> ($ᵗ (ZMod 2))] = 𝒟[$ᵗ (ZMod 2)] := by
+  simp only [evalDist_add_left_uniform]
+
+/-! # 6. The shape of `do`
+The automation should see through the full surface syntax of `do`-notation: a pure `let :=`, nested
+blocks, pattern-matching binds, `if`/`then`/`else`, and long chains. None of these can fail. -/
+
+/-- A pure `let :=` step inside `do`. -/
+def coinThenNeg : ProbComp Bool := do
+  let x ← $ᵗ Bool
+  let y := !x
+  pure y
+
+/-- A pattern-matching bind over a nested product draw. -/
+def twoThenAnd : ProbComp Bool := do
+  let (a, b) ← (do let x ← $ᵗ Bool; let y ← $ᵗ Bool; pure (x, y))
+  pure (a && b)
+
+/-- A nested `do` block whose result feeds the outer one. -/
+def nestedDraw : ProbComp Bool := do
+  let x ← $ᵗ Bool
+  let y ← (do let z ← $ᵗ Bool; pure (x && z))
+  pure y
+
+/-- An `if`/`then`/`else` branch on a coin. -/
+def branchToFin : ProbComp (Fin 2) := do
+  let b ← $ᵗ Bool
+  if b then pure 0 else pure 1
+
+/-- A five-step chain of independent coins. -/
+def fiveCoins : ProbComp Bool := do
+  let a ← $ᵗ Bool; let b ← $ᵗ Bool; let c ← $ᵗ Bool; let d ← $ᵗ Bool; let e ← $ᵗ Bool
+  pure (a && b && c && d && e)
+
+example : Pr[⊥ | coinThenNeg] = 0 := by simp [coinThenNeg]
+example : Pr[⊥ | twoThenAnd] = 0 := by simp [twoThenAnd]
+example : Pr[⊥ | nestedDraw] = 0 := by simp [nestedDraw]
+example : Pr[⊥ | branchToFin] = 0 := by simp [branchToFin]
+example : Pr[⊥ | fiveCoins] = 0 := by simp [fiveCoins]
+
+example : Pr[= false | coinThenNeg] = Pr[= true | $ᵗ Bool] := by simp [coinThenNeg]
+
+/-- Abort unless the coin comes up `true`: fails with probability one half. -/
+def abortOnFalse : OptionT ProbComp Bool := do
+  let b ← $ᵗ Bool
+  if b then pure true else failure
+
+example : Pr[⊥ | abortOnFalse] = 2⁻¹ := by
+  simp [abortOnFalse, probFailure_bind_eq_add_tsum]
+
+/-! # 7. Cryptography prerequisites
+The kind of facts an intro-to-cryptography course assumes: guessing a uniform secret, collision
+probability, and outcome probabilities summing to one. -/
+
+example (guess : Fin 6) : Pr[= guess | $ᵗ (Fin 6)] = 6⁻¹ := by simp
+
+example : Pr[fun p => p.1 = p.2 | $ᵗ (Fin 6 × Fin 6)] = 6 / 36 := by simp; congr 1
+
+example : ∑ k : Fin 6, Pr[= k | $ᵗ (Fin 6)] = 1 := sum_probOutput_eq_one (by simp)
+
+/-! # 8. Abstract carriers
+The same facts over an arbitrary `SampleableType` carrier. `grind` handles the symbolic ones
+(equiprobability, never-fails, nonempty support); `grind` cannot factor the applicative product, so
+the product equiprobability is `simp; grind` (`simp` factors, `grind` finishes). -/
+
+section abstract
+variable (α β : Type) [SampleableType α] [SampleableType β]
+
+example (x y : α) : Pr[= x | $ᵗ α] = Pr[= y | $ᵗ α] := by grind
+
+example : support ($ᵗ α) = Set.univ := by simp
+example : support ($ᵗ α) = Set.univ := by grind
+
+example (z : α × β) :
+    Pr[= z | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] = Pr[= z.1 | $ᵗ α] * Pr[= z.2 | $ᵗ β] := by simp
+
+-- target(grind): equiprobability of a uniform product. `grind` cannot factor the applicative
+-- product (second factor under a binder); `simp` factors it, then `grind` closes the equal factors.
+example (x y : α × β) :
+    Pr[= x | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] = Pr[= y | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] := by
+  simp only [probOutput_seq_map_prod_mk_eq_mul]; grind
+
+end abstract
+
+/-! # 9. Library-shape sentinels
+Small facts in the shape of goals discharged throughout the library, to catch silent regressions of
+the probability automation in isolation. -/
+
+example (α : Type) [SampleableType α] (x : α) : x ∈ support ($ᵗ α) := by grind
+
+example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] = 0 ↔ x ∉ support mx := by grind
+
+end VCVioTest.ProbabilityTactics

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -246,6 +246,17 @@ example (mx : ProbComp Bool) (x : Bool) : Pr[= x | mx] = 0 ↔ x ∉ support mx 
 example (mx : ProbComp Bool) (x : Bool) : 0 < Pr[= x | mx] ↔ x ∈ support mx := by simp
 example (mx : ProbComp Bool) (x : Bool) : 0 < Pr[= x | mx] ↔ x ∈ support mx := by grind
 
+/-! ## Event support via `Set.Nonempty`
+An *event* has (non)zero probability exactly when some / no reachable output satisfies it. The
+`grind`-friendly companions phrase this with `Set.Nonempty` of the filtered support
+`{x ∈ support mx | p x}`, keeping the witness atomic where the `simp`-only `∃`/`∀ x ∈ support` forms
+would saturate. -/
+
+example (mx : ProbComp Bool) (p : Bool → Prop) :
+    Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty := by grind
+example (mx : ProbComp Bool) (p : Bool → Prop) :
+    Pr[ p | mx] = 0 ↔ ¬ {x ∈ support mx | p x}.Nonempty := by grind
+
 /-! ## Structured supports
 target(grind): a non-trivial `<$>`/`do` support equality needs `simp`'s computation normalisation
 (and a set extensionality); `grind` would expand it instead. -/

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -135,7 +135,7 @@ example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≠ ⊤ := by grin
 -- target(grind): `grind` routes `Pr[fun _ => False]` through the support machinery and fails.
 example (mx : ProbComp Bool) : Pr[fun _ => False | mx] = 0 := by simp
 example : Pr[fun b => b = true | $ᵗ Bool] = 2⁻¹ := by simp
-example : Pr[fun n => n < 3 | $ᵗ (Fin 6)] = 3 / 6 := by simp; congr 1
+example : Pr[fun n => n < 3 | $ᵗ (Fin 6)] = 3 / 6 := by simp; rfl
 
 /-! ## Monotonicity and complement
 An event implies a wider event; the complement subtracts from one. -/
@@ -146,10 +146,10 @@ example (mx : ProbComp Bool) (p q : Bool → Prop) (h : ∀ x, p x → q x) :
 example : Pr[fun b => b ≠ true | $ᵗ Bool] = 2⁻¹ := by simp
 
 /-! ## Counting (favourable / total)
-target(grind): the finite count needs `congr 1` after the `probEvent_uniformSample` rewrite; ideally
+target(grind): the finite count needs `rfl` after the `probEvent_uniformSample` rewrite; ideally
 `grind` evaluates the count itself. -/
 
-example : Pr[fun n => n = 0 ∨ n = 1 | $ᵗ (Fin 6)] = 2 / 6 := by simp; congr 1
+example : Pr[fun n => n = 0 ∨ n = 1 | $ᵗ (Fin 6)] = 2 / 6 := by simp; rfl
 example : Pr[fun p => p.1 = true ∨ p.2 = true | $ᵗ (Bool × Bool)] = 3 / 4 := by simp; congr 1
 
 /-! ## Map pushforward
@@ -311,6 +311,12 @@ example : Pr[⊥ | nestedDraw] = 0 := by simp [nestedDraw]
 example : Pr[⊥ | branchToFin] = 0 := by simp [branchToFin]
 example : Pr[⊥ | fiveCoins] = 0 := by simp [fiveCoins]
 
+example : Pr[⊥ | coinThenNeg] = 0 := by grind [coinThenNeg]
+example : Pr[⊥ | twoThenAnd] = 0 := by grind [twoThenAnd]
+example : Pr[⊥ | nestedDraw] = 0 := by grind [nestedDraw]
+example : Pr[⊥ | branchToFin] = 0 := by grind [branchToFin]
+example : Pr[⊥ | fiveCoins] = 0 := by grind [fiveCoins]
+
 example : Pr[= false | coinThenNeg] = Pr[= true | $ᵗ Bool] := by simp [coinThenNeg]
 
 /-- Abort unless the coin comes up `true`: fails with probability one half. -/
@@ -327,7 +333,7 @@ probability, and outcome probabilities summing to one. -/
 
 example (guess : Fin 6) : Pr[= guess | $ᵗ (Fin 6)] = 6⁻¹ := by simp
 
-example : Pr[fun p => p.1 = p.2 | $ᵗ (Fin 6 × Fin 6)] = 6 / 36 := by simp; congr 1
+example : Pr[fun p => p.1 = p.2 | $ᵗ (Fin 6 × Fin 6)] = 6 / 36 := by simp; rfl
 
 example : ∑ k : Fin 6, Pr[= k | $ᵗ (Fin 6)] = 1 := sum_probOutput_eq_one (by simp)
 

--- a/VCVioTest/ProbabilityTactics.lean
+++ b/VCVioTest/ProbabilityTactics.lean
@@ -105,8 +105,12 @@ example (x : Bool) : Pr[= x | (do let _ ← $ᵗ Bool; pure x : ProbComp Bool)] 
 /-! ## Independence and the multiplication rule
 Two independent uniform draws factor: the joint mass is the product of the marginals.
 
-target(grind): `grind` cannot factor an independent product — the second factor sits under a binder
-(`<*>`'s thunk or `bind`'s continuation), unindexable by `grind`; `simp` factors it. -/
+The applicative (`<$> … <*>`) spelling factors under `grind` via the `@[grind norm]` rule
+`probOutput_seq_map_prod_mk_eq_mul` (the `Seq.seq` thunk is unindexable for E-matching, but
+`grind`'s normalization phase handles it).
+
+target(grind): the `bind`-spelled product — the second draw sits under `bind`'s continuation, which
+neither E-matching nor the seq-keyed norm rule reaches; `simp` factors it. -/
 
 example (a b : Bool) :
     Pr[= (a, b) | do let x ← $ᵗ Bool; let y ← $ᵗ Bool; pure (x, y)]
@@ -119,6 +123,9 @@ example :
 example (z : Bool × Bool) :
     Pr[= z | (·, ·) <$> ($ᵗ Bool) <*> ($ᵗ Bool)]
       = Pr[= z.1 | $ᵗ Bool] * Pr[= z.2 | $ᵗ Bool] := by simp
+example (z : Bool × Bool) :
+    Pr[= z | (·, ·) <$> ($ᵗ Bool) <*> ($ᵗ Bool)]
+      = Pr[= z.1 | $ᵗ Bool] * Pr[= z.2 | $ᵗ Bool] := by grind
 
 /-! # 2. Event probability — `Pr[ p | _]` -/
 
@@ -132,8 +139,8 @@ example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≠ ⊤ := by simp
 example (mx : ProbComp Bool) (p : Bool → Prop) : Pr[p | mx] ≠ ⊤ := by grind
 
 -- The impossible event has probability zero; a single fair outcome has probability one half.
--- target(grind): `grind` routes `Pr[fun _ => False]` through the support machinery and fails.
 example (mx : ProbComp Bool) : Pr[fun _ => False | mx] = 0 := by simp
+example (mx : ProbComp Bool) : Pr[fun _ => False | mx] = 0 := by grind
 example : Pr[fun b => b = true | $ᵗ Bool] = 2⁻¹ := by simp
 example : Pr[fun n => n < 3 | $ᵗ (Fin 6)] = 3 / 6 := by simp; rfl
 
@@ -363,12 +370,13 @@ example : support ($ᵗ α) = Set.univ := by grind
 
 example (z : α × β) :
     Pr[= z | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] = Pr[= z.1 | $ᵗ α] * Pr[= z.2 | $ᵗ β] := by simp
+example (z : α × β) :
+    Pr[= z | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] = Pr[= z.1 | $ᵗ α] * Pr[= z.2 | $ᵗ β] := by grind
 
--- target(grind): equiprobability of a uniform product. `grind` cannot factor the applicative
--- product (second factor under a binder); `simp` factors it, then `grind` closes the equal factors.
+-- equiprobability of a uniform product: the `@[grind norm]` factorization rule lets bare `grind`
+-- factor the applicative product, then close the equal factors
 example (x y : α × β) :
-    Pr[= x | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] = Pr[= y | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] := by
-  simp only [probOutput_seq_map_prod_mk_eq_mul]; grind
+    Pr[= x | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] = Pr[= y | (·, ·) <$> ($ᵗ α) <*> ($ᵗ β)] := by grind
 
 end abstract
 

--- a/docs/agents/gotchas.md
+++ b/docs/agents/gotchas.md
@@ -51,9 +51,21 @@ The bare `query` identifier is the `export`ed `HasQuery.query`, so writing `quer
 
 ## Proof Patterns
 
-### 9. `probOutput_bind_eq_tsum` is `@[grind =]` but NOT `@[simp]`
+### 9. `grind`/`simp` tagging is split deliberately on probability lemmas
 
-`simp` won't unfold `probOutput` of a bind. Use `rw [probOutput_bind_eq_tsum]` or `grind`.
+`probOutput_bind_eq_tsum` is `@[grind =]` but NOT `@[simp]`: `simp` won't unfold `probOutput` of a
+bind, so use `rw [probOutput_bind_eq_tsum]` or `grind`.
+
+Conversely, the support-*characterization* lemmas (`Pr[…] = 0/1 ↔ ∃/∀ x ∈ support …`,
+`support = {x}`, `support = ∅`: `probEvent_eq_zero_iff`, `probEvent_pos_iff`, `probOutput_eq_one_iff`,
+`probFailure_eq_one_iff`, `mem_support_bind_iff`, …) are `@[simp]` but deliberately **NOT** `@[grind]`.
+Their RHS introduces an unbounded support quantifier that `grind` Skolemizes into fresh witnesses with
+no finite grounding, so a naive `grind` on a probability value/event goal would *saturate and time
+out*. Dropped from the default `grind` set, `grind` instead fails fast. If a `grind` proof genuinely
+needs one, re-supply it: `grind [probEvent_eq_zero_iff]`. The directed single-variable membership
+bridges (`probOutput_eq_zero_iff`, `probOutput_pos_iff`, `mem_finSupport_iff`) stay `@[grind =]`. See
+*`grind` vs `simp` on Probability Goals* in [`probability.md`](probability.md) and the benchmark
+`VCVioTest/ProbabilityTactics.lean`.
 
 ### 10. Plain `vcstep` may solve a probability equality when you only wanted a rewrite
 

--- a/docs/agents/gotchas.md
+++ b/docs/agents/gotchas.md
@@ -57,15 +57,18 @@ The bare `query` identifier is the `export`ed `HasQuery.query`, so writing `quer
 bind, so use `rw [probOutput_bind_eq_tsum]` or `grind`.
 
 Conversely, the support-*characterization* lemmas (`Pr[…] = 0/1 ↔ ∃/∀ x ∈ support …`,
-`support = {x}`, `support = ∅`: `probEvent_eq_zero_iff`, `probEvent_pos_iff`, `probOutput_eq_one_iff`,
+`support = {x}`, `support = ∅`: `probEvent_eq_zero_iff`, `probEvent_eq_one_iff`, `probOutput_eq_one_iff`,
 `probFailure_eq_one_iff`, `mem_support_bind_iff`, …) are `@[simp]` but deliberately **NOT** `@[grind]`.
 Their RHS introduces an unbounded support quantifier that `grind` Skolemizes into fresh witnesses with
-no finite grounding, so a naive `grind` on a probability value/event goal would *saturate and time
-out*. Dropped from the default `grind` set, `grind` instead fails fast. If a `grind` proof genuinely
+no finite grounding; tagged *together* they form a re-trigger cycle so a naive `grind` on a probability
+value/event goal would *saturate and time out*. The saturation is **combinatorial** — no single lemma
+saturates alone (a few that sit outside the cycle, e.g. `probEvent_pos_iff` and
+`probFailure_bind_eq_zero_iff`, keep `@[grind =]`); the `probEvent_eq_one_iff` family is the cycle's
+hub. Dropped from the default `grind` set, `grind` instead fails fast. If a `grind` proof genuinely
 needs one, re-supply it: `grind [probEvent_eq_zero_iff]`. The directed single-variable membership
 bridges (`probOutput_eq_zero_iff`, `probOutput_pos_iff`, `mem_finSupport_iff`) stay `@[grind =]`. See
-*`grind` vs `simp` on Probability Goals* in [`probability.md`](probability.md) and the benchmark
-`VCVioTest/ProbabilityTactics.lean`.
+*`grind` vs `simp` on Probability Goals* in [`probability.md`](probability.md) and the benchmarks
+`VCVioTest/ProbabilityTactics.lean` / `VCVioTest/LongChainPrograms.lean`.
 
 ### 10. Plain `vcstep` may solve a probability equality when you only wanted a rewrite
 

--- a/docs/agents/gotchas.md
+++ b/docs/agents/gotchas.md
@@ -68,7 +68,13 @@ hub. Dropped from the default `grind` set, `grind` instead fails fast. If a `gri
 needs one, re-supply it: `grind [probEvent_eq_zero_iff]`. The directed single-variable membership
 bridges (`probOutput_eq_zero_iff`, `probOutput_pos_iff`, `mem_finSupport_iff`) stay `@[grind =]`. See
 *`grind` vs `simp` on Probability Goals* in [`probability.md`](probability.md) and the benchmarks
-`VCVioTest/ProbabilityTactics.lean` / `VCVioTest/LongChainPrograms.lean`.
+`VCVioTest/ProbabilityTactics.lean` / `VCVioTest/LongChainPrograms.lean`;
+`VCVioTest/GrindFailFast.lean` gates that each dropped lemma stays dropped (and that the opt-in
+still works).
+
+Downstream escape hatches, since these tags are inherited by importing projects: `grind [-lemma]`
+(disable per call), `grind only [...]` (ignore the default set), `attribute [-grind] lemma`
+(unset for a file), and `grind?` (print a minimal `grind only` call).
 
 ### 10. Plain `vcstep` may solve a probability equality when you only wanted a rewrite
 

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -116,6 +116,83 @@ Available for: `Bool`, `Fin n` (for `[NeZero n]`), `ZMod n`, `BitVec n`, `α × 
 7. **Two computations have same distribution?**
    → Show `evalDist oa = evalDist ob`, or use `relTriple_eqRel_of_evalDist_eq`
 
+## `grind` vs `simp` on Probability Goals
+
+`grind` and `simp` have complementary strengths here, and reaching for the wrong one is the most
+common way to get a `grind` that hangs.
+
+**Use `simp` to compute a concrete probability or factor structure.** `simp` evaluates
+`Pr[= x | $ᵗ T]`, `Pr[p | $ᵗ T]`, products of uniform draws, etc.; `grind` is not an `ℝ≥0∞`/`Fintype.card`
+arithmetic engine and will not finish these (it fails fast).
+
+**Use `grind` for symbolic / membership / directed-iff goals.** Equiprobability
+(`Pr[= x | $ᵗ T] = Pr[= y | $ᵗ T]`), `x ∈ support (…)`, `Pr[= x | mx] = 0 ↔ x ∉ support mx`, and
+similar are squarely in `grind`'s wheelhouse.
+
+**Why some characterization lemmas are `@[simp]` but not `@[grind]`.** A characterization whose RHS
+introduces an *unbounded* quantifier or set over the support —
+`Pr[…] = 0/1 ↔ ∃/∀ x ∈ support …`, `support = {x}`, `support = ∅` — is a `grind` **saturation
+hazard**: as `grind` case-splits the iff it instantiates and Skolemizes the support quantifier into
+fresh witnesses that re-trigger each other, with no finite grounding (`support ($ᵗ α) = Set.univ` is
+infinite). Such lemmas are kept `@[simp]` (fixed orientation, no case-split — safe) and **dropped from
+the default `grind` set**. The *directed single-variable* membership bridges
+(`probOutput_eq_zero_iff : … ↔ x ∉ support`, `probOutput_pos_iff`, `mem_finSupport_iff`,
+`mem_finSupport_iff_mem_support`) are confluent and stay `@[grind =]`.
+
+Lemmas that are `@[simp]`-only by this rule (in `EvalDist/Defs/Basic.lean` unless noted):
+`probEvent_eq_zero_iff(')`, `probEvent_ne_zero_iff(')`, `probEvent_pos_iff(')`,
+`probEvent_eq_one_iff(')`, `one_eq_probEvent_iff(')`, `probOutput_eq_one_iff(')`,
+`one_eq_probOutput_iff`, `probFailure_eq_one_iff`; and in `EvalDist/Monad/Basic.lean`,
+`probFailure_bind_eq_zero_iff` (`@[simp]`), `mem_support_bind_iff` / `mem_finSupport_bind_iff`
+(untagged — `support_bind` / `finSupport_bind` are the `simp` forms).
+
+**If a `grind` proof needs one of these, re-supply it locally:** `grind [probEvent_eq_zero_iff]`. This
+keeps the bridge out of the default set (so naive `grind` on a probability goal fails fast instead of
+hanging) while letting the proof that genuinely needs it opt in.
+
+**`Set.Nonempty`-phrased companions stay in the default `grind` set.** `grind` keeps `Set.Nonempty`
+atomic (it does not unfold it to `∃ x ∈ support`), so a characterization phrased via `Nonempty`
+carries the same information without the saturating quantifier. `probFailure_eq_one_iff_not_nonempty`
+(`Pr[⊥ | mx] = 1 ↔ ¬ (support mx).Nonempty`) is the `grind`-friendly companion to the `simp`-only
+`probFailure_eq_one_iff` (`… ↔ support mx = ∅`); reach for the `Nonempty` form when a `grind` proof
+needs to reason about a computation failing (or not) with probability one.
+`support_uniformSample_nonempty` (`(support ($ᵗ α)).Nonempty`, `@[grind]`) closes the loop, letting
+`grind` conclude e.g. `Pr[⊥ | $ᵗ α] ≠ 1` end-to-end.
+
+**Monad/functor laws normalise structure for `grind`.** `bind_pure`, `pure_bind`, `bind_assoc`, and
+`map_pure` are tagged `@[grind =]` (in `EvalDist/Monad/Basic.lean`). They are confluent rewrites, so
+`grind` collapses a computation's structure (`mx >>= pure = mx`, `pure a >>= f = f a`, …) *before*
+falling into `probOutput`/`tsum` expansion — turning what would otherwise be a `grind` *explosion* on
+a `bind`/`pure`-shaped probability/support/distribution equality into a quick solve
+(`Pr[= x | mx >>= pure] = Pr[= x | mx]`, `𝒟[do let x ← mx; pure x] = 𝒟[mx]`,
+`support (do let b ← $ᵗ Bool; pure b) = Set.univ` all close by bare `grind`). `bind_pure_comp` /
+`map_eq_bind` are omitted (function argument under a binder, unindexable). A *non-trivial*
+`<$>` / `if` / `<*>` does not normalise to a `pure`, so those structured equalities stay
+`simp`-terminal.
+
+**`grind` cannot factor an independent product.** `Pr[= z | (·, ·) <$> mx <*> my]` or its `bind`
+spelling does not reduce under `grind`: the second factor `my` is a free variable under a binder
+(`Seq.seq`'s `Unit → _` thunk, or `bind`'s continuation), which `grind`'s pattern compiler cannot
+index — tagging the factorization lemma yields an "invalid pattern" error. Factor with `simp`
+(`probOutput_seq_map_prod_mk_eq_mul` is `@[simp high]`), then hand the resulting goal to `grind`.
+
+`VCVioTest/ProbabilityTactics.lean` is the living benchmark and **gate** for all of this: a broad
+corpus of probability / event / failure / support / distribution facts organised by category, each
+closed by a single *terminal* tactic. Where a fact closes by **both** `simp` and `grind`, both are
+kept (the mirror), so each tactic stays exercised on that shape; where only one closes, the gap is a
+`target(simp)` / `target(grind)` note. A regression in either tactic surfaces there in isolation.
+When adding probability automation, add the corresponding battery rows.
+
+`VCVioTest/MonadProbability.lean` is the **generic-`m`** companion: the same gate over an abstract
+monad `m` with the EvalDist instance stack (`[LawfulMonadLiftT m SPMF]`, …) and over the concrete
+transformers (`OptionT`, `ExceptT`, `SPMF`, `Id`), where the lemmas are actually stated. It surfaces
+facts `ProbComp` masks — chiefly the **failure factor**: over a monad that can fail,
+`Pr[= y | mx *> my] = (1 - Pr[⊥ | mx]) * Pr[= y | my]` and `Pr[⊥ | mx <* my]` /
+`Pr[⊥ | mf <*> mx]` are inclusion–exclusion (`Pr[⊥|a] + Pr[⊥|b] - Pr[⊥|a]*Pr[⊥|b]`); both collapse
+to the `ProbComp` forms only because `Pr[⊥] = 0` there. New API filled along the way:
+`probOutput_map` (the `probOutput`/`<$>` companion to `probEvent_map`, `@[grind =]`), `support_guard`,
+and the `orElse` (`<|>`) probability lemmas for `OptionT (OracleComp spec)` (`probFailure_orElse` etc.).
+
 ## Common Mistakes
 
 1. **Missing probability spec classes**: on `OracleComp spec`, `evalDist`/`probOutput`/`Pr[...]` require `[IsProbabilitySpec spec]`. Uniform/cardinality lemmas and support-probability lemmas require `[IsUniformSpec spec]`, not just `[spec.Fintype] [spec.Inhabited]`. Use `IsUniformSpec.ofFintypeInhabited spec` when a concrete finite inhabited spec should use uniform sampling.

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -133,18 +133,33 @@ similar are squarely in `grind`'s wheelhouse.
 introduces an *unbounded* quantifier or set over the support —
 `Pr[…] = 0/1 ↔ ∃/∀ x ∈ support …`, `support = {x}`, `support = ∅` — is a `grind` **saturation
 hazard**: as `grind` case-splits the iff it instantiates and Skolemizes the support quantifier into
-fresh witnesses that re-trigger each other, with no finite grounding (`support ($ᵗ α) = Set.univ` is
-infinite). Such lemmas are kept `@[simp]` (fixed orientation, no case-split — safe) and **dropped from
-the default `grind` set**. The *directed single-variable* membership bridges
-(`probOutput_eq_zero_iff : … ↔ x ∉ support`, `probOutput_pos_iff`, `mem_finSupport_iff`,
-`mem_finSupport_iff_mem_support`) are confluent and stay `@[grind =]`.
+fresh witnesses, which the always-tagged `bind`-expansion lemmas (`support_bind`,
+`probFailure_bind_eq_add_tsum`, `mem_support_bind_iff`, …) re-expand into yet more `support`/`Pr[…]`
+terms, with no finite grounding (`support ($ᵗ α) = Set.univ` is infinite). The hazard is
+**combinatorial, not per-lemma**: no single one of these lemmas saturates `grind` on its own (restore
+any one and a `grind` that should fail fast stays fast), but tagged *together* they form a re-trigger
+cycle — restoring all of them makes that same `grind` run ~25× longer. The **hub of the cycle is the
+`probEvent_eq_one_iff` family**: its RHS `Pr[⊥|mx]=0 ∧ ∀ x∈support, p x` couples the `probEvent`,
+`probFailure`, and `support` layers at once (drop it and the blow-up roughly quarters). So that
+family, together with the `∃`-Skolemizing `probEvent_ne_zero_iff` and the `probEvent_eq_zero_iff`
+families, is kept `@[simp]`-only (fixed orientation, no case-split — safe). The *directed
+single-variable* membership bridges (`probOutput_eq_zero_iff : … ↔ x ∉ support`, `probOutput_pos_iff`,
+`mem_finSupport_iff`, `mem_finSupport_iff_mem_support`) are confluent and stay `@[grind =]`.
 
-Lemmas that are `@[simp]`-only by this rule (in `EvalDist/Defs/Basic.lean` unless noted):
-`probEvent_eq_zero_iff(')`, `probEvent_ne_zero_iff(')`, `probEvent_pos_iff(')`,
-`probEvent_eq_one_iff(')`, `one_eq_probEvent_iff(')`, `probOutput_eq_one_iff(')`,
-`one_eq_probOutput_iff`, `probFailure_eq_one_iff`; and in `EvalDist/Monad/Basic.lean`,
-`probFailure_bind_eq_zero_iff` (`@[simp]`), `mem_support_bind_iff` / `mem_finSupport_bind_iff`
-(untagged — `support_bind` / `finSupport_bind` are the `simp` forms).
+Lemmas kept `@[simp]`-only by this rule (in `EvalDist/Defs/Basic.lean` unless noted):
+`probEvent_eq_zero_iff(')`, `probEvent_ne_zero_iff(')`, `probEvent_eq_one_iff(')`,
+`one_eq_probEvent_iff(')`, `probOutput_eq_one_iff`, `one_eq_probOutput_iff`, `probFailure_eq_one_iff`;
+and `mem_support_bind_iff` / `mem_finSupport_bind_iff` (untagged — `support_bind` / `finSupport_bind`
+are the `simp` forms).
+
+**Support-quantifier lemmas verified safe in isolation, kept `@[grind =]`.** A few carry the support
+quantifier yet sit *outside* the `probEvent_eq_one_iff` hub cycle and add no measurable `grind` cost
+on their own, so they keep their `grind` tag: `probEvent_pos_iff(')`, `probOutput_eq_one_iff'` (the
+mirror of the never-dropped `one_eq_probOutput_iff'` — both are the `finSupport`-singleton form), and
+`probFailure_bind_eq_zero_iff` (in `EvalDist/Monad/Basic.lean`). These are safe **only while the hub
+family stays `@[simp]`-only**: re-tagging the `probEvent_eq_one_iff` family alongside them re-forms the
+saturation cycle. `VCVioTest/LongChainPrograms.lean` is the 10+-step stress benchmark for exactly
+this.
 
 **If a `grind` proof needs one of these, re-supply it locally:** `grind [probEvent_eq_zero_iff]`. This
 keeps the bridge out of the default set (so naive `grind` on a probability goal fails fast instead of
@@ -158,6 +173,16 @@ carries the same information without the saturating quantifier. `probFailure_eq_
 needs to reason about a computation failing (or not) with probability one.
 `support_uniformSample_nonempty` (`(support ($ᵗ α)).Nonempty`, `@[grind]`) closes the loop, letting
 `grind` conclude e.g. `Pr[⊥ | $ᵗ α] ≠ 1` end-to-end.
+
+The event-probability versions follow the same recipe with the *filtered* support `{x ∈ support mx | p x}`
+(the reachable outputs satisfying `p`): `probEvent_ne_zero_iff_nonempty`
+(`Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty`) and `probEvent_eq_zero_iff_not_nonempty`
+(`Pr[ p | mx] = 0 ↔ ¬ …`) are the `@[grind =]` companions to the `simp`-only `probEvent_ne_zero_iff` /
+`probEvent_eq_zero_iff`. The `Pr[…] = 1` companions are deliberately *omitted*: a `Nonempty`-phrased
+`probEvent_eq_one` keeps its `Pr[⊥ | mx] = 0` conjunct, which re-couples it to the hub family and
+re-creates the combination slowdown even though it is cheap in isolation. The two event companions add
+a small fixed `grind` cost that does not compound, so they stay in the default set; the `= 1` cases use
+`grind [probEvent_eq_one_iff]` opt-in instead.
 
 **Monad/functor laws normalise structure for `grind`.** `bind_pure`, `pure_bind`, `bind_assoc`, and
 `map_pure` are tagged `@[grind =]` (in `EvalDist/Monad/Basic.lean`). They are confluent rewrites, so

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -175,17 +175,25 @@ needs to reason about a computation failing (or not) with probability one.
 `grind` conclude e.g. `Pr[⊥ | $ᵗ α] ≠ 1` end-to-end.
 
 The event-probability versions follow the same recipe with the *filtered* support `{x ∈ support mx | p x}`
-(the reachable outputs satisfying `p`): `probEvent_ne_zero_iff_nonempty`
-(`Pr[ p | mx] ≠ 0 ↔ {x ∈ support mx | p x}.Nonempty`) and `probEvent_eq_zero_iff_not_nonempty`
-(`Pr[ p | mx] = 0 ↔ ¬ …`) are the `@[grind =]` companions to the `simp`-only `probEvent_ne_zero_iff` /
-`probEvent_eq_zero_iff`. The `Pr[…] = 1` companions are deliberately *omitted*: a `Nonempty`-phrased
-`probEvent_eq_one` keeps its `Pr[⊥ | mx] = 0` conjunct, which re-couples it to the hub family and
-re-creates the combination slowdown even though it is cheap in isolation. The two event companions add
-a small fixed `grind` cost that does not compound, so they stay in the default set; the `= 1` cases use
-`grind [probEvent_eq_one_iff]` opt-in instead.
+(the reachable outputs satisfying `p`): `probEvent_eq_zero_iff_not_nonempty`
+(`Pr[ p | mx] = 0 ↔ ¬ {x ∈ support mx | p x}.Nonempty`) is the `@[grind =]` companion to the
+`simp`-only `probEvent_eq_zero_iff`. Its sibling `probEvent_ne_zero_iff_nonempty` (`Pr[ p | mx] ≠ 0 ↔ …`)
+exists but is deliberately **untagged**: the trio of `Nonempty` companions tagged together re-forms
+a saturation cycle in the *generic-monad* context (`grind` on the `probEvent_eq_one_iff` statement
+shape times out instead of failing fast; dropping any one of the three restores fail-fast), and
+dropping the `≠ 0` sibling is free — `grind` recovers `≠ 0 ↔ Nonempty` from the kept
+`= 0 ↔ ¬ Nonempty` form by classical negation. The `Pr[…] = 1` companions are deliberately
+*omitted* entirely: a `Nonempty`-phrased `probEvent_eq_one` keeps its `Pr[⊥ | mx] = 0` conjunct,
+which re-couples it to the hub family; the `= 1` cases use `grind [probEvent_eq_one_iff]` opt-in
+instead. `VCVioTest/GrindFailFast.lean` gates all of this: each dropped lemma has a
+`fail_if_success grind` + `grind [<lemma>]` example over a generic `m`, so both a bad re-tag
+(bare `grind` starts succeeding) and a new saturation (the timeout escapes `fail_if_success`)
+fail the build loudly.
 
-**Monad/functor laws normalise structure for `grind`.** `bind_pure`, `pure_bind`, `bind_assoc`, and
-`map_pure` are tagged `@[grind =]` (in `EvalDist/Monad/Basic.lean`). They are confluent rewrites, so
+**Monad/functor laws normalise structure for `grind`.** `bind_pure`, `bind_assoc`, and
+`map_pure` are tagged `@[grind =]` (in `EvalDist/Monad/Basic.lean`); `pure_bind` is already in the
+default set from core (`attribute [grind <=] pure_bind` in `Init.Control.Lawful`), so it is not
+re-tagged here. They are confluent rewrites, so
 `grind` collapses a computation's structure (`mx >>= pure = mx`, `pure a >>= f = f a`, …) *before*
 falling into `probOutput`/`tsum` expansion — turning what would otherwise be a `grind` *explosion* on
 a `bind`/`pure`-shaped probability/support/distribution equality into a quick solve
@@ -195,11 +203,32 @@ a `bind`/`pure`-shaped probability/support/distribution equality into a quick so
 `<$>` / `if` / `<*>` does not normalise to a `pure`, so those structured equalities stay
 `simp`-terminal.
 
-**`grind` cannot factor an independent product.** `Pr[= z | (·, ·) <$> mx <*> my]` or its `bind`
-spelling does not reduce under `grind`: the second factor `my` is a free variable under a binder
-(`Seq.seq`'s `Unit → _` thunk, or `bind`'s continuation), which `grind`'s pattern compiler cannot
-index — tagging the factorization lemma yields an "invalid pattern" error. Factor with `simp`
-(`probOutput_seq_map_prod_mk_eq_mul` is `@[simp high]`), then hand the resulting goal to `grind`.
+**Independent products factor via `@[grind norm]`, not E-matching.** The second factor of
+`Pr[= z | (·, ·) <$> mx <*> my]` sits under a binder (`Seq.seq`'s `Unit → _` thunk), which
+`grind`'s pattern compiler cannot index — tagging the factorization lemma `@[grind =]` yields an
+"invalid pattern" error (so do `pure_seq`/`seq_pure`). The escape is `grind`'s *normalization*
+phase: `probOutput_seq_map_prod_mk_eq_mul` is `@[simp high, grind norm]`, so bare `grind` factors
+the applicative spelling (and closes e.g. equiprobability of a uniform product). The `bind`-spelled
+product (`do let x ← mx; let y ← my; pure (x, y)`) remains `simp`-only — the second draw sits under
+`bind`'s continuation, which the seq-keyed norm rule does not reach.
+
+**`grind norm` can starve E-matching — use it sparingly.** Norm rules rewrite goal/hypothesis
+terms *before* E-matching, so a norm rule whose result no longer matches the `@[grind =]` patterns
+disconnects them. Concretely: `@[grind norm] bind_pure_comp` (`mx >>= fun a => pure (f a)` →
+`f <$> mx`) closes a couple of `target(grind)` gaps but breaks the `replicate` gates — the goal's
+do-block normalises to a `<$>` form while the E-matching-side `replicate` unfolds stay in `bind`
+form, and the E-graph never connects the two. It is therefore deliberately **not** tagged. Gate any
+new `@[grind norm]` candidate against all of `VCVioTest/{ProbabilityTactics,MonadProbability,`
+`LongChainPrograms,GrindFailFast}.lean` before keeping it.
+
+**Structural additions to the default set** (all gated in `VCVioTest/GrindFailFast.lean`):
+`OracleComp.replicate` unfolds (`replicate_zero`, `replicate_succ_bind`, `replicate_pure`,
+`replicateTR_*` — the proof-level loop combinator; core already grind-tags the `List.mapM` /
+`foldlM` / `forIn` layer), `Functor.map_map`, `probEvent_False`/`probEvent_false`, and the
+`simulateQ` routing layer (`QueryImpl.add_apply_inl/inr`, `simulateQ_add_liftComp_left/right`,
+the `withBadFlag`/`withBadUpdate`/`flattenStateT` run-shapes, `simulateQ_option_elim(M)`). The
+`simulateQ_add_liftComp` pair also *fixes a saturation*: bare `grind` used to time out on a routed
+`simulateQ (impl₁ + impl₂)` goal over a lifted computation.
 
 `VCVioTest/ProbabilityTactics.lean` is the living benchmark and **gate** for all of this: a broad
 corpus of probability / event / failure / support / distribution facts organised by category, each
@@ -217,6 +246,14 @@ facts `ProbComp` masks — chiefly the **failure factor**: over a monad that can
 to the `ProbComp` forms only because `Pr[⊥] = 0` there. New API filled along the way:
 `probOutput_map` (the `probOutput`/`<$>` companion to `probEvent_map`, `@[grind =]`), `support_guard`,
 and the `orElse` (`<|>`) probability lemmas for `OptionT (OracleComp spec)` (`probFailure_orElse` etc.).
+
+**Opting out downstream.** VCVio deliberately extends the *default* `grind` set — the monad laws
+above plus the probability/support bridges — and these tags are inherited by every project that
+imports it. All of the standard escape hatches work if a downstream `grind` call misbehaves:
+disable a rule per call (`grind [-bind_pure]`), ignore the default set entirely
+(`grind only [the, lemmas, you, want]`), or unset a tag for a whole file
+(`attribute [-grind] bind_pure`). `grind?` reports a minimal `grind only [...]` call for a goal it
+closes, which is the easiest way to make a fragile call site independent of the default set.
 
 ## Common Mistakes
 


### PR DESCRIPTION
## Summary

`grind` could saturate and time out on routine probability goals. This PR drops the `@[grind]` tags
responsible so `grind` now fails fast (with a cleaner residual goal) instead of looping, while
keeping the information it needs reachable through narrower companions. Adds three benchmark files
that gate `simp`/`grind` over the probability surface.

## The `grind` problem

The support-*characterization* lemmas rewrite a probability/failure fact into an unbounded
quantifier or set over `support`:

- `Pr[ p | mx] = 0 ↔ ∀ x ∈ support mx, ¬ p x`
- `Pr[ p | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ ∀ x ∈ support mx, p x`
- `Pr[= x | mx] = 1 ↔ Pr[⊥ | mx] = 0 ∧ support mx = {x}`
- `Pr[⊥ | mx] = 1 ↔ support mx = ∅`, …

Tagged `@[grind]`, these are a **saturation hazard**: as `grind` case-splits the iff it Skolemizes
the support quantifier into fresh witnesses, which the always-on `bind`-expansion lemmas
(`support_bind`, `mem_support_bind_iff`, …) re-expand into more `support`/`Pr[…]` terms with no
finite grounding (`support ($ᵗ α) = Set.univ` is infinite). The hazard is **combinatorial, not
per-lemma** — no single one saturates alone, but tagged *together* they form a re-trigger cycle and
a naive `grind` on a probability goal runs ~25× longer. The hub of the cycle is the
`probEvent_eq_one_iff` family, whose RHS couples the `probEvent`, `probFailure`, and `support`
layers at once (dropping it alone roughly quarters the blow-up).

## Dropped tags

Now `@[simp]`-only (fixed orientation, no case-split — safe): `probEvent_eq_zero_iff(')`,
`probEvent_ne_zero_iff(')`, `probEvent_eq_one_iff(')`, `one_eq_probEvent_iff(')`,
`probOutput_eq_one_iff`, `one_eq_probOutput_iff`, `probFailure_eq_one_iff`, plus
`mem_support_bind_iff` / `mem_finSupport_bind_iff` (untagged).

Kept `@[grind =]`: the directed single-variable membership bridges (`probOutput_eq_zero_iff`,
`probOutput_pos_iff`, `mem_finSupport_iff`) and a few support-quantifier lemmas verified to sit
*outside* the hub cycle (`probEvent_pos_iff(')`, `probOutput_eq_one_iff'`,
`probFailure_bind_eq_zero_iff`).

To keep the dropped information reachable without re-forming the cycle:

- **`Set.Nonempty` companions** (`@[grind =]`): `grind` keeps `Set.Nonempty` atomic, so
  `probFailure_eq_one_iff_not_nonempty`, `probEvent_ne_zero_iff_nonempty`,
  `probEvent_eq_zero_iff_not_nonempty` (+ `support_uniformSample_nonempty`) carry the same facts
  without the saturating quantifier. The `= 1` event companions are deliberately omitted — their
  `Pr[⊥] = 0` conjunct re-couples them to the hub.
- **Monad/functor law normalization**: `bind_pure`, `pure_bind`, `bind_assoc`, `map_pure` are now
  `@[grind =]`, so `grind` collapses computation structure *before* falling into `tsum` expansion.
- If a proof genuinely needs a dropped lemma, re-supply it locally:
  `grind [probEvent_eq_zero_iff]`. Downstream call sites were updated this way (or to explicit
  terms).

## Test gates — "`grind` should solve these"

Three benchmark files lock in the intended `simp`/`grind` behavior so a regression in either
surfaces in isolation rather than deep in a downstream proof. Each fact closes by a single
*terminal* tactic; where both close it, both are kept (mirrors); where only one does, the gap is a
`target(simp)` / `target(grind)` note.

- `VCVioTest/ProbabilityTactics.lean` — broad corpus over concrete `ProbComp`, organised by
  category (outcome / event / failure / support / distribution).
- `VCVioTest/MonadProbability.lean` — the same gate over a generic monad `m` and the concrete
  transformers (`OptionT`, `ExceptT`, `SPMF`, `Id`); surfaces facts `ProbComp` masks, chiefly the
  failure factor.
- `VCVioTest/LongChainPrograms.lean` — programs with 10+ sequential binds; gates that `grind` keeps
  pace with `simp` on the deep failure-probability telescope and on abstract monad-law
  normalization.

## Also

- Docs: a new "`grind` vs `simp` on Probability Goals" section in `docs/agents/probability.md`, and
  an updated gotcha in `docs/agents/gotchas.md`.
- Minor new API filled in along the way: `probOutput_map`, `support_guard`, and the `orElse`
  (`<|>`) probability lemmas for `OptionT (OracleComp spec)`; plus a `QueryCache` cleanup (redundant
  `[spec.DecidableEq]` dropped, a few confluent `@[grind]` tags added).
