### PR TITLE
feat(encoding): expose bit-range lemma for ML-KEM byteDecode1

### DIFF
--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -1006,6 +1006,15 @@ def concreteEncoding (params : Params) : Encoding params where
   byteEncode1 := byteEncode1Msg
   byteDecode1 := byteDecode1Msg
 
+/-- Coefficients produced by the concrete ML-KEM message decoder `byteDecode1` are bit coefficients,
+    represented by values below `2`. -/
+theorem byteDecode1_get_val_lt_two
+    (params : Params) (m : Message) (i : Fin ringDegree) :
+    (((concreteEncoding params).byteDecode1 m).get i : Coeff).val < 2 := by
+  change ((byteDecode1Msg m).get i : Coeff).val < 2
+  rw [byteDecode1Msg_val]
+  exact bytesToBits_getD_lt_two (ByteArray.mk m.toArray) i.val
+
 /-- Proof bundle showing that the concrete ML-KEM encoding satisfies the abstract encoding laws
 under the standard bit-width side conditions. -/
 theorem concreteEncodingLaws (params : Params)


### PR DESCRIPTION
This PR adds a public lemma stating that coefficients produced by the concrete ML-KEM `byteDecode1` message decoder are bits.

Motivation: downstream correctness proofs (current WIP in a local branch of https://github.com/Beneficial-AI-Foundation/secure-messaging) for ML-KEM need the range invariant of the public concrete encoding. In particular, to prove the FIPS 203 message-recovery property for Compress₁/Decompress₁, one needs to know that byteDecode1 returns coefficients representing decoded message bits, i.e. only values 0 or 1.

Currently this fact is available internally through private lemmas. This PR expose the final range making the public concrete encoding usable in external correctness proofs.