### PR TITLE
feat(framework): deferred-sampling + relational-coupling engine

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -129,8 +129,10 @@ import VCVio.OracleComp.QueryTracking.ProgrammingOracle
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.QueryTracking.QueryCost
 import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
+import VCVio.OracleComp.QueryTracking.RandomOracle.DeferredSampling
 import VCVio.OracleComp.QueryTracking.RandomOracle.Eager
 import VCVio.OracleComp.QueryTracking.RandomOracle.EagerTable
+import VCVio.OracleComp.QueryTracking.RandomOracle.ProbeEps
 import VCVio.OracleComp.QueryTracking.RandomOracle.Simulation
 import VCVio.OracleComp.QueryTracking.ResourceProfile
 import VCVio.OracleComp.QueryTracking.SeededOracle

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -2421,24 +2421,6 @@ private lemma probOutput_uniform_bind_fst_replayRunWithTraceValue_takeBeforeFork
   exact congrFun (congrArg DFunLike.coe
     (evalDist_uniform_bind_fst_replayRunWithTraceValue_takeBeforeForkAt main i log s)) x
 
-omit [∀ j, SampleableType (spec.Range j)] [unifSpec ⊂ₒ spec]
-  [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
-private lemma tsum_probOutput_map_mul [IsUniformSpec spec] {γ δ : Type} (mn : OracleComp spec γ)
-    (f : γ → δ) (g : δ → ℝ≥0∞) :
-    ∑' y : δ, Pr[= y | (f <$> mn : OracleComp spec δ)] * g y =
-    ∑' x : γ, Pr[= x | mn] * g (f x) := by
-  classical
-  simp_rw [probOutput_map_eq_tsum, ← ENNReal.tsum_mul_right]
-  rw [ENNReal.tsum_comm]
-  refine tsum_congr fun x => ?_
-  simp_rw [mul_assoc]
-  rw [ENNReal.tsum_mul_left]
-  refine congrArg _ ?_
-  refine (tsum_eq_single (f x) fun y hy => ?_).trans ?_
-  · have : DecidableEq δ := Classical.decEq δ
-    rw [probOutput_pure, if_neg hy, zero_mul]
-  · rw [probOutput_pure_self, one_mul]
-
 omit [unifSpec ˡ⊂ₒ spec] [spec.DecidableEq] in
 private lemma probOutput_map_fst_bind_liftComp_congr [IsUniformSpec spec] {β σ : Type}
     (j : ι) (f : α → β) (y : β)

--- a/VCVio/EvalDist/Defs/Basic.lean
+++ b/VCVio/EvalDist/Defs/Basic.lean
@@ -763,7 +763,42 @@ lemma probEvent_or_le (mx : m α) (p q : α → Prop) :
   refine ENNReal.tsum_le_tsum fun x => ?_
   by_cases hp : p x <;> by_cases hq : q x <;> simp [hp, hq]
 
+/-- **First-moment / Markov bound.** The probability of `p` is at most the expectation of any
+`ℝ≥0∞`-valued cost `c` that is `≥ 1` wherever `p` holds. This is the elementary core of a
+first-moment (union) argument: a monotone "bad" event whose occurrence forces a unit of some
+nonnegative cost has probability bounded by the expected cost. -/
+lemma probEvent_le_tsum_probOutput_mul_cost (mx : m α) (p : α → Prop) (c : α → ℝ≥0∞)
+    (hc : ∀ x, p x → 1 ≤ c x) :
+    Pr[ p | mx] ≤ ∑' x : α, Pr[= x | mx] * c x := by
+  have := Classical.decPred p
+  rw [probEvent_eq_tsum_ite mx p]
+  refine ENNReal.tsum_le_tsum fun x => ?_
+  split_ifs with hp
+  · calc Pr[= x | mx] = Pr[= x | mx] * 1 := (mul_one _).symm
+      _ ≤ Pr[= x | mx] * c x := by gcongr; exact hc x hp
+  · exact zero_le'
+
 variable [MonadLiftT m SetM] [EvalDistCompatible m]
+
+/-- **First-moment / Markov bound** (`support`-restricted cost). Variant of
+`probEvent_le_tsum_probOutput_mul_cost` whose `c ≥ 1` hypothesis need only hold on the
+`support` of `mx`. -/
+lemma probEvent_le_tsum_probOutput_mul_cost_of_mem_support
+    (mx : m α) (p : α → Prop) (c : α → ℝ≥0∞)
+    (hc : ∀ x ∈ support mx, p x → 1 ≤ c x) :
+    Pr[ p | mx] ≤ ∑' x : α, Pr[= x | mx] * c x := by
+  have := Classical.decPred p
+  rw [probEvent_eq_tsum_ite mx p]
+  refine ENNReal.tsum_le_tsum fun x => ?_
+  by_cases hx : x ∈ support mx
+  · split_ifs with hp
+    · calc Pr[= x | mx] = Pr[= x | mx] * 1 := (mul_one _).symm
+        _ ≤ Pr[= x | mx] * c x := by
+              gcongr
+              exact hc x hx hp
+    · exact zero_le'
+  · rw [probOutput_eq_zero_of_not_mem_support hx]
+    simp
 
 /-- If `p` implies `q` on the `support` of a computation then it is more likely to happen. -/
 lemma probEvent_mono (h : ∀ x ∈ support mx, p x → q x) : Pr[ p | mx] ≤ Pr[ q | mx] := by

--- a/VCVio/EvalDist/Monad/Basic.lean
+++ b/VCVio/EvalDist/Monad/Basic.lean
@@ -781,3 +781,51 @@ lemma probEvent_exists_finset_le_sum
   gcongr
 
 end union_bound
+
+/-! ## Expectation algebra for nonnegative functionals -/
+
+section tsum_probOutput_mul
+
+variable [MonadLiftT m SPMF] [LawfulMonadLiftT m SPMF]
+
+/-- Expectation of a nonnegative functional under a `pure` computation. -/
+@[simp]
+lemma tsum_probOutput_pure_mul (y : α) (f : α → ℝ≥0∞) :
+    ∑' z, Pr[= z | (pure y : m α)] * f z = f y := by
+  have : DecidableEq α := Classical.decEq α
+  rw [tsum_eq_single y fun z hz => by rw [probOutput_pure, if_neg hz, zero_mul]]
+  rw [probOutput_pure_self, one_mul]
+
+/-- Tonelli-style rearrangement: the expectation of a nonnegative functional under a
+`bind` is the outer expectation of the inner expectations. -/
+lemma tsum_probOutput_bind_mul (mx : m α) (g : α → m β) (f : β → ℝ≥0∞) :
+    ∑' z, Pr[= z | mx >>= g] * f z =
+      ∑' x, Pr[= x | mx] * ∑' z, Pr[= z | g x] * f z := by
+  simp_rw [probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_right]
+  rw [ENNReal.tsum_comm]
+  simp_rw [mul_assoc, ENNReal.tsum_mul_left]
+
+/-- Expectation of a nonnegative functional under a `Functor.map`: the functional is
+precomposed with the map. -/
+lemma tsum_probOutput_map_mul [LawfulMonad m] (mx : m α) (f : α → β) (g : β → ℝ≥0∞) :
+    ∑' z, Pr[= z | f <$> mx] * g z = ∑' x, Pr[= x | mx] * g (f x) := by
+  rw [map_eq_bind_pure_comp, tsum_probOutput_bind_mul]
+  refine tsum_congr fun x => ?_
+  simp only [Function.comp_apply]
+  rw [tsum_probOutput_pure_mul]
+
+omit [Monad m] [LawfulMonadLiftT m SPMF] in
+/-- The expectation of a nonnegative functional `F` that is constant (equal to `c`) on the
+support of a never-failing (sub)probability computation equals `c`. -/
+lemma tsum_probOutput_mul_of_const_on_support [MonadLiftT m SetM] [EvalDistCompatible m]
+    (mx : m α) {c : ℝ≥0∞}
+    {F : α → ℝ≥0∞} (hconst : ∀ z ∈ support mx, F z = c) (hmass : Pr[⊥ | mx] = 0) :
+    ∑' z, Pr[= z | mx] * F z = c := by
+  have hsum : (∑' z, Pr[= z | mx] * F z) = ∑' z, Pr[= z | mx] * c := by
+    refine tsum_congr fun z => ?_
+    by_cases hz : z ∈ support mx
+    · rw [hconst z hz]
+    · rw [probOutput_eq_zero_of_not_mem_support hz, zero_mul, zero_mul]
+  rw [hsum, ENNReal.tsum_mul_right, tsum_probOutput_eq_one' hmass, one_mul]
+
+end tsum_probOutput_mul

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/DeferredSampling.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/DeferredSampling.lean
@@ -1,0 +1,333 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+import VCVio.OracleComp.QueryTracking.RandomOracle.ProbeEps
+
+/-!
+# Deferred sampling: tape factorization of answer-irrelevant draws
+
+This module collects the reusable, scheme-independent kernels behind the
+*deferred-sampling* technique: rewriting a probabilistic computation whose per-step
+draws do not influence the control flow into one where those draws are *front-loaded*
+into a single independent "tape", drawn ahead of time and then consumed.
+
+The technique underlies several proofs in this library (Fiat–Shamir with abort, GPV
+preimage sampling, collision/birthday bounds). Those proofs each instantiate a bespoke
+state machine; what is genuinely generic — and lives here — is:
+
+* **Expectation algebra** (`tsum_probOutput_*`): Tonelli-style rearrangements of an
+  expected nonnegative functional through `pure` / `bind` / `Functor.map`, and the
+  collapse of a constant-on-support functional. These are the workhorses for pushing a
+  fold's expected observable through the monad structure.
+* **i.i.d. bind-commutation** (`evalDist_bind_comm`, `evalDist_bind_const_neverFails`,
+  `evalDist_bind_congr_left`): the *answer-irrelevant draw commutes past its
+  continuation* step at the distribution level. `OracleComp`'s syntactic `bind` is not
+  commutative, but its `evalDist` image into `SPMF` is; this is what lets a per-step draw
+  be moved to the front tape.
+* **The list-multiplicity ε-kernel** (`tsum_count_eq_length`,
+  `tsum_probOutput_fresh_mul_count_le`): one fresh draw `w ← oa`, *independent of* a
+  value-free list `rl`, contributes expected multiplicity
+  `E[rl.count (key w)] ≤ ε · rl.length` whenever each slot is hit with probability `≤ ε`.
+  This is the single source of the `ε` in deferred-sampling read bounds.
+* **The general factorization statement** (`DeferredTape.Factorizes`): an abstract
+  predicate packaging "the read-recording run distributes as a single front draw block
+  followed by a tape-consuming run". Scheme-specific factorizations (e.g.
+  `FiatShamirWithAbort.evalDist_deferredDrawRead_eq_drawList_tapeDrawRead`) are instances
+  of this shape; the predicate names the target so downstream consumers share vocabulary.
+
+The genuinely hard, scheme-specific glue — proving a particular state machine's run *is*
+a tape factorization — is not generic and stays with each scheme. What this module
+provides is the toolbox that those proofs are built out of.
+-/
+
+open OracleComp OracleSpec
+open scoped BigOperators ENNReal
+
+namespace OracleComp.DeferredSampling
+
+/-! ## Expectation algebra for nonnegative functionals -/
+
+/-- Expectation of a nonnegative functional under a `pure` computation. -/
+lemma tsum_probOutput_pure_mul {β : Type} (y : β) (f : β → ℝ≥0∞) :
+    ∑' z, Pr[= z | (pure y : ProbComp β)] * f z = f y := by
+  rw [tsum_eq_single y fun z hz => by
+    rw [probOutput_eq_zero_of_not_mem_support (by simp [hz]), zero_mul]]
+  rw [probOutput_pure_self, one_mul]
+
+/-- Tonelli-style rearrangement: the expectation of a nonnegative functional under a
+`bind` is the outer expectation of the inner expectations. -/
+lemma tsum_probOutput_bind_mul {α β : Type} (oa : ProbComp α)
+    (g : α → ProbComp β) (f : β → ℝ≥0∞) :
+    ∑' z, Pr[= z | oa >>= g] * f z =
+      ∑' x, Pr[= x | oa] * ∑' z, Pr[= z | g x] * f z := by
+  simp_rw [probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_right]
+  rw [ENNReal.tsum_comm]
+  simp_rw [mul_assoc, ENNReal.tsum_mul_left]
+
+/-- Expectation of a nonnegative functional under a `Functor.map`: the functional is
+precomposed with the map. -/
+lemma tsum_probOutput_map_mul {α β : Type} (oa : ProbComp α) (f : α → β) (g : β → ℝ≥0∞) :
+    ∑' z, Pr[= z | f <$> oa] * g z = ∑' x, Pr[= x | oa] * g (f x) := by
+  rw [map_eq_bind_pure_comp, tsum_probOutput_bind_mul]
+  refine tsum_congr fun x => ?_
+  simp only [Function.comp_apply]
+  rw [tsum_probOutput_pure_mul]
+
+/-- The expectation of a nonnegative functional `F` that is constant (equal to `c`) on the
+support of a never-failing (sub)probability computation equals `c`. -/
+lemma tsum_probOutput_mul_of_const_on_support {β : Type} (run : ProbComp β) {c : ℝ≥0∞}
+    {F : β → ℝ≥0∞} (hconst : ∀ z ∈ support run, F z = c) (hmass : Pr[⊥ | run] = 0) :
+    ∑' z, Pr[= z | run] * F z = c := by
+  have hsum : (∑' z, Pr[= z | run] * F z) = ∑' z, Pr[= z | run] * c := by
+    refine tsum_congr fun z => ?_
+    by_cases hz : z ∈ support run
+    · rw [hconst z hz]
+    · rw [probOutput_eq_zero_of_not_mem_support hz, zero_mul, zero_mul]
+  rw [hsum, ENNReal.tsum_mul_right, tsum_probOutput_eq_one' hmass, one_mul]
+
+/-! ## i.i.d. bind-commutation at the distribution level
+
+These lemmas implement the *answer-irrelevant draw commutes past its continuation* step.
+`OracleComp`'s `bind` is syntactic and *not* commutative as a free monad, but its
+`evalDist` image into `SPMF` is — the two iterated sums over independent draws exchange by
+`ENNReal.tsum_comm`. This is the local resampling step that front-loads a draw whose value
+the rest of the computation may use but whose *position* is irrelevant. -/
+
+/-- **i.i.d. bind-commutation.** Two independent draws `oa`, `ob` feeding a common
+continuation `k` may be drawn in either order without changing the output distribution. -/
+theorem evalDist_bind_comm {α β γ : Type} (oa : ProbComp α) (ob : ProbComp β)
+    (k : α → β → ProbComp γ) :
+    𝒟[oa >>= fun a => ob >>= fun b => k a b] = 𝒟[ob >>= fun b => oa >>= fun a => k a b] := by
+  refine SPMF.ext fun x => ?_
+  rw [show 𝒟[oa >>= fun a => ob >>= fun b => k a b] x
+        = Pr[= x | oa >>= fun a => ob >>= fun b => k a b] from (probOutput_def _ _).symm,
+    show 𝒟[ob >>= fun b => oa >>= fun a => k a b] x
+        = Pr[= x | ob >>= fun b => oa >>= fun a => k a b] from (probOutput_def _ _).symm]
+  rw [probOutput_bind_eq_tsum]
+  rw [show (∑' a : α, Pr[= a | oa] * Pr[= x | ob >>= fun b => k a b])
+      = ∑' (a : α) (b : β), Pr[= a | oa] * (Pr[= b | ob] * Pr[= x | k a b]) from
+    tsum_congr fun a => by rw [probOutput_bind_eq_tsum, ENNReal.tsum_mul_left]]
+  rw [probOutput_bind_eq_tsum]
+  rw [show (∑' b : β, Pr[= b | ob] * Pr[= x | oa >>= fun a => k a b])
+      = ∑' (b : β) (a : α), Pr[= b | ob] * (Pr[= a | oa] * Pr[= x | k a b]) from
+    tsum_congr fun b => by rw [probOutput_bind_eq_tsum, ENNReal.tsum_mul_left]]
+  rw [ENNReal.tsum_comm]
+  exact tsum_congr fun a => tsum_congr fun b => by ring
+
+/-- **Dropping a never-failing value-irrelevant prefix.** A leading draw `od` whose
+continuation ignores its value contributes only its total mass; when `od` never fails
+(mass `1`, e.g. a `drawList` front block) it can be discarded from the output
+distribution. -/
+theorem evalDist_bind_const_neverFails {α γ : Type} (od : ProbComp α) (hmass : Pr[⊥ | od] = 0)
+    (k : ProbComp γ) : 𝒟[od >>= fun _ => k] = 𝒟[k] := by
+  refine SPMF.ext fun x => ?_
+  rw [show 𝒟[od >>= fun _ => k] x = Pr[= x | od >>= fun _ => k] from (probOutput_def _ _).symm,
+    show 𝒟[k] x = Pr[= x | k] from (probOutput_def _ _).symm]
+  rw [probOutput_bind_const, hmass]; simp
+
+/-- **Distribution-level congruence under a leading bind.** If two continuations agree as
+distributions pointwise then the bound computations agree as distributions. -/
+theorem evalDist_bind_congr_left {α β : Type} (oa : ProbComp α) (f g : α → ProbComp β)
+    (h : ∀ a, 𝒟[f a] = 𝒟[g a]) : 𝒟[oa >>= f] = 𝒟[oa >>= g] := by
+  rw [evalDist_bind, evalDist_bind]; exact congrArg _ (funext h)
+
+/-! ## The list-multiplicity ε-kernel
+
+The single source of the `ε` in a deferred-sampling read bound: one fresh draw,
+independent of a value-free list, hits each list slot with probability `≤ ε`. -/
+
+/-- Summing the multiplicity `rl.count rc` of every element `rc` over the whole index type
+recovers the list length (the multiplicities partition the list). -/
+lemma tsum_count_eq_length {C : Type} [DecidableEq C] (rl : List C) :
+    (∑' rc : C, (rl.count rc : ℝ≥0∞)) = (rl.length : ℝ≥0∞) := by
+  induction rl with
+  | nil => simp
+  | cons a rl ih =>
+      have hsplit : ∀ rc : C,
+          ((a :: rl).count rc : ℝ≥0∞) = (if rc = a then 1 else 0) + (rl.count rc : ℝ≥0∞) := by
+        intro rc; rw [List.count_cons]; by_cases h : rc = a
+        · subst h; simp [add_comm]
+        · simp [h, Ne.symm h]
+      simp_rw [hsplit]
+      rw [ENNReal.tsum_add, ih, List.length_cons, tsum_ite_eq]
+      push_cast; ring
+
+/-- **The atomic value-free charge.** One fresh draw `w ← oa : ProbComp (C × P)`,
+*independent of* a value-free list `rl : List C`, contributes expected multiplicity
+`E[rl.count (key w)] ≤ ε · rl.length`: each of the `rl.length` slots of `rl` is hit by the
+fresh draw's key with probability `Pr[= slot | key <$> oa] ≤ ε`.
+
+Stated for `key = Prod.fst` (a draw of a `(C × P)`-pair, of which only the `C`-component is
+matched against the list), as it arises when a commitment draw carries an auxiliary private
+state. This is the irreducible probabilistic kernel of a deferred-sampling read bound. -/
+lemma tsum_probOutput_fresh_mul_count_le {C P : Type} [DecidableEq C]
+    (oa : ProbComp (C × P)) (rl : List C) (ε : ℝ)
+    (hGuess : ∀ cm : C, Pr[= cm | Prod.fst <$> oa] ≤ ENNReal.ofReal ε) :
+    (∑' w : C × P, Pr[= w | oa] * (rl.count w.1 : ℝ≥0∞))
+      ≤ ENNReal.ofReal ε * (rl.length : ℝ≥0∞) := by
+  have hcount : ∀ w : C × P,
+      ((rl.count w.1 : ℕ) : ℝ≥0∞)
+        = ∑' rc : C, (rl.count rc : ℝ≥0∞) * (if w.1 = rc then 1 else 0) := by
+    intro w; rw [tsum_eq_single w.1 (fun rc hrc => by simp [Ne.symm hrc])]; simp
+  simp_rw [hcount]
+  rw [show (∑' w : C × P, Pr[= w | oa] *
+        ∑' rc : C, (rl.count rc : ℝ≥0∞) * (if w.1 = rc then 1 else 0))
+      = ∑' rc : C, ∑' w : C × P,
+          Pr[= w | oa] * ((rl.count rc : ℝ≥0∞) * (if w.1 = rc then 1 else 0)) from by
+    rw [ENNReal.tsum_comm]; exact tsum_congr fun w => by rw [ENNReal.tsum_mul_left]]
+  have hmarg : ∀ rc : C,
+      (∑' w : C × P, Pr[= w | oa] * ((rl.count rc : ℝ≥0∞) * (if w.1 = rc then 1 else 0)))
+        = (rl.count rc : ℝ≥0∞) * Pr[= rc | Prod.fst <$> oa] := by
+    intro rc
+    rw [show Pr[= rc | Prod.fst <$> oa]
+          = ∑' w : C × P, Pr[= w | oa] * (if w.1 = rc then 1 else 0) from by
+      rw [probOutput_map_eq_tsum]; refine tsum_congr fun w => ?_
+      simp only [eq_comm]; split <;> rename_i h <;> simp [h]]
+    rw [show (∑' w : C × P,
+            Pr[= w | oa] * ((rl.count rc : ℝ≥0∞) * (if w.1 = rc then 1 else 0)))
+          = ∑' w : C × P,
+              (rl.count rc : ℝ≥0∞) * (Pr[= w | oa] * (if w.1 = rc then 1 else 0)) from
+      tsum_congr fun w => by ring]
+    rw [ENNReal.tsum_mul_left]
+  simp_rw [hmarg]
+  calc (∑' rc : C, (rl.count rc : ℝ≥0∞) * Pr[= rc | Prod.fst <$> oa])
+      ≤ ∑' rc : C, (rl.count rc : ℝ≥0∞) * ENNReal.ofReal ε :=
+        ENNReal.tsum_le_tsum fun rc => by gcongr; exact hGuess rc
+    _ = ENNReal.ofReal ε * (rl.length : ℝ≥0∞) := by
+        rw [ENNReal.tsum_mul_right, mul_comm, tsum_count_eq_length]
+
+/-! ## The general factorization shape
+
+The hard, scheme-specific content of deferred sampling is proving that a particular
+read-recording run *equals* a front-tape factorization. The shape of that target is
+generic and named here, so that scheme instances and downstream consumers share a single
+vocabulary. -/
+
+/-- **The deferred-tape factorization predicate.** `Factorizes run tape tapeRun` asserts
+that running the deferred-draw computation `run : ProbComp γ` is distributionally identical
+to first drawing an independent front tape `tape : ProbComp τ` and then running the
+tape-consuming variant `tapeRun : τ → ProbComp γ` that reads its per-step draws off the
+tape head-first:
+
+`𝒟[run] = 𝒟[tape >>= tapeRun]`.
+
+A scheme establishes this by induction on its adversary computation: at an
+*answer-irrelevant* step the front tape commutes past the query (`evalDist_bind_comm`), and
+at a *drawing* step the inline draw block is split off the front tape. The
+over-provisioned suffix of the tape is discarded by the never-failing prefix lemma
+(`evalDist_bind_const_neverFails`). See
+`FiatShamirWithAbort.evalDist_deferredDrawRead_eq_drawList_tapeDrawRead` for a worked
+instance. -/
+def Factorizes {γ τ : Type} (run : ProbComp γ) (tape : ProbComp τ)
+    (tapeRun : τ → ProbComp γ) : Prop :=
+  𝒟[run] = 𝒟[tape >>= tapeRun]
+
+/-- A factorization may be rewritten through any distribution-level continuation: if
+`run` factorizes through `tape`/`tapeRun`, then binding a continuation `k` after `run`
+factorizes through `tape` and `tapeRun >=> k` (definitional unfolding plus `evalDist_bind`
+associativity). This is the recombination step used when a factorized head feeds a fold. -/
+theorem Factorizes.bind {γ τ δ : Type} {run : ProbComp γ} {tape : ProbComp τ}
+    {tapeRun : τ → ProbComp γ} (h : Factorizes run tape tapeRun) (k : γ → ProbComp δ) :
+    Factorizes (run >>= k) tape (fun t => tapeRun t >>= k) := by
+  simp only [Factorizes, evalDist_bind] at h ⊢
+  rw [h, bind_assoc]
+
+/-! ## The answer-irrelevant step commute (the framework induction step)
+
+The inductive heart of a tape factorization is: at a query whose per-step draw does *not* consult
+the tape, the front tape commutes past the step. This is the abstract, state-shape-independent form
+of that step — it takes the per-continuation factorization as a hypothesis (the inductive
+hypothesis) and concludes the factorization for one more leading answer-irrelevant step. Drawing and
+read steps are handled by their own (scheme-specific) splice/commute; this is the
+*answer-irrelevant* case, which is fully generic. -/
+
+/-- **Answer-irrelevant step commutes past the front tape.** An answer-irrelevant step
+`step : ProbComp (Ans × S)` (a query whose answer-draw does not consult the front tape) composed
+with a deferred continuation `defCont` factors as the front tape `tape : ProbComp τ` drawn first,
+followed by a tape-threaded continuation:
+
+* `defCont a s' : ProbComp (γ × S)` is the deferred continuation after the step;
+* `tapeCont a (s', t) : ProbComp (γ × ρ)` is its tape-consuming variant, threading the tape `t`;
+* `proj : γ × ρ → γ × S` discards the spent-tape suffix on output.
+
+Given the per-continuation factorization `hcont` (supplied by the inductive hypothesis), the leading
+answer-irrelevant step commutes past the front draw block: the continuation is rewritten by `hcont`
+under the step bind (`evalDist_bind_congr_left`), the front tape commutes past the answer-irrelevant
+step (`evalDist_bind_comm`), and the inner step bind is re-associated into the mapped tape-step form
+(`bind_map_left`/`map_bind`). This is the genuine framework content of a tape factorization's
+non-drawing case; see
+`FiatShamirWithAbort.evalDist_tapePreserving_step_commute` for the worked Fiat–Shamir instance
+(`tape := drawList (ids.commit pk sk) L`, `S := DeferredReadState …`). -/
+theorem evalDist_step_commute_tape {γ S Ans τ ρ : Type}
+    (step : ProbComp (Ans × S)) (tape : ProbComp τ)
+    (proj : γ × ρ → γ × S)
+    (defCont : Ans → S → ProbComp (γ × S))
+    (tapeCont : Ans → S × τ → ProbComp (γ × ρ))
+    (hcont : ∀ (a : Ans) (s' : S),
+      𝒟[defCont a s'] = 𝒟[tape >>= fun t => proj <$> tapeCont a (s', t)]) :
+    𝒟[step >>= fun p => defCont p.1 p.2] =
+      𝒟[tape >>= fun t =>
+          proj <$>
+            (((fun p : Ans × S => (p.1, (p.2, t))) <$> step) >>= fun p => tapeCont p.1 p.2)] := by
+  classical
+  rw [evalDist_bind_congr_left step (fun p => defCont p.1 p.2)
+    (fun p => tape >>= fun t => proj <$> tapeCont p.1 (p.2, t)) (fun p => hcont p.1 p.2)]
+  rw [evalDist_bind_comm step tape (fun p t => proj <$> tapeCont p.1 (p.2, t))]
+  refine evalDist_bind_congr_left tape _ _ (fun t => ?_)
+  rw [bind_map_left, map_bind]
+
+/-! ## State-relation transfer for expected output functionals
+
+The value-substitution lemmas of deferred sampling (e.g. "the recorded read list of the run is
+independent of the rejected-draw content of the start state") are instances of a single generic
+fact: an expected output functional through `simulateQ impl` of a `StateT σ ProbComp` handler is
+equal at two start states related by `Rel`, provided every query step transfers `Rel` to its
+continuation and the functional is `Rel`-invariant. -/
+
+/-- **State-relation transfer for an expected output functional.** Let
+`impl : QueryImpl spec (StateT σ ProbComp)` and let `Rel : σ → σ → Prop` be a relation on the
+handler state. Suppose:
+
+* every query step transfers `Rel`: for `Rel`-related start states and any `Rel`-invariant
+  continuation functional `K`, the per-query expected `K` agrees at the two states (`hstep`);
+* the output functional `F : γ → σ → ℝ≥0∞` is `Rel`-invariant (`hF`).
+
+Then the run-level expected output `∑' z, Pr[= z | (simulateQ impl oa).run s] * F z.1 z.2` agrees at
+`Rel`-related start states `s₁`, `s₂`. The proof inducts on `oa`: at `pure` the output is the start
+state (`hF` applies); at a query bind the step's expected continuation functional is itself
+`Rel`-invariant by the inductive hypothesis, so `hstep` closes the step.
+
+This is the generic value-substitution engine; a scheme discharges `hstep` by its per-query run
+shapes. See `FiatShamirWithAbort.deferredDrawRead_run_count_dl_invariant` for the worked instance
+(the recorded read-list multiplicity is invariant under the start drawn-list and bad-flag). -/
+theorem tsum_probOutput_simulateQ_run_mul_of_rel
+    {ι : Type} {spec : OracleSpec ι} {σ : Type}
+    (impl : QueryImpl spec (StateT σ ProbComp))
+    {γ : Type} (oa : OracleComp spec γ)
+    (Rel : σ → σ → Prop)
+    (hstep : ∀ (t : spec.Domain) (s₁ s₂ : σ), Rel s₁ s₂ →
+      ∀ (K : spec.Range t → σ → ℝ≥0∞),
+        (∀ (b : spec.Range t) (t₁ t₂ : σ), Rel t₁ t₂ → K b t₁ = K b t₂) →
+        (∑' p : spec.Range t × σ, Pr[= p | (impl t).run s₁] * K p.1 p.2)
+          = ∑' p : spec.Range t × σ, Pr[= p | (impl t).run s₂] * K p.1 p.2) :
+    ∀ (F : γ → σ → ℝ≥0∞), (∀ (g : γ) (s₁ s₂ : σ), Rel s₁ s₂ → F g s₁ = F g s₂) →
+      ∀ (s₁ s₂ : σ), Rel s₁ s₂ →
+        (∑' z : γ × σ, Pr[= z | (simulateQ impl oa).run s₁] * F z.1 z.2)
+          = ∑' z : γ × σ, Pr[= z | (simulateQ impl oa).run s₂] * F z.1 z.2 := by
+  induction oa using OracleComp.inductionOn with
+  | pure a =>
+      intro F hF s₁ s₂ hs
+      simp only [simulateQ_pure, StateT.run_pure, tsum_probOutput_pure_mul]
+      exact hF a s₁ s₂ hs
+  | query_bind t ob ih =>
+      intro F hF s₁ s₂ hs
+      simp only [simulateQ_bind, simulateQ_spec_query, StateT.run_bind, tsum_probOutput_bind_mul]
+      set K : spec.Range t → σ → ℝ≥0∞ := fun b u =>
+        ∑' z : γ × σ, Pr[= z | (simulateQ impl (ob b)).run u] * F z.1 z.2 with hK
+      have hKinv : ∀ (b : spec.Range t) (t₁ t₂ : σ), Rel t₁ t₂ → K b t₁ = K b t₂ :=
+        fun b t₁ t₂ ht => ih b F hF t₁ t₂ ht
+      exact hstep t s₁ s₂ hs K hKinv
+
+end OracleComp.DeferredSampling

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/DeferredSampling.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/DeferredSampling.lean
@@ -17,10 +17,6 @@ The technique underlies several proofs in this library (Fiat–Shamir with abort
 preimage sampling, collision/birthday bounds). Those proofs each instantiate a bespoke
 state machine; what is genuinely generic — and lives here — is:
 
-* **Expectation algebra** (`tsum_probOutput_*`): Tonelli-style rearrangements of an
-  expected nonnegative functional through `pure` / `bind` / `Functor.map`, and the
-  collapse of a constant-on-support functional. These are the workhorses for pushing a
-  fold's expected observable through the monad structure.
 * **i.i.d. bind-commutation** (`evalDist_bind_comm`, `evalDist_bind_const_neverFails`,
   `evalDist_bind_congr_left`): the *answer-irrelevant draw commutes past its
   continuation* step at the distribution level. `OracleComp`'s syntactic `bind` is not
@@ -46,46 +42,6 @@ open OracleComp OracleSpec
 open scoped BigOperators ENNReal
 
 namespace OracleComp.DeferredSampling
-
-/-! ## Expectation algebra for nonnegative functionals -/
-
-/-- Expectation of a nonnegative functional under a `pure` computation. -/
-lemma tsum_probOutput_pure_mul {β : Type} (y : β) (f : β → ℝ≥0∞) :
-    ∑' z, Pr[= z | (pure y : ProbComp β)] * f z = f y := by
-  rw [tsum_eq_single y fun z hz => by
-    rw [probOutput_eq_zero_of_not_mem_support (by simp [hz]), zero_mul]]
-  rw [probOutput_pure_self, one_mul]
-
-/-- Tonelli-style rearrangement: the expectation of a nonnegative functional under a
-`bind` is the outer expectation of the inner expectations. -/
-lemma tsum_probOutput_bind_mul {α β : Type} (oa : ProbComp α)
-    (g : α → ProbComp β) (f : β → ℝ≥0∞) :
-    ∑' z, Pr[= z | oa >>= g] * f z =
-      ∑' x, Pr[= x | oa] * ∑' z, Pr[= z | g x] * f z := by
-  simp_rw [probOutput_bind_eq_tsum, ← ENNReal.tsum_mul_right]
-  rw [ENNReal.tsum_comm]
-  simp_rw [mul_assoc, ENNReal.tsum_mul_left]
-
-/-- Expectation of a nonnegative functional under a `Functor.map`: the functional is
-precomposed with the map. -/
-lemma tsum_probOutput_map_mul {α β : Type} (oa : ProbComp α) (f : α → β) (g : β → ℝ≥0∞) :
-    ∑' z, Pr[= z | f <$> oa] * g z = ∑' x, Pr[= x | oa] * g (f x) := by
-  rw [map_eq_bind_pure_comp, tsum_probOutput_bind_mul]
-  refine tsum_congr fun x => ?_
-  simp only [Function.comp_apply]
-  rw [tsum_probOutput_pure_mul]
-
-/-- The expectation of a nonnegative functional `F` that is constant (equal to `c`) on the
-support of a never-failing (sub)probability computation equals `c`. -/
-lemma tsum_probOutput_mul_of_const_on_support {β : Type} (run : ProbComp β) {c : ℝ≥0∞}
-    {F : β → ℝ≥0∞} (hconst : ∀ z ∈ support run, F z = c) (hmass : Pr[⊥ | run] = 0) :
-    ∑' z, Pr[= z | run] * F z = c := by
-  have hsum : (∑' z, Pr[= z | run] * F z) = ∑' z, Pr[= z | run] * c := by
-    refine tsum_congr fun z => ?_
-    by_cases hz : z ∈ support run
-    · rw [hconst z hz]
-    · rw [probOutput_eq_zero_of_not_mem_support hz, zero_mul, zero_mul]
-  rw [hsum, ENNReal.tsum_mul_right, tsum_probOutput_eq_one' hmass, one_mul]
 
 /-! ## i.i.d. bind-commutation at the distribution level
 

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean
@@ -1,0 +1,514 @@
+/-
+Copyright (c) 2026 Oleksandr Vovkotrub. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Oleksandr Vovkotrub
+-/
+import VCVio.OracleComp.ProbComp
+
+/-!
+# ε-Cell First-Fire Probe Bound
+
+This file generalizes the *first-fire probe bound* from a uniform per-cell value to an arbitrary
+sampler `oa : ProbComp R` whose every outcome has probability at most `ε`. Where the uniform
+development (`FirstFire.lean`) charges a state-dependent `1 / (|R| - S.card)` per genuine probe and
+needs an exact telescope to fold the growing exclusion sets, the ε-development charges a single
+uniform `ε` per genuine probe, valid in *every* state. The first-fire telescope therefore collapses
+to a plain union bound: an adaptive `q`-probe strategy fires with probability at most `q · ε`.
+
+## The model
+
+A probe targets a *cell* `d : D`. Each cell carries a value drawn from `oa`; the adversary never
+sees the value, only the boolean reply "does cell `d` hold `a`?" to a probe `(d, a)`. We model the
+genuine probe memorylessly: each genuine probe draws a fresh sample `v ← oa` and replies
+`decide (v = a)`. Because the per-outcome bound `∀ r, Pr[= r | oa] ≤ ε` holds unconditionally, the
+fresh-draw model is a sound upper bound for any state-conditioned commitment law (the conditioning
+that inflates a re-targeted cell's firing probability in the uniform case is, in the ε-case,
+already absorbed into the hypothesis `hε`, which bounds *every* outcome's mass).
+
+## Main results
+
+* `probeStepEps` / `probeManyEps` : the single-probe and adaptive `q`-probe programs.
+* `probEvent_probeStepEps_le` : a single probe fires with probability at most `ε`.
+* `probEvent_probeManyEps_le` : the adaptive first-fire union bound `Pr[fire] ≤ q · ε`.
+-/
+
+open OracleComp OracleSpec
+open scoped ENNReal
+
+namespace OracleComp
+
+variable {D R : Type} [DecidableEq R]
+
+/-- One ε-probe at cell `d` (the cell index is carried only for documentation/adaptivity) with
+target `a`: draw a fresh value `v ← oa` and reply whether `v = a`. The genuine-fire flag is exactly
+this boolean. -/
+noncomputable def probeStepEps (oa : ProbComp R) (a : R) : ProbComp Bool :=
+  (fun v => decide (v = a)) <$> oa
+
+/-- A single ε-probe fires with probability at most `ε`, in *any* state, whenever every outcome of
+`oa` has mass at most `ε`. -/
+theorem probEvent_probeStepEps_le {oa : ProbComp R} {ε : ℝ≥0∞} (a : R)
+    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) :
+    Pr[ (fun b : Bool => b = true) | probeStepEps oa a ] ≤ ε := by
+  rw [probeStepEps, probEvent_map]
+  have hpred : ((fun b : Bool => b = true) ∘ fun v : R => decide (v = a)) = fun v : R => v = a := by
+    funext v
+    rw [Function.comp_apply, decide_eq_true_eq]
+  rw [hpred, probEvent_eq_eq_probOutput]
+  exact hε a
+
+/-- An adaptive `q`-probe ε-program: the strategy `σ` maps the list of boolean replies seen so far
+to the next probe target, and the program returns whether some probe fired. Each step draws a fresh
+sample from `oa` and OR-s the reply onto the tail. -/
+noncomputable def probeManyEps (oa : ProbComp R) : ℕ → (List Bool → R) → ProbComp Bool
+  | 0, _ => pure false
+  | q + 1, σ =>
+    probeStepEps oa (σ []) >>= fun b =>
+      (fun b' => b || b') <$> probeManyEps oa q fun h => σ (b :: h)
+
+@[simp]
+theorem probeManyEps_zero (oa : ProbComp R) (σ : List Bool → R) :
+    probeManyEps oa 0 σ = pure false := rfl
+
+theorem probeManyEps_succ (oa : ProbComp R) (q : ℕ) (σ : List Bool → R) :
+    probeManyEps oa (q + 1) σ =
+      probeStepEps oa (σ []) >>= fun b =>
+        (fun b' => b || b') <$> probeManyEps oa q fun h => σ (b :: h) := rfl
+
+/-- **ε-cell first-fire bound.** An adaptive strategy issuing `q` probes against a sampler whose
+every outcome has mass at most `ε` fires with probability at most `q · ε`. The per-step charge is a
+uniform `ε` (`probEvent_probeStepEps_le`), valid in every state, so the union bound is exact: there
+is no growing exclusion set to telescope. -/
+theorem probEvent_probeManyEps_le {oa : ProbComp R} {ε : ℝ≥0∞} (hε : ∀ r : R, Pr[= r | oa] ≤ ε)
+    (q : ℕ) (σ : List Bool → R) :
+    Pr[ (fun b : Bool => b = true) | probeManyEps oa q σ ] ≤ (q : ℝ≥0∞) * ε := by
+  induction q generalizing σ with
+  | zero => simp
+  | succ q ih =>
+    rw [probeManyEps_succ, probEvent_bind_eq_tsum]
+    -- Split on the head reply `b`. Genuine head fire (`b = true`) is charged `ε`; on a head miss
+    -- (`b = false`) the OR collapses to the tail, charged `q · ε` by the inductive hypothesis.
+    have hsplit : ∀ b : Bool,
+        Pr[= b | probeStepEps oa (σ [])] *
+          Pr[ (fun c : Bool => c = true) |
+            (fun b' => b || b') <$> probeManyEps oa q fun h => σ (b :: h)] ≤
+          (if b = true then ε else (q : ℝ≥0∞) * ε) := by
+      intro b
+      cases b with
+      | true =>
+        -- The OR is constantly `true`, so the event holds with probability `1`; the head reaches
+        -- `true` with probability at most `ε`.
+        simp only [Bool.true_or]
+        refine le_trans (mul_le_mul' (le_refl _) probEvent_le_one) ?_
+        rw [mul_one,
+          show Pr[= true | probeStepEps oa (σ [])] =
+            Pr[ (fun c : Bool => c = true) | probeStepEps oa (σ [])] from
+            (probEvent_eq_eq_probOutput _ true).symm]
+        exact probEvent_probeStepEps_le _ hε
+      | false =>
+        -- The OR collapses to the tail; the head mass is at most `1`.
+        simp only [if_neg (by simp : ¬ (false = true)), Bool.false_or, probEvent_map]
+        have htail : Pr[ ((fun c : Bool => c = true) ∘ fun b' => b') |
+            probeManyEps oa q fun h => σ (false :: h)] ≤ (q : ℝ≥0∞) * ε := by
+          have : ((fun c : Bool => c = true) ∘ fun b' : Bool => b') =
+              fun c : Bool => c = true := rfl
+          rw [this]; exact ih _
+        exact le_trans (mul_le_mul' probOutput_le_one htail) (one_mul _).le
+    refine le_trans (ENNReal.tsum_le_tsum hsplit) ?_
+    rw [tsum_bool, if_pos rfl, if_neg (by simp : ¬ (false = true))]
+    rw [Nat.cast_succ, add_mul, one_mul, add_comm]
+
+/-! ## Hidden-target adaptive first-fire bound
+
+The companion of `probeManyEps` for the *same-target-reused* regime. Where `probeManyEps`
+redraws a fresh sample `v ← oa` at **every** probe (the memoryless, deferred-sampling model),
+`hiddenReadMany` draws a single hidden target `w ← oa` **once** and lets an adaptive `q`-read
+strategy probe that *fixed* `w` repeatedly. This is the structure of an eager run that commits a
+sampled key into its state at draw time and then exposes it only through later membership tests:
+the key's value is hidden until the first hit, so up to the first hit the read points are fixed
+(determined by the all-miss reply history) and independent of `w`. Averaging over the single hidden
+draw — without ever conditioning on the drawn value — gives the same union bound `q · ε`. -/
+
+/-- Adaptive `q`-read game against a FIXED hidden target `w`: the strategy `σ` maps the list of
+boolean replies (hit/miss) seen so far to the next read point, and the game fires (returns `true`)
+iff some read equals `w`. The target `w` is reused across all reads; it is drawn once, outside this
+program (see `hiddenReadMany`). -/
+noncomputable def readMany (w : R) : ℕ → (List Bool → R) → Bool
+  | 0, _ => false
+  | q + 1, σ =>
+    let b := decide (σ [] = w)
+    b || readMany w q (fun h => σ (b :: h))
+
+/-- The hidden-target game: draw the target `w ← oa` **once**, then run `q` adaptive reads against
+that fixed `w`. -/
+noncomputable def hiddenReadMany (oa : ProbComp R) (q : ℕ) (σ : List Bool → R) : ProbComp Bool :=
+  oa >>= fun w => pure (readMany w q σ)
+
+/-- **Fixed read points before the first hit.** A FIXED-target adaptive read game fires iff the
+hidden target `w` equals one of the `q` read points reached along the all-miss history
+`σ (List.replicate j false)`. The point: those read points do **not** depend on `w` (until a hit,
+every reply is a miss, so the history is `replicate j false`), which is exactly what turns the
+averaged firing probability into a plain union bound. -/
+theorem readMany_true_iff (w : R) (q : ℕ) (σ : List Bool → R) :
+    readMany w q σ = true ↔ ∃ j < q, w = σ (List.replicate j false) := by
+  induction q generalizing σ with
+  | zero => simp [readMany]
+  | succ q ih =>
+    rw [readMany]
+    simp only [Bool.or_eq_true, decide_eq_true_eq]
+    constructor
+    · rintro (h | h)
+      · exact ⟨0, Nat.succ_pos q, by simpa using h.symm⟩
+      · by_cases hhead : σ [] = w
+        · exact ⟨0, Nat.succ_pos q, hhead.symm⟩
+        · rw [decide_eq_false (by simpa using hhead)] at h
+          obtain ⟨j, hj, hwj⟩ := (ih (fun h => σ (false :: h))).1 h
+          exact ⟨j + 1, Nat.succ_lt_succ hj, by simpa [List.replicate_succ] using hwj⟩
+    · rintro ⟨j, hj, hwj⟩
+      cases j with
+      | zero => left; simpa using hwj.symm
+      | succ j =>
+        by_cases hhead : σ [] = w
+        · exact Or.inl hhead
+        · refine Or.inr ?_
+          rw [decide_eq_false (by simpa using hhead)]
+          exact (ih (fun h => σ (false :: h))).2
+            ⟨j, Nat.lt_of_succ_lt_succ hj, by simpa [List.replicate_succ] using hwj⟩
+
+/-- **Hidden-target adaptive first-fire bound.** A FIXED target `w ← oa` drawn **once** and probed
+by `q` adaptive reads fires with probability at most `q · ε`, whenever every outcome of `oa` has
+mass at most `ε`. The averaging is over the single hidden draw; we never condition on `w`. Because
+the read points are fixed by the all-miss history (`readMany_true_iff`), the firing event is the
+union of the `q` fixed singletons `{w = σ (replicate j false)}`, each of mass at most `ε`. This is
+the same-target-reused sibling of `probEvent_probeManyEps_le`. -/
+theorem probEvent_hiddenReadMany_le {oa : ProbComp R} {ε : ℝ≥0∞}
+    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (σ : List Bool → R) :
+    Pr[ (fun b : Bool => b = true) | hiddenReadMany oa q σ ] ≤ (q : ℝ≥0∞) * ε := by
+  rw [hiddenReadMany, probEvent_bind_eq_tsum]
+  have hstep : ∀ w : R,
+      Pr[= w | oa] * Pr[(fun b => b = true) | (pure (readMany w q σ) : ProbComp Bool)]
+        ≤ ∑ j ∈ Finset.range q,
+            if w = σ (List.replicate j false) then Pr[= w | oa] else 0 := by
+    intro w
+    by_cases hfire : readMany w q σ = true
+    · rw [probEvent_pure]
+      simp only [hfire, if_true, mul_one]
+      obtain ⟨j, hj, hwj⟩ := (readMany_true_iff w q σ).1 hfire
+      calc Pr[= w | oa]
+          = (if w = σ (List.replicate j false) then Pr[= w | oa] else 0) := by rw [if_pos hwj]
+        _ ≤ ∑ j ∈ Finset.range q,
+              if w = σ (List.replicate j false) then Pr[= w | oa] else 0 :=
+            Finset.single_le_sum
+              (f := fun j => if w = σ (List.replicate j false) then Pr[= w | oa] else 0)
+              (fun i _ => by positivity) (Finset.mem_range.2 hj)
+    · rw [probEvent_pure, if_neg hfire, mul_zero]
+      exact zero_le'
+  refine le_trans (ENNReal.tsum_le_tsum hstep) ?_
+  rw [Summable.tsum_finsetSum (fun _ _ => ENNReal.summable)]
+  calc ∑ j ∈ Finset.range q, ∑' w : R,
+          (if w = σ (List.replicate j false) then Pr[= w | oa] else 0)
+      ≤ ∑ j ∈ Finset.range q, ε := by
+        refine Finset.sum_le_sum fun j _ => ?_
+        rw [tsum_eq_single (σ (List.replicate j false))
+          (by intro b hb; rw [if_neg hb])]
+        rw [if_pos rfl]
+        exact hε _
+    _ = (q : ℝ≥0∞) * ε := by rw [Finset.sum_const, Finset.card_range, nsmul_eq_mul]
+
+/-- The multi-key fixed-target game: a list `ws` of hidden keys, each probed by the same `q`
+adaptive reads; fires iff some read hits some key. Used to model the eager ghost run, whose ghost
+cache accumulates one sampled key per rejected signing attempt. -/
+noncomputable def readManyList (ws : List R) (q : ℕ) (σ : List Bool → R) : Bool :=
+  ws.any (fun w => readMany w q σ)
+
+/-- The list game fires iff some individual key's game fires. -/
+theorem readManyList_true_iff (ws : List R) (q : ℕ) (σ : List Bool → R) :
+    readManyList ws q σ = true ↔ ∃ w ∈ ws, readMany w q σ = true := by
+  simp [readManyList, List.any_eq_true]
+
+/-- Appending a fixed OR-flag `q` to a Boolean draw raises the firing probability by at most the
+mass of `q` (i.e. `1` when `q = true`, `0` otherwise) over the residual draw. -/
+theorem probEvent_bind_const_or_pure (q : Bool) (mb : ProbComp Bool) :
+    Pr[(fun c : Bool => c = true) | mb >>= fun b => pure (q || b)]
+      ≤ Pr[(fun c : Bool => c = true) | (pure q : ProbComp Bool)]
+        + Pr[(fun c : Bool => c = true) | mb] := by
+  cases q with
+  | true => simp
+  | false => simp
+
+/-- The probabilistic multi-key game: draw `n` hidden targets independently from `oa`, one per
+rejected signing attempt, and probe each by the same `q` adaptive reads; fire iff some read hits
+some target. This is the accumulating-ghost-cache form of `hiddenReadMany`. -/
+noncomputable def hiddenReadList (oa : ProbComp R) (q : ℕ) (σ : List Bool → R) :
+    ℕ → ProbComp Bool
+  | 0 => pure false
+  | n + 1 => do
+    let w ← oa
+    let b ← hiddenReadList oa q σ n
+    pure (readMany w q σ || b)
+
+/-- **Multi-key hidden-target first-fire bound.** Drawing `n` independent hidden targets from `oa`
+(each outcome of mass at most `ε`) and probing each by `q` adaptive reads fires with probability at
+most `n · q · ε`. Proved by induction on `n`: the head key's contribution is the single-target
+bound `probEvent_hiddenReadMany_le` (`≤ q · ε`), the tail's is the inductive hypothesis
+(`≤ n · q · ε`), combined by the OR-append step `probEvent_bind_const_or_pure`. This is the form
+that bounds the eager ghost run's bad probability once the run is factored so that each rejected
+signing attempt's key draw is read off as an independent `hiddenReadMany` target. -/
+theorem probEvent_hiddenReadList_le {oa : ProbComp R} {ε : ℝ≥0∞} (hε : ∀ r : R, Pr[= r | oa] ≤ ε)
+    (q : ℕ) (σ : List Bool → R) (n : ℕ) :
+    Pr[(fun b : Bool => b = true) | hiddenReadList oa q σ n] ≤ (n : ℝ≥0∞) * ((q : ℝ≥0∞) * ε) := by
+  induction n with
+  | zero => simp [hiddenReadList]
+  | succ n ih =>
+    rw [hiddenReadList, probEvent_bind_eq_tsum]
+    have hsplit : ∀ w : R,
+        Pr[= w | oa] * Pr[(fun c : Bool => c = true) |
+            hiddenReadList oa q σ n >>= fun b => pure (readMany w q σ || b)]
+          ≤ Pr[= w | oa] * Pr[(fun c : Bool => c = true) | (pure (readMany w q σ) : ProbComp Bool)]
+            + Pr[= w | oa] * Pr[(fun c : Bool => c = true) | hiddenReadList oa q σ n] := by
+      intro w
+      rw [← mul_add]
+      gcongr
+      exact probEvent_bind_const_or_pure (readMany w q σ) (hiddenReadList oa q σ n)
+    refine le_trans (ENNReal.tsum_le_tsum hsplit) ?_
+    rw [ENNReal.tsum_add]
+    have h1 : (∑' w : R, Pr[= w | oa] *
+        Pr[(fun c : Bool => c = true) | (pure (readMany w q σ) : ProbComp Bool)])
+        = Pr[(fun b : Bool => b = true) | hiddenReadMany oa q σ] := by
+      rw [hiddenReadMany, probEvent_bind_eq_tsum]
+    have h2 : (∑' w : R, Pr[= w | oa] *
+        Pr[(fun c : Bool => c = true) | hiddenReadList oa q σ n])
+        ≤ Pr[(fun c : Bool => c = true) | hiddenReadList oa q σ n] := by
+      rw [ENNReal.tsum_mul_right]
+      exact mul_le_of_le_one_left zero_le' tsum_probOutput_le_one
+    rw [h1]
+    calc Pr[(fun b : Bool => b = true) | hiddenReadMany oa q σ]
+          + (∑' w : R, Pr[= w | oa] *
+              Pr[(fun c : Bool => c = true) | hiddenReadList oa q σ n])
+        ≤ (q : ℝ≥0∞) * ε + (n : ℝ≥0∞) * ((q : ℝ≥0∞) * ε) :=
+          add_le_add (probEvent_hiddenReadMany_le hε q σ) (le_trans h2 ih)
+      _ = (↑(n + 1) : ℝ≥0∞) * ((q : ℝ≥0∞) * ε) := by push_cast; ring
+
+/-! ## Averaging the key count and the run-factorization bridge
+
+The multi-key bound `probEvent_hiddenReadList_le` is stated for a *fixed* number of keys `n`. In
+the intended application the key count is itself random (one ghost key is drawn per *rejected*
+signing attempt), so the closing step averages the bound over a key-count distribution
+`kn : ProbComp ℕ`, yielding `E[n] · q · ε`. The final bridge
+`probEvent_le_of_eq_bind_hiddenReadList`
+packages the union-bound side of the *direct route*: once a run's bad marginal is exhibited as a
+`kn >>= hiddenReadList oa q σ` game (the deferred-sampling factorization), the bound is immediate.
+-/
+
+/-- **Averaged multi-key hidden-target bound.** When the number of independently drawn hidden keys
+is itself sampled from `kn : ProbComp ℕ`, the firing probability of the multi-key game is at most
+`E[n] · q · ε`, where `E[n] = ∑' n, Pr[= n | kn] · n` is the expected key count. This is the
+averaging step (`C3`) of the direct route: it folds the fixed-`n` bound
+`probEvent_hiddenReadList_le` against the key-count distribution. Combined with an expected-count
+bound `E[n] ≤ qS / (1 - p)` it gives the target `qS · q · ε / (1 - p)`. -/
+theorem probEvent_bind_hiddenReadList_le {oa : ProbComp R} {ε : ℝ≥0∞}
+    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (σ : List Bool → R) (kn : ProbComp ℕ) :
+    Pr[(fun b : Bool => b = true) | kn >>= fun n => hiddenReadList oa q σ n]
+      ≤ (∑' n : ℕ, Pr[= n | kn] * (n : ℝ≥0∞)) * ((q : ℝ≥0∞) * ε) := by
+  rw [probEvent_bind_eq_tsum, ← ENNReal.tsum_mul_right]
+  refine ENNReal.tsum_le_tsum fun n => ?_
+  rw [mul_assoc]
+  gcongr
+  exact probEvent_hiddenReadList_le hε q σ n
+
+/-- **Direct-route union-bound bridge.** If an arbitrary run `run : ProbComp β` with a bad
+event `bad : β → Prop` has its bad marginal exhibited as the averaged multi-key hidden-target game
+`kn >>= hiddenReadList oa q σ` — i.e. the deferred-sampling factorization that pulls the run's
+hidden key draws into an independent front block, reading each off as a `hiddenReadMany` target
+probed by the `q` subsequent adaptive reads — then the run's bad probability is bounded by the
+expected-count union bound `E[n] · q · ε`.
+
+This is the reusable closing lemma of the direct route: the entire remaining content is supplied as
+the hypothesis `hfac`, the distributional equality between the run's bad indicator and the abstract
+game. Establishing `hfac` is the deferred-sampling commutation (factoring the run's per-key draws to
+the front so the pre-first-hit reads become the deterministic strategy `σ`); the union-bound side it
+feeds into is fully discharged here via `probEvent_bind_hiddenReadList_le`. -/
+theorem probEvent_le_of_eq_bind_hiddenReadList {β : Type} {run : ProbComp β} {bad : β → Prop}
+    {oa : ProbComp R} {ε : ℝ≥0∞} (hε : ∀ r : R, Pr[= r | oa] ≤ ε)
+    (q : ℕ) (σ : List Bool → R) (kn : ProbComp ℕ)
+    (hfac : Pr[bad | run]
+      ≤ Pr[(fun b : Bool => b = true) | kn >>= fun n => hiddenReadList oa q σ n]) :
+    Pr[bad | run] ≤ (∑' n : ℕ, Pr[= n | kn] * (n : ℝ≥0∞)) * ((q : ℝ≥0∞) * ε) :=
+  hfac.trans (probEvent_bind_hiddenReadList_le hε q σ kn)
+
+/-! ## Single output-irrelevant draw deferral
+
+The lemmas above take the read strategy `σ` (and, in `hiddenReadList`, the key count) as already
+*extracted* data. The genuine new content of the sound route is the **deferral primitive**: lifting
+a single hidden draw out of an arbitrary run when that draw is used *only output-irrelevantly* —
+i.e. it influences neither the run's visible output nor the read points, only the boolean "fire"
+flag computed by membership tests against an adaptive read sequence.
+
+The key observation (cf. `ghostHybridImpl_proj_trans`: the ghost cache is a per-step deterministic
+projection of the single ghost-blind run, and the read answer is independent of the ghost value) is
+that such a draw can be *deferred* past its continuation. Concretely, a run `oa >>= k` whose
+continuation `k w` is built from a `w`-free generator `gen` (producing both the visible output and
+the read strategy) with `w` entering only through `readMany w q σ`, has its fire-marginal equal to
+that of the deferred game `gen >>= fun p => oa >>= fun w => …`. Each generated branch is then a
+`hiddenReadMany` game on a *fixed* strategy `p.2`, charged `q · ε` by
+`probEvent_hiddenReadMany_le`. This converts "front-load the draw across the opaque continuation"
+into a local `bind`-commutation, the tractable route. -/
+
+/-- **Bind-commutation for an output-irrelevant draw.** When the continuation `k w` is `gen >>= fun
+p => pure (p.1, readMany w q p.2)` — a `w`-free generator `gen` producing both the visible output
+`p.1` and the read strategy `p.2`, with the hidden draw `w` entering only through the fixed read
+game `readMany w q p.2` — the fire-marginal of the run `oa >>= k` is unchanged by deferring the
+draw of `w` to *after* `gen`. This is the local deferral step that replaces the abstract
+"front-load across the fold" with a `PMF.bind`-commutation, proved here directly at the
+`probEvent` level via `ENNReal.tsum_comm`. -/
+theorem probEvent_bind_fire_eq_defer {α : Type} (oa : ProbComp R)
+    (q : ℕ) (gen : ProbComp (α × (List Bool → R))) (k : R → ProbComp (α × Bool))
+    (hk : ∀ w : R, k w = gen >>= fun p => pure (p.1, readMany w q p.2)) :
+    Pr[(fun z : α × Bool => z.2 = true) | oa >>= k]
+      = Pr[(fun z : α × Bool => z.2 = true) |
+          gen >>= fun p => oa >>= fun w =>
+            (pure (p.1, readMany w q p.2) : ProbComp (α × Bool))] := by
+  have hL : Pr[(fun z : α × Bool => z.2 = true) | oa >>= k]
+      = ∑' (w : R) (p : α × (List Bool → R)),
+          Pr[= w | oa] * (Pr[= p | gen] *
+            Pr[(fun z : α × Bool => z.2 = true) |
+              (pure (p.1, readMany w q p.2) : ProbComp (α × Bool))]) := by
+    rw [probEvent_bind_eq_tsum]
+    refine tsum_congr fun w => ?_
+    rw [hk w, probEvent_bind_eq_tsum, ENNReal.tsum_mul_left]
+  have hR : Pr[(fun z : α × Bool => z.2 = true) |
+          gen >>= fun p => oa >>= fun w =>
+            (pure (p.1, readMany w q p.2) : ProbComp (α × Bool))]
+      = ∑' (p : α × (List Bool → R)) (w : R),
+          Pr[= p | gen] * (Pr[= w | oa] *
+            Pr[(fun z : α × Bool => z.2 = true) |
+              (pure (p.1, readMany w q p.2) : ProbComp (α × Bool))]) := by
+    rw [probEvent_bind_eq_tsum]
+    refine tsum_congr fun p => ?_
+    rw [probEvent_bind_eq_tsum, ENNReal.tsum_mul_left]
+  rw [hL, hR, ENNReal.tsum_comm]
+  refine tsum_congr fun p => tsum_congr fun w => ?_
+  ring
+
+/-- **Single output-irrelevant draw first-fire bound (structural form).** A run `oa >>= k` that
+draws one hidden value `w ← oa` (each outcome of mass at most `ε`) and feeds it to a continuation
+`k w = gen >>= fun p => pure (p.1, readMany w q p.2)` — a `w`-free generator `gen` producing the
+visible output and the read strategy, with `w` entering *only* through the fixed read game — fires
+with probability at most `q · ε`.
+
+This is the reusable single-draw deferral primitive of the sound route. It formalizes
+"output-irrelevant draw ⇒ the read points are a fixed strategy independent of `w`" by demanding the
+continuation factor through a `w`-free `gen`; the proof defers the draw past `gen`
+(`probEvent_bind_fire_eq_defer`) so each generated branch becomes a `hiddenReadMany` game on a fixed
+strategy `p.2`, charged `q · ε` by `probEvent_hiddenReadMany_le`. Stage B lifts the `n`-interleaved
+draws by induction with `gen` carrying the remaining draws; Stage C instantiates `gen`/`k` for the
+ghost-blind run via the projection `ghostHybridImpl_proj_trans`. -/
+theorem probEvent_bind_fire_le_of_gen {α : Type} {oa : ProbComp R} {ε : ℝ≥0∞}
+    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (gen : ProbComp (α × (List Bool → R)))
+    (k : R → ProbComp (α × Bool))
+    (hk : ∀ w : R, k w = gen >>= fun p => pure (p.1, readMany w q p.2)) :
+    Pr[(fun z : α × Bool => z.2 = true) | oa >>= k] ≤ (q : ℝ≥0∞) * ε := by
+  rw [probEvent_bind_fire_eq_defer oa q gen k hk]
+  refine probEvent_bind_le_of_forall_le fun p _ => ?_
+  have hinner : Pr[(fun z : α × Bool => z.2 = true) |
+        oa >>= fun w => (pure (p.1, readMany w q p.2) : ProbComp (α × Bool))]
+      = Pr[(fun b : Bool => b = true) | hiddenReadMany oa q p.2] := by
+    rw [hiddenReadMany, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
+    refine tsum_congr fun w => ?_
+    rw [probEvent_pure, probEvent_pure]
+  rw [hinner]
+  exact probEvent_hiddenReadMany_le hε q p.2
+
+/-- **Single output-irrelevant draw first-fire bound (marginal form).** The convenience special
+case of `probEvent_bind_fire_le_of_gen` for a run `oa >>= k` whose continuation's fire-marginal is,
+for *every* hidden value `w`, exactly that of the fixed read game `readMany w q σ` against a single
+strategy `σ` independent of `w`. Whenever every outcome of `oa` has mass at most `ε`, the run fires
+with probability at most `q · ε`.
+
+Use this form when the deferred read strategy is a *fixed* `σ` (the simplest output-irrelevant
+case); use the structural `probEvent_bind_fire_le_of_gen` when the strategy is itself produced by
+`w`-free randomness. -/
+theorem probEvent_bind_fire_le_of_marginal_eq_readMany {α : Type} {oa : ProbComp R} {ε : ℝ≥0∞}
+    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (σ : List Bool → R) (k : R → ProbComp (α × Bool))
+    (hmarg : ∀ w : R, Pr[(fun z : α × Bool => z.2 = true) | k w]
+      = Pr[(fun b : Bool => b = true) | (pure (readMany w q σ) : ProbComp Bool)]) :
+    Pr[(fun z : α × Bool => z.2 = true) | oa >>= k] ≤ (q : ℝ≥0∞) * ε := by
+  have hcongr : Pr[(fun z : α × Bool => z.2 = true) | oa >>= k]
+      = Pr[(fun b : Bool => b = true) | hiddenReadMany oa q σ] := by
+    rw [hiddenReadMany, probEvent_bind_eq_tsum, probEvent_bind_eq_tsum]
+    exact tsum_congr fun w => by rw [hmarg w]
+  rw [hcongr]
+  exact probEvent_hiddenReadMany_le hε q σ
+
+/-! ## Iterated draws: the explicit key-list game
+
+Stage A defers a *single* output-irrelevant draw. Stage B lifts this to `n` interleaved draws by
+exhibiting the i.i.d. multi-key game `hiddenReadList` as the explicit *draw-then-test* game
+`drawList oa n >>= readManyList · q σ`: draw a list of `n` independent keys up front, then fire iff
+some key is read-hit by the fixed `q`-read all-miss strategy. The two are *equal* as computations
+(`drawList_readManyList_eq_hiddenReadList`), which is the structural bridge from "the run's hidden
+draws collected into a front list" to the abstract `hiddenReadList` charge. -/
+
+/-- Draw a list of `n` independent keys from `oa` (the front block of the deferred-sampling
+factorization). The keys are the hidden targets; the list length is the key count `n`. -/
+noncomputable def drawList (oa : ProbComp R) : ℕ → ProbComp (List R)
+  | 0 => pure []
+  | n + 1 => do
+      let w ← oa
+      let ws ← drawList oa n
+      pure (w :: ws)
+
+omit [DecidableEq R] in
+/-- The front-block draw never fails: it only ever draws from `oa` (which is failure-free) and
+returns, so `drawList oa n` has zero failure mass. -/
+@[simp] lemma probFailure_drawList (oa : ProbComp R) (n : ℕ) :
+    Pr[⊥ | drawList oa n] = 0 := by
+  induction n with
+  | zero => simp [drawList]
+  | succ n _ => rw [drawList]; simp
+
+omit [DecidableEq R] in
+/-- Total output mass of the front-block draw is `1` (it never fails). -/
+lemma tsum_probOutput_drawList_eq_one (oa : ProbComp R) (n : ℕ) :
+    (∑' ws : List R, Pr[= ws | drawList oa n]) = 1 :=
+  tsum_probOutput_eq_one' (probFailure_drawList oa n)
+
+/-- **Explicit-list ↔ i.i.d. multi-key game.** Drawing `n` independent keys into a list and firing
+iff some key is read-hit (`drawList oa n >>= readManyList · q σ`) is *exactly* the i.i.d. multi-key
+hidden-target game `hiddenReadList oa q σ n` as a computation. The head key contributes its own
+`readMany` test (OR-ed in via `readManyList (w :: ws) = readMany w || readManyList ws`) and the tail
+is the inductive hypothesis, matching `hiddenReadList`'s own `readMany w q σ || b` recursion. This
+is the Stage B structural bridge: it lets a run whose hidden draws are collected into an explicit
+front list be charged by the banked `hiddenReadList` union bound. -/
+theorem drawList_readManyList_eq_hiddenReadList (oa : ProbComp R) (q : ℕ) (σ : List Bool → R)
+    (n : ℕ) :
+    (drawList oa n >>= fun ws => pure (readManyList ws q σ)) = hiddenReadList oa q σ n := by
+  induction n with
+  | zero => simp [drawList, hiddenReadList, readManyList]
+  | succ n ih =>
+    rw [hiddenReadList, drawList]
+    simp only [bind_assoc, pure_bind]
+    refine bind_congr fun w => ?_
+    rw [← ih, bind_assoc]
+    refine bind_congr fun ws => ?_
+    rw [pure_bind]
+    simp [readManyList]
+
+/-- **Averaged explicit-list multi-key bound.** When the key count is sampled from
+`kn : ProbComp ℕ`, the explicit draw-then-test game fires with probability at most `E[n] · q · ε`.
+Immediate from the list↔i.i.d. bridge `drawList_readManyList_eq_hiddenReadList` and the banked
+averaged i.i.d. bound `probEvent_bind_hiddenReadList_le`. This is the Stage B form that the M3
+charge consumes once the run's hidden draws are exhibited as an explicit front list indexed by
+`kn`. -/
+theorem probEvent_bind_drawList_readManyList_le {oa : ProbComp R} {ε : ℝ≥0∞}
+    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (σ : List Bool → R) (kn : ProbComp ℕ) :
+    Pr[(fun b : Bool => b = true) |
+        kn >>= fun n => drawList oa n >>= fun ws => pure (readManyList ws q σ)]
+      ≤ (∑' n : ℕ, Pr[= n | kn] * (n : ℝ≥0∞)) * ((q : ℝ≥0∞) * ε) := by
+  have hrw : (kn >>= fun n => drawList oa n >>= fun ws => pure (readManyList ws q σ))
+      = kn >>= fun n => hiddenReadList oa q σ n :=
+    bind_congr fun n => drawList_readManyList_eq_hiddenReadList oa q σ n
+  rw [hrw]
+  exact probEvent_bind_hiddenReadList_le hε q σ kn
+
+end OracleComp

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean
@@ -6,30 +6,36 @@ Authors: Oleksandr Vovkotrub
 import VCVio.OracleComp.ProbComp
 
 /-!
-# ε-Cell First-Fire Probe Bound
+# ε-Cell First-Fire Bound
 
-This file generalizes the *first-fire probe bound* from a uniform per-cell value to an arbitrary
-sampler `oa : ProbComp R` whose every outcome has probability at most `ε`. Where the uniform
-development (`FirstFire.lean`) charges a state-dependent `1 / (|R| - S.card)` per genuine probe and
-needs an exact telescope to fold the growing exclusion sets, the ε-development charges a single
-uniform `ε` per genuine probe, valid in *every* state. The first-fire telescope therefore collapses
-to a plain union bound: an adaptive `q`-probe strategy fires with probability at most `q · ε`.
+This file develops the *first-fire bound* for a hidden value drawn from an arbitrary sampler
+`oa : ProbComp R` whose every outcome has probability at most `ε`. Where the uniform development
+(`FirstFire.lean`) charges a state-dependent `1 / (|R| - S.card)` per genuine read and needs an
+exact telescope to fold the growing exclusion sets, the ε-development charges a single uniform `ε`
+per read, valid in *every* state. The first-fire telescope collapses to a plain union bound: an
+adaptive `q`-read strategy fires with probability at most `q · ε`.
 
 ## The model
 
-A probe targets a *cell* `d : D`. Each cell carries a value drawn from `oa`; the adversary never
-sees the value, only the boolean reply "does cell `d` hold `a`?" to a probe `(d, a)`. We model the
-genuine probe memorylessly: each genuine probe draws a fresh sample `v ← oa` and replies
-`decide (v = a)`. Because the per-outcome bound `∀ r, Pr[= r | oa] ≤ ε` holds unconditionally, the
-fresh-draw model is a sound upper bound for any state-conditioned commitment law (the conditioning
-that inflates a re-targeted cell's firing probability in the uniform case is, in the ε-case,
-already absorbed into the hypothesis `hε`, which bounds *every* outcome's mass).
+A hidden target `w ← oa` is drawn **once** and committed into the run's state; an adaptive
+`q`-read strategy `σ : List Bool → R`, mapping the boolean reply history (hit/miss) to the next
+read point, then probes that fixed `w`, firing as soon as some read equals `w`. Up to the first
+hit the read points are fixed by the all-miss history and independent of `w`, so averaging over
+the single hidden draw — without ever conditioning on the drawn value — bounds the firing
+probability by the union of `q` fixed singletons, each of mass at most `ε`. This models an eager
+run that commits a sampled key at draw time and exposes it only through later membership tests.
+Because the per-outcome bound `∀ r, Pr[= r | oa] ≤ ε` holds unconditionally, the bound is valid
+in every state.
 
 ## Main results
 
-* `probeStepEps` / `probeManyEps` : the single-probe and adaptive `q`-probe programs.
-* `probEvent_probeStepEps_le` : a single probe fires with probability at most `ε`.
-* `probEvent_probeManyEps_le` : the adaptive first-fire union bound `Pr[fire] ≤ q · ε`.
+* `hiddenReadMany` / `probEvent_hiddenReadMany_le` : the single-target adaptive read game and its
+  first-fire union bound `Pr[fire] ≤ q · ε`.
+* `hiddenReadList` / `probEvent_hiddenReadList_le` : the per-attempt-fresh-target list game and
+  its union bound.
+* `probEvent_bind_fire_le_of_gen` : the deferred-sampling fire bound whose marginal is a
+  hidden-target read, against an opaque continuation.
+* `drawList` : the explicit i.i.d. front-tape form of the per-attempt draws.
 -/
 
 open OracleComp OracleSpec
@@ -37,97 +43,16 @@ open scoped ENNReal
 
 namespace OracleComp
 
-variable {D R : Type} [DecidableEq R]
-
-/-- One ε-probe at cell `d` (the cell index is carried only for documentation/adaptivity) with
-target `a`: draw a fresh value `v ← oa` and reply whether `v = a`. The genuine-fire flag is exactly
-this boolean. -/
-noncomputable def probeStepEps (oa : ProbComp R) (a : R) : ProbComp Bool :=
-  (fun v => decide (v = a)) <$> oa
-
-/-- A single ε-probe fires with probability at most `ε`, in *any* state, whenever every outcome of
-`oa` has mass at most `ε`. -/
-theorem probEvent_probeStepEps_le {oa : ProbComp R} {ε : ℝ≥0∞} (a : R)
-    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) :
-    Pr[ (fun b : Bool => b = true) | probeStepEps oa a ] ≤ ε := by
-  rw [probeStepEps, probEvent_map]
-  have hpred : ((fun b : Bool => b = true) ∘ fun v : R => decide (v = a)) = fun v : R => v = a := by
-    funext v
-    rw [Function.comp_apply, decide_eq_true_eq]
-  rw [hpred, probEvent_eq_eq_probOutput]
-  exact hε a
-
-/-- An adaptive `q`-probe ε-program: the strategy `σ` maps the list of boolean replies seen so far
-to the next probe target, and the program returns whether some probe fired. Each step draws a fresh
-sample from `oa` and OR-s the reply onto the tail. -/
-noncomputable def probeManyEps (oa : ProbComp R) : ℕ → (List Bool → R) → ProbComp Bool
-  | 0, _ => pure false
-  | q + 1, σ =>
-    probeStepEps oa (σ []) >>= fun b =>
-      (fun b' => b || b') <$> probeManyEps oa q fun h => σ (b :: h)
-
-@[simp]
-theorem probeManyEps_zero (oa : ProbComp R) (σ : List Bool → R) :
-    probeManyEps oa 0 σ = pure false := rfl
-
-theorem probeManyEps_succ (oa : ProbComp R) (q : ℕ) (σ : List Bool → R) :
-    probeManyEps oa (q + 1) σ =
-      probeStepEps oa (σ []) >>= fun b =>
-        (fun b' => b || b') <$> probeManyEps oa q fun h => σ (b :: h) := rfl
-
-/-- **ε-cell first-fire bound.** An adaptive strategy issuing `q` probes against a sampler whose
-every outcome has mass at most `ε` fires with probability at most `q · ε`. The per-step charge is a
-uniform `ε` (`probEvent_probeStepEps_le`), valid in every state, so the union bound is exact: there
-is no growing exclusion set to telescope. -/
-theorem probEvent_probeManyEps_le {oa : ProbComp R} {ε : ℝ≥0∞} (hε : ∀ r : R, Pr[= r | oa] ≤ ε)
-    (q : ℕ) (σ : List Bool → R) :
-    Pr[ (fun b : Bool => b = true) | probeManyEps oa q σ ] ≤ (q : ℝ≥0∞) * ε := by
-  induction q generalizing σ with
-  | zero => simp
-  | succ q ih =>
-    rw [probeManyEps_succ, probEvent_bind_eq_tsum]
-    -- Split on the head reply `b`. Genuine head fire (`b = true`) is charged `ε`; on a head miss
-    -- (`b = false`) the OR collapses to the tail, charged `q · ε` by the inductive hypothesis.
-    have hsplit : ∀ b : Bool,
-        Pr[= b | probeStepEps oa (σ [])] *
-          Pr[ (fun c : Bool => c = true) |
-            (fun b' => b || b') <$> probeManyEps oa q fun h => σ (b :: h)] ≤
-          (if b = true then ε else (q : ℝ≥0∞) * ε) := by
-      intro b
-      cases b with
-      | true =>
-        -- The OR is constantly `true`, so the event holds with probability `1`; the head reaches
-        -- `true` with probability at most `ε`.
-        simp only [Bool.true_or]
-        refine le_trans (mul_le_mul' (le_refl _) probEvent_le_one) ?_
-        rw [mul_one,
-          show Pr[= true | probeStepEps oa (σ [])] =
-            Pr[ (fun c : Bool => c = true) | probeStepEps oa (σ [])] from
-            (probEvent_eq_eq_probOutput _ true).symm]
-        exact probEvent_probeStepEps_le _ hε
-      | false =>
-        -- The OR collapses to the tail; the head mass is at most `1`.
-        simp only [if_neg (by simp : ¬ (false = true)), Bool.false_or, probEvent_map]
-        have htail : Pr[ ((fun c : Bool => c = true) ∘ fun b' => b') |
-            probeManyEps oa q fun h => σ (false :: h)] ≤ (q : ℝ≥0∞) * ε := by
-          have : ((fun c : Bool => c = true) ∘ fun b' : Bool => b') =
-              fun c : Bool => c = true := rfl
-          rw [this]; exact ih _
-        exact le_trans (mul_le_mul' probOutput_le_one htail) (one_mul _).le
-    refine le_trans (ENNReal.tsum_le_tsum hsplit) ?_
-    rw [tsum_bool, if_pos rfl, if_neg (by simp : ¬ (false = true))]
-    rw [Nat.cast_succ, add_mul, one_mul, add_comm]
+variable {R : Type} [DecidableEq R]
 
 /-! ## Hidden-target adaptive first-fire bound
 
-The companion of `probeManyEps` for the *same-target-reused* regime. Where `probeManyEps`
-redraws a fresh sample `v ← oa` at **every** probe (the memoryless, deferred-sampling model),
 `hiddenReadMany` draws a single hidden target `w ← oa` **once** and lets an adaptive `q`-read
 strategy probe that *fixed* `w` repeatedly. This is the structure of an eager run that commits a
 sampled key into its state at draw time and then exposes it only through later membership tests:
 the key's value is hidden until the first hit, so up to the first hit the read points are fixed
 (determined by the all-miss reply history) and independent of `w`. Averaging over the single hidden
-draw — without ever conditioning on the drawn value — gives the same union bound `q · ε`. -/
+draw — without ever conditioning on the drawn value — gives the union bound `q · ε`. -/
 
 /-- Adaptive `q`-read game against a FIXED hidden target `w`: the strategy `σ` maps the list of
 boolean replies (hit/miss) seen so far to the next read point, and the game fires (returns `true`)
@@ -179,8 +104,7 @@ theorem readMany_true_iff (w : R) (q : ℕ) (σ : List Bool → R) :
 by `q` adaptive reads fires with probability at most `q · ε`, whenever every outcome of `oa` has
 mass at most `ε`. The averaging is over the single hidden draw; we never condition on `w`. Because
 the read points are fixed by the all-miss history (`readMany_true_iff`), the firing event is the
-union of the `q` fixed singletons `{w = σ (replicate j false)}`, each of mass at most `ε`. This is
-the same-target-reused sibling of `probEvent_probeManyEps_le`. -/
+union of the `q` fixed singletons `{w = σ (replicate j false)}`, each of mass at most `ε`. -/
 theorem probEvent_hiddenReadMany_le {oa : ProbComp R} {ε : ℝ≥0∞}
     (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (σ : List Bool → R) :
     Pr[ (fun b : Bool => b = true) | hiddenReadMany oa q σ ] ≤ (q : ℝ≥0∞) * ε := by

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean
@@ -364,14 +364,12 @@ theorem probEvent_bind_fire_le_of_marginal_eq_readMany {α : Type} {oa : ProbCom
   rw [hcongr]
   exact probEvent_hiddenReadMany_le hε q σ
 
-/-! ## Iterated draws: the explicit key-list game
+/-! ## Iterated draws: the explicit front-block key list
 
-Stage A defers a *single* output-irrelevant draw. Stage B lifts this to `n` interleaved draws by
-exhibiting the i.i.d. multi-key game `hiddenReadList` as the explicit *draw-then-test* game
-`drawList oa n >>= readManyList · q σ`: draw a list of `n` independent keys up front, then fire iff
-some key is read-hit by the fixed `q`-read all-miss strategy. The two are *equal* as computations
-(`drawList_readManyList_eq_hiddenReadList`), which is the structural bridge from "the run's hidden
-draws collected into a front list" to the abstract `hiddenReadList` charge. -/
+Stage A defers a *single* output-irrelevant draw. `drawList` lifts this to `n` interleaved draws
+by collecting them into an explicit front block: draw a list of `n` independent keys up front,
+against which a run's hidden draws can be exhibited and then charged by the abstract
+`hiddenReadList` union bound. -/
 
 /-- Draw a list of `n` independent keys from `oa` (the front block of the deferred-sampling
 factorization). The keys are the hidden targets; the list length is the key count `n`. -/
@@ -396,43 +394,5 @@ omit [DecidableEq R] in
 lemma tsum_probOutput_drawList_eq_one (oa : ProbComp R) (n : ℕ) :
     (∑' ws : List R, Pr[= ws | drawList oa n]) = 1 :=
   tsum_probOutput_eq_one' (probFailure_drawList oa n)
-
-/-- **Explicit-list ↔ i.i.d. multi-key game.** Drawing `n` independent keys into a list and firing
-iff some key is read-hit (`drawList oa n >>= readManyList · q σ`) is *exactly* the i.i.d. multi-key
-hidden-target game `hiddenReadList oa q σ n` as a computation. The head key contributes its own
-`readMany` test (OR-ed in via `readManyList (w :: ws) = readMany w || readManyList ws`) and the tail
-is the inductive hypothesis, matching `hiddenReadList`'s own `readMany w q σ || b` recursion. This
-is the Stage B structural bridge: it lets a run whose hidden draws are collected into an explicit
-front list be charged by the banked `hiddenReadList` union bound. -/
-theorem drawList_readManyList_eq_hiddenReadList (oa : ProbComp R) (q : ℕ) (σ : List Bool → R)
-    (n : ℕ) :
-    (drawList oa n >>= fun ws => pure (readManyList ws q σ)) = hiddenReadList oa q σ n := by
-  induction n with
-  | zero => simp [drawList, hiddenReadList, readManyList]
-  | succ n ih =>
-    rw [hiddenReadList, drawList]
-    simp only [bind_assoc, pure_bind]
-    refine bind_congr fun w => ?_
-    rw [← ih, bind_assoc]
-    refine bind_congr fun ws => ?_
-    rw [pure_bind]
-    simp [readManyList]
-
-/-- **Averaged explicit-list multi-key bound.** When the key count is sampled from
-`kn : ProbComp ℕ`, the explicit draw-then-test game fires with probability at most `E[n] · q · ε`.
-Immediate from the list↔i.i.d. bridge `drawList_readManyList_eq_hiddenReadList` and the banked
-averaged i.i.d. bound `probEvent_bind_hiddenReadList_le`. This is the Stage B form that the M3
-charge consumes once the run's hidden draws are exhibited as an explicit front list indexed by
-`kn`. -/
-theorem probEvent_bind_drawList_readManyList_le {oa : ProbComp R} {ε : ℝ≥0∞}
-    (hε : ∀ r : R, Pr[= r | oa] ≤ ε) (q : ℕ) (σ : List Bool → R) (kn : ProbComp ℕ) :
-    Pr[(fun b : Bool => b = true) |
-        kn >>= fun n => drawList oa n >>= fun ws => pure (readManyList ws q σ)]
-      ≤ (∑' n : ℕ, Pr[= n | kn] * (n : ℝ≥0∞)) * ((q : ℝ≥0∞) * ε) := by
-  have hrw : (kn >>= fun n => drawList oa n >>= fun ws => pure (readManyList ws q σ))
-      = kn >>= fun n => hiddenReadList oa q σ n :=
-    bind_congr fun n => drawList_readManyList_eq_hiddenReadList oa q σ n
-  rw [hrw]
-  exact probEvent_bind_hiddenReadList_le hε q σ kn
 
 end OracleComp

--- a/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
+++ b/VCVio/ProgramLogic/Relational/ProgrammingOracle.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Quang Dao
 -/
 import VCVio.OracleComp.QueryTracking.ProgrammingOracle
+import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
 import VCVio.ProgramLogic.Relational.SimulateQ
 
 /-!
@@ -195,5 +196,183 @@ theorem programming_collision_bound_qP_qH_β
     (ENNReal.mul_lt_top
       (ENNReal.mul_lt_top (ENNReal.natCast_lt_top _) (ENNReal.natCast_lt_top _)) hβ_lt_top)
     hBad
+
+/-! ## Heterogeneous inner monad: ProbComp-valued random-oracle bridge
+
+The bridges above fix the inner monad of the wrapped oracle to `OracleComp spec` (the same
+spec as the simulated computation). The lazy random oracle `OracleSpec.randomOracle` is instead
+`uniformSampleImpl.withCaching`, whose base implementation `uniformSampleImpl` lives in
+`ProbComp = OracleComp unifSpec` — a *different* spec from the surface program. The bridge below
+re-establishes the identical-until-bad TV-distance bound when the base implementation `so` is
+valued in `OracleComp spec'` for an arbitrary uniform `spec'` (taking `spec' = unifSpec` recovers
+the random-oracle case). It is driven by the heterogeneous engine
+`tvDist_simulateQ_run_le_probEvent_output_bad` and the heterogeneous projection
+`withCachingTrackingPolicy_run'_eq'`.
+
+These lemmas are the random-oracle-state-threading component of the GPV hash-and-sign EUF-CMA
+reduction (`VCVio/CryptoFoundations/GPVHashAndSign.lean`): they let one replace the unprogrammed
+lazy random oracle by a programmed one up to the salt/programming bad event. -/
+
+section HeterogeneousInner
+
+variable {ι' : Type} {spec' : OracleSpec ι'} [IsUniformSpec spec']
+
+omit [IsUniformSpec spec] in
+/-- Per-step distributional agreement on non-bad outputs, with the base implementation valued in
+`OracleComp spec'` (heterogeneous inner monad). This is the `spec'`-generalization of
+`probOutput_withProgramming_eq_withCachingTrackingPolicy_of_not_bad_output`; the proof is
+identical (case split on cache hit / policy fire) and uses nothing specific to the inner spec. -/
+private lemma probOutput_withProgramming_eq_withCachingTrackingPolicy_of_not_bad_output'
+    (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
+    (t : spec.Domain) (cache : spec.QueryCache)
+    (u : spec.Range t) (cache' : spec.QueryCache) :
+    Pr[= (u, (cache', false)) | (so.withProgramming policy t).run (cache, false)] =
+      Pr[= (u, (cache', false)) | (so.withCachingTrackingPolicy policy t).run (cache, false)] := by
+  classical
+  cases hcache : cache t with
+  | some v =>
+    have hL : (so.withProgramming policy t).run (cache, false) =
+        (pure (v, (cache, false)) :
+          OracleComp spec' (spec.Range t × spec.QueryCache × Bool)) := by
+      simp [QueryImpl.withProgramming_apply, hcache]
+    have hR : (so.withCachingTrackingPolicy policy t).run (cache, false) =
+        (pure (v, (cache, false)) :
+          OracleComp spec' (spec.Range t × spec.QueryCache × Bool)) := by
+      simp [QueryImpl.withCachingTrackingPolicy_apply, hcache]
+    rw [hL, hR]
+  | none =>
+    cases hpol : policy t with
+    | none =>
+      have hL : (so.withProgramming policy t).run (cache, false) =
+          (so t >>= fun u' => pure (u', (cache.cacheQuery t u', false)) :
+            OracleComp spec' (spec.Range t × spec.QueryCache × Bool)) := by
+        simp [QueryImpl.withProgramming_apply, hcache, hpol, Functor.map_map]
+      have hR : (so.withCachingTrackingPolicy policy t).run (cache, false) =
+          (so t >>= fun u' => pure (u', (cache.cacheQuery t u', false)) :
+            OracleComp spec' (spec.Range t × spec.QueryCache × Bool)) := by
+        simp [QueryImpl.withCachingTrackingPolicy_apply, hcache, hpol, Functor.map_map]
+      rw [hL, hR]
+    | some v =>
+      have hne : ∀ (w : spec.Range t) (c : spec.QueryCache),
+          ((u, (cache', false)) : spec.Range t × spec.QueryCache × Bool) ≠ (w, (c, true)) := by
+        intro w c hcontr
+        injection hcontr with _ h2
+        injection h2 with _ h3
+        cases h3
+      have hL_run : (so.withProgramming policy t).run (cache, false) =
+          (pure (v, (cache.cacheQuery t v, true)) :
+            OracleComp spec' (spec.Range t × spec.QueryCache × Bool)) := by
+        simp [QueryImpl.withProgramming_apply, hcache, hpol]
+      have hR_run : (so.withCachingTrackingPolicy policy t).run (cache, false) =
+          (so t >>= fun u' => pure (u', (cache.cacheQuery t u', true)) :
+            OracleComp spec' (spec.Range t × spec.QueryCache × Bool)) := by
+        simp [QueryImpl.withCachingTrackingPolicy_apply, hcache, hpol, Functor.map_map]
+      rw [hL_run, hR_run]
+      rw [probOutput_pure, if_neg (hne v _)]
+      rw [probOutput_bind_eq_tsum]
+      symm
+      refine ENNReal.tsum_eq_zero.mpr (fun u' => ?_)
+      rw [probOutput_pure, if_neg (hne u' _), mul_zero]
+
+omit [IsUniformSpec spec] in
+/-- Joint (state-included) identical-until-bad TV-distance bound between `withProgramming policy`
+and its tracking partner `withCachingTrackingPolicy policy`, with the base implementation valued
+in `OracleComp spec'`. The conclusion keeps the final `(cache, bad)` state, so a state-dependent
+continuation (e.g. GPV `verify` reading the run's cache) can be appended on both sides. -/
+theorem tvDist_withProgramming_withCachingTrackingPolicy_run_le_probEvent_bad'
+    (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) :
+    tvDist
+        ((simulateQ (so.withProgramming policy) oa).run (cache, false))
+        ((simulateQ (so.withCachingTrackingPolicy policy) oa).run (cache, false))
+      ≤ Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+          (simulateQ (so.withProgramming policy) oa).run (cache, false)].toReal := by
+  refine tvDist_simulateQ_run_le_probEvent_output_bad
+    (impl₁ := so.withProgramming policy)
+    (impl₂ := so.withCachingTrackingPolicy policy)
+    (oa := oa) (s₀ := cache)
+    (fun t s u s' =>
+      probOutput_withProgramming_eq_withCachingTrackingPolicy_of_not_bad_output'
+        so policy t s u s') ?_ ?_
+  · intro t p hp z hz
+    rcases p with ⟨c, b⟩; cases (show b = true from hp)
+    exact QueryImpl.withProgramming_bad_monotone (so := so) (policy := policy) t c z hz
+  · intro t p hp z hz
+    rcases p with ⟨c, b⟩; cases (show b = true from hp)
+    exact QueryImpl.withCachingTrackingPolicy_bad_monotone (so := so) (policy := policy) t c z hz
+
+omit [IsUniformSpec spec] in
+/-- **Heterogeneous identical-until-bad bridge (output marginal).**
+
+The TV-distance between the output marginal of `so.withCaching` and the output marginal of
+`so.withProgramming policy` is bounded by the probability that the bad flag of
+`withProgramming policy` fires during the run, for any base implementation `so` valued in
+`OracleComp spec'` with `spec'` uniform.
+
+This is the `spec'`-generalization of
+`tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad`; specializing `so` to
+`uniformSampleImpl` (so `spec' = unifSpec`) gives the lazy-random-oracle bridge
+`tvDist_simulateQ_randomOracle_withProgramming_le_probEvent_bad`. -/
+theorem tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad'
+    (so : QueryImpl spec (OracleComp spec')) (policy : ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) :
+    tvDist
+        ((simulateQ so.withCaching oa).run' cache)
+        ((simulateQ (so.withProgramming policy) oa).run' (cache, false))
+      ≤ Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+          (simulateQ (so.withProgramming policy) oa).run (cache, false)].toReal := by
+  classical
+  set sim₁ := (simulateQ (so.withProgramming policy) oa).run (cache, false) with hs1
+  set sim₂ := (simulateQ (so.withCachingTrackingPolicy policy) oa).run (cache, false) with hs2
+  have h_joint :
+      tvDist sim₁ sim₂ ≤
+        Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true | sim₁].toReal :=
+    tvDist_withProgramming_withCachingTrackingPolicy_run_le_probEvent_bad' so policy oa cache
+  have h_map :
+      tvDist ((simulateQ (so.withProgramming policy) oa).run' (cache, false))
+          ((simulateQ (so.withCachingTrackingPolicy policy) oa).run' (cache, false))
+        ≤ tvDist sim₁ sim₂ := by
+    simpa [hs1, hs2, StateT.run'] using
+      (tvDist_map_le (m := OracleComp spec') (α := α × spec.QueryCache × Bool) (β := α)
+        Prod.fst sim₁ sim₂)
+  have h_proj :
+      (simulateQ (so.withCachingTrackingPolicy policy) oa).run' (cache, false) =
+        (simulateQ so.withCaching oa).run' cache :=
+    withCachingTrackingPolicy_run'_eq' so policy oa cache false
+  rw [tvDist_comm, ← h_proj]
+  exact le_trans h_map h_joint
+
+end HeterogeneousInner
+
+/-! ## Lazy random-oracle state-threading bridge
+
+The specialization of the heterogeneous bridge to the lazy random oracle
+`OracleSpec.randomOracle = uniformSampleImpl.withCaching`. This is the reusable state-threading
+infrastructure consumed by the GPV hash-and-sign EUF-CMA reduction: it replaces the unprogrammed
+lazy random oracle by a `policy`-programmed one, up to the programming bad event. -/
+
+/-- **Random-oracle state-threading bridge.**
+
+For a lazy random oracle over a spec with sampleable ranges, the TV-distance between the output
+marginal of the unprogrammed run (`simulateQ spec.randomOracle oa`, started from `cache`) and the
+programmed run (`simulateQ (uniformSampleImpl.withProgramming policy) oa`, started from
+`(cache, false)`) is bounded by the probability that the programming bad flag fires.
+
+This instantiates `tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad'` at
+`so := uniformSampleImpl` (so the inner monad is `ProbComp = OracleComp unifSpec`), using
+`OracleSpec.randomOracle = uniformSampleImpl.withCaching` definitionally. -/
+theorem tvDist_simulateQ_randomOracle_withProgramming_le_probEvent_bad
+    {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
+    [∀ t : spec.Domain, SampleableType (spec.Range t)] [IsUniformSpec spec] {α : Type}
+    (policy : OracleSpec.ProgrammingPolicy spec)
+    (oa : OracleComp spec α) (cache : spec.QueryCache) :
+    tvDist
+        ((simulateQ spec.randomOracle oa).run' cache)
+        ((simulateQ (QueryImpl.withProgramming uniformSampleImpl policy) oa).run' (cache, false))
+      ≤ Pr[fun z : α × spec.QueryCache × Bool => z.2.2 = true |
+          (simulateQ (QueryImpl.withProgramming uniformSampleImpl policy) oa).run
+            (cache, false)].toReal :=
+  tvDist_simulateQ_withCaching_withProgramming_le_probEvent_bad'
+    (spec' := unifSpec) uniformSampleImpl policy oa cache
 
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -169,6 +169,33 @@ theorem relTriple_simulateQ_run'
     exact hp.1
   exact relTriple_map h_weak
 
+/-- `probEvent` monotonicity between two relational `simulateQ` runs. Simulating the same adversary
+`oa` under two `StateT` implementations related per query by `rState` (via
+`relTriple_simulateQ_run`), any event implication that holds along the run postcondition
+`z₁.1 = z₂.1 ∧ rState z₁.2 z₂.2` transports to `Pr[p | run impl₁] ≤ Pr[q | run impl₂]`. The
+`simulateQ` form of `probEvent_le_of_relTriple`; the events range over the full `(output, state)`
+pair, so it covers output events, state events, and their conjunctions over the two
+`(output, state)` spaces (the output type is shared; the state spaces `σ₁`/`σ₂` differ). -/
+theorem probEvent_le_of_relTriple_simulateQ_run
+    {ι₁ ι₂ : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    {σ₁ σ₂ : Type}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (rState : σ₁ → σ₂ → Prop)
+    (oa : OracleComp spec α)
+    (himpl : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂),
+      rState s₁ s₂ →
+      RelTriple ((impl₁ t).run s₁) ((impl₂ t).run s₂)
+        (fun p₁ p₂ => p₁.1 = p₂.1 ∧ rState p₁.2 p₂.2))
+    (s₁ : σ₁) (s₂ : σ₂) (hs : rState s₁ s₂)
+    {p : α × σ₁ → Prop} {q : α × σ₂ → Prop}
+    (himp : ∀ z₁ z₂, z₁.1 = z₂.1 → rState z₁.2 z₂.2 → p z₁ → q z₂) :
+    Pr[p | (simulateQ impl₁ oa).run s₁] ≤ Pr[q | (simulateQ impl₂ oa).run s₂] :=
+  probEvent_le_of_relTriple
+    (relTriple_simulateQ_run impl₁ impl₂ rState oa himpl s₁ s₂ hs)
+    (fun z₁ z₂ h => himp z₁ z₂ h.1 h.2)
+
 /-- Exact-distribution specialization of `relTriple_simulateQ_run'`.
 
 If corresponding oracle calls have identical full `(output, state)` distributions whenever the

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -70,6 +70,80 @@ theorem relTriple_simulateQ_run
     exact (relTriple_bind (himpl t s₁ s₂ hs) (fun ⟨u₁, s₁'⟩ ⟨u₂, s₂'⟩ ⟨eq_u, hs'⟩ => by
       dsimp at eq_u hs' ⊢; subst eq_u; exact ih u₁ s₁' s₂' hs')) trivial
 
+/-- **Monotone relational `simulateQ`.** A generalization of `relTriple_simulateQ_run` that
+does *not* require equal per-query outputs. Instead, each per-query coupling must (a) preserve
+the state invariant and (b) supply, for the *same* free-monad continuation applied to the two
+(possibly different) coupled outputs, a recoupling of the two continued simulations preserving
+the invariant. This is the right shape when the two handlers genuinely diverge on the answer
+returned to the caller (e.g. an eager vs. deferred-sampling random-oracle read), so output
+equality cannot be maintained and the coupling must be rebuilt across the branch point.
+
+The continuation hypothesis is self-referential by design: discharging it is exactly the
+construction of the divergent-branch coupling, which is the hard probabilistic content this
+lemma isolates from the free-monad bookkeeping. -/
+theorem relTriple_simulateQ_run_mono
+    {ι₁ : Type u} {ι₂ : Type u}
+    {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    {σ₁ σ₂ : Type}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (R_state : σ₁ → σ₂ → Prop)
+    (oa : OracleComp spec α)
+    (himpl : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂),
+      R_state s₁ s₂ →
+      RelTriple ((impl₁ t).run s₁) ((impl₂ t).run s₂)
+        (fun p₁ p₂ => R_state p₁.2 p₂.2 ∧
+          ∀ (ob : spec.Range t → OracleComp spec α),
+            RelTriple ((simulateQ impl₁ (ob p₁.1)).run p₁.2)
+                      ((simulateQ impl₂ (ob p₂.1)).run p₂.2)
+              (fun q₁ q₂ => R_state q₁.2 q₂.2)))
+    (s₁ : σ₁) (s₂ : σ₂) (hs : R_state s₁ s₂) :
+    RelTriple
+      ((simulateQ impl₁ oa).run s₁)
+      ((simulateQ impl₂ oa).run s₂)
+      (fun p₁ p₂ => R_state p₁.2 p₂.2) := by
+  induction oa using OracleComp.inductionOn generalizing s₁ s₂ with
+  | pure x =>
+    simp only [simulateQ_pure, StateT.run_pure, relTriple_iff_relWP,
+      MAlgRelOrdered.relWP_pure]
+    exact hs
+  | query_bind t ob ih =>
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind, relTriple_iff_relWP, relWP_iff_couplingPost]
+    refine (relTriple_bind (himpl t s₁ s₂ hs) ?_) trivial
+    rintro ⟨u₁, s₁'⟩ ⟨u₂, s₂'⟩ ⟨_, hcont⟩
+    exact hcont ob
+
+/-- **Marginal stochastic dominance from a coupling.** If `oa` and `ob` are related by a
+coupling whose post-relation `R` carries an event implication `P a → Q b`, then the marginal
+probability of `P` on the left is at most that of `Q` on the right. This is the one-sided
+(inequality) counterpart of `evalDist_map_eq_of_relTriple`: where the latter extracts a
+distributional equality from output equality, this extracts a probability inequality from an
+output implication. The proof reads off both marginals from the single coupling distribution
+`c` and applies pointwise monotonicity of `probEvent` on `c`. -/
+theorem probEvent_le_of_relTriple_imp
+    {ι₁ : Type u} {ι₂ : Type u}
+    {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    {β : Type}
+    {oa : OracleComp spec₁ α} {ob : OracleComp spec₂ β}
+    {R : α → β → Prop} {P : α → Prop} {Q : β → Prop}
+    (h : RelTriple oa ob R)
+    (himp : ∀ a b, R a b → P a → Q b) :
+    Pr[P | oa] ≤ Pr[Q | ob] := by
+  rw [relTriple_iff_relWP, relWP_iff_couplingPost] at h
+  obtain ⟨c, hc⟩ := h
+  have hfst : (Prod.fst <$> c.1 : SPMF α) = 𝒟[oa] := c.2.map_fst
+  have hsnd : (Prod.snd <$> c.1 : SPMF β) = 𝒟[ob] := c.2.map_snd
+  calc Pr[P | oa]
+      = Pr[P | (Prod.fst <$> c.1 : SPMF α)] := by rw [hfst]; rfl
+    _ = Pr[fun z => P z.1 | c.1] := probEvent_fst_map _ _
+    _ ≤ Pr[fun z => Q z.2 | c.1] :=
+        probEvent_mono fun z hz hPz => himp z.1 z.2 (hc z hz) hPz
+    _ = Pr[Q | (Prod.snd <$> c.1 : SPMF β)] := (probEvent_snd_map _ _).symm
+    _ = Pr[Q | ob] := by rw [hsnd]; rfl
+
 /-- Projection: relational `simulateQ` preserving only output equality. -/
 theorem relTriple_simulateQ_run'
     {ι₁ ι₂ : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
@@ -94,33 +168,6 @@ theorem relTriple_simulateQ_run'
     intro p₁ p₂ hp
     exact hp.1
   exact relTriple_map h_weak
-
-/-- `probEvent` monotonicity between two relational `simulateQ` runs. Simulating the same adversary
-`oa` under two `StateT` implementations related per query by `rState` (via
-`relTriple_simulateQ_run`), any event implication that holds along the run postcondition
-`z₁.1 = z₂.1 ∧ rState z₁.2 z₂.2` transports to `Pr[p | run impl₁] ≤ Pr[q | run impl₂]`. The
-`simulateQ` form of `probEvent_le_of_relTriple`; the events range over the full `(output, state)`
-pair, so it covers output events, state events, and their conjunctions over the two
-`(output, state)` spaces (the output type is shared; the state spaces `σ₁`/`σ₂` differ). -/
-theorem probEvent_le_of_relTriple_simulateQ_run
-    {ι₁ ι₂ : Type u} {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
-    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
-    {σ₁ σ₂ : Type}
-    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
-    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
-    (rState : σ₁ → σ₂ → Prop)
-    (oa : OracleComp spec α)
-    (himpl : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂),
-      rState s₁ s₂ →
-      RelTriple ((impl₁ t).run s₁) ((impl₂ t).run s₂)
-        (fun p₁ p₂ => p₁.1 = p₂.1 ∧ rState p₁.2 p₂.2))
-    (s₁ : σ₁) (s₂ : σ₂) (hs : rState s₁ s₂)
-    {p : α × σ₁ → Prop} {q : α × σ₂ → Prop}
-    (himp : ∀ z₁ z₂, z₁.1 = z₂.1 → rState z₁.2 z₂.2 → p z₁ → q z₂) :
-    Pr[p | (simulateQ impl₁ oa).run s₁] ≤ Pr[q | (simulateQ impl₂ oa).run s₂] :=
-  probEvent_le_of_relTriple
-    (relTriple_simulateQ_run impl₁ impl₂ rState oa himpl s₁ s₂ hs)
-    (fun z₁ z₂ h => himp z₁ z₂ h.1 h.2)
 
 /-- Exact-distribution specialization of `relTriple_simulateQ_run'`.
 
@@ -534,6 +581,129 @@ private lemma probEvent_bad_eq
         rw [← h2]; exact ENNReal.add_sub_cancel_right
           (ne_top_of_le_ne_top one_ne_top probEvent_le_one)
 
+omit [IsUniformSpec spec] in
+/-- **Marginal stochastic dominance through `simulateQ` (self-referential / Fubini form).**
+
+The marginal counterpart of `relTriple_simulateQ_run_mono`. Where the latter demands a
+*pointwise* per-step coupling whose support respects an output-and-state relation, this lemma
+demands only a *marginal* per-step inequality: at every query and every pair of `R`-related
+states, the one-step run of `impl₁` followed by *any* left tail `k₁` has bad-marginal at most
+the one-step run of `impl₂` followed by *any* right tail `k₂`, provided the two tails are
+themselves marginally bad-dominated from every pair of `R`-related successor states.
+
+This is the right shape when the two handlers genuinely diverge on the answer distribution at a
+single step (e.g. an eager deterministic ghost read vs. a deferred-sampling read), so no
+pointwise coupling can dominate the bad flag at that step, yet the *marginal* bad mass — the
+`tsum` over the deferred draw, taken before the divergent continuation is applied — is still
+ordered (Fubini / tsum-swap). The per-step premise is self-referential by design: discharging
+it at the divergent step is exactly the marginal draw-commutation, the hard content this lemma
+isolates from the free-monad bookkeeping.
+
+The base hypothesis `h_base` (`R s₁ s₂ → bad₁ s₁ → bad₂ s₂`) discharges the `pure` leaf, where no
+further step can repair the bad flag: there the bad marginal is exactly the indicator of the
+current state, so `R` must already carry the bad implication. -/
+theorem probEvent_marginal_simulateQ_mono
+    {ι₁ : Type u} {ι₂ : Type u}
+    {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    {σ₁ σ₂ : Type}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (R : σ₁ → σ₂ → Prop)
+    (bad₁ : σ₁ → Prop) (bad₂ : σ₂ → Prop)
+    (h_base : ∀ (s₁ : σ₁) (s₂ : σ₂), R s₁ s₂ → bad₁ s₁ → bad₂ s₂)
+    (h_step : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂), R s₁ s₂ →
+      ∀ {γ : Type} (k₁ : (spec.Range t × σ₁) → OracleComp spec₁ (γ × σ₁))
+        (k₂ : (spec.Range t × σ₂) → OracleComp spec₂ (γ × σ₂)),
+        (∀ (u : spec.Range t) (s₁' : σ₁) (s₂' : σ₂), R s₁' s₂' →
+          Pr[ fun z => bad₁ z.2 | k₁ (u, s₁')] ≤ Pr[ fun z => bad₂ z.2 | k₂ (u, s₂')]) →
+        Pr[ fun z => bad₁ z.2 | (impl₁ t).run s₁ >>= k₁] ≤
+          Pr[ fun z => bad₂ z.2 | (impl₂ t).run s₂ >>= k₂])
+    (oa : OracleComp spec α) (s₁ : σ₁) (s₂ : σ₂) (hR : R s₁ s₂) :
+    Pr[fun z => bad₁ z.2 | (simulateQ impl₁ oa).run s₁] ≤
+      Pr[fun z => bad₂ z.2 | (simulateQ impl₂ oa).run s₂] := by
+  classical
+  induction oa using OracleComp.inductionOn generalizing s₁ s₂ with
+  | pure a =>
+    simp only [simulateQ_pure, StateT.run_pure]
+    -- both sides are point masses on `(a, s₁)` / `(a, s₂)`; reduce to the base implication.
+    by_cases hb : bad₁ s₁
+    · have hb₂ : bad₂ s₂ := h_base s₁ s₂ hR hb
+      calc Pr[fun z => bad₁ z.2 | (pure (a, s₁) : OracleComp spec₁ (α × σ₁))]
+          ≤ 1 := probEvent_le_one
+        _ = Pr[fun z => bad₂ z.2 | (pure (a, s₂) : OracleComp spec₂ (α × σ₂))] := by
+            rw [probEvent_pure]; simp [hb₂]
+    · rw [probEvent_pure]
+      simp [hb]
+  | query_bind t ob ih =>
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind]
+    refine h_step t s₁ s₂ hR
+      (fun p => (simulateQ impl₁ (ob p.1)).run p.2)
+      (fun p => (simulateQ impl₂ (ob p.1)).run p.2) ?_
+    intro u s₁' s₂' hR'
+    exact ih u s₁' s₂' hR'
+
+omit [IsUniformSpec spec] in
+/-- **Distribution-level stochastic dominance through `simulateQ`.**
+
+The *distribution-level* sibling of `probEvent_marginal_simulateQ_mono`. Where the latter carries
+a **pointwise** state relation `R : σ₁ → σ₂ → Prop` and discharges the per-query step at every pair
+of `R`-related *states*, this lemma carries a relation `Rrun` directly on the two run
+**distributions** (the whole `OracleComp spec₁ (γ × σ₁)` / `OracleComp spec₂ (γ × σ₂)`
+computations), generic over the output type `γ`. This is the shape needed when the per-step
+recoupling is inherently *joint-law* — e.g. an eager handler that has already committed sampled
+keys into its state versus a deferred-sampling handler that only carries a pending *count*, so that
+no pointwise state predicate relates the two successor states yet the two run distributions are
+related by a coupling over the deferred draw.
+
+The induction is pure free-monad bookkeeping; the entire probabilistic content is isolated into the
+two premises:
+
+* `h_pure` seeds the relation at the `pure` leaves (the run distributions are the two point masses
+  `pure (a, s₁)` / `pure (a, s₂)`);
+* `h_bind` is the distribution-level bind congruence: given a query `t` and any two tails `k₁ k₂`
+  whose per-output continuations are already `Rrun`-related, the one-step runs followed by those
+  tails are again `Rrun`-related. Discharging `h_bind` at a divergent step *is* the marginal
+  draw-commutation, the hard content this lemma isolates.
+
+Once the relation is established along the whole run, `h_bad` reads off the ordered bad marginals.
+
+`s₁ : σ₁`, `s₂ : σ₂` are the initial states and `hbase : Rrun (pure …) …`-free: instead the
+seed is supplied through `h_pure`, applied at the actual reachable leaves during the induction, so
+no separate base hypothesis on `s₁ s₂` is required beyond what `h_pure`/`h_bind` carry. -/
+theorem probEvent_dist_simulateQ_mono
+    {ι₁ : Type u} {ι₂ : Type u}
+    {spec₁ : OracleSpec ι₁} {spec₂ : OracleSpec ι₂}
+    [IsUniformSpec spec₁] [IsUniformSpec spec₂]
+    {σ₁ σ₂ : Type}
+    (impl₁ : QueryImpl spec (StateT σ₁ (OracleComp spec₁)))
+    (impl₂ : QueryImpl spec (StateT σ₂ (OracleComp spec₂)))
+    (Rrun : ∀ {γ : Type}, OracleComp spec₁ (γ × σ₁) → OracleComp spec₂ (γ × σ₂) → Prop)
+    (bad₁ : σ₁ → Prop) (bad₂ : σ₂ → Prop)
+    (h_pure : ∀ {γ : Type} (a : γ) (s₁ : σ₁) (s₂ : σ₂),
+      Rrun (pure (a, s₁)) (pure (a, s₂)))
+    (h_bind : ∀ (t : spec.Domain) (s₁ : σ₁) (s₂ : σ₂),
+      ∀ {γ : Type} (k₁ : (spec.Range t × σ₁) → OracleComp spec₁ (γ × σ₁))
+        (k₂ : (spec.Range t × σ₂) → OracleComp spec₂ (γ × σ₂)),
+        (∀ (u : spec.Range t) (s₁' : σ₁) (s₂' : σ₂), Rrun (k₁ (u, s₁')) (k₂ (u, s₂'))) →
+        Rrun ((impl₁ t).run s₁ >>= k₁) ((impl₂ t).run s₂ >>= k₂))
+    (h_bad : ∀ {γ : Type} (r₁ : OracleComp spec₁ (γ × σ₁)) (r₂ : OracleComp spec₂ (γ × σ₂)),
+      Rrun r₁ r₂ → Pr[ fun z => bad₁ z.2 | r₁] ≤ Pr[ fun z => bad₂ z.2 | r₂])
+    (oa : OracleComp spec α) (s₁ : σ₁) (s₂ : σ₂) :
+    Pr[fun z => bad₁ z.2 | (simulateQ impl₁ oa).run s₁] ≤
+      Pr[fun z => bad₂ z.2 | (simulateQ impl₂ oa).run s₂] := by
+  classical
+  refine h_bad _ _ ?_
+  induction oa using OracleComp.inductionOn generalizing s₁ s₂ with
+  | pure a =>
+    simp only [simulateQ_pure, StateT.run_pure]
+    exact h_pure a s₁ s₂
+  | query_bind t ob ih =>
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query, OracleQuery.cont_query,
+      id_map, StateT.run_bind]
+    exact h_bind t s₁ s₂ _ _ (fun u s₁' s₂' => ih u s₁' s₂')
+
 /-- The fundamental lemma of game playing: if two oracle implementations agree whenever
 a "bad" flag is unset, then the total variation distance between the two simulations
 is bounded by the probability that bad gets set.
@@ -922,6 +1092,144 @@ private lemma probEvent_simulateQ_run_bad_eq_one_of_bad
     Pr[fun z : α × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p] = 1 := by
   rw [probEvent_eq_one_iff]
   exact ⟨by simp, mem_support_simulateQ_run_of_bad impl h_mono oa p hp⟩
+
+/-! ### Exact identical-until-bad with output bad flag: joint heterogeneous variant
+
+`tvDist_simulateQ_le_probEvent_output_bad` fixes the inner monad to `OracleComp spec`
+over the same spec as the simulated computation, and projects the conclusion to the
+output marginal. The variant here generalizes the inner monad to `OracleComp spec'` and
+keeps the conclusion on the **joint** output-and-state distribution, which is what a
+game with a state-dependent continuation (e.g. a final verification step reading the
+run's cache) consumes. -/
+
+private lemma probOutput_simulateQ_run_eq_zero_of_output_bad'
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (h_mono : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (p : σ × Bool) (hp : p.2 = true) (x : α) (s : σ) :
+    Pr[= (x, (s, false)) | (simulateQ impl oa).run p] = 0 := by
+  refine probOutput_eq_zero_of_not_mem_support fun h => ?_
+  simpa using mem_support_simulateQ_run_of_bad impl h_mono oa p hp (x, (s, false)) h
+
+private lemma probOutput_simulateQ_run_eq_of_not_output_bad'
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (s₀ : σ) (x : α) (s : σ) :
+    Pr[= (x, (s, false)) | (simulateQ impl₁ oa).run (s₀, false)] =
+      Pr[= (x, (s, false)) | (simulateQ impl₂ oa).run (s₀, false)] := by
+  induction oa using OracleComp.inductionOn generalizing s₀ with
+  | pure a =>
+    simp only [simulateQ_pure]
+  | query_bind t oa ih =>
+    simp only [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+      OracleQuery.cont_query, id_map, StateT.run_bind]
+    rw [probOutput_bind_eq_tsum, probOutput_bind_eq_tsum]
+    refine tsum_congr ?_
+    rintro ⟨u, ⟨s', b⟩⟩
+    cases b with
+    | true =>
+      have h₁ : Pr[= (x, (s, false)) | (simulateQ impl₁ (oa u)).run (s', true)] = 0 :=
+        probOutput_simulateQ_run_eq_zero_of_output_bad' impl₁ h_mono₁ (oa u)
+          (s', true) rfl x s
+      have h₂ : Pr[= (x, (s, false)) | (simulateQ impl₂ (oa u)).run (s', true)] = 0 :=
+        probOutput_simulateQ_run_eq_zero_of_output_bad' impl₂ h_mono₂ (oa u)
+          (s', true) rfl x s
+      simp [h₁, h₂]
+    | false =>
+      rw [h_agree_good t s₀ u s', ih u s']
+
+open scoped Classical in
+/-- **Bad-event equality for exact identical-until-bad**, with the inner monad over an
+arbitrary uniform spec `spec'`. Two state-extended implementations that agree on every
+non-bad output transition from a non-bad input state (`h_agree_good`) and are bad-input
+monotone (`h_mono₁`, `h_mono₂`) flip the output bad flag with *exactly the same*
+probability. This is the equality counterpart of `tvDist_simulateQ_run_le_probEvent_output_bad`
+(which bounds only the TV distance): the bad marginals coincide because the two runs differ
+only on the already-bad trajectory, where both flags read `true`. -/
+theorem probEvent_output_bad_eq'
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true)
+    (oa : OracleComp spec α) (s₀ : σ) :
+    Pr[fun z : α × σ × Bool => z.2.2 = true | (simulateQ impl₁ oa).run (s₀, false)] =
+      Pr[fun z : α × σ × Bool => z.2.2 = true | (simulateQ impl₂ oa).run (s₀, false)] := by
+  set sim₁ := (simulateQ impl₁ oa).run (s₀, false)
+  set sim₂ := (simulateQ impl₂ oa).run (s₀, false)
+  have h₁ := probEvent_compl sim₁ (fun z : α × σ × Bool => z.2.2 = true)
+  have h₂ := probEvent_compl sim₂ (fun z : α × σ × Bool => z.2.2 = true)
+  simp only [NeverFail.probFailure_eq_zero, tsub_zero] at h₁ h₂
+  have h_not_eq :
+      Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₁] =
+        Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₂] := by
+    rw [probEvent_eq_tsum_ite, probEvent_eq_tsum_ite]
+    refine tsum_congr ?_
+    rintro ⟨a, s, b⟩
+    by_cases hb : b = true
+    · simp [hb]
+    · have hb' : b = false := by cases b <;> simp_all
+      subst hb'
+      simpa using
+        probOutput_simulateQ_run_eq_of_not_output_bad' impl₁ impl₂ h_agree_good
+          h_mono₁ h_mono₂ oa s₀ a s
+  have hne₁ : Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₁] ≠ ⊤ :=
+    ne_top_of_le_ne_top one_ne_top probEvent_le_one
+  calc Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁]
+      = 1 - Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₁] := by
+        rw [← h₁]; exact (ENNReal.add_sub_cancel_right hne₁).symm
+    _ = 1 - Pr[fun z : α × σ × Bool => ¬z.2.2 = true | sim₂] := by rw [h_not_eq]
+    _ = Pr[fun z : α × σ × Bool => z.2.2 = true | sim₂] := by
+        rw [← h₂]; exact ENNReal.add_sub_cancel_right
+          (ne_top_of_le_ne_top one_ne_top probEvent_le_one)
+
+/-- "Identical until bad" with an output bad flag, on the **joint** output-and-state
+distribution, with the inner monad over an arbitrary uniform spec `spec'`.
+
+Two state-extended oracle implementations that agree on non-bad output transitions from
+non-bad input states (and are bad-input monotone) produce simulated runs whose joint
+output-and-state distributions are within the probability of the flag firing in the run
+of `impl₁`. Unlike `tvDist_simulateQ_le_probEvent_output_bad`, the conclusion keeps the
+final state, so a state-dependent continuation (e.g. verification against the final
+cache) can be appended on both sides. -/
+theorem tvDist_simulateQ_run_le_probEvent_output_bad
+    (impl₁ impl₂ : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (oa : OracleComp spec α) (s₀ : σ)
+    (h_agree_good : ∀ (t : spec.Domain) (s : σ) (u : spec.Range t) (s' : σ),
+      Pr[= (u, (s', false)) | (impl₁ t).run (s, false)] =
+        Pr[= (u, (s', false)) | (impl₂ t).run (s, false)])
+    (h_mono₁ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₁ t).run p), z.2.2 = true)
+    (h_mono₂ : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = true →
+      ∀ z ∈ support ((impl₂ t).run p), z.2.2 = true) :
+    tvDist ((simulateQ impl₁ oa).run (s₀, false))
+        ((simulateQ impl₂ oa).run (s₀, false))
+      ≤ Pr[fun z : α × σ × Bool => z.2.2 = true |
+          (simulateQ impl₁ oa).run (s₀, false)].toReal := by
+  classical
+  set sim₁ := (simulateQ impl₁ oa).run (s₀, false)
+  set sim₂ := (simulateQ impl₂ oa).run (s₀, false)
+  have h_eq : ∀ (z : α × σ × Bool), ¬(z.2.2 = true) → Pr[= z | sim₁] = Pr[= z | sim₂] := by
+    rintro ⟨x, s, b⟩ hb
+    have hb' : b = false := by cases b <;> simp_all
+    subst hb'
+    exact probOutput_simulateQ_run_eq_of_not_output_bad' impl₁ impl₂ h_agree_good
+      h_mono₁ h_mono₂ oa s₀ x s
+  have h_event_eq :
+      Pr[fun z : α × σ × Bool => z.2.2 = true | sim₁] =
+        Pr[fun z : α × σ × Bool => z.2.2 = true | sim₂] :=
+    probEvent_output_bad_eq' impl₁ impl₂ h_agree_good h_mono₁ h_mono₂ oa s₀
+  exact tvDist_le_probEvent_of_probOutput_eq_of_not (mx := sim₁) (my := sim₂)
+    (fun z : α × σ × Bool => z.2.2 = true) h_eq h_event_eq
 
 /-! ### ε-perturbed identical-until-bad: helper lemmas (in dependency order) -/
 
@@ -1384,6 +1692,112 @@ theorem tvDist_simulateQ_le_queryBound_mul_slack_plus_probEvent_bad
   simpa [StateT.run'] using
     (tvDist_map_le (m := OracleComp spec') (α := α × σ × Bool) (β := α) Prod.fst
       ((simulateQ impl₁ oa).run (s₀, false)) ((simulateQ impl₂ oa).run (s₀, false)))
+
+/-! #### Query-bounded TV budget without a bad event
+
+When the two implementations agree exactly off the charged queries and no bad event is
+tracked, the selective bound simplifies to a pure per-query budget `qS * ε` on the joint
+output-and-state distribution, with no bad-flag plumbing in the state. -/
+
+/-- Bound the weighted TV sum from `tvDist_bind_left_le` by a uniform pointwise constant:
+the output weights sum to at most one, so the weighted average of per-continuation TV
+distances is at most any uniform bound on them. -/
+private lemma tsum_probOutput_mul_tvDist_le_const
+    {β γ : Type} (mx : OracleComp spec' β) (f₁ f₂ : β → OracleComp spec' γ)
+    {c : ℝ} (hc : 0 ≤ c) (h_le : ∀ z : β, tvDist (f₁ z) (f₂ z) ≤ c) :
+    (∑' z : β, Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z)) ≤ c := by
+  have h_p_sum_le_one : (∑' z : β, Pr[= z | mx]) ≤ 1 := tsum_probOutput_le_one
+  have h_p_summable : Summable (fun z : β => Pr[= z | mx].toReal) :=
+    ENNReal.summable_toReal (ne_top_of_le_ne_top one_ne_top h_p_sum_le_one)
+  have h_nonneg : ∀ z : β, 0 ≤ Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) :=
+    fun z => mul_nonneg ENNReal.toReal_nonneg (tvDist_nonneg _ _)
+  have h_le' : ∀ z : β,
+      Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z) ≤ Pr[= z | mx].toReal * c :=
+    fun z => mul_le_mul_of_nonneg_left (h_le z) ENNReal.toReal_nonneg
+  have h_sum_toReal_le_one : (∑' z : β, Pr[= z | mx].toReal) ≤ 1 := by
+    have h := ENNReal.toReal_mono one_ne_top h_p_sum_le_one
+    rwa [ENNReal.toReal_one, ENNReal.tsum_toReal_eq
+      (fun z => ne_top_of_le_ne_top one_ne_top probOutput_le_one)] at h
+  calc (∑' z : β, Pr[= z | mx].toReal * tvDist (f₁ z) (f₂ z))
+      ≤ ∑' z : β, Pr[= z | mx].toReal * c :=
+        Summable.tsum_le_tsum h_le'
+          (Summable.of_nonneg_of_le h_nonneg h_le' (h_p_summable.mul_right c))
+          (h_p_summable.mul_right c)
+    _ = (∑' z : β, Pr[= z | mx].toReal) * c := tsum_mul_right
+    _ ≤ 1 * c := mul_le_mul_of_nonneg_right h_sum_toReal_le_one hc
+    _ = c := one_mul c
+
+/-- **Query-bounded total-variation budget for `simulateQ`.**
+
+If two stateful oracle implementations agree exactly on every query outside a designated
+set `S`, and on `S`-queries are within total-variation distance `ε` on the joint
+answer-and-state distribution — uniformly in the carried state — then simulating any
+computation making at most `qS` queries to `S` keeps the joint output-and-state
+distributions within `qS * ε`, from any shared starting state.
+
+This is the bad-event-free counterpart of
+`tvDist_simulateQ_run_le_queryBound_mul_slack_plus_probEvent_bad`: the per-query budgets
+telescope across the simulation by the triangle inequality, the hybrid for the `i`-th
+charged query swapping which implementation answers it. Typical use: a signing oracle
+whose real and simulated bodies are within `ε` from every shared random-oracle cache,
+with all remaining oracles handled identically on both sides. -/
+theorem tvDist_simulateQ_run_le_queryBoundP_mul
+    (impl₁ impl₂ : QueryImpl spec (StateT σ (OracleComp spec')))
+    {ε : ℝ} (hε : 0 ≤ ε)
+    (S : ι → Prop) [DecidablePred S]
+    (h_step_tv_S : ∀ (t : ι), S t → ∀ (s : σ),
+      tvDist ((impl₁ t).run s) ((impl₂ t).run s) ≤ ε)
+    (h_step_eq_nS : ∀ (t : ι), ¬ S t → ∀ (s : σ),
+      (impl₁ t).run s = (impl₂ t).run s)
+    (oa : OracleComp spec α) {qS : ℕ}
+    (h_qb : OracleComp.IsQueryBoundP oa S qS) (s₀ : σ) :
+    tvDist ((simulateQ impl₁ oa).run s₀) ((simulateQ impl₂ oa).run s₀) ≤ qS * ε := by
+  induction oa using OracleComp.inductionOn generalizing qS s₀ with
+  | pure x =>
+      simp only [simulateQ_pure, StateT.run_pure, tvDist_self]
+      exact mul_nonneg (Nat.cast_nonneg _) hε
+  | query_bind t cont ih =>
+      rw [isQueryBoundP_query_bind_iff] at h_qb
+      obtain ⟨h_can, h_cont⟩ := h_qb
+      set f₁ : spec.Range t × σ → OracleComp spec' (α × σ) :=
+        fun z => (simulateQ impl₁ (cont z.1)).run z.2 with hf₁_def
+      set f₂ : spec.Range t × σ → OracleComp spec' (α × σ) :=
+        fun z => (simulateQ impl₂ (cont z.1)).run z.2 with hf₂_def
+      have hsim₁_eq : (simulateQ impl₁ (query t >>= cont)).run s₀ =
+          (impl₁ t).run s₀ >>= f₁ := by
+        simp [hf₁_def, simulateQ_bind, simulateQ_query,
+          OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind]
+      have hsim₂_eq : (simulateQ impl₂ (query t >>= cont)).run s₀ =
+          (impl₂ t).run s₀ >>= f₂ := by
+        simp [hf₂_def, simulateQ_bind, simulateQ_query,
+          OracleQuery.input_query, OracleQuery.cont_query, StateT.run_bind]
+      rw [hsim₁_eq, hsim₂_eq]
+      by_cases hSt : S t
+      · -- Charged query: swap the step (cost `ε`), then recurse with budget `qS - 1`.
+        simp only [if_pos hSt] at h_cont
+        have hqS_pos : 0 < qS := h_can.resolve_left (not_not_intro hSt)
+        have h_first : tvDist ((impl₁ t).run s₀ >>= f₁) ((impl₁ t).run s₀ >>= f₂)
+            ≤ ↑(qS - 1) * ε :=
+          le_trans (tvDist_bind_left_le _ _ _)
+            (tsum_probOutput_mul_tvDist_le_const _ f₁ f₂
+              (mul_nonneg (Nat.cast_nonneg _) hε) (fun z => ih z.1 (h_cont z.1) z.2))
+        have h_second : tvDist ((impl₁ t).run s₀ >>= f₂) ((impl₂ t).run s₀ >>= f₂) ≤ ε :=
+          le_trans (tvDist_bind_right_le _ _ _) (h_step_tv_S t hSt s₀)
+        have hq_arith : (↑(qS - 1) + 1 : ℝ) = (qS : ℝ) := by
+          exact_mod_cast congrArg Nat.cast (Nat.sub_add_cancel hqS_pos)
+        calc tvDist ((impl₁ t).run s₀ >>= f₁) ((impl₂ t).run s₀ >>= f₂)
+            ≤ tvDist ((impl₁ t).run s₀ >>= f₁) ((impl₁ t).run s₀ >>= f₂) +
+                tvDist ((impl₁ t).run s₀ >>= f₂) ((impl₂ t).run s₀ >>= f₂) :=
+              tvDist_triangle _ _ _
+          _ ≤ ↑(qS - 1) * ε + ε := add_le_add h_first h_second
+          _ = (↑(qS - 1) + 1) * ε := by ring
+          _ = ↑qS * ε := by rw [hq_arith]
+      · -- Free query: the step is shared; recurse with the budget intact.
+        simp only [if_neg hSt] at h_cont
+        rw [← h_step_eq_nS t hSt s₀]
+        exact le_trans (tvDist_bind_left_le _ _ _)
+          (tsum_probOutput_mul_tvDist_le_const _ f₁ f₂
+            (mul_nonneg (Nat.cast_nonneg _) hε) (fun z => ih z.1 (h_cont z.1) z.2))
 
 end IdenticalUntilBadEpsilonSelective
 
@@ -2169,6 +2583,299 @@ lemma expectedQuerySlack_resource_le
               rw [ENNReal.tsum_mul_right]
               exact mul_le_of_le_one_left (by positivity) tsum_probOutput_le_one
 
+/-- Expected-growth resource bound for `expectedQuerySlack`.
+
+Like `expectedQuerySlack_resource_le`, but a charged query may grow the resource by more
+than one in support, as long as it grows by at most `g` **in expectation** under the
+handler. Growth queries grow the resource by at most one in support, and free queries
+never grow it. The accumulated slack of a computation with at most `qS` charged and `qH`
+growth queries is then at most `qS·ζ + (qS·R s + qS·qH + C(qS,2)·g)·β`, the binomial
+cross term coming from the expected resource increase of earlier charged queries. -/
+lemma expectedQuerySlack_expected_resource_le
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (chargedQuery growthQuery : spec.Domain → Prop)
+    [DecidablePred chargedQuery] [DecidablePred growthQuery]
+    (R : σ → ℝ≥0∞) (ζ β g : ℝ≥0∞)
+    (h_charged : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = false → chargedQuery t →
+      ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] * R z.2.1 ≤ R p.1 + g)
+    (h_growth : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = false →
+      ¬ chargedQuery t → growthQuery t →
+      ∀ z ∈ support ((impl t).run p), R z.2.1 ≤ R p.1 + 1)
+    (h_free : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = false →
+      ¬ chargedQuery t → ¬ growthQuery t →
+      ∀ z ∈ support ((impl t).run p), R z.2.1 ≤ R p.1)
+    (oa : OracleComp spec α) {qS qH : ℕ}
+    (h_qS : OracleComp.IsQueryBoundP oa chargedQuery qS)
+    (h_qH : OracleComp.IsQueryBoundP oa growthQuery qH)
+    (s : σ) :
+    expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β) oa qS (s, false)
+      ≤ (qS : ℝ≥0∞) * ζ +
+        ((qS : ℝ≥0∞) * R s + (qS : ℝ≥0∞) * (qH : ℝ≥0∞) +
+          (qS.choose 2 : ℝ≥0∞) * g) * β := by
+  induction oa using OracleComp.inductionOn generalizing qS qH s with
+  | pure x => simp only [expectedQuerySlack_pure, zero_le]
+  | query_bind t cont ih =>
+      rw [isQueryBoundP_query_bind_iff] at h_qS h_qH
+      obtain ⟨hcanS, hcontS⟩ := h_qS
+      obtain ⟨hcanH, hcontH⟩ := h_qH
+      by_cases hSt : chargedQuery t
+      · simp only [hSt, if_true] at hcontS
+        have hqS_pos : 0 < qS := hcanS.resolve_left (· hSt)
+        obtain ⟨m, rfl⟩ : ∃ m, qS = m + 1 := ⟨qS - 1, by omega⟩
+        rw [expectedQuerySlack_query_bind,
+          expectedQuerySlackStep_costly_pos _ _ _ _ _ _ _ hSt hqS_pos]
+        simp only [Nat.add_sub_cancel] at hcontS ⊢
+        have h_sum_le : ∀ z : spec.Range t × σ × Bool,
+            Pr[= z | (impl t).run (s, false)] *
+              expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β) (cont z.1) m z.2
+            ≤ Pr[= z | (impl t).run (s, false)] *
+                ((m : ℝ≥0∞) * ζ +
+                  ((m : ℝ≥0∞) * (qH : ℝ≥0∞) + (m.choose 2 : ℝ≥0∞) * g) * β)
+              + (m : ℝ≥0∞) * β * (Pr[= z | (impl t).run (s, false)] * R z.2.1) := by
+          rintro ⟨u, s', bad'⟩
+          cases bad' with
+          | true => simp
+          | false =>
+              have hIH : expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β)
+                  (cont u) m (s', false)
+                  ≤ (m : ℝ≥0∞) * ζ + ((m : ℝ≥0∞) * R s' + (m : ℝ≥0∞) * (qH : ℝ≥0∞)
+                      + (m.choose 2 : ℝ≥0∞) * g) * β := by
+                have hqH'_le : (if growthQuery t then qH - 1 else qH) ≤ qH := by
+                  split_ifs <;> omega
+                refine (ih u (hcontS u) (hcontH u) s').trans ?_
+                gcongr
+              refine (mul_le_mul_right hIH _).trans (le_of_eq ?_)
+              ring
+        have h_tsum : (∑' z : spec.Range t × σ × Bool,
+              Pr[= z | (impl t).run (s, false)] *
+                expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β) (cont z.1) m z.2)
+            ≤ ((m : ℝ≥0∞) * ζ +
+                ((m : ℝ≥0∞) * (qH : ℝ≥0∞) + (m.choose 2 : ℝ≥0∞) * g) * β)
+              + (m : ℝ≥0∞) * β * (R s + g) := by
+          refine (ENNReal.tsum_le_tsum h_sum_le).trans ?_
+          rw [ENNReal.tsum_add, ENNReal.tsum_mul_right, ENNReal.tsum_mul_left]
+          exact add_le_add
+            (mul_le_of_le_one_left (by positivity) tsum_probOutput_le_one)
+            (mul_le_mul_right (h_charged t (s, false) rfl hSt) _)
+        have hch : (((m + 1).choose 2 : ℕ) : ℝ≥0∞) = (m : ℝ≥0∞) + (m.choose 2 : ℝ≥0∞) := by
+          have hch_nat : (m + 1).choose 2 = m + m.choose 2 := by
+            rw [Nat.choose_succ_succ', Nat.choose_one_right]
+          exact_mod_cast hch_nat
+        calc ζ + R s * β + (∑' z : spec.Range t × σ × Bool,
+              Pr[= z | (impl t).run (s, false)] *
+                expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β) (cont z.1) m z.2)
+            ≤ ζ + R s * β
+              + (((m : ℝ≥0∞) * ζ +
+                  ((m : ℝ≥0∞) * (qH : ℝ≥0∞) + (m.choose 2 : ℝ≥0∞) * g) * β)
+                + (m : ℝ≥0∞) * β * (R s + g)) := by gcongr
+          _ = ((m : ℝ≥0∞) + 1) * ζ
+              + (((m : ℝ≥0∞) + 1) * R s + (m : ℝ≥0∞) * (qH : ℝ≥0∞)
+                + ((m : ℝ≥0∞) + (m.choose 2 : ℝ≥0∞)) * g) * β := by ring
+          _ ≤ ((m : ℝ≥0∞) + 1) * ζ
+              + (((m : ℝ≥0∞) + 1) * R s + ((m : ℝ≥0∞) + 1) * (qH : ℝ≥0∞)
+                + ((m : ℝ≥0∞) + (m.choose 2 : ℝ≥0∞)) * g) * β := by
+              gcongr
+              exact le_self_add
+          _ = ((m + 1 : ℕ) : ℝ≥0∞) * ζ
+              + (((m + 1 : ℕ) : ℝ≥0∞) * R s + ((m + 1 : ℕ) : ℝ≥0∞) * (qH : ℝ≥0∞)
+                + (((m + 1).choose 2 : ℕ) : ℝ≥0∞) * g) * β := by
+              rw [Nat.cast_add_one, hch]
+      · simp only [hSt, if_false] at hcontS
+        rw [expectedQuerySlack_query_bind, expectedQuerySlackStep_free _ _ _ _ _ _ _ hSt]
+        have h_z : ∀ z ∈ support ((impl t).run (s, false)),
+            expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β) (cont z.1) qS z.2
+              ≤ (qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * R s + (qS : ℝ≥0∞) * (qH : ℝ≥0∞)
+                  + (qS.choose 2 : ℝ≥0∞) * g) * β := by
+          rintro ⟨u, s', bad'⟩ hz
+          cases bad' with
+          | true => simp
+          | false =>
+              refine (ih u (hcontS u) (hcontH u) s').trans ?_
+              by_cases hHt : growthQuery t
+              · have hqH_pos : 0 < qH := hcanH.resolve_left (· hHt)
+                have hqH_cast : ((qH - 1 : ℕ) : ℝ≥0∞) + 1 = (qH : ℝ≥0∞) := by
+                  exact_mod_cast Nat.sub_add_cancel hqH_pos
+                have hRs' : R s' ≤ R s + 1 := h_growth t (s, false) rfl hSt hHt _ hz
+                rw [if_pos hHt]
+                calc (qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * R s'
+                        + (qS : ℝ≥0∞) * ((qH - 1 : ℕ) : ℝ≥0∞)
+                        + (qS.choose 2 : ℝ≥0∞) * g) * β
+                    ≤ (qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * (R s + 1)
+                        + (qS : ℝ≥0∞) * ((qH - 1 : ℕ) : ℝ≥0∞)
+                        + (qS.choose 2 : ℝ≥0∞) * g) * β := by gcongr
+                  _ = (qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * R s
+                        + (qS : ℝ≥0∞) * (((qH - 1 : ℕ) : ℝ≥0∞) + 1)
+                        + (qS.choose 2 : ℝ≥0∞) * g) * β := by ring
+                  _ = (qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * R s + (qS : ℝ≥0∞) * (qH : ℝ≥0∞)
+                        + (qS.choose 2 : ℝ≥0∞) * g) * β := by rw [hqH_cast]
+              · have hRs' : R s' ≤ R s := h_free t (s, false) rfl hSt hHt _ hz
+                rw [if_neg hHt]
+                gcongr
+        calc (∑' z : spec.Range t × σ × Bool,
+              Pr[= z | (impl t).run (s, false)] *
+                expectedQuerySlack impl chargedQuery (fun s => ζ + R s * β) (cont z.1) qS z.2)
+            ≤ ∑' z : spec.Range t × σ × Bool,
+                Pr[= z | (impl t).run (s, false)] *
+                  ((qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * R s + (qS : ℝ≥0∞) * (qH : ℝ≥0∞)
+                    + (qS.choose 2 : ℝ≥0∞) * g) * β) :=
+              ENNReal.tsum_le_tsum fun z => by
+                by_cases hz : z ∈ support ((impl t).run (s, false))
+                · exact mul_le_mul_right (h_z z hz) _
+                · simp [probOutput_eq_zero_of_not_mem_support hz]
+          _ ≤ (qS : ℝ≥0∞) * ζ + ((qS : ℝ≥0∞) * R s + (qS : ℝ≥0∞) * (qH : ℝ≥0∞)
+                + (qS.choose 2 : ℝ≥0∞) * g) * β := by
+              rw [ENNReal.tsum_mul_right]
+              exact mul_le_of_le_one_left (by positivity) tsum_probOutput_le_one
+
+/-- **Charged-read / expected-growth resource bound for `expectedQuerySlack`.**
+
+A variant of `expectedQuerySlack_expected_resource_le` for the situation where the
+*charged* queries never grow the resource (they only read it), while a separate class of
+*growth* queries grows the resource by at most `g` **in expectation** (and may grow it by
+arbitrarily much in support). Free queries never grow it.
+
+Each charged query pays `R s · β` at the state `s` reached when it fires. Since the
+charged queries do not grow `R`, and the growth queries grow it by at most `g` in
+expectation, the resource seen by any charged query is at most `R s₀ + qH · g` in
+expectation, where `s₀` is the starting state and `qH` bounds the growth queries. Folding
+the `qS` charged reads against this expected cap gives accumulated slack at most
+`qS · (R s₀ + qH · g) · β`, with **no** `(qS choose 2)` cross-term and **no** dependence on
+the in-support growth of the resource (which `expectedQuerySlack_expected_resource_le`
+would charge through its `h_growth`/`h_charged ≤ R p.1 + g` shape).
+
+This is the fold used by the ghost-read collision charge of the Fiat-Shamir-with-aborts
+Prog → Trans hop, where the charged queries are the adversary's random-oracle reads (which
+only grow the *real* cache, leaving the *ghost* cache `R` untouched) and the growth queries
+are the signing queries (which grow the ghost cache by the number of rejected attempts, up
+to `maxAttempts − 1` in support but at most `∑_{a} p^a ≤ 1/(1−p)` in expectation). -/
+lemma expectedQuerySlack_charged_read_expected_growth_le
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (chargedQuery growthQuery : spec.Domain → Prop)
+    [DecidablePred chargedQuery] [DecidablePred growthQuery]
+    (R : σ → ℝ≥0∞) (β g : ℝ≥0∞)
+    (h_charged : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = false → chargedQuery t →
+      ∀ z ∈ support ((impl t).run p), R z.2.1 ≤ R p.1)
+    (h_growth : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = false →
+      ¬ chargedQuery t → growthQuery t →
+      ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] * R z.2.1 ≤ R p.1 + g)
+    (h_free : ∀ (t : spec.Domain) (p : σ × Bool), p.2 = false →
+      ¬ chargedQuery t → ¬ growthQuery t →
+      ∀ z ∈ support ((impl t).run p), R z.2.1 ≤ R p.1)
+    (oa : OracleComp spec α) {qS qH : ℕ}
+    (h_qS : OracleComp.IsQueryBoundP oa chargedQuery qS)
+    (h_qH : OracleComp.IsQueryBoundP oa growthQuery qH)
+    (s : σ) :
+    expectedQuerySlack impl chargedQuery (fun s => R s * β) oa qS (s, false)
+      ≤ (qS : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by
+  induction oa using OracleComp.inductionOn generalizing qS qH s with
+  | pure x => simp only [expectedQuerySlack_pure, zero_le]
+  | query_bind t cont ih =>
+      rw [isQueryBoundP_query_bind_iff] at h_qS h_qH
+      obtain ⟨hcanS, hcontS⟩ := h_qS
+      obtain ⟨hcanH, hcontH⟩ := h_qH
+      by_cases hSt : chargedQuery t
+      · -- Charged read: pays `R s · β`, does not grow `R`, continuation budget `qS - 1`.
+        simp only [hSt, if_true] at hcontS
+        have hqS_pos : 0 < qS := hcanS.resolve_left (· hSt)
+        obtain ⟨m, rfl⟩ : ∃ m, qS = m + 1 := ⟨qS - 1, by omega⟩
+        rw [expectedQuerySlack_query_bind,
+          expectedQuerySlackStep_costly_pos _ _ _ _ _ _ _ hSt hqS_pos]
+        simp only [Nat.add_sub_cancel] at hcontS ⊢
+        -- A charged query is not a growth query budget-wise: continuation keeps budget `qH`.
+        have hqH'_le : (if growthQuery t then qH - 1 else qH) ≤ qH := by split_ifs <;> omega
+        have h_tsum_le :
+            (∑' z : spec.Range t × σ × Bool,
+              Pr[= z | (impl t).run (s, false)] *
+                expectedQuerySlack impl chargedQuery (fun s => R s * β) (cont z.1) m z.2)
+              ≤ (m : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by
+          calc (∑' z : spec.Range t × σ × Bool,
+                Pr[= z | (impl t).run (s, false)] *
+                  expectedQuerySlack impl chargedQuery (fun s => R s * β) (cont z.1) m z.2)
+              ≤ ∑' z : spec.Range t × σ × Bool,
+                  Pr[= z | (impl t).run (s, false)] *
+                    ((m : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β) :=
+                ENNReal.tsum_le_tsum fun z => by
+                  by_cases hz : z ∈ support ((impl t).run (s, false))
+                  · obtain ⟨u, s', bad'⟩ := z
+                    cases bad' with
+                    | true => simp
+                    | false =>
+                        refine mul_le_mul_right ((ih u (hcontS u) (hcontH u) s').trans ?_) _
+                        have hRs' : R s' ≤ R s := h_charged t (s, false) rfl hSt _ hz
+                        gcongr
+                  · simp [probOutput_eq_zero_of_not_mem_support hz]
+            _ ≤ (m : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by
+                rw [ENNReal.tsum_mul_right]
+                exact mul_le_of_le_one_left (by positivity) tsum_probOutput_le_one
+        calc R s * β +
+              (∑' z : spec.Range t × σ × Bool,
+                Pr[= z | (impl t).run (s, false)] *
+                  expectedQuerySlack impl chargedQuery (fun s => R s * β) (cont z.1) m z.2)
+            ≤ R s * β + (m : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by gcongr
+          _ ≤ (R s + (qH : ℝ≥0∞) * g) * β + (m : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by
+              gcongr
+              exact le_self_add
+          _ = ((m + 1 : ℕ) : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by push_cast; ring
+      · -- Uncharged query: no charge. Split growth vs. free.
+        simp only [hSt, if_false] at hcontS
+        rw [expectedQuerySlack_query_bind, expectedQuerySlackStep_free _ _ _ _ _ _ _ hSt]
+        by_cases hHt : growthQuery t
+        · -- Growth query: `R` grows by `≤ g` in expectation, charged budget unchanged.
+          have hqH_pos : 0 < qH := hcanH.resolve_left (· hHt)
+          obtain ⟨h, rfl⟩ : ∃ h, qH = h + 1 := ⟨qH - 1, by omega⟩
+          simp only [hHt, if_true] at hcontH
+          simp only [Nat.add_sub_cancel] at hcontH
+          calc (∑' z : spec.Range t × σ × Bool,
+                Pr[= z | (impl t).run (s, false)] *
+                  expectedQuerySlack impl chargedQuery (fun s => R s * β) (cont z.1) qS z.2)
+              ≤ ∑' z : spec.Range t × σ × Bool,
+                  Pr[= z | (impl t).run (s, false)] *
+                    ((qS : ℝ≥0∞) * (R z.2.1 + (h : ℝ≥0∞) * g) * β) :=
+                ENNReal.tsum_le_tsum fun z => by
+                  obtain ⟨u, s', bad'⟩ := z
+                  cases bad' with
+                  | true => simp
+                  | false => exact mul_le_mul_right (ih u (hcontS u) (hcontH u) s') _
+            _ = (qS : ℝ≥0∞) * β *
+                  (∑' z : spec.Range t × σ × Bool,
+                    Pr[= z | (impl t).run (s, false)] * (R z.2.1 + (h : ℝ≥0∞) * g)) := by
+                rw [← ENNReal.tsum_mul_left]
+                refine tsum_congr fun z => ?_
+                ring
+            _ ≤ (qS : ℝ≥0∞) * β * ((R s + g) + (h : ℝ≥0∞) * g) := by
+                gcongr
+                calc (∑' z : spec.Range t × σ × Bool,
+                      Pr[= z | (impl t).run (s, false)] * (R z.2.1 + (h : ℝ≥0∞) * g))
+                    = (∑' z, Pr[= z | (impl t).run (s, false)] * R z.2.1)
+                        + ∑' z, Pr[= z | (impl t).run (s, false)] * ((h : ℝ≥0∞) * g) := by
+                      rw [← ENNReal.tsum_add]; exact tsum_congr fun z => by rw [mul_add]
+                  _ ≤ (R s + g) + (h : ℝ≥0∞) * g := by
+                      refine add_le_add (h_growth t (s, false) rfl hSt hHt) ?_
+                      rw [ENNReal.tsum_mul_right]
+                      exact mul_le_of_le_one_left (by positivity) tsum_probOutput_le_one
+            _ = (qS : ℝ≥0∞) * (R s + ((h + 1 : ℕ) : ℝ≥0∞) * g) * β := by push_cast; ring
+        · -- Free query: `R` does not grow, budgets unchanged.
+          simp only [hHt, if_false] at hcontH
+          calc (∑' z : spec.Range t × σ × Bool,
+                Pr[= z | (impl t).run (s, false)] *
+                  expectedQuerySlack impl chargedQuery (fun s => R s * β) (cont z.1) qS z.2)
+              ≤ ∑' z : spec.Range t × σ × Bool,
+                  Pr[= z | (impl t).run (s, false)] *
+                    ((qS : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β) :=
+                ENNReal.tsum_le_tsum fun z => by
+                  by_cases hz : z ∈ support ((impl t).run (s, false))
+                  · obtain ⟨u, s', bad'⟩ := z
+                    cases bad' with
+                    | true => simp
+                    | false =>
+                        refine mul_le_mul_right ((ih u (hcontS u) (hcontH u) s').trans ?_) _
+                        have hRs' : R s' ≤ R s := h_free t (s, false) rfl hSt hHt _ hz
+                        gcongr
+                  · simp [probOutput_eq_zero_of_not_mem_support hz]
+            _ ≤ (qS : ℝ≥0∞) * (R s + (qH : ℝ≥0∞) * g) * β := by
+                rw [ENNReal.tsum_mul_right]
+                exact mul_le_of_le_one_left (by positivity) tsum_probOutput_le_one
+
 /-- **Constant-ε version of the bridge as a corollary of the state-dep version.**
 
 This is the ENNReal-form analogue of the existing real-valued
@@ -2418,5 +3125,975 @@ theorem probOutput_simulateQ_run'_le_add_bad_add_slack
   exact hjoint
 
 end HeterogeneousBadSlack
+
+/-! ## Single-world resource-charged bad accumulator
+
+A *single-world* accumulator bounding `Pr[flag = true]` for a stateful simulation whose
+state `σ × Bool` carries a monotone resource `R : σ → ℝ≥0∞` and a never-reset bad flag.
+Unlike the identical-until-bad theorems above, which bound only the TV distance between two
+worlds and treat `Pr[output bad]` as an *additive remainder term they never bound*, this
+lemma bounds the bad-flag mass directly, by the resource-weighted query slack
+`expectedQuerySlack impl charged (fun s => R s · ε)`.
+
+The per-step hypotheses are:
+
+* `h_charged_step`: at a *charged* (read) step from a non-bad state, the bad mass after the
+  step-and-continuation is at most `R s · ε` (the flip charge) plus the expected
+  continuation bad mass;
+* `h_free_step`: at a *free* step, no flip charge is paid.
+
+Folding the resulting `expectedQuerySlack` against a resource bound (e.g. via
+`expectedQuerySlack_resource_le` / `expectedQuerySlack_expected_resource_le`) yields a
+closed-form bilinear bound. -/
+section SingleWorldResourceBad
+
+variable {ι : Type} {spec : OracleSpec ι}
+variable {ι' : Type} {spec' : OracleSpec ι'} [IsUniformSpec spec']
+variable {σ γ : Type}
+
+/-- Collapse a `tsum` over a state-bool product to its non-bad slice when the bad slice
+vanishes. Used to discard bad-output terms (whose `expectedQuerySlack` is `0`) in the
+inductive step of `probEvent_bad_simulateQ_run_le_expectedQuerySlack`. -/
+private lemma tsum_prod_right_bool_eq_of_zero {A B : Type} (f : A × B × Bool → ℝ≥0∞)
+    (h : ∀ z : A × B, f (z.1, z.2, true) = 0) :
+    (∑' z : A × B × Bool, f z) = ∑' z : A × B, f (z.1, z.2, false) := by
+  have e : (∑' z : A × B × Bool, f z)
+      = ∑' z : (A × B) × Bool, f (z.1.1, z.1.2, z.2) :=
+    ((Equiv.tsum_eq (Equiv.prodAssoc A B Bool) f).symm.trans rfl)
+  rw [e, ENNReal.tsum_prod']
+  refine tsum_congr fun z => ?_
+  rw [tsum_bool (f := fun b => f (z.1, z.2, b)), h z, add_zero]
+
+/-- **Single-world resource-charged bad accumulator.**
+
+For `simulateQ impl oa` over a state `σ × Bool` (resource `σ`, never-reset bad flag), if
+
+* every charged step pays a flip charge `R s · ε` (`h_charged_step`), routing any further
+  bad mass through its good (non-flagged) output states, while
+* every free step pays nothing and introduces no bad mass (`h_free_step`),
+
+then the probability the flag is set after the whole run from a non-bad state is bounded by
+the resource-weighted query slack
+`expectedQuerySlack impl charged (fun s => R s * ε) oa qS (s, false)`. This is the
+single-world, output-event analogue of
+`probEvent_fst_simulateQ_run_le_add_bad_add_slack`: the inductive structure (good branch
+reduced through the head bind by the per-step premise, bad output states discarded since
+their slack is `0`) is similar, but the conclusion bounds `Pr[bad]` itself rather than
+carrying it as
+an additive remainder. -/
+theorem probEvent_bad_simulateQ_run_le_expectedQuerySlack
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (charged : spec.Domain → Prop) [DecidablePred charged]
+    (R : σ → ℝ≥0∞) (ε : ℝ≥0∞)
+    (h_charged_step : ∀ (t : spec.Domain) (s : σ), charged t →
+      ∀ (k : spec.Range t × σ × Bool → OracleComp spec' (γ × σ × Bool)),
+        Pr[ fun z : γ × σ × Bool => z.2.2 = true | (impl t).run (s, false) >>= k] ≤
+          R s * ε +
+          ∑' z : spec.Range t × σ,
+            Pr[= (z.1, z.2, false) | (impl t).run (s, false)] *
+              Pr[fun w : γ × σ × Bool => w.2.2 = true | k (z.1, z.2, false)])
+    (h_free_step : ∀ (t : spec.Domain) (s : σ), ¬ charged t →
+      ∀ (k : spec.Range t × σ × Bool → OracleComp spec' (γ × σ × Bool)),
+        Pr[fun z : γ × σ × Bool => z.2.2 = true | (impl t).run (s, false) >>= k] ≤
+          ∑' z : spec.Range t × σ,
+            Pr[= (z.1, z.2, false) | (impl t).run (s, false)] *
+              Pr[fun w : γ × σ × Bool => w.2.2 = true | k (z.1, z.2, false)])
+    (oa : OracleComp spec γ) :
+    ∀ {qS : ℕ}, OracleComp.IsQueryBoundP oa charged qS →
+      ∀ (s : σ),
+        Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run (s, false)] ≤
+          expectedQuerySlack impl charged (fun s => R s * ε) oa qS (s, false) := by
+  induction oa using OracleComp.inductionOn with
+  | pure x =>
+      intro qS _ s
+      simp only [simulateQ_pure, StateT.run_pure, probEvent_pure, expectedQuerySlack_pure,
+        Bool.false_eq_true, if_false, le_refl]
+  | @query_bind t cont ih =>
+      intro qS hqb s
+      rw [isQueryBoundP_query_bind_iff] at hqb
+      obtain ⟨hvalid, hcont⟩ := hqb
+      -- Rewrite the run to head-bind form.
+      have hsim : (simulateQ impl (query t >>= cont)).run (s, false) =
+          (impl t).run (s, false) >>= fun z => (simulateQ impl (cont z.1)).run z.2 := by
+        simp [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+          OracleQuery.cont_query, StateT.run_bind]
+      rw [hsim]
+      set k : spec.Range t × σ × Bool → OracleComp spec' (γ × σ × Bool) :=
+        fun z => (simulateQ impl (cont z.1)).run z.2 with hk
+      rw [expectedQuerySlack_query_bind]
+      by_cases hSt : charged t
+      · -- Charged step: pay `R s · ε` then forward to the IH on the good output states.
+        have hqS_pos : 0 < qS := hvalid.resolve_left (· hSt)
+        rw [expectedQuerySlackStep_costly_pos _ _ _ _ _ _ _ hSt hqS_pos,
+          tsum_prod_right_bool_eq_of_zero
+            (f := fun z : spec.Range t × σ × Bool =>
+              Pr[= z | (impl t).run (s, false)] *
+                expectedQuerySlack impl charged (fun s => R s * ε) (cont z.1) (qS - 1) z.2)
+            (by rintro ⟨u, s'⟩; simp)]
+        refine (h_charged_step t s hSt k).trans
+          (add_le_add le_rfl (ENNReal.tsum_le_tsum fun z => ?_))
+        rcases z with ⟨u, s'⟩
+        simp only [hk]
+        gcongr
+        have := ih u (hcont u) s'
+        rwa [if_pos hSt] at this
+      · -- Free step: no charge.
+        rw [expectedQuerySlackStep_free _ _ _ _ _ _ _ hSt,
+          tsum_prod_right_bool_eq_of_zero
+            (f := fun z : spec.Range t × σ × Bool =>
+              Pr[= z | (impl t).run (s, false)] *
+                expectedQuerySlack impl charged (fun s => R s * ε) (cont z.1) qS z.2)
+            (by rintro ⟨u, s'⟩; simp)]
+        refine (h_free_step t s hSt k).trans (ENNReal.tsum_le_tsum fun z => ?_)
+        rcases z with ⟨u, s'⟩
+        simp only [hk]
+        gcongr
+        have := ih u (hcont u) s'
+        rwa [if_neg hSt] at this
+
+end SingleWorldResourceBad
+
+/-! ## Averaged-state-measure bad accumulator
+
+The single-world resource accumulator `probEvent_bad_simulateQ_run_le_expectedQuerySlack`
+charges a flip cost `R s · ε` **at a fixed reachable state** `s`. That is exactly the right
+shape for a handler that *draws the hidden randomness at the read* (the lazy /
+deferred-sampling handler), where the per-state read charge is genuinely the averaged
+guessing mass `R s · ε < 1`.
+
+It is the *wrong* shape for an **eager** handler that *commits the hidden draw upstream*
+(at signing time) and then reads it back deterministically: at a committed state `s` the
+read-hit indicator `1_{mc ∈ slot(s)}` is `0` or `1`, never `ε`. The averaging that
+produces `ε` happened earlier, at the commit draw, and cannot be localized to any fixed
+read state.
+
+The fix carried here is to average not over a single fixed state but over a **state
+measure** `μ : PMF (σ × Bool)` — the *law* of the eager handler's slot under the pending
+upstream draws. The averaged bad mass
+
+  `avgBad impl μ oa := ∑' p, μ p · Pr[bad | (simulateQ impl oa).run p]`
+
+telescopes through the free monad exactly like `expectedQuerySlack`, but the read step's
+charge is now `∑' p, μ p · 1_{mc ∈ slot(p)} = Pr_{p∼μ}[mc ∈ slot(p)]`, a genuine
+probability over the state law. When `μ` is the pushforward of the upstream commit draws,
+this collapses (by Fubini / `tsum`-swap over the pending draws) to the *same* mass the lazy
+handler charges at the read — `probOutput_lazyGhostFire_one` is its single-pending base
+case. This is the missing-framework analogue of `expectedQuerySlack`: it carries a
+state-**law** plus an averaged-output invariant rather than a per-state resource charge.
+
+This section builds the reusable telescoping scaffold (`avgBad`, its `pure`/`query_bind`
+unfoldings, and the pushforward step law `avgBad_query_bind_eq`) and isolates the read-step
+charge as the standalone Fubini lemma the instantiation must match against the lazy run. -/
+section AveragedStateMeasureBad
+
+variable {ι : Type} {spec : OracleSpec ι}
+variable {ι' : Type} {spec' : OracleSpec ι'} [IsUniformSpec spec']
+variable {σ γ : Type}
+
+/-! ### Bare-measure averaged bad mass
+
+The `avgBad` scaffold below averages the per-state bad mass against a *probability*
+state law `μ : PMF (σ × Bool)`. That total-mass-1 constraint is never used: the telescoping
+identities and the free-monad induction only ever use `μ p` as an `ℝ≥0∞` weight. An
+**aborting** signing step, however, produces a *sub*-probability post-step state law (its
+total mass drops by the rejection mass), so a `PMF`-typed average cannot carry the charge
+invariant across it.
+
+This block re-states the whole scaffold over a **bare measure** `ν : σ × Bool → ℝ≥0∞`
+(no total-mass constraint), so the same telescoping carries sub-probability post-step laws.
+The `PMF` lemmas above are recovered verbatim as corollaries by instantiating `ν := fun p => μ p`.
+
+A caller (e.g. the deferred-sampling charge route) instantiates `avgBadM_le_of_steps_inv`
+directly at the sub-probability state laws produced by the aborting sign step. -/
+
+/-- **Bare-measure averaged bad mass.** As `avgBad`, but averaging against an arbitrary
+measure `ν : σ × Bool → ℝ≥0∞` rather than a probability law. The total-mass-1 constraint of
+`PMF` is never needed by the telescoping, so this version carries the sub-probability
+post-step laws emitted by an aborting step. -/
+noncomputable def avgBadM
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (oa : OracleComp spec γ) : ℝ≥0∞ :=
+  ∑' p : σ × Bool, ν p *
+    Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p]
+
+open scoped Classical in
+/-- `avgBadM` at a Dirac (single-point indicator) measure is the plain per-state bad
+probability. The bare-measure analogue of `avgBad_pure_state`. -/
+lemma avgBadM_pure_state
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (p₀ : σ × Bool) (oa : OracleComp spec γ) :
+    avgBadM impl (fun p => if p = p₀ then 1 else 0) oa =
+      Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p₀] := by
+  rw [avgBadM, tsum_eq_single p₀ (by intro p hp; rw [if_neg hp, zero_mul]), if_pos rfl, one_mul]
+
+open scoped Classical in
+/-- **Linearity of `avgBadM` in the state measure.** The bare-measure analogue of
+`avgBad_eq_tsum_pure`: the averaged bad mass over `ν` is the `ν`-weighted sum of the
+per-state (Dirac) bad masses. -/
+lemma avgBadM_eq_tsum_pure
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (oa : OracleComp spec γ) :
+    avgBadM impl ν oa =
+      ∑' s' : σ × Bool, ν s' * avgBadM impl (fun p => if p = s' then 1 else 0) oa := by
+  rw [avgBadM]
+  exact tsum_congr fun s' => by rw [avgBadM_pure_state]
+
+/-- **Pure base case of `avgBadM`.** With no queries, the bad mass is exactly the carried
+bad mass of the measure `ν` — the `ν`-mass on states with the flag already set. Bare-measure
+analogue of `avgBad_pure`. -/
+lemma avgBadM_pure
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (x : γ) :
+    avgBadM impl ν (pure x : OracleComp spec γ) =
+      ∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0) := by
+  rw [avgBadM]
+  refine tsum_congr fun p => ?_
+  rw [simulateQ_pure, StateT.run_pure]
+  rcases p with ⟨s, b⟩
+  cases b with
+  | false => simp
+  | true => simp [probEvent_pure]
+
+/-- **One-step telescoping of `avgBadM` (joint-law form).** Bare-measure analogue of
+`avgBad_query_bind_eq`: moves one query off the front and exposes the post-step joint law,
+holding for any impl and any measure `ν`. No probabilistic content — pure rearrangement. -/
+lemma avgBadM_query_bind_eq
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
+    avgBadM impl ν (query t >>= cont) =
+      ∑' p : σ × Bool, ν p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2] := by
+  rw [avgBadM]
+  refine tsum_congr fun p => ?_
+  congr 1
+  have hsim : (simulateQ impl (query t >>= cont)).run p =
+      (impl t).run p >>= fun z => (simulateQ impl (cont z.1)).run z.2 := by
+    simp [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+      OracleQuery.cont_query, StateT.run_bind]
+  rw [hsim, probEvent_bind_eq_tsum]
+
+/-- **Post-step joint measure of a query step (bare-measure form).** The measure over
+`(output, post-state)` produced by averaging the per-state impl step `Pr[= z | (impl t).run p]`
+against the state measure `ν`. Bare-measure analogue of `postStepJoint`; stated directly as a
+`tsum` since `ν` need not be a probability law. -/
+noncomputable def postStepJointM
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (z : spec.Range t × σ × Bool) : ℝ≥0∞ :=
+  ∑' p : σ × Bool, ν p * Pr[= z | (impl t).run p]
+
+open scoped Classical in
+/-- **Output-grouped telescoping of the bare-measure average.** Bare-measure analogue of
+`avgBad_telescope_eq_tsum_postStep`: the telescoped one-step average regroups as a single
+`tsum` over the post-step joint measure `postStepJointM impl ν t`, weighting each
+`(output, post-state)` pair by the Dirac bad mass at the post-state. Pure `tsum`-Fubini. -/
+lemma avgBadM_telescope_eq_tsum_postStep
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
+    (∑' p : σ × Bool, ν p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2]) =
+      ∑' z : spec.Range t × σ × Bool,
+        postStepJointM impl ν t z *
+          avgBadM impl (fun p => if p = z.2 then 1 else 0) (cont z.1) := by
+  classical
+  have hstep : (∑' p : σ × Bool, ν p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2]) =
+      ∑' p : σ × Bool, ∑' z : spec.Range t × σ × Bool,
+          ν p * (Pr[= z | (impl t).run p] *
+            avgBadM impl (fun q => if q = z.2 then 1 else 0) (cont z.1)) := by
+    refine tsum_congr fun p => ?_
+    rw [← ENNReal.tsum_mul_left]
+    refine tsum_congr fun z => ?_
+    rw [avgBadM_pure_state, ← mul_assoc]
+  rw [hstep, ENNReal.tsum_comm]
+  refine tsum_congr fun z => ?_
+  rw [postStepJointM, ← ENNReal.tsum_mul_right]
+  refine tsum_congr fun p => ?_
+  rw [mul_assoc]
+
+/-- **Per-output post-step state measure.** Grouping the post-step joint measure
+`postStepJointM impl ν t` by the query *output* `u`: the resulting state measure assigns to
+each post-state `s` the joint mass of producing `(u, s)`. The state coordinate of the
+output-`u` slice of the post-step joint measure. -/
+noncomputable def postStepOutM
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (u : spec.Range t) (s : σ × Bool) : ℝ≥0∞ :=
+  postStepJointM impl ν t (u, s)
+
+open scoped Classical in
+/-- **Output-grouped one-step telescoping of `avgBadM`.** The telescoped one-step average
+regroups as a `tsum` over the query *output* `u`, each weighted by the averaged bad mass of
+the continuation `cont u` run from the per-output post-step state measure
+`postStepOutM impl ν t u`. This is the form the threaded-charge induction consumes: it
+applies the inductive hypothesis once per output, at a genuine state *measure* (not a Dirac),
+so the per-target charge of the post-step measure can be bounded as a measure (avoiding the
+`∑`-of-`⨆` blow-up of the per-post-state Dirac grouping). -/
+lemma avgBadM_query_bind_eq_tsum_output
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
+    avgBadM impl ν (query t >>= cont) =
+      ∑' u : spec.Range t, avgBadM impl (postStepOutM impl ν t u) (cont u) := by
+  classical
+  rw [avgBadM_query_bind_eq, avgBadM_telescope_eq_tsum_postStep, ENNReal.tsum_prod']
+  refine tsum_congr fun u => ?_
+  rw [avgBadM_eq_tsum_pure]
+  refine tsum_congr fun s => ?_
+  rw [postStepOutM]
+
+/-- **Bare-measure averaged-bad telescoping with a state-measure invariant.** Bare-measure
+analogue of `avgBad_le_of_steps_inv`: threads a predicate `Inv : (σ × Bool → ℝ≥0∞) → Prop`
+on the state *measure* through the free-monad induction. The conclusion holds for every
+measure `ν` satisfying `Inv ν`, and the two per-step premises may assume `Inv ν`. The
+total-mass-1 constraint is never used, so an aborting step's sub-probability post-step law is
+admissible — which is exactly why this generalization is needed for the charge route. -/
+theorem avgBadM_le_of_steps_inv
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (bound : {β : Type} → OracleComp spec β → (σ × Bool → ℝ≥0∞) → ℝ≥0∞)
+    (Inv : (σ × Bool → ℝ≥0∞) → Prop)
+    (h_pure : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (x : γ),
+      (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0))
+        ≤ bound (pure x : OracleComp spec γ) ν)
+    (h_step : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain)
+      (cont : spec.Range t → OracleComp spec γ),
+      (∀ (ν' : σ × Bool → ℝ≥0∞), Inv ν' → ∀ (u : spec.Range t),
+        avgBadM impl ν' (cont u) ≤ bound (cont u) ν') →
+      (∑' p : σ × Bool, ν p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2])
+        ≤ bound (query t >>= cont) ν)
+    (oa : OracleComp spec γ) :
+    ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → avgBadM impl ν oa ≤ bound oa ν := by
+  induction oa using OracleComp.inductionOn with
+  | pure x =>
+      intro ν hν
+      rw [avgBadM_pure]
+      exact h_pure ν hν x
+  | @query_bind t cont ih =>
+      intro ν hν
+      rw [avgBadM_query_bind_eq]
+      exact h_step ν hν t cont (fun ν' hν' u => ih u ν' hν')
+
+/-- **Bare-measure averaged-bad telescoping (invariant-free corollary).** The
+`Inv := fun _ => True` specialization of `avgBadM_le_of_steps_inv`. -/
+theorem avgBadM_le_of_steps
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (bound : {β : Type} → OracleComp spec β → (σ × Bool → ℝ≥0∞) → ℝ≥0∞)
+    (h_pure : ∀ (ν : σ × Bool → ℝ≥0∞) (x : γ),
+      (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0))
+        ≤ bound (pure x : OracleComp spec γ) ν)
+    (h_step : ∀ (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain)
+      (cont : spec.Range t → OracleComp spec γ),
+      (∀ (ν' : σ × Bool → ℝ≥0∞) (u : spec.Range t),
+        avgBadM impl ν' (cont u) ≤ bound (cont u) ν') →
+      (∑' p : σ × Bool, ν p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2])
+        ≤ bound (query t >>= cont) ν)
+    (oa : OracleComp spec γ) :
+    ∀ (ν : σ × Bool → ℝ≥0∞), avgBadM impl ν oa ≤ bound oa ν := by
+  intro ν
+  exact avgBadM_le_of_steps_inv impl bound (fun _ => True)
+    (fun ν _ x => h_pure ν x)
+    (fun ν _ t cont ih => h_step ν t cont (fun ν' u => ih ν' trivial u))
+    oa ν trivial
+
+/-- **Averaged bad mass over a state measure.** The probability the bad flag is set after
+`(simulateQ impl oa).run p`, *averaged* over the starting state `p` drawn from the state
+law `μ : PMF (σ × Bool)`. This is the quantity an eager (commit-upstream) handler must be
+bounded by: the averaging happens over the state law `μ` rather than at a fixed reachable
+state, so the deterministic per-state read charge `1_{mc ∈ slot(p)}` averages to the
+genuine guessing mass `Pr_{p∼μ}[mc ∈ slot(p)]`. Specializing `μ := PMF.pure (s, false)`
+recovers the plain per-state bad probability `Pr[bad | (simulateQ impl oa).run (s, false)]`
+(see `avgBad_pure_state`). -/
+noncomputable def avgBad
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (oa : OracleComp spec γ) : ℝ≥0∞ :=
+  ∑' p : σ × Bool, μ p *
+    Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p]
+
+/-- **Bridge: `avgBad` is `avgBadM` at the underlying measure.** The `PMF`-typed average is
+definitionally the bare-measure average against the coerced measure `fun p => μ p`. This lets
+every `PMF` corollary be derived from its bare-measure counterpart, and lets a caller move a
+`PMF` hypothesis into the bare-measure machinery. -/
+lemma avgBad_eq_avgBadM
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (oa : OracleComp spec γ) :
+    avgBad impl μ oa = avgBadM impl (fun p => μ p) oa := rfl
+
+/-- `avgBad` at a Dirac state measure is the plain per-state bad probability: the average
+over `PMF.pure p₀` collapses to the single term at `p₀`. This is the bridge that reduces
+the averaged invariant back to the concrete eager probability at the empty-cache start
+state (`μ = δ_∅`). -/
+lemma avgBad_pure_state
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (p₀ : σ × Bool) (oa : OracleComp spec γ) :
+    avgBad impl (PMF.pure p₀) oa =
+      Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p₀] := by
+  rw [avgBad, tsum_eq_single p₀ (by intro p hp; rw [PMF.pure_apply, if_neg hp, zero_mul]),
+    PMF.pure_apply, if_pos rfl, one_mul]
+
+/-- **Linearity of `avgBad` in the state law.** The averaged bad mass over a state law `μ`
+is the `μ`-weighted average of the per-state (Dirac) bad masses. Immediate from
+`avgBad_pure_state` under the `tsum` defining `avgBad`. This is the structural fact that
+lets the output-grouped telescoping fold the inductive hypothesis at an *unnormalized*
+post-step measure: a `tsum`-weighted sum of Dirac `avgBad`s is itself an `avgBad` at the
+weighting law. -/
+lemma avgBad_eq_tsum_pure
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (oa : OracleComp spec γ) :
+    avgBad impl μ oa =
+      ∑' s' : σ × Bool, μ s' * avgBad impl (PMF.pure s') oa := by
+  rw [avgBad]
+  exact tsum_congr fun s' => by rw [avgBad_pure_state]
+
+/-- **Pure base case of `avgBad`.** With no queries, the run leaves the state untouched and
+the bad mass is exactly the carried bad mass of the state law `μ` — the probability `μ`
+assigns to states with the flag already set. -/
+lemma avgBad_pure
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (x : γ) :
+    avgBad impl μ (pure x : OracleComp spec γ) =
+      ∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0) := by
+  rw [avgBad]
+  refine tsum_congr fun p => ?_
+  rw [simulateQ_pure, StateT.run_pure]
+  rcases p with ⟨s, b⟩
+  cases b with
+  | false => simp
+  | true => simp [probEvent_pure]
+
+/-- **One-step telescoping of `avgBad` (joint-law form).** Averaging the bad mass of a
+`query t >>= cont` run over the state law `μ` equals averaging, over `μ` *and* the
+per-state impl step `(impl t).run p`, the bad mass of the continuation run started from the
+post-step state. This is the averaged analogue of `expectedQuerySlack_query_bind`: it moves
+one query off the front and exposes the post-step joint law `(p, z)` over which the next
+`avgBad` is taken. No probabilistic content yet — it is a pure rearrangement
+(`probEvent_bind_eq_tsum` inside the average) and holds for *any* impl and `μ`. -/
+lemma avgBad_query_bind_eq
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
+    avgBad impl μ (query t >>= cont) =
+      ∑' p : σ × Bool, μ p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2] := by
+  rw [avgBad]
+  refine tsum_congr fun p => ?_
+  congr 1
+  have hsim : (simulateQ impl (query t >>= cont)).run p =
+      (impl t).run p >>= fun z => (simulateQ impl (cont z.1)).run z.2 := by
+    simp [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
+      OracleQuery.cont_query, StateT.run_bind]
+  rw [hsim, probEvent_bind_eq_tsum]
+
+/-- **Post-step joint law of a query step.** The law over `(output, post-state)` produced by
+drawing the starting state from `μ` and running one impl step `(impl t).run p`. This is the
+`SPMF`-valued joint measure whose first marginal is the output law and whose conditional
+second marginal (given an output) is the post-step state law the inductive hypothesis is
+folded at. -/
+noncomputable def postStepJoint
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (t : spec.Domain) :
+    SPMF (spec.Range t × σ × Bool) :=
+  (liftM μ : SPMF (σ × Bool)) >>= fun p => evalDist ((impl t).run p)
+
+/-- The post-step joint law evaluated pointwise: the `μ`-average of the per-state impl-step
+output probability. -/
+lemma postStepJoint_apply
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (t : spec.Domain) (z : spec.Range t × σ × Bool) :
+    postStepJoint impl μ t z = ∑' p : σ × Bool, μ p * Pr[= z | (impl t).run p] := by
+  rw [postStepJoint, SPMF.bind_apply_eq_tsum]
+  refine tsum_congr fun p => ?_
+  rw [SPMF.liftM_apply]
+  rfl
+
+/-- **Output-grouped telescoping of the eager average.** The telescoped one-step eager
+average (the right-hand side of `avgBad_query_bind_eq`) regroups as a single `tsum` over the
+post-step joint law `postStepJoint impl μ t`, weighting each `(output u, post-state s')` pair
+by the Dirac bad mass `avgBad impl δ_{s'} (cont u)`. This is the pure `tsum`-Fubini
+rearrangement that exposes the post-step state `s'` (grouped by output `u`) so the inductive
+hypothesis can be folded at the genuine post-step law rather than collapsed to a Dirac at a
+single reachable state. No probabilistic content — `PMF.bind` Fubini plus `avgBad_pure_state`. -/
+lemma avgBad_telescope_eq_tsum_postStep
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (μ : PMF (σ × Bool)) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
+    (∑' p : σ × Bool, μ p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2]) =
+      ∑' z : spec.Range t × σ × Bool,
+        postStepJoint impl μ t z * avgBad impl (PMF.pure z.2) (cont z.1) := by
+  classical
+  -- Pull the `μ p` weight inside the inner `tsum` and replace the Dirac bad mass.
+  have hstep : (∑' p : σ × Bool, μ p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2]) =
+      ∑' p : σ × Bool, ∑' z : spec.Range t × σ × Bool,
+          μ p * (Pr[= z | (impl t).run p] *
+            avgBad impl (PMF.pure z.2) (cont z.1)) := by
+    refine tsum_congr fun p => ?_
+    rw [← ENNReal.tsum_mul_left]
+    refine tsum_congr fun z => ?_
+    rw [avgBad_pure_state, ← mul_assoc]
+  rw [hstep, ENNReal.tsum_comm]
+  refine tsum_congr fun z => ?_
+  rw [postStepJoint_apply, ← ENNReal.tsum_mul_right]
+  refine tsum_congr fun p => ?_
+  rw [mul_assoc]
+
+/-! ### Read-step Fubini charge equality (the genuine new content)
+
+The eager read at a structural ghost hit pays a *deterministic* charge `1_{mc ∈ slot(p)}`
+at the committed state `p`. The averaged-state-measure invariant turns this into a genuine
+probability by averaging over the state law `μ`:
+
+  `E_{p∼μ}[1_{mc ∈ slot(p)}] = Pr_{p∼μ}[mc ∈ slot(p)]`.
+
+When `μ` is the pushforward of the upstream commit draws into the slot, this collapses (by
+`tsum`-swap over the pending draws) to the *same* mass the lazy handler charges at the read.
+The lemmas here express that collapse abstractly: a membership-indicator average over a
+**pushforward measure** equals the draw's hit probability. The single-pending case is the
+framework analogue of the banked `probOutput_lazyGhostFire_one`. -/
+
+/-- **Single-pending read-charge Fubini equality.** Let `draw : PMF κ` be one pending draw,
+let `place : κ → σ × Bool` push a drawn value into the slot, and let `hit : σ × Bool → ℝ≥0∞`
+read the (deterministic) charge off the resulting state. Averaging the read charge over the
+pushforward law `draw.map place` equals averaging `hit ∘ place` directly over `draw`. This is
+the pure change-of-variables that moves the averaging site from the *state law* (eager view:
+the slot is already populated) to the *draw* (lazy view: the value is sampled at read time);
+the eager `1_{mc ∈ slot}` after `place` becomes the lazy `decide (w = mc)` charge under the
+draw. The multi-pending case is the `tsum`-swap over independent draws (the genuine residual
+isolated below). -/
+lemma tsum_pushforward_eq_tsum_draw {κ : Type}
+    (draw : PMF κ) (place : κ → σ × Bool) (hit : σ × Bool → ℝ≥0∞) :
+    (∑' p : σ × Bool, (draw.map place) p * hit p) =
+      ∑' w : κ, draw w * hit (place w) := by
+  classical
+  simp only [PMF.map_apply, ← ENNReal.tsum_mul_right]
+  rw [ENNReal.tsum_comm]
+  refine tsum_congr fun w => ?_
+  rw [tsum_eq_single (place w) (by intro p hp; rw [if_neg hp, zero_mul]), if_pos rfl]
+
+/-- **Membership-indicator average over a pushforward equals hit probability.** Specialize
+`tsum_pushforward_eq_tsum_draw` with the read charge being the structural membership
+indicator of the read point `mc` in the slot reached by `place`. The eager averaged
+read-hit charge `E_{p∼μ}[1_{mc ∈ slot(p)}]` (here `μ = draw.map place`, `slot` extracted by
+`testMem`) equals the draw's mass on values that `place` maps to a hit. With
+`testMem (place w) = decide (w hits mc)` this is exactly the lazy single-pending fire mass
+(`probOutput_lazyGhostFire_one`). -/
+lemma tsum_pushforward_mem_eq_draw_hit {κ : Type}
+    (draw : PMF κ) (place : κ → σ × Bool) (testMem : σ × Bool → Bool) :
+    (∑' p : σ × Bool, (draw.map place) p * (if testMem p = true then 1 else 0)) =
+      ∑' w : κ, draw w * (if testMem (place w) = true then 1 else 0) :=
+  tsum_pushforward_eq_tsum_draw draw place (fun p => if testMem p = true then 1 else 0)
+
+/-! ### Averaged-bad telescoping skeleton
+
+The fully-proven free-monad telescoping for the averaged invariant. The theorem
+`avgBad_le_of_steps` reduces the averaged eager bad mass `avgBad impl_e μ oa` to a target
+`bound : OracleComp spec γ → PMF (σ × Bool) → ℝ≥0∞` supplied by the caller (the lazy /
+deferred-sampling charge), provided two per-step premises hold:
+
+* `h_pure`: at a `pure` leaf the carried bad mass of `μ` is below the target's leaf value;
+* `h_step`: at each `query t >>= cont`, the one-step telescoped eager average
+  (`avgBad_query_bind_eq`) — i.e. the impl-`t` push of `μ` into the continuation average —
+  is dominated by the target at the same point.
+
+The proof is a pure free-monad induction: `pure` discharges by `h_pure`, and `query_bind`
+rewrites the eager side by `avgBad_query_bind_eq` and discharges by `h_step` (whose premise
+in turn folds the inductive hypothesis through the post-step law). All free-monad
+bookkeeping is handled here; the *probabilistic* content lives entirely in discharging
+`h_step` at the read query, where the caller must supply the Fubini charge equality
+(`tsum_pushforward_mem_eq_draw_hit`) recoupling the post-read state law `μ'` — the genuine
+residual isolated for the instantiation. -/
+
+/-- **Averaged-bad telescoping with a state-law invariant.** A strict generalization of
+`avgBad_le_of_steps` that threads a predicate `Inv : PMF (σ × Bool) → Prop` on the state law
+through the free-monad induction. The conclusion holds for every `μ` satisfying `Inv μ`, and
+the two per-step premises may *assume* `Inv μ`:
+
+* `h_pure` discharges the `pure` leaf assuming `Inv μ`;
+* `h_step` discharges one telescoped query step assuming `Inv μ`, and is handed an inductive
+  hypothesis that fires only at post-step laws `μ'` for which `Inv μ'` holds — so `h_step` is
+  responsible for re-establishing `Inv` on every post-step law it feeds the IH.
+
+This is the shape required by the deferred-sampling read step: the eager read flips the bad
+flag deterministically at a structural ghost-hit state, so a *per-state* bound is false; the
+collapse to the lazy fire mass only happens once the average is taken against a state law that
+is a pushforward of the upstream commit draws. The invariant carries exactly that pushforward
+structure across the induction (preserved by reads — the ghost cache is untouched — grown by
+signs — one more draw — and holding at the empty-cache Dirac start). The probabilistic content
+still lives entirely in discharging `h_step`; the framework supplies only the `Inv` plumbing. -/
+theorem avgBad_le_of_steps_inv
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (bound : {β : Type} → OracleComp spec β → PMF (σ × Bool) → ℝ≥0∞)
+    (Inv : PMF (σ × Bool) → Prop)
+    (h_pure : ∀ (μ : PMF (σ × Bool)), Inv μ → ∀ (x : γ),
+      (∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0))
+        ≤ bound (pure x : OracleComp spec γ) μ)
+    (h_step : ∀ (μ : PMF (σ × Bool)), Inv μ → ∀ (t : spec.Domain)
+      (cont : spec.Range t → OracleComp spec γ),
+      (∀ (μ' : PMF (σ × Bool)), Inv μ' → ∀ (u : spec.Range t),
+        avgBad impl μ' (cont u) ≤ bound (cont u) μ') →
+      (∑' p : σ × Bool, μ p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2])
+        ≤ bound (query t >>= cont) μ)
+    (oa : OracleComp spec γ) :
+    ∀ (μ : PMF (σ × Bool)), Inv μ → avgBad impl μ oa ≤ bound oa μ := by
+  induction oa using OracleComp.inductionOn with
+  | pure x =>
+      intro μ hμ
+      rw [avgBad_pure]
+      exact h_pure μ hμ x
+  | @query_bind t cont ih =>
+      intro μ hμ
+      rw [avgBad_query_bind_eq]
+      exact h_step μ hμ t cont (fun μ' hμ' u => ih u μ' hμ')
+
+/-- **Averaged-bad telescoping (invariant-free corollary).** The `Inv := fun _ => True`
+specialization of `avgBad_le_of_steps_inv`: the original telescoping shape, recovered so
+callers that do not need a state-law invariant are unaffected. -/
+theorem avgBad_le_of_steps
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (bound : {β : Type} → OracleComp spec β → PMF (σ × Bool) → ℝ≥0∞)
+    (h_pure : ∀ (μ : PMF (σ × Bool)) (x : γ),
+      (∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0))
+        ≤ bound (pure x : OracleComp spec γ) μ)
+    (h_step : ∀ (μ : PMF (σ × Bool)) (t : spec.Domain)
+      (cont : spec.Range t → OracleComp spec γ),
+      (∀ (μ' : PMF (σ × Bool)) (u : spec.Range t),
+        avgBad impl μ' (cont u) ≤ bound (cont u) μ') →
+      (∑' p : σ × Bool, μ p *
+        ∑' z : spec.Range t × σ × Bool,
+          Pr[= z | (impl t).run p] *
+            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
+              (simulateQ impl (cont z.1)).run z.2])
+        ≤ bound (query t >>= cont) μ)
+    (oa : OracleComp spec γ) :
+    ∀ (μ : PMF (σ × Bool)), avgBad impl μ oa ≤ bound oa μ := by
+  intro μ
+  exact avgBad_le_of_steps_inv impl bound (fun _ => True)
+    (fun μ _ x => h_pure μ x)
+    (fun μ _ t cont ih => h_step μ t cont (fun μ' u => ih μ' trivial u))
+    oa μ trivial
+
+/-- **Total post-step joint mass equals the `ν`-weighted per-state step mass.** Marginalizing
+the post-step joint measure over all `(output, post-state)` pairs gives the `ν`-average of the
+per-state impl-step total mass `∑' z, Pr[= z | (impl t).run p]`. -/
+lemma tsum_postStepJointM_eq
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) :
+    (∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z)
+      = ∑' p : σ × Bool, ν p *
+          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] := by
+  unfold postStepJointM
+  rw [ENNReal.tsum_comm]
+  exact tsum_congr fun p => ENNReal.tsum_mul_left
+
+/-- **Per-output post-step mass is bounded by the pre-step mass.** Each per-output slice
+`postStepOutM impl ν t u` has total mass at most the total mass of `ν`, since the per-state
+step `(impl t).run p` is a sub-probability. The `h_massU` premise of
+`avgBadM_le_threaded_linear`. -/
+lemma tsum_postStepOutM_single_le
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (u : spec.Range t) :
+    (∑' s : σ × Bool, postStepOutM impl ν t u s) ≤ ∑' p : σ × Bool, ν p := by
+  calc (∑' s : σ × Bool, postStepOutM impl ν t u s)
+      ≤ ∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z := by
+        simp only [postStepOutM]
+        rw [ENNReal.tsum_prod' (f := fun z => postStepJointM impl ν t z)]
+        exact ENNReal.le_tsum u
+    _ = ∑' p : σ × Bool, ν p *
+          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] :=
+        tsum_postStepJointM_eq impl ν t
+    _ ≤ ∑' p : σ × Bool, ν p :=
+        ENNReal.tsum_le_tsum fun p => mul_le_of_le_one_right zero_le' tsum_probOutput_le_one
+
+/-- **Total post-step mass is bounded by the pre-step mass.** Summed over both the query
+output `u` and the post-state, the post-step joint mass is at most the total mass of `ν`. The
+`h_mass` premise of `avgBadM_le_threaded_linear`. -/
+lemma tsum_tsum_postStepOutM_le
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) :
+    (∑' u : spec.Range t, ∑' s : σ × Bool, postStepOutM impl ν t u s)
+      ≤ ∑' p : σ × Bool, ν p := by
+  calc (∑' u : spec.Range t, ∑' s : σ × Bool, postStepOutM impl ν t u s)
+      = ∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z := by
+        simp only [postStepOutM]
+        rw [ENNReal.tsum_prod' (f := fun z => postStepJointM impl ν t z)]
+    _ = ∑' p : σ × Bool, ν p *
+          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] :=
+        tsum_postStepJointM_eq impl ν t
+    _ ≤ ∑' p : σ × Bool, ν p :=
+        ENNReal.tsum_le_tsum fun p => mul_le_of_le_one_right zero_le' tsum_probOutput_le_one
+
+open scoped Classical in
+/-- **Weighted post-step rearrangement.** Summing any post-state functional `F` against the
+post-step measure (over output `u` and post-state `s`) equals the `ν`-average of the per-state
+expected value of `F` after one impl step. The Fubini bridge used to push a per-state charge
+bound (e.g. ghost-size or membership-charge growth) through the post-step measure. -/
+lemma tsum_tsum_postStepOutM_mul
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (F : σ × Bool → ℝ≥0∞) :
+    (∑' u : spec.Range t, ∑' s : σ × Bool, postStepOutM impl ν t u s * F s)
+      = ∑' p : σ × Bool, ν p *
+          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] * F z.2 := by
+  classical
+  calc (∑' u : spec.Range t, ∑' s : σ × Bool, postStepOutM impl ν t u s * F s)
+      = ∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z * F z.2 := by
+        simp only [postStepOutM]
+        rw [ENNReal.tsum_prod' (f := fun z => postStepJointM impl ν t z * F z.2)]
+    _ = ∑' z : spec.Range t × σ × Bool,
+          (∑' p : σ × Bool, ν p * Pr[= z | (impl t).run p]) * F z.2 := by
+        refine tsum_congr fun z => ?_
+        rw [postStepJointM]
+    _ = ∑' z : spec.Range t × σ × Bool,
+          ∑' p : σ × Bool, ν p * (Pr[= z | (impl t).run p] * F z.2) := by
+        refine tsum_congr fun z => ?_
+        rw [← ENNReal.tsum_mul_right]
+        exact tsum_congr fun p => by ring
+    _ = ∑' p : σ × Bool, ν p *
+          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] * F z.2 := by
+        rw [ENNReal.tsum_comm]
+        exact tsum_congr fun p => ENNReal.tsum_mul_left
+
+/-- **Threaded linear (mass-weighted) accumulator bound for `avgBadM`.** A reusable
+free-monad telescoping that, unlike `avgBadM_le_of_steps_inv`, bakes in a *linear,
+mass-weighted, additive* bound shape so it telescopes across the output-branching of a
+query step (where a `⨆`-ceiling bound does not).
+
+The bound carried for a measure `ν` at read/sign budgets `(qHb, qSb)` is
+`carriedBad ν + qHb · (K ν · ε) + (mass ν) · qHb · qSb · (g · ε)`,
+where `carriedBad ν := ∑' p, ν p · 1_{p.2}`, `mass ν := ∑' p, ν p`, `K` is an arbitrary
+charge functional, and `g, ε : ℝ≥0∞` are constants.
+
+Each query domain point `t` is classified by two decidable predicates `pHb` (a "read":
+consumes a read unit, pays its hit charge `≤ K ν · ε` into the post-step carried bad mass)
+and `pSb` (a "sign": consumes a sign unit, raises the post-step charge by `≤ g · mass ν`).
+Steps that fire neither predicate are inert (preserve everything). The numeric premises,
+summed over the query output `u` against the per-output post-step measures
+`νu := postStepOutM impl ν t u`, are:
+
+* `h_carry` — the carried bad mass telescopes, paying the read hit charge on a read step
+  (the charge `≤ K ν · ε` is provided by the carried invariant `Inv ν`);
+* `h_mass` — the total mass is non-increasing across the step;
+* `h_K` — the charge telescopes, growing by `≤ g · mass ν` on a sign step;
+* `h_massU` — each per-output mass is bounded by the pre-step mass (so the IH's
+  sub-probability hypothesis is re-established);
+* `h_inv` — the invariant `Inv` is preserved across every per-output post-step measure.
+
+The read charge bound `Inv ν → C(ν, ·) ≤ K ν · ε` is in general only an *averaged* fact
+(the rejected commit lands at the read target with probability `≤ ε`), so it cannot be a
+universal hypothesis over arbitrary `ν`; it is carried as the invariant `Inv` and
+re-established incrementally on each post-step measure. The read/sign budgets are threaded
+by `isQueryBoundP_query_bind_iff`; the budget decrement on the fired predicate exactly
+absorbs the charge increment. -/
+theorem avgBadM_le_threaded_linear
+    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
+    (K : (σ × Bool → ℝ≥0∞) → ℝ≥0∞) (g ε : ℝ≥0∞)
+    (Inv : (σ × Bool → ℝ≥0∞) → Prop)
+    (pHb pSb : ι → Prop) [DecidablePred pHb] [DecidablePred pSb]
+    (hpExcl : ∀ t, pHb t → pSb t → False)
+    (h_carry : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain),
+      (∑' u : spec.Range t,
+          ∑' p : σ × Bool, postStepOutM impl ν t u p * (if p.2 = true then 1 else 0))
+        ≤ (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0)) +
+            (if pHb t then K ν * ε else 0))
+    (h_mass : ∀ (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain),
+      (∑' u : spec.Range t, ∑' p : σ × Bool, postStepOutM impl ν t u p)
+        ≤ ∑' p : σ × Bool, ν p)
+    (h_massU : ∀ (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (u : spec.Range t),
+      (∑' p : σ × Bool, postStepOutM impl ν t u p) ≤ ∑' p : σ × Bool, ν p)
+    (h_K : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain),
+      (∑' u : spec.Range t, K (postStepOutM impl ν t u))
+        ≤ K ν + (if pSb t then g * (∑' p : σ × Bool, ν p) else 0))
+    (h_inv : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain) (u : spec.Range t),
+      Inv (postStepOutM impl ν t u))
+    (oa : OracleComp spec γ) :
+    ∀ (ν : σ × Bool → ℝ≥0∞) (qHb qSb : ℕ),
+      Inv ν → (∑' p : σ × Bool, ν p) ≤ 1 →
+      oa.IsQueryBoundP pHb qHb → oa.IsQueryBoundP pSb qSb →
+      avgBadM impl ν oa
+        ≤ (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0)) +
+            (qHb : ℝ≥0∞) * (K ν * ε) +
+            (∑' p : σ × Bool, ν p) * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
+  classical
+  induction oa using OracleComp.inductionOn with
+  | pure x =>
+      intro ν qHb qSb _ _ _ _
+      rw [avgBadM_pure]
+      exact le_add_right (le_add_right le_rfl)
+  | @query_bind t cont ih =>
+      intro ν qHb qSb hInv hν hqH hqS
+      rw [avgBadM_query_bind_eq_tsum_output]
+      -- Abbreviations.
+      set cb : (σ × Bool → ℝ≥0∞) → ℝ≥0∞ :=
+        fun μ => ∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0) with hcb
+      set M : (σ × Bool → ℝ≥0∞) → ℝ≥0∞ := fun μ => ∑' p : σ × Bool, μ p with hM
+      set νu : spec.Range t → (σ × Bool → ℝ≥0∞) := fun u => postStepOutM impl ν t u with hνu
+      -- Per-output mass ≤ 1, from `h_massU` and `hν`.
+      have hνuMass : ∀ u, M (νu u) ≤ 1 := fun u =>
+        le_trans (h_massU ν t u) hν
+      -- The invariant is preserved on every per-output post-step measure.
+      have hInvU : ∀ u, Inv (νu u) := fun u => h_inv ν hInv t u
+      rw [isQueryBoundP_query_bind_iff] at hqH hqS
+      obtain ⟨hqHfst, hqHcont⟩ := hqH
+      obtain ⟨hqSfst, hqScont⟩ := hqS
+      -- Three cases by which predicate fires.
+      by_cases hHb : pHb t
+      · -- Read step: `pHb t` true, `pSb t` false; budgets `(qHb-1, qSb)`.
+        have hSbF : ¬ pSb t := fun hSb => hpExcl t hHb hSb
+        have hpos : 0 < qHb := by
+          rcases hqHfst with h | h
+          · exact absurd hHb h
+          · exact h
+        simp only [hHb, if_pos, hSbF, if_neg, not_false_eq_true] at hqHcont hqScont
+        have hqHcont : ∀ u, (cont u).IsQueryBoundP pHb (qHb - 1) := hqHcont
+        have hqScont' : ∀ u, (cont u).IsQueryBoundP pSb qSb := hqScont
+        -- Per-output IH, summed.
+        calc (∑' u : spec.Range t, avgBadM impl (νu u) (cont u))
+            ≤ ∑' u : spec.Range t,
+                (cb (νu u) + ((qHb - 1 : ℕ) : ℝ≥0∞) * (K (νu u) * ε) +
+                  M (νu u) * ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε)) :=
+              ENNReal.tsum_le_tsum fun u =>
+                ih u (νu u) (qHb - 1) qSb (hInvU u) (hνuMass u) (hqHcont u) (hqScont' u)
+          _ = (∑' u, cb (νu u)) +
+                ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * (∑' u, K (νu u)) +
+                ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (∑' u, M (νu u)) := by
+              rw [ENNReal.tsum_add, ENNReal.tsum_add, ← ENNReal.tsum_mul_left,
+                ← ENNReal.tsum_mul_left]
+              congr 1
+              · congr 1
+                exact tsum_congr fun u => by ring
+              · exact tsum_congr fun u => by ring
+          _ ≤ (cb ν + K ν * ε) +
+                ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * (K ν) +
+                ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (M ν) := by
+              refine add_le_add (add_le_add ?_ ?_) ?_
+              · have := h_carry ν hInv t; simpa [hcb, hνu, hHb] using this
+              · gcongr
+                have := h_K ν hInv t; simpa [hνu, hSbF] using this
+              · gcongr
+                have := h_mass ν t; simpa [hM, hνu] using this
+          _ ≤ cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
+                M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
+              have hsucc : ((qHb - 1 : ℕ) : ℝ≥0∞) + 1 = (qHb : ℝ≥0∞) := by
+                rw [show ((qHb - 1 : ℕ) : ℝ≥0∞) + 1 = (((qHb - 1) + 1 : ℕ) : ℝ≥0∞) by
+                  push_cast; ring, Nat.sub_add_cancel hpos]
+              -- Charge term: `(K ν · ε) + (qHb-1)·ε·K ν = qHb·(K ν · ε)`.
+              have hch : K ν * ε + ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * K ν
+                  = (qHb : ℝ≥0∞) * (K ν * ε) := by
+                rw [← hsucc]; ring
+              -- Future term: `(qHb-1) ≤ qHb`.
+              have hfut : ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * M ν
+                  ≤ M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
+                rw [show M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε)
+                      = ((qHb : ℝ≥0∞)) * (qSb : ℝ≥0∞) * (g * ε) * M ν by ring]
+                gcongr
+                exact_mod_cast Nat.sub_le qHb 1
+              calc cb ν + K ν * ε + ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * K ν +
+                    ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * M ν
+                  = cb ν + (K ν * ε + ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * K ν) +
+                      ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * M ν := by ring
+                _ ≤ cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
+                      M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
+                    rw [hch]; gcongr
+      · by_cases hSb : pSb t
+        · -- Sign step: `pSb t` true, `pHb t` false; budgets `(qHb, qSb-1)`.
+          have hpos : 0 < qSb := by
+            rcases hqSfst with h | h
+            · exact absurd hSb h
+            · exact h
+          simp only [hHb, if_neg, not_false_eq_true, hSb, if_pos] at hqHcont hqScont
+          have hqHcont' : ∀ u, (cont u).IsQueryBoundP pHb qHb := hqHcont
+          have hqScont' : ∀ u, (cont u).IsQueryBoundP pSb (qSb - 1) := hqScont
+          calc (∑' u : spec.Range t, avgBadM impl (νu u) (cont u))
+              ≤ ∑' u : spec.Range t,
+                  (cb (νu u) + (qHb : ℝ≥0∞) * (K (νu u) * ε) +
+                    M (νu u) * (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε)) :=
+                ENNReal.tsum_le_tsum fun u =>
+                  ih u (νu u) qHb (qSb - 1) (hInvU u) (hνuMass u) (hqHcont' u) (hqScont' u)
+            _ = (∑' u, cb (νu u)) +
+                  (qHb : ℝ≥0∞) * ε * (∑' u, K (νu u)) +
+                  (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε) * (∑' u, M (νu u)) := by
+                rw [ENNReal.tsum_add, ENNReal.tsum_add, ← ENNReal.tsum_mul_left,
+                  ← ENNReal.tsum_mul_left]
+                congr 1
+                · congr 1
+                  exact tsum_congr fun u => by ring
+                · exact tsum_congr fun u => by ring
+            _ ≤ cb ν +
+                  (qHb : ℝ≥0∞) * ε * (K ν + g * M ν) +
+                  (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε) * (M ν) := by
+                refine add_le_add (add_le_add ?_ ?_) ?_
+                · have := h_carry ν hInv t; simpa [hcb, hνu, hHb] using this
+                · gcongr
+                  have := h_K ν hInv t; simpa [hM, hνu, hSb] using this
+                · gcongr
+                  have := h_mass ν t; simpa [hM, hνu] using this
+            _ ≤ cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
+                  M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
+                have hsucc : ((qSb - 1 : ℕ) : ℝ≥0∞) + 1 = (qSb : ℝ≥0∞) := by
+                  rw [show ((qSb - 1 : ℕ) : ℝ≥0∞) + 1 = (((qSb - 1) + 1 : ℕ) : ℝ≥0∞) by
+                    push_cast; ring, Nat.sub_add_cancel hpos]
+                -- Charge: `qHb·ε·(K ν + g·M ν) = qHb·K ν·ε + qHb·g·ε·M ν`; the second piece
+                -- combines with the future term via the `qSb-1 → qSb` increment.
+                refine le_of_eq ?_
+                rw [show cb ν + (qHb : ℝ≥0∞) * ε * (K ν + g * M ν) +
+                      (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε) * (M ν)
+                    = cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
+                      M ν * (qHb : ℝ≥0∞) * (((qSb - 1 : ℕ) : ℝ≥0∞) + 1) * (g * ε) by ring,
+                  hsucc]
+        · -- Inert step: neither fires; budgets `(qHb, qSb)`.
+          simp only [hHb, if_neg, not_false_eq_true, hSb] at hqHcont hqScont
+          have hqHcont' : ∀ u, (cont u).IsQueryBoundP pHb qHb := hqHcont
+          have hqScont' : ∀ u, (cont u).IsQueryBoundP pSb qSb := hqScont
+          calc (∑' u : spec.Range t, avgBadM impl (νu u) (cont u))
+              ≤ ∑' u : spec.Range t,
+                  (cb (νu u) + (qHb : ℝ≥0∞) * (K (νu u) * ε) +
+                    M (νu u) * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε)) :=
+                ENNReal.tsum_le_tsum fun u =>
+                  ih u (νu u) qHb qSb (hInvU u) (hνuMass u) (hqHcont' u) (hqScont' u)
+            _ = (∑' u, cb (νu u)) +
+                  (qHb : ℝ≥0∞) * ε * (∑' u, K (νu u)) +
+                  (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (∑' u, M (νu u)) := by
+                rw [ENNReal.tsum_add, ENNReal.tsum_add, ← ENNReal.tsum_mul_left,
+                  ← ENNReal.tsum_mul_left]
+                congr 1
+                · congr 1
+                  exact tsum_congr fun u => by ring
+                · exact tsum_congr fun u => by ring
+            _ ≤ cb ν + (qHb : ℝ≥0∞) * ε * (K ν) +
+                  (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (M ν) := by
+                refine add_le_add (add_le_add ?_ ?_) ?_
+                · have := h_carry ν hInv t; simpa [hcb, hνu, hHb] using this
+                · gcongr
+                  have := h_K ν hInv t; simpa [hνu, hSb] using this
+                · gcongr
+                  have := h_mass ν t; simpa [hM, hνu] using this
+            _ = cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
+                  M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by ring
+
+end AveragedStateMeasureBad
 
 end OracleComp.ProgramLogic.Relational

--- a/VCVio/ProgramLogic/Relational/SimulateQ.lean
+++ b/VCVio/ProgramLogic/Relational/SimulateQ.lean
@@ -3295,22 +3295,23 @@ produces `ε` happened earlier, at the commit draw, and cannot be localized to a
 read state.
 
 The fix carried here is to average not over a single fixed state but over a **state
-measure** `μ : PMF (σ × Bool)` — the *law* of the eager handler's slot under the pending
+measure** `ν : σ × Bool → ℝ≥0∞` — the *law* of the eager handler's slot under the pending
 upstream draws. The averaged bad mass
 
-  `avgBad impl μ oa := ∑' p, μ p · Pr[bad | (simulateQ impl oa).run p]`
+  `avgBadM impl ν oa := ∑' p, ν p · Pr[bad | (simulateQ impl oa).run p]`
 
 telescopes through the free monad exactly like `expectedQuerySlack`, but the read step's
-charge is now `∑' p, μ p · 1_{mc ∈ slot(p)} = Pr_{p∼μ}[mc ∈ slot(p)]`, a genuine
-probability over the state law. When `μ` is the pushforward of the upstream commit draws,
+charge is now `∑' p, ν p · 1_{mc ∈ slot(p)} = Pr_{p∼ν}[mc ∈ slot(p)]`, a genuine
+probability over the state law. When `ν` is the pushforward of the upstream commit draws,
 this collapses (by Fubini / `tsum`-swap over the pending draws) to the *same* mass the lazy
 handler charges at the read — `probOutput_lazyGhostFire_one` is its single-pending base
 case. This is the missing-framework analogue of `expectedQuerySlack`: it carries a
 state-**law** plus an averaged-output invariant rather than a per-state resource charge.
 
-This section builds the reusable telescoping scaffold (`avgBad`, its `pure`/`query_bind`
-unfoldings, and the pushforward step law `avgBad_query_bind_eq`) and isolates the read-step
-charge as the standalone Fubini lemma the instantiation must match against the lazy run. -/
+This section builds the reusable telescoping scaffold (`avgBadM`, its `pure`/`query_bind`
+unfoldings, and the output-grouped step law `avgBadM_query_bind_eq_tsum_output`) and isolates
+the read-step charge as the standalone Fubini lemma (`tsum_tsum_postStepOutM_mul`) the
+instantiation must match against the lazy run. -/
 section AveragedStateMeasureBad
 
 variable {ι : Type} {spec : OracleSpec ι}
@@ -3319,23 +3320,19 @@ variable {σ γ : Type}
 
 /-! ### Bare-measure averaged bad mass
 
-The `avgBad` scaffold below averages the per-state bad mass against a *probability*
-state law `μ : PMF (σ × Bool)`. That total-mass-1 constraint is never used: the telescoping
-identities and the free-monad induction only ever use `μ p` as an `ℝ≥0∞` weight. An
-**aborting** signing step, however, produces a *sub*-probability post-step state law (its
-total mass drops by the rejection mass), so a `PMF`-typed average cannot carry the charge
-invariant across it.
+The scaffold is stated over a **bare measure** `ν : σ × Bool → ℝ≥0∞` rather than a
+probability law: the telescoping identities and the free-monad induction only ever use
+`ν p` as an `ℝ≥0∞` weight, and an **aborting** signing step produces a *sub*-probability
+post-step state law (its total mass drops by the rejection mass), which a `PMF`-typed
+average could not carry.
 
-This block re-states the whole scaffold over a **bare measure** `ν : σ × Bool → ℝ≥0∞`
-(no total-mass constraint), so the same telescoping carries sub-probability post-step laws.
-The `PMF` lemmas above are recovered verbatim as corollaries by instantiating `ν := fun p => μ p`.
+A caller (e.g. the deferred-sampling charge route) telescopes with
+`avgBadM_query_bind_eq_tsum_output` directly at the sub-probability state laws produced by
+the aborting sign step. -/
 
-A caller (e.g. the deferred-sampling charge route) instantiates `avgBadM_le_of_steps_inv`
-directly at the sub-probability state laws produced by the aborting sign step. -/
-
-/-- **Bare-measure averaged bad mass.** As `avgBad`, but averaging against an arbitrary
-measure `ν : σ × Bool → ℝ≥0∞` rather than a probability law. The total-mass-1 constraint of
-`PMF` is never needed by the telescoping, so this version carries the sub-probability
+/-- **Bare-measure averaged bad mass.** The per-state bad mass of a run, averaged against an
+arbitrary measure `ν : σ × Bool → ℝ≥0∞` rather than a probability law. No total-mass
+constraint is needed by the telescoping, so the average carries the sub-probability
 post-step laws emitted by an aborting step. -/
 noncomputable def avgBadM
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
@@ -3345,7 +3342,7 @@ noncomputable def avgBadM
 
 open scoped Classical in
 /-- `avgBadM` at a Dirac (single-point indicator) measure is the plain per-state bad
-probability. The bare-measure analogue of `avgBad_pure_state`. -/
+probability. -/
 lemma avgBadM_pure_state
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (p₀ : σ × Bool) (oa : OracleComp spec γ) :
@@ -3354,9 +3351,8 @@ lemma avgBadM_pure_state
   rw [avgBadM, tsum_eq_single p₀ (by intro p hp; rw [if_neg hp, zero_mul]), if_pos rfl, one_mul]
 
 open scoped Classical in
-/-- **Linearity of `avgBadM` in the state measure.** The bare-measure analogue of
-`avgBad_eq_tsum_pure`: the averaged bad mass over `ν` is the `ν`-weighted sum of the
-per-state (Dirac) bad masses. -/
+/-- **Linearity of `avgBadM` in the state measure.** The averaged bad mass over `ν` is the
+`ν`-weighted sum of the per-state (Dirac) bad masses. -/
 lemma avgBadM_eq_tsum_pure
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (ν : σ × Bool → ℝ≥0∞) (oa : OracleComp spec γ) :
@@ -3366,8 +3362,7 @@ lemma avgBadM_eq_tsum_pure
   exact tsum_congr fun s' => by rw [avgBadM_pure_state]
 
 /-- **Pure base case of `avgBadM`.** With no queries, the bad mass is exactly the carried
-bad mass of the measure `ν` — the `ν`-mass on states with the flag already set. Bare-measure
-analogue of `avgBad_pure`. -/
+bad mass of the measure `ν` — the `ν`-mass on states with the flag already set. -/
 lemma avgBadM_pure
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (ν : σ × Bool → ℝ≥0∞) (x : γ) :
@@ -3381,9 +3376,9 @@ lemma avgBadM_pure
   | false => simp
   | true => simp [probEvent_pure]
 
-/-- **One-step telescoping of `avgBadM` (joint-law form).** Bare-measure analogue of
-`avgBad_query_bind_eq`: moves one query off the front and exposes the post-step joint law,
-holding for any impl and any measure `ν`. No probabilistic content — pure rearrangement. -/
+/-- **One-step telescoping of `avgBadM` (joint-law form).** Moves one query off the front
+and exposes the post-step joint law, holding for any impl and any measure `ν`. No
+probabilistic content — pure rearrangement. -/
 lemma avgBadM_query_bind_eq
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
@@ -3404,18 +3399,18 @@ lemma avgBadM_query_bind_eq
 
 /-- **Post-step joint measure of a query step (bare-measure form).** The measure over
 `(output, post-state)` produced by averaging the per-state impl step `Pr[= z | (impl t).run p]`
-against the state measure `ν`. Bare-measure analogue of `postStepJoint`; stated directly as a
-`tsum` since `ν` need not be a probability law. -/
+against the state measure `ν`. Stated directly as a `tsum` since `ν` need not be a
+probability law. -/
 noncomputable def postStepJointM
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (z : spec.Range t × σ × Bool) : ℝ≥0∞ :=
   ∑' p : σ × Bool, ν p * Pr[= z | (impl t).run p]
 
 open scoped Classical in
-/-- **Output-grouped telescoping of the bare-measure average.** Bare-measure analogue of
-`avgBad_telescope_eq_tsum_postStep`: the telescoped one-step average regroups as a single
-`tsum` over the post-step joint measure `postStepJointM impl ν t`, weighting each
-`(output, post-state)` pair by the Dirac bad mass at the post-state. Pure `tsum`-Fubini. -/
+/-- **Output-grouped telescoping of the bare-measure average.** The telescoped one-step
+average regroups as a single `tsum` over the post-step joint measure `postStepJointM impl ν t`,
+weighting each `(output, post-state)` pair by the Dirac bad mass at the post-state.
+Pure `tsum`-Fubini. -/
 lemma avgBadM_telescope_eq_tsum_postStep
     (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
     (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
@@ -3475,405 +3470,6 @@ lemma avgBadM_query_bind_eq_tsum_output
   refine tsum_congr fun s => ?_
   rw [postStepOutM]
 
-/-- **Bare-measure averaged-bad telescoping with a state-measure invariant.** Bare-measure
-analogue of `avgBad_le_of_steps_inv`: threads a predicate `Inv : (σ × Bool → ℝ≥0∞) → Prop`
-on the state *measure* through the free-monad induction. The conclusion holds for every
-measure `ν` satisfying `Inv ν`, and the two per-step premises may assume `Inv ν`. The
-total-mass-1 constraint is never used, so an aborting step's sub-probability post-step law is
-admissible — which is exactly why this generalization is needed for the charge route. -/
-theorem avgBadM_le_of_steps_inv
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (bound : {β : Type} → OracleComp spec β → (σ × Bool → ℝ≥0∞) → ℝ≥0∞)
-    (Inv : (σ × Bool → ℝ≥0∞) → Prop)
-    (h_pure : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (x : γ),
-      (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0))
-        ≤ bound (pure x : OracleComp spec γ) ν)
-    (h_step : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain)
-      (cont : spec.Range t → OracleComp spec γ),
-      (∀ (ν' : σ × Bool → ℝ≥0∞), Inv ν' → ∀ (u : spec.Range t),
-        avgBadM impl ν' (cont u) ≤ bound (cont u) ν') →
-      (∑' p : σ × Bool, ν p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2])
-        ≤ bound (query t >>= cont) ν)
-    (oa : OracleComp spec γ) :
-    ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → avgBadM impl ν oa ≤ bound oa ν := by
-  induction oa using OracleComp.inductionOn with
-  | pure x =>
-      intro ν hν
-      rw [avgBadM_pure]
-      exact h_pure ν hν x
-  | @query_bind t cont ih =>
-      intro ν hν
-      rw [avgBadM_query_bind_eq]
-      exact h_step ν hν t cont (fun ν' hν' u => ih u ν' hν')
-
-/-- **Bare-measure averaged-bad telescoping (invariant-free corollary).** The
-`Inv := fun _ => True` specialization of `avgBadM_le_of_steps_inv`. -/
-theorem avgBadM_le_of_steps
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (bound : {β : Type} → OracleComp spec β → (σ × Bool → ℝ≥0∞) → ℝ≥0∞)
-    (h_pure : ∀ (ν : σ × Bool → ℝ≥0∞) (x : γ),
-      (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0))
-        ≤ bound (pure x : OracleComp spec γ) ν)
-    (h_step : ∀ (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain)
-      (cont : spec.Range t → OracleComp spec γ),
-      (∀ (ν' : σ × Bool → ℝ≥0∞) (u : spec.Range t),
-        avgBadM impl ν' (cont u) ≤ bound (cont u) ν') →
-      (∑' p : σ × Bool, ν p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2])
-        ≤ bound (query t >>= cont) ν)
-    (oa : OracleComp spec γ) :
-    ∀ (ν : σ × Bool → ℝ≥0∞), avgBadM impl ν oa ≤ bound oa ν := by
-  intro ν
-  exact avgBadM_le_of_steps_inv impl bound (fun _ => True)
-    (fun ν _ x => h_pure ν x)
-    (fun ν _ t cont ih => h_step ν t cont (fun ν' u => ih ν' trivial u))
-    oa ν trivial
-
-/-- **Averaged bad mass over a state measure.** The probability the bad flag is set after
-`(simulateQ impl oa).run p`, *averaged* over the starting state `p` drawn from the state
-law `μ : PMF (σ × Bool)`. This is the quantity an eager (commit-upstream) handler must be
-bounded by: the averaging happens over the state law `μ` rather than at a fixed reachable
-state, so the deterministic per-state read charge `1_{mc ∈ slot(p)}` averages to the
-genuine guessing mass `Pr_{p∼μ}[mc ∈ slot(p)]`. Specializing `μ := PMF.pure (s, false)`
-recovers the plain per-state bad probability `Pr[bad | (simulateQ impl oa).run (s, false)]`
-(see `avgBad_pure_state`). -/
-noncomputable def avgBad
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (oa : OracleComp spec γ) : ℝ≥0∞ :=
-  ∑' p : σ × Bool, μ p *
-    Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p]
-
-/-- **Bridge: `avgBad` is `avgBadM` at the underlying measure.** The `PMF`-typed average is
-definitionally the bare-measure average against the coerced measure `fun p => μ p`. This lets
-every `PMF` corollary be derived from its bare-measure counterpart, and lets a caller move a
-`PMF` hypothesis into the bare-measure machinery. -/
-lemma avgBad_eq_avgBadM
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (oa : OracleComp spec γ) :
-    avgBad impl μ oa = avgBadM impl (fun p => μ p) oa := rfl
-
-/-- `avgBad` at a Dirac state measure is the plain per-state bad probability: the average
-over `PMF.pure p₀` collapses to the single term at `p₀`. This is the bridge that reduces
-the averaged invariant back to the concrete eager probability at the empty-cache start
-state (`μ = δ_∅`). -/
-lemma avgBad_pure_state
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (p₀ : σ × Bool) (oa : OracleComp spec γ) :
-    avgBad impl (PMF.pure p₀) oa =
-      Pr[fun z : γ × σ × Bool => z.2.2 = true | (simulateQ impl oa).run p₀] := by
-  rw [avgBad, tsum_eq_single p₀ (by intro p hp; rw [PMF.pure_apply, if_neg hp, zero_mul]),
-    PMF.pure_apply, if_pos rfl, one_mul]
-
-/-- **Linearity of `avgBad` in the state law.** The averaged bad mass over a state law `μ`
-is the `μ`-weighted average of the per-state (Dirac) bad masses. Immediate from
-`avgBad_pure_state` under the `tsum` defining `avgBad`. This is the structural fact that
-lets the output-grouped telescoping fold the inductive hypothesis at an *unnormalized*
-post-step measure: a `tsum`-weighted sum of Dirac `avgBad`s is itself an `avgBad` at the
-weighting law. -/
-lemma avgBad_eq_tsum_pure
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (oa : OracleComp spec γ) :
-    avgBad impl μ oa =
-      ∑' s' : σ × Bool, μ s' * avgBad impl (PMF.pure s') oa := by
-  rw [avgBad]
-  exact tsum_congr fun s' => by rw [avgBad_pure_state]
-
-/-- **Pure base case of `avgBad`.** With no queries, the run leaves the state untouched and
-the bad mass is exactly the carried bad mass of the state law `μ` — the probability `μ`
-assigns to states with the flag already set. -/
-lemma avgBad_pure
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (x : γ) :
-    avgBad impl μ (pure x : OracleComp spec γ) =
-      ∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0) := by
-  rw [avgBad]
-  refine tsum_congr fun p => ?_
-  rw [simulateQ_pure, StateT.run_pure]
-  rcases p with ⟨s, b⟩
-  cases b with
-  | false => simp
-  | true => simp [probEvent_pure]
-
-/-- **One-step telescoping of `avgBad` (joint-law form).** Averaging the bad mass of a
-`query t >>= cont` run over the state law `μ` equals averaging, over `μ` *and* the
-per-state impl step `(impl t).run p`, the bad mass of the continuation run started from the
-post-step state. This is the averaged analogue of `expectedQuerySlack_query_bind`: it moves
-one query off the front and exposes the post-step joint law `(p, z)` over which the next
-`avgBad` is taken. No probabilistic content yet — it is a pure rearrangement
-(`probEvent_bind_eq_tsum` inside the average) and holds for *any* impl and `μ`. -/
-lemma avgBad_query_bind_eq
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
-    avgBad impl μ (query t >>= cont) =
-      ∑' p : σ × Bool, μ p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2] := by
-  rw [avgBad]
-  refine tsum_congr fun p => ?_
-  congr 1
-  have hsim : (simulateQ impl (query t >>= cont)).run p =
-      (impl t).run p >>= fun z => (simulateQ impl (cont z.1)).run z.2 := by
-    simp [simulateQ_bind, simulateQ_query, OracleQuery.input_query,
-      OracleQuery.cont_query, StateT.run_bind]
-  rw [hsim, probEvent_bind_eq_tsum]
-
-/-- **Post-step joint law of a query step.** The law over `(output, post-state)` produced by
-drawing the starting state from `μ` and running one impl step `(impl t).run p`. This is the
-`SPMF`-valued joint measure whose first marginal is the output law and whose conditional
-second marginal (given an output) is the post-step state law the inductive hypothesis is
-folded at. -/
-noncomputable def postStepJoint
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (t : spec.Domain) :
-    SPMF (spec.Range t × σ × Bool) :=
-  (liftM μ : SPMF (σ × Bool)) >>= fun p => evalDist ((impl t).run p)
-
-/-- The post-step joint law evaluated pointwise: the `μ`-average of the per-state impl-step
-output probability. -/
-lemma postStepJoint_apply
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (t : spec.Domain) (z : spec.Range t × σ × Bool) :
-    postStepJoint impl μ t z = ∑' p : σ × Bool, μ p * Pr[= z | (impl t).run p] := by
-  rw [postStepJoint, SPMF.bind_apply_eq_tsum]
-  refine tsum_congr fun p => ?_
-  rw [SPMF.liftM_apply]
-  rfl
-
-/-- **Output-grouped telescoping of the eager average.** The telescoped one-step eager
-average (the right-hand side of `avgBad_query_bind_eq`) regroups as a single `tsum` over the
-post-step joint law `postStepJoint impl μ t`, weighting each `(output u, post-state s')` pair
-by the Dirac bad mass `avgBad impl δ_{s'} (cont u)`. This is the pure `tsum`-Fubini
-rearrangement that exposes the post-step state `s'` (grouped by output `u`) so the inductive
-hypothesis can be folded at the genuine post-step law rather than collapsed to a Dirac at a
-single reachable state. No probabilistic content — `PMF.bind` Fubini plus `avgBad_pure_state`. -/
-lemma avgBad_telescope_eq_tsum_postStep
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (μ : PMF (σ × Bool)) (t : spec.Domain) (cont : spec.Range t → OracleComp spec γ) :
-    (∑' p : σ × Bool, μ p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2]) =
-      ∑' z : spec.Range t × σ × Bool,
-        postStepJoint impl μ t z * avgBad impl (PMF.pure z.2) (cont z.1) := by
-  classical
-  -- Pull the `μ p` weight inside the inner `tsum` and replace the Dirac bad mass.
-  have hstep : (∑' p : σ × Bool, μ p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2]) =
-      ∑' p : σ × Bool, ∑' z : spec.Range t × σ × Bool,
-          μ p * (Pr[= z | (impl t).run p] *
-            avgBad impl (PMF.pure z.2) (cont z.1)) := by
-    refine tsum_congr fun p => ?_
-    rw [← ENNReal.tsum_mul_left]
-    refine tsum_congr fun z => ?_
-    rw [avgBad_pure_state, ← mul_assoc]
-  rw [hstep, ENNReal.tsum_comm]
-  refine tsum_congr fun z => ?_
-  rw [postStepJoint_apply, ← ENNReal.tsum_mul_right]
-  refine tsum_congr fun p => ?_
-  rw [mul_assoc]
-
-/-! ### Read-step Fubini charge equality (the genuine new content)
-
-The eager read at a structural ghost hit pays a *deterministic* charge `1_{mc ∈ slot(p)}`
-at the committed state `p`. The averaged-state-measure invariant turns this into a genuine
-probability by averaging over the state law `μ`:
-
-  `E_{p∼μ}[1_{mc ∈ slot(p)}] = Pr_{p∼μ}[mc ∈ slot(p)]`.
-
-When `μ` is the pushforward of the upstream commit draws into the slot, this collapses (by
-`tsum`-swap over the pending draws) to the *same* mass the lazy handler charges at the read.
-The lemmas here express that collapse abstractly: a membership-indicator average over a
-**pushforward measure** equals the draw's hit probability. The single-pending case is the
-framework analogue of the banked `probOutput_lazyGhostFire_one`. -/
-
-/-- **Single-pending read-charge Fubini equality.** Let `draw : PMF κ` be one pending draw,
-let `place : κ → σ × Bool` push a drawn value into the slot, and let `hit : σ × Bool → ℝ≥0∞`
-read the (deterministic) charge off the resulting state. Averaging the read charge over the
-pushforward law `draw.map place` equals averaging `hit ∘ place` directly over `draw`. This is
-the pure change-of-variables that moves the averaging site from the *state law* (eager view:
-the slot is already populated) to the *draw* (lazy view: the value is sampled at read time);
-the eager `1_{mc ∈ slot}` after `place` becomes the lazy `decide (w = mc)` charge under the
-draw. The multi-pending case is the `tsum`-swap over independent draws (the genuine residual
-isolated below). -/
-lemma tsum_pushforward_eq_tsum_draw {κ : Type}
-    (draw : PMF κ) (place : κ → σ × Bool) (hit : σ × Bool → ℝ≥0∞) :
-    (∑' p : σ × Bool, (draw.map place) p * hit p) =
-      ∑' w : κ, draw w * hit (place w) := by
-  classical
-  simp only [PMF.map_apply, ← ENNReal.tsum_mul_right]
-  rw [ENNReal.tsum_comm]
-  refine tsum_congr fun w => ?_
-  rw [tsum_eq_single (place w) (by intro p hp; rw [if_neg hp, zero_mul]), if_pos rfl]
-
-/-- **Membership-indicator average over a pushforward equals hit probability.** Specialize
-`tsum_pushforward_eq_tsum_draw` with the read charge being the structural membership
-indicator of the read point `mc` in the slot reached by `place`. The eager averaged
-read-hit charge `E_{p∼μ}[1_{mc ∈ slot(p)}]` (here `μ = draw.map place`, `slot` extracted by
-`testMem`) equals the draw's mass on values that `place` maps to a hit. With
-`testMem (place w) = decide (w hits mc)` this is exactly the lazy single-pending fire mass
-(`probOutput_lazyGhostFire_one`). -/
-lemma tsum_pushforward_mem_eq_draw_hit {κ : Type}
-    (draw : PMF κ) (place : κ → σ × Bool) (testMem : σ × Bool → Bool) :
-    (∑' p : σ × Bool, (draw.map place) p * (if testMem p = true then 1 else 0)) =
-      ∑' w : κ, draw w * (if testMem (place w) = true then 1 else 0) :=
-  tsum_pushforward_eq_tsum_draw draw place (fun p => if testMem p = true then 1 else 0)
-
-/-! ### Averaged-bad telescoping skeleton
-
-The fully-proven free-monad telescoping for the averaged invariant. The theorem
-`avgBad_le_of_steps` reduces the averaged eager bad mass `avgBad impl_e μ oa` to a target
-`bound : OracleComp spec γ → PMF (σ × Bool) → ℝ≥0∞` supplied by the caller (the lazy /
-deferred-sampling charge), provided two per-step premises hold:
-
-* `h_pure`: at a `pure` leaf the carried bad mass of `μ` is below the target's leaf value;
-* `h_step`: at each `query t >>= cont`, the one-step telescoped eager average
-  (`avgBad_query_bind_eq`) — i.e. the impl-`t` push of `μ` into the continuation average —
-  is dominated by the target at the same point.
-
-The proof is a pure free-monad induction: `pure` discharges by `h_pure`, and `query_bind`
-rewrites the eager side by `avgBad_query_bind_eq` and discharges by `h_step` (whose premise
-in turn folds the inductive hypothesis through the post-step law). All free-monad
-bookkeeping is handled here; the *probabilistic* content lives entirely in discharging
-`h_step` at the read query, where the caller must supply the Fubini charge equality
-(`tsum_pushforward_mem_eq_draw_hit`) recoupling the post-read state law `μ'` — the genuine
-residual isolated for the instantiation. -/
-
-/-- **Averaged-bad telescoping with a state-law invariant.** A strict generalization of
-`avgBad_le_of_steps` that threads a predicate `Inv : PMF (σ × Bool) → Prop` on the state law
-through the free-monad induction. The conclusion holds for every `μ` satisfying `Inv μ`, and
-the two per-step premises may *assume* `Inv μ`:
-
-* `h_pure` discharges the `pure` leaf assuming `Inv μ`;
-* `h_step` discharges one telescoped query step assuming `Inv μ`, and is handed an inductive
-  hypothesis that fires only at post-step laws `μ'` for which `Inv μ'` holds — so `h_step` is
-  responsible for re-establishing `Inv` on every post-step law it feeds the IH.
-
-This is the shape required by the deferred-sampling read step: the eager read flips the bad
-flag deterministically at a structural ghost-hit state, so a *per-state* bound is false; the
-collapse to the lazy fire mass only happens once the average is taken against a state law that
-is a pushforward of the upstream commit draws. The invariant carries exactly that pushforward
-structure across the induction (preserved by reads — the ghost cache is untouched — grown by
-signs — one more draw — and holding at the empty-cache Dirac start). The probabilistic content
-still lives entirely in discharging `h_step`; the framework supplies only the `Inv` plumbing. -/
-theorem avgBad_le_of_steps_inv
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (bound : {β : Type} → OracleComp spec β → PMF (σ × Bool) → ℝ≥0∞)
-    (Inv : PMF (σ × Bool) → Prop)
-    (h_pure : ∀ (μ : PMF (σ × Bool)), Inv μ → ∀ (x : γ),
-      (∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0))
-        ≤ bound (pure x : OracleComp spec γ) μ)
-    (h_step : ∀ (μ : PMF (σ × Bool)), Inv μ → ∀ (t : spec.Domain)
-      (cont : spec.Range t → OracleComp spec γ),
-      (∀ (μ' : PMF (σ × Bool)), Inv μ' → ∀ (u : spec.Range t),
-        avgBad impl μ' (cont u) ≤ bound (cont u) μ') →
-      (∑' p : σ × Bool, μ p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2])
-        ≤ bound (query t >>= cont) μ)
-    (oa : OracleComp spec γ) :
-    ∀ (μ : PMF (σ × Bool)), Inv μ → avgBad impl μ oa ≤ bound oa μ := by
-  induction oa using OracleComp.inductionOn with
-  | pure x =>
-      intro μ hμ
-      rw [avgBad_pure]
-      exact h_pure μ hμ x
-  | @query_bind t cont ih =>
-      intro μ hμ
-      rw [avgBad_query_bind_eq]
-      exact h_step μ hμ t cont (fun μ' hμ' u => ih u μ' hμ')
-
-/-- **Averaged-bad telescoping (invariant-free corollary).** The `Inv := fun _ => True`
-specialization of `avgBad_le_of_steps_inv`: the original telescoping shape, recovered so
-callers that do not need a state-law invariant are unaffected. -/
-theorem avgBad_le_of_steps
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (bound : {β : Type} → OracleComp spec β → PMF (σ × Bool) → ℝ≥0∞)
-    (h_pure : ∀ (μ : PMF (σ × Bool)) (x : γ),
-      (∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0))
-        ≤ bound (pure x : OracleComp spec γ) μ)
-    (h_step : ∀ (μ : PMF (σ × Bool)) (t : spec.Domain)
-      (cont : spec.Range t → OracleComp spec γ),
-      (∀ (μ' : PMF (σ × Bool)) (u : spec.Range t),
-        avgBad impl μ' (cont u) ≤ bound (cont u) μ') →
-      (∑' p : σ × Bool, μ p *
-        ∑' z : spec.Range t × σ × Bool,
-          Pr[= z | (impl t).run p] *
-            Pr[ fun w : γ × σ × Bool => w.2.2 = true |
-              (simulateQ impl (cont z.1)).run z.2])
-        ≤ bound (query t >>= cont) μ)
-    (oa : OracleComp spec γ) :
-    ∀ (μ : PMF (σ × Bool)), avgBad impl μ oa ≤ bound oa μ := by
-  intro μ
-  exact avgBad_le_of_steps_inv impl bound (fun _ => True)
-    (fun μ _ x => h_pure μ x)
-    (fun μ _ t cont ih => h_step μ t cont (fun μ' u => ih μ' trivial u))
-    oa μ trivial
-
-/-- **Total post-step joint mass equals the `ν`-weighted per-state step mass.** Marginalizing
-the post-step joint measure over all `(output, post-state)` pairs gives the `ν`-average of the
-per-state impl-step total mass `∑' z, Pr[= z | (impl t).run p]`. -/
-lemma tsum_postStepJointM_eq
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) :
-    (∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z)
-      = ∑' p : σ × Bool, ν p *
-          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] := by
-  unfold postStepJointM
-  rw [ENNReal.tsum_comm]
-  exact tsum_congr fun p => ENNReal.tsum_mul_left
-
-/-- **Per-output post-step mass is bounded by the pre-step mass.** Each per-output slice
-`postStepOutM impl ν t u` has total mass at most the total mass of `ν`, since the per-state
-step `(impl t).run p` is a sub-probability. The `h_massU` premise of
-`avgBadM_le_threaded_linear`. -/
-lemma tsum_postStepOutM_single_le
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (u : spec.Range t) :
-    (∑' s : σ × Bool, postStepOutM impl ν t u s) ≤ ∑' p : σ × Bool, ν p := by
-  calc (∑' s : σ × Bool, postStepOutM impl ν t u s)
-      ≤ ∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z := by
-        simp only [postStepOutM]
-        rw [ENNReal.tsum_prod' (f := fun z => postStepJointM impl ν t z)]
-        exact ENNReal.le_tsum u
-    _ = ∑' p : σ × Bool, ν p *
-          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] :=
-        tsum_postStepJointM_eq impl ν t
-    _ ≤ ∑' p : σ × Bool, ν p :=
-        ENNReal.tsum_le_tsum fun p => mul_le_of_le_one_right zero_le' tsum_probOutput_le_one
-
-/-- **Total post-step mass is bounded by the pre-step mass.** Summed over both the query
-output `u` and the post-state, the post-step joint mass is at most the total mass of `ν`. The
-`h_mass` premise of `avgBadM_le_threaded_linear`. -/
-lemma tsum_tsum_postStepOutM_le
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) :
-    (∑' u : spec.Range t, ∑' s : σ × Bool, postStepOutM impl ν t u s)
-      ≤ ∑' p : σ × Bool, ν p := by
-  calc (∑' u : spec.Range t, ∑' s : σ × Bool, postStepOutM impl ν t u s)
-      = ∑' z : spec.Range t × σ × Bool, postStepJointM impl ν t z := by
-        simp only [postStepOutM]
-        rw [ENNReal.tsum_prod' (f := fun z => postStepJointM impl ν t z)]
-    _ = ∑' p : σ × Bool, ν p *
-          ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] :=
-        tsum_postStepJointM_eq impl ν t
-    _ ≤ ∑' p : σ × Bool, ν p :=
-        ENNReal.tsum_le_tsum fun p => mul_le_of_le_one_right zero_le' tsum_probOutput_le_one
-
 open scoped Classical in
 /-- **Weighted post-step rearrangement.** Summing any post-state functional `F` against the
 post-step measure (over output `u` and post-state `s`) equals the `ν`-average of the per-state
@@ -3903,223 +3499,6 @@ lemma tsum_tsum_postStepOutM_mul
           ∑' z : spec.Range t × σ × Bool, Pr[= z | (impl t).run p] * F z.2 := by
         rw [ENNReal.tsum_comm]
         exact tsum_congr fun p => ENNReal.tsum_mul_left
-
-/-- **Threaded linear (mass-weighted) accumulator bound for `avgBadM`.** A reusable
-free-monad telescoping that, unlike `avgBadM_le_of_steps_inv`, bakes in a *linear,
-mass-weighted, additive* bound shape so it telescopes across the output-branching of a
-query step (where a `⨆`-ceiling bound does not).
-
-The bound carried for a measure `ν` at read/sign budgets `(qHb, qSb)` is
-`carriedBad ν + qHb · (K ν · ε) + (mass ν) · qHb · qSb · (g · ε)`,
-where `carriedBad ν := ∑' p, ν p · 1_{p.2}`, `mass ν := ∑' p, ν p`, `K` is an arbitrary
-charge functional, and `g, ε : ℝ≥0∞` are constants.
-
-Each query domain point `t` is classified by two decidable predicates `pHb` (a "read":
-consumes a read unit, pays its hit charge `≤ K ν · ε` into the post-step carried bad mass)
-and `pSb` (a "sign": consumes a sign unit, raises the post-step charge by `≤ g · mass ν`).
-Steps that fire neither predicate are inert (preserve everything). The numeric premises,
-summed over the query output `u` against the per-output post-step measures
-`νu := postStepOutM impl ν t u`, are:
-
-* `h_carry` — the carried bad mass telescopes, paying the read hit charge on a read step
-  (the charge `≤ K ν · ε` is provided by the carried invariant `Inv ν`);
-* `h_mass` — the total mass is non-increasing across the step;
-* `h_K` — the charge telescopes, growing by `≤ g · mass ν` on a sign step;
-* `h_massU` — each per-output mass is bounded by the pre-step mass (so the IH's
-  sub-probability hypothesis is re-established);
-* `h_inv` — the invariant `Inv` is preserved across every per-output post-step measure.
-
-The read charge bound `Inv ν → C(ν, ·) ≤ K ν · ε` is in general only an *averaged* fact
-(the rejected commit lands at the read target with probability `≤ ε`), so it cannot be a
-universal hypothesis over arbitrary `ν`; it is carried as the invariant `Inv` and
-re-established incrementally on each post-step measure. The read/sign budgets are threaded
-by `isQueryBoundP_query_bind_iff`; the budget decrement on the fired predicate exactly
-absorbs the charge increment. -/
-theorem avgBadM_le_threaded_linear
-    (impl : QueryImpl spec (StateT (σ × Bool) (OracleComp spec')))
-    (K : (σ × Bool → ℝ≥0∞) → ℝ≥0∞) (g ε : ℝ≥0∞)
-    (Inv : (σ × Bool → ℝ≥0∞) → Prop)
-    (pHb pSb : ι → Prop) [DecidablePred pHb] [DecidablePred pSb]
-    (hpExcl : ∀ t, pHb t → pSb t → False)
-    (h_carry : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain),
-      (∑' u : spec.Range t,
-          ∑' p : σ × Bool, postStepOutM impl ν t u p * (if p.2 = true then 1 else 0))
-        ≤ (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0)) +
-            (if pHb t then K ν * ε else 0))
-    (h_mass : ∀ (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain),
-      (∑' u : spec.Range t, ∑' p : σ × Bool, postStepOutM impl ν t u p)
-        ≤ ∑' p : σ × Bool, ν p)
-    (h_massU : ∀ (ν : σ × Bool → ℝ≥0∞) (t : spec.Domain) (u : spec.Range t),
-      (∑' p : σ × Bool, postStepOutM impl ν t u p) ≤ ∑' p : σ × Bool, ν p)
-    (h_K : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain),
-      (∑' u : spec.Range t, K (postStepOutM impl ν t u))
-        ≤ K ν + (if pSb t then g * (∑' p : σ × Bool, ν p) else 0))
-    (h_inv : ∀ (ν : σ × Bool → ℝ≥0∞), Inv ν → ∀ (t : spec.Domain) (u : spec.Range t),
-      Inv (postStepOutM impl ν t u))
-    (oa : OracleComp spec γ) :
-    ∀ (ν : σ × Bool → ℝ≥0∞) (qHb qSb : ℕ),
-      Inv ν → (∑' p : σ × Bool, ν p) ≤ 1 →
-      oa.IsQueryBoundP pHb qHb → oa.IsQueryBoundP pSb qSb →
-      avgBadM impl ν oa
-        ≤ (∑' p : σ × Bool, ν p * (if p.2 = true then 1 else 0)) +
-            (qHb : ℝ≥0∞) * (K ν * ε) +
-            (∑' p : σ × Bool, ν p) * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
-  classical
-  induction oa using OracleComp.inductionOn with
-  | pure x =>
-      intro ν qHb qSb _ _ _ _
-      rw [avgBadM_pure]
-      exact le_add_right (le_add_right le_rfl)
-  | @query_bind t cont ih =>
-      intro ν qHb qSb hInv hν hqH hqS
-      rw [avgBadM_query_bind_eq_tsum_output]
-      -- Abbreviations.
-      set cb : (σ × Bool → ℝ≥0∞) → ℝ≥0∞ :=
-        fun μ => ∑' p : σ × Bool, μ p * (if p.2 = true then 1 else 0) with hcb
-      set M : (σ × Bool → ℝ≥0∞) → ℝ≥0∞ := fun μ => ∑' p : σ × Bool, μ p with hM
-      set νu : spec.Range t → (σ × Bool → ℝ≥0∞) := fun u => postStepOutM impl ν t u with hνu
-      -- Per-output mass ≤ 1, from `h_massU` and `hν`.
-      have hνuMass : ∀ u, M (νu u) ≤ 1 := fun u =>
-        le_trans (h_massU ν t u) hν
-      -- The invariant is preserved on every per-output post-step measure.
-      have hInvU : ∀ u, Inv (νu u) := fun u => h_inv ν hInv t u
-      rw [isQueryBoundP_query_bind_iff] at hqH hqS
-      obtain ⟨hqHfst, hqHcont⟩ := hqH
-      obtain ⟨hqSfst, hqScont⟩ := hqS
-      -- Three cases by which predicate fires.
-      by_cases hHb : pHb t
-      · -- Read step: `pHb t` true, `pSb t` false; budgets `(qHb-1, qSb)`.
-        have hSbF : ¬ pSb t := fun hSb => hpExcl t hHb hSb
-        have hpos : 0 < qHb := by
-          rcases hqHfst with h | h
-          · exact absurd hHb h
-          · exact h
-        simp only [hHb, if_pos, hSbF, if_neg, not_false_eq_true] at hqHcont hqScont
-        have hqHcont : ∀ u, (cont u).IsQueryBoundP pHb (qHb - 1) := hqHcont
-        have hqScont' : ∀ u, (cont u).IsQueryBoundP pSb qSb := hqScont
-        -- Per-output IH, summed.
-        calc (∑' u : spec.Range t, avgBadM impl (νu u) (cont u))
-            ≤ ∑' u : spec.Range t,
-                (cb (νu u) + ((qHb - 1 : ℕ) : ℝ≥0∞) * (K (νu u) * ε) +
-                  M (νu u) * ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε)) :=
-              ENNReal.tsum_le_tsum fun u =>
-                ih u (νu u) (qHb - 1) qSb (hInvU u) (hνuMass u) (hqHcont u) (hqScont' u)
-          _ = (∑' u, cb (νu u)) +
-                ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * (∑' u, K (νu u)) +
-                ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (∑' u, M (νu u)) := by
-              rw [ENNReal.tsum_add, ENNReal.tsum_add, ← ENNReal.tsum_mul_left,
-                ← ENNReal.tsum_mul_left]
-              congr 1
-              · congr 1
-                exact tsum_congr fun u => by ring
-              · exact tsum_congr fun u => by ring
-          _ ≤ (cb ν + K ν * ε) +
-                ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * (K ν) +
-                ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (M ν) := by
-              refine add_le_add (add_le_add ?_ ?_) ?_
-              · have := h_carry ν hInv t; simpa [hcb, hνu, hHb] using this
-              · gcongr
-                have := h_K ν hInv t; simpa [hνu, hSbF] using this
-              · gcongr
-                have := h_mass ν t; simpa [hM, hνu] using this
-          _ ≤ cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
-                M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
-              have hsucc : ((qHb - 1 : ℕ) : ℝ≥0∞) + 1 = (qHb : ℝ≥0∞) := by
-                rw [show ((qHb - 1 : ℕ) : ℝ≥0∞) + 1 = (((qHb - 1) + 1 : ℕ) : ℝ≥0∞) by
-                  push_cast; ring, Nat.sub_add_cancel hpos]
-              -- Charge term: `(K ν · ε) + (qHb-1)·ε·K ν = qHb·(K ν · ε)`.
-              have hch : K ν * ε + ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * K ν
-                  = (qHb : ℝ≥0∞) * (K ν * ε) := by
-                rw [← hsucc]; ring
-              -- Future term: `(qHb-1) ≤ qHb`.
-              have hfut : ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * M ν
-                  ≤ M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
-                rw [show M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε)
-                      = ((qHb : ℝ≥0∞)) * (qSb : ℝ≥0∞) * (g * ε) * M ν by ring]
-                gcongr
-                exact_mod_cast Nat.sub_le qHb 1
-              calc cb ν + K ν * ε + ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * K ν +
-                    ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * M ν
-                  = cb ν + (K ν * ε + ((qHb - 1 : ℕ) : ℝ≥0∞) * ε * K ν) +
-                      ((qHb - 1 : ℕ) : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * M ν := by ring
-                _ ≤ cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
-                      M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
-                    rw [hch]; gcongr
-      · by_cases hSb : pSb t
-        · -- Sign step: `pSb t` true, `pHb t` false; budgets `(qHb, qSb-1)`.
-          have hpos : 0 < qSb := by
-            rcases hqSfst with h | h
-            · exact absurd hSb h
-            · exact h
-          simp only [hHb, if_neg, not_false_eq_true, hSb, if_pos] at hqHcont hqScont
-          have hqHcont' : ∀ u, (cont u).IsQueryBoundP pHb qHb := hqHcont
-          have hqScont' : ∀ u, (cont u).IsQueryBoundP pSb (qSb - 1) := hqScont
-          calc (∑' u : spec.Range t, avgBadM impl (νu u) (cont u))
-              ≤ ∑' u : spec.Range t,
-                  (cb (νu u) + (qHb : ℝ≥0∞) * (K (νu u) * ε) +
-                    M (νu u) * (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε)) :=
-                ENNReal.tsum_le_tsum fun u =>
-                  ih u (νu u) qHb (qSb - 1) (hInvU u) (hνuMass u) (hqHcont' u) (hqScont' u)
-            _ = (∑' u, cb (νu u)) +
-                  (qHb : ℝ≥0∞) * ε * (∑' u, K (νu u)) +
-                  (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε) * (∑' u, M (νu u)) := by
-                rw [ENNReal.tsum_add, ENNReal.tsum_add, ← ENNReal.tsum_mul_left,
-                  ← ENNReal.tsum_mul_left]
-                congr 1
-                · congr 1
-                  exact tsum_congr fun u => by ring
-                · exact tsum_congr fun u => by ring
-            _ ≤ cb ν +
-                  (qHb : ℝ≥0∞) * ε * (K ν + g * M ν) +
-                  (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε) * (M ν) := by
-                refine add_le_add (add_le_add ?_ ?_) ?_
-                · have := h_carry ν hInv t; simpa [hcb, hνu, hHb] using this
-                · gcongr
-                  have := h_K ν hInv t; simpa [hM, hνu, hSb] using this
-                · gcongr
-                  have := h_mass ν t; simpa [hM, hνu] using this
-            _ ≤ cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
-                  M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by
-                have hsucc : ((qSb - 1 : ℕ) : ℝ≥0∞) + 1 = (qSb : ℝ≥0∞) := by
-                  rw [show ((qSb - 1 : ℕ) : ℝ≥0∞) + 1 = (((qSb - 1) + 1 : ℕ) : ℝ≥0∞) by
-                    push_cast; ring, Nat.sub_add_cancel hpos]
-                -- Charge: `qHb·ε·(K ν + g·M ν) = qHb·K ν·ε + qHb·g·ε·M ν`; the second piece
-                -- combines with the future term via the `qSb-1 → qSb` increment.
-                refine le_of_eq ?_
-                rw [show cb ν + (qHb : ℝ≥0∞) * ε * (K ν + g * M ν) +
-                      (qHb : ℝ≥0∞) * ((qSb - 1 : ℕ) : ℝ≥0∞) * (g * ε) * (M ν)
-                    = cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
-                      M ν * (qHb : ℝ≥0∞) * (((qSb - 1 : ℕ) : ℝ≥0∞) + 1) * (g * ε) by ring,
-                  hsucc]
-        · -- Inert step: neither fires; budgets `(qHb, qSb)`.
-          simp only [hHb, if_neg, not_false_eq_true, hSb] at hqHcont hqScont
-          have hqHcont' : ∀ u, (cont u).IsQueryBoundP pHb qHb := hqHcont
-          have hqScont' : ∀ u, (cont u).IsQueryBoundP pSb qSb := hqScont
-          calc (∑' u : spec.Range t, avgBadM impl (νu u) (cont u))
-              ≤ ∑' u : spec.Range t,
-                  (cb (νu u) + (qHb : ℝ≥0∞) * (K (νu u) * ε) +
-                    M (νu u) * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε)) :=
-                ENNReal.tsum_le_tsum fun u =>
-                  ih u (νu u) qHb qSb (hInvU u) (hνuMass u) (hqHcont' u) (hqScont' u)
-            _ = (∑' u, cb (νu u)) +
-                  (qHb : ℝ≥0∞) * ε * (∑' u, K (νu u)) +
-                  (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (∑' u, M (νu u)) := by
-                rw [ENNReal.tsum_add, ENNReal.tsum_add, ← ENNReal.tsum_mul_left,
-                  ← ENNReal.tsum_mul_left]
-                congr 1
-                · congr 1
-                  exact tsum_congr fun u => by ring
-                · exact tsum_congr fun u => by ring
-            _ ≤ cb ν + (qHb : ℝ≥0∞) * ε * (K ν) +
-                  (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) * (M ν) := by
-                refine add_le_add (add_le_add ?_ ?_) ?_
-                · have := h_carry ν hInv t; simpa [hcb, hνu, hHb] using this
-                · gcongr
-                  have := h_K ν hInv t; simpa [hνu, hSb] using this
-                · gcongr
-                  have := h_mass ν t; simpa [hM, hνu] using this
-            _ = cb ν + (qHb : ℝ≥0∞) * (K ν * ε) +
-                  M ν * (qHb : ℝ≥0∞) * (qSb : ℝ≥0∞) * (g * ε) := by ring
 
 end AveragedStateMeasureBad
 


### PR DESCRIPTION
Adds the deferred-sampling and relational-coupling engine that the GPV/#188 and MLDSA/#228 security proofs build on. Purely additive: no existing declaration is changed or removed.

## What's included

- `VCVio/OracleComp/QueryTracking/RandomOracle/DeferredSampling.lean` — expectation algebra for deferred draws: i.i.d. bind-commutation (`evalDist_bind_comm`), the ε-multiplicity kernel (`tsum_probOutput_fresh_mul_count_le`), the `Factorizes` front-tape predicate with `evalDist_step_commute_tape`, and the state-relation transfer lemma `tsum_probOutput_simulateQ_run_mul_of_rel`.
- `VCVio/OracleComp/QueryTracking/RandomOracle/ProbeEps.lean` — hidden-target read games: single-target `q·ε` bound (`probEvent_hiddenReadMany_le`), i.i.d. multi-key `n·q·ε` bound (`probEvent_hiddenReadList_le`), the averaged `E[n]·q·ε` bridge, single-draw deferral (`probEvent_bind_fire_le_of_gen`), and the explicit front-block `drawList`.
- `VCVio/ProgramLogic/Relational/SimulateQ.lean` (additions) — relational-triple monotonicity/implication lemmas, the single-world expected-query-slack accumulator (`probEvent_bad_simulateQ_run_le_expectedQuerySlack`), and the bare-measure averaged-bad primitives (`avgBadM`, `postStepOutM`, `avgBadM_query_bind_eq_tsum_output`, `tsum_tsum_postStepOutM_mul`) used by the aborting-signer coupling.
- `VCVio/ProgramLogic/Relational/ProgrammingOracle.lean` (additions) — TV-distance-to-bad-event bounds for programmed random oracles, including the caching/programming bridge consumed by the GPV reduction.
- `VCVio/EvalDist/Defs/Basic.lean` (additions) — the first-moment bound `probEvent_le_tsum_probOutput_mul_cost` (+ support-restricted variant).

A soundness note for reviewers of the averaged-bad layer: the per-output invariant threading is stated over **un-normalized sub-probability state measures** (`postStepOutM` has no output-conditioning division), which is the formulation that avoids the mass-concentration pathology of a per-output *conditioned* invariant. The packaged PMF-typed telescoping layer that earlier drafts carried was dropped — both downstream consumers telescope directly from the bare-measure primitives, so only the consumed API ships.

## Verification

- `lake build` of the full CI library set: green.
- `#print axioms` on the load-bearing engine lemmas (`probEvent_le_of_relTriple_simulateQ_run`, `probEvent_bad_simulateQ_run_le_expectedQuerySlack`, `tvDist_simulateQ_randomOracle_withProgramming_le_probEvent_bad`, `probEvent_hiddenReadList_le`, `probEvent_bind_fire_le_of_gen`, `tsum_probOutput_fresh_mul_count_le`, `evalDist_step_commute_tape`, `tsum_probOutput_simulateQ_run_mul_of_rel`): all `[propext, Classical.choice, Quot.sound]` — no `sorryAx`, no custom axioms.
- New files are clean under `-Dweak.linter.mathlibStandardSet=true`.

## Relation to the other PRs

The GPV/#188+Falcon PR and the MLDSA/#228 PR are stacked on this branch and consume this engine; this PR must merge first.
