### PR TITLE
feat(coinductive): wire PolyFun responders into IND-CPA

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -102,6 +102,8 @@ import VCVio.OracleComp.Coinductive.Bridge
 import VCVio.OracleComp.Coinductive.Composition
 import VCVio.OracleComp.Coinductive.DynSystem
 import VCVio.OracleComp.Coinductive.Machine
+import VCVio.OracleComp.Coinductive.Responder
+import VCVio.OracleComp.Coinductive.WiredRun
 import VCVio.OracleComp.Constructions.BitVec
 import VCVio.OracleComp.Constructions.GenerateSeed
 import VCVio.OracleComp.Constructions.Replicate

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
@@ -5,6 +5,7 @@ Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
 import VCVio.OracleComp.Coercions.SubSpec
+import VCVio.OracleComp.Coinductive.WiredRun
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.SimSemantics.Append
@@ -81,6 +82,73 @@ def IND_CPA_queryImpl' (encAlg : AsymmEncAlg ProbComp M PK SK C)
   IND_CPA_queryImplFromChallenge encAlg
     (IND_CPA_cachedChallengeOracle encAlg pk
       (fun mm => if b then mm.1 else mm.2))
+
+/-- The cached left/right oracle as a probabilistic responder. This is a thin wrapper around
+`IND_CPA_queryImpl'`; the existing `StateT ProbComp` implementation remains the source of truth. -/
+noncomputable def IND_CPA_responder (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (pk : PK) (b : Bool) : ProbResponder encAlg.IND_CPA_oracleSpec :=
+  .ofStateQueryImpl (encAlg.IND_CPA_queryImpl' pk b)
+
+@[simp] theorem IND_CPA_responder_state (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (pk : PK) (b : Bool) : (encAlg.IND_CPA_responder pk b).State = encAlg.IND_CPA_Cache := rfl
+
+/-- Running a program against the responder is the evaluation distribution of the existing
+cached `StateT ProbComp` interpretation. -/
+theorem run_IND_CPA_responder_eq (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (pk : PK) (b : Bool) {γ : Type} (oa : OracleComp encAlg.IND_CPA_oracleSpec γ)
+    (cache : encAlg.IND_CPA_Cache) :
+    (simulateQ (encAlg.IND_CPA_responder pk b).toQueryImpl oa).run cache =
+      𝒟[(simulateQ (encAlg.IND_CPA_queryImpl' pk b) oa).run cache] :=
+  ProbResponder.run_simulateQ_toQueryImpl_ofStateQueryImpl
+    (encAlg.IND_CPA_queryImpl' pk b) oa cache
+
+/-- Machine-level reading of the existing IND-CPA oracle execution. Any pointed machine
+implementing the program adversary has exactly the same joint output/cache distribution. -/
+theorem wireKRun_IND_CPA_responder_eq (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (adversary : encAlg.IND_CPA_adversary)
+    (machine : OracleMachine encAlg.IND_CPA_oracleSpec PK Bool) {k : ℕ}
+    (himp : machine.Implements adversary k) (pk : PK) (b : Bool)
+    (cache : encAlg.IND_CPA_Cache) :
+    machine.wireKRun (encAlg.IND_CPA_responder pk b) k (cache, machine.init pk) =
+      (fun p => (some p.1, p.2)) <$>
+        𝒟[(simulateQ (encAlg.IND_CPA_queryImpl' pk b) (adversary pk)).run cache] := by
+  rw [OracleMachine.wireKRun, himp.runK_eq (encAlg.IND_CPA_responder pk b).toQueryImpl pk,
+    StateT.run_map, run_IND_CPA_responder_eq]
+  rfl
+
+/-! ## Left/right message swapping as a PolyFun reduction -/
+
+/-- The interface lens that swaps the two messages in a challenge query. Responses are unchanged. -/
+def IND_CPA_swapChallengeLens :
+    PFunctor.Lens (M × M →ₒ C).toPFunctor (M × M →ₒ C).toPFunctor where
+  toFunA mm := (mm.2, mm.1)
+  toFunB _ := id
+
+/-- The IND-CPA interface reduction that leaves randomness queries alone and swaps the two
+messages at every challenge query. -/
+def IND_CPA_swapLens (encAlg : AsymmEncAlg ProbComp M PK SK C) :
+    PFunctor.Lens encAlg.IND_CPA_oracleSpec.toPFunctor
+      encAlg.IND_CPA_oracleSpec.toPFunctor :=
+  PFunctor.Lens.sumMap (PFunctor.Lens.id unifSpec.toPFunctor) IND_CPA_swapChallengeLens
+
+omit [DecidableEq M] in
+@[simp] theorem IND_CPA_swapLens_query_left (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (t : unifSpec.Domain) : encAlg.IND_CPA_swapLens.toFunA (.inl t) = .inl t := rfl
+
+omit [DecidableEq M] in
+@[simp] theorem IND_CPA_swapLens_query_right (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (mm : M × M) : encAlg.IND_CPA_swapLens.toFunA (.inr mm) = .inr (mm.2, mm.1) := rfl
+
+omit [DecidableEq M] in
+/-- Wrapping an IND-CPA machine with message swapping is exactly responder pullback along the
+same PolyFun lens. This is the machine-level reduction statement; no protocol-specific run
+induction is required. -/
+theorem wireKRun_IND_CPA_swap (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (machine : OracleMachine encAlg.IND_CPA_oracleSpec PK Bool)
+    (R : ProbResponder encAlg.IND_CPA_oracleSpec) (k : ℕ) (r : R.State) (s : machine.State) :
+    (machine.wrapIface encAlg.IND_CPA_swapLens).wireKRun R k (r, s) =
+      machine.wireKRun (R.pullback encAlg.IND_CPA_swapLens) k (r, s) :=
+  machine.wireKRun_wrap encAlg.IND_CPA_swapLens R k r s
 
 /-- Oracle IND-CPA experiment with caching on the LR oracle. -/
 def IND_CPA_experiment {encAlg : AsymmEncAlg ProbComp M PK SK C}

--- a/VCVio/OracleComp/Coinductive/Responder.lean
+++ b/VCVio/OracleComp/Coinductive/Responder.lean
@@ -1,0 +1,183 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio.OracleComp.Coinductive.DynSystem
+import VCVio.OracleComp.SimSemantics.StateT.Basic
+import PolyFun.PFunctor.Dynamical.Game
+
+/-!
+# Probabilistic Responders for Oracle Strategies
+
+A `ProbResponder spec` bundles PolyFun's stateful-handler presentation of an effectful Mealy
+machine, specialized to `SPMF` and the polynomial interface of an `OracleSpec`. Its wired strategy
+runs are the `SPMF` specialization of PolyFun's generic `DynSystem.stepWith` and
+`DynSystem.iterWith`.
+-/
+
+universe u
+
+open OracleSpec
+
+variable {ι : Type u} {spec : OracleSpec.{u, u} ι} {S : Type u}
+
+/-- A stateful probabilistic responder for an oracle interface, as an existentially bundled
+PolyFun handler in the `StateT State SPMF` Kleisli category. -/
+structure ProbResponder (spec : OracleSpec.{u, u} ι) where
+  /-- Private responder state. -/
+  State : Type u
+  /-- PolyFun handler jointly producing an answer and successor state. -/
+  handler : PFunctor.Handler (StateT State SPMF) spec.toPFunctor
+
+namespace ProbResponder
+
+/-- Read a responder as a handler in the state monad. -/
+def toQueryImpl (R : ProbResponder spec) : QueryImpl spec (StateT R.State SPMF) :=
+  R.handler
+
+/-- Run the responder's PolyFun handler at a state and query. -/
+def answer (R : ProbResponder spec) (s : R.State) (t : spec.Domain) :
+    SPMF (spec.Range t × R.State) :=
+  R.handler t s
+
+/-- Bundle a stateful `SPMF` handler as a responder. -/
+def ofQueryImpl {σ : Type u} (impl : QueryImpl spec (StateT σ SPMF)) : ProbResponder spec where
+  State := σ
+  handler := impl
+
+@[simp] theorem toQueryImpl_ofQueryImpl {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) : (ofQueryImpl impl).toQueryImpl = impl := rfl
+
+@[simp] theorem ofQueryImpl_toQueryImpl (R : ProbResponder spec) :
+    ofQueryImpl R.toQueryImpl = R := rfl
+
+/-- A family of memoryless handlers indexed by state that remains constant during a run. -/
+noncomputable def ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec) :
+    ProbResponder spec where
+  State := Γ
+  handler t γ := (fun r => (r, γ)) <$> h γ t
+
+@[simp] theorem ofHandlerFamily_state {Γ : Type u} (h : Γ → ProbHandler spec) :
+    (ofHandlerFamily h).State = Γ := rfl
+
+/-- A memoryless handler as a trivial-state responder. -/
+noncomputable def ofHandler (H : ProbHandler spec) : ProbResponder spec :=
+  ofHandlerFamily fun _ : PUnit => H
+
+/-- Lift a `ProbComp` stateful handler through evaluation semantics. -/
+noncomputable def ofStateQueryImpl {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀}
+    {σ : Type} (impl : QueryImpl spec₀ (StateT σ ProbComp)) : ProbResponder spec₀ where
+  State := σ
+  handler t := StateT.mapHom (MonadHom.ofLift ProbComp SPMF) (impl t)
+
+@[simp] theorem ofStateQueryImpl_state {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀}
+    {σ : Type} (impl : QueryImpl spec₀ (StateT σ ProbComp)) :
+    (ofStateQueryImpl impl).State = σ := rfl
+
+/-- Evaluation-distribution naturality for a stateful handler. This is PolyFun's stateful
+naturality theorem for the universal fold, rather than a new induction on `OracleComp`. -/
+theorem run_simulateQ_toQueryImpl_ofStateQueryImpl {ι₀ : Type}
+    {spec₀ : OracleSpec.{0, 0} ι₀} {σ α : Type}
+    (impl : QueryImpl spec₀ (StateT σ ProbComp)) (oa : OracleComp spec₀ α) (s : σ) :
+    (simulateQ (ofStateQueryImpl impl).toQueryImpl oa).run s =
+      𝒟[(simulateQ impl oa).run s] := by
+  exact PFunctor.FreeM.run_mapM_mapHom (MonadHom.ofLift ProbComp SPMF) impl oa s
+
+/-- Embed an actual PolyFun deterministic responder into the probabilistic Kleisli model. The
+Mealy presentation comes from `Responder.toStateHandler`; only its effects are lifted to `SPMF`. -/
+noncomputable def ofResponder {σ : Type u}
+    (R : PFunctor.Responder σ spec.toPFunctor) : ProbResponder spec where
+  State := σ
+  handler t := StateT.mapHom (MonadHom.pure SPMF) (R.toStateHandler t)
+
+@[simp] theorem ofResponder_state {σ : Type u}
+    (R : PFunctor.Responder σ spec.toPFunctor) : (ofResponder R).State = σ := rfl
+
+/-- Pull a responder back along an interface lens. -/
+noncomputable def pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec') :
+    ProbResponder spec where
+  State := R.State
+  handler t s := (fun q => (w.toFunB t q.1, q.2)) <$> R.handler (w.toFunA t) s
+
+@[simp] theorem toQueryImpl_pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    (t : spec.Domain) :
+    (pullback w R).toQueryImpl t =
+      (fun a => w.toFunB t a) <$> R.toQueryImpl (w.toFunA t) := by
+  funext s
+  rfl
+
+end ProbResponder
+
+namespace OracleStrategy
+
+/-- One PolyFun-wired step against a stateful probabilistic responder. -/
+noncomputable def wireKStep (A : OracleStrategy S spec) (R : ProbResponder spec) :
+    R.State × S → SPMF (R.State × S) :=
+  PFunctor.DynSystem.stepWith R.toQueryImpl A
+
+@[simp] theorem wireKStep_apply (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (p : R.State × S) :
+    wireKStep A R p =
+      (fun q => (q.2, A.update p.2 q.1)) <$> R.handler (A.expose p.2) p.1 := rfl
+
+/-- The PolyFun-wired finite run against a responder. -/
+noncomputable def wireKIterate (A : OracleStrategy S spec) (R : ProbResponder spec) :
+    ℕ → R.State × S → SPMF (R.State × S) :=
+  PFunctor.DynSystem.iterWith R.toQueryImpl A
+
+@[simp] theorem wireKIterate_zero (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (p : R.State × S) : wireKIterate A R 0 p = pure p := rfl
+
+theorem wireKIterate_succ (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (n : ℕ) (p : R.State × S) :
+    wireKIterate A R (n + 1) p = wireKStep A R p >>= wireKIterate A R n := rfl
+
+/-- The probabilistic embedding of a PolyFun responder wires exactly as its deterministic closed
+game, wrapped in `SPMF.pure`. -/
+@[simp] theorem wireKStep_ofResponder {σ : Type u}
+    (R : PFunctor.Responder σ spec.toPFunctor) (A : OracleStrategy S spec) (p : σ × S) :
+    wireKStep A (ProbResponder.ofResponder R) p =
+      pure ((PFunctor.DynSystem.closedGame R A).step p) := by
+  change (fun dt : spec.Range (A.expose p.2) × σ => (dt.2, A.update p.2 dt.1)) <$>
+      pure (R.answer p.1 (A.expose p.2), R.next p.1 (A.expose p.2)) = _
+  rw [map_pure]
+  rfl
+
+@[simp] theorem wireKStep_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
+    (A : OracleStrategy S spec) (p : Γ × S) :
+    wireKStep A (ProbResponder.ofHandlerFamily h) p =
+      (fun s' => (p.1, s')) <$> kleisliStep (h p.1) A p.2 := by
+  simp only [wireKStep_apply, ProbResponder.ofHandlerFamily, kleisliStep, Functor.map_map]
+
+@[simp] theorem wireKIterate_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
+    (A : OracleStrategy S spec) (n : ℕ) (p : Γ × S) :
+    wireKIterate A (ProbResponder.ofHandlerFamily h) n p =
+      (fun s' => (p.1, s')) <$> kleisliIterate (h p.1) A n p.2 := by
+  induction n generalizing p with
+  | zero =>
+    simp only [wireKIterate_zero, kleisliIterate, map_pure]
+    rfl
+  | succ n ih =>
+    calc
+      wireKIterate A (ProbResponder.ofHandlerFamily h) (n + 1) p =
+          ((fun s' => (p.1, s')) <$> kleisliStep (h p.1) A p.2) >>=
+            wireKIterate A (ProbResponder.ofHandlerFamily h) n := by
+        rw [wireKIterate_succ, wireKStep_ofHandlerFamily]
+        rfl
+      _ = kleisliStep (h p.1) A p.2 >>= fun s' =>
+          wireKIterate A (ProbResponder.ofHandlerFamily h) n (p.1, s') := by
+        rw [map_eq_bind_pure_comp, bind_assoc]
+        exact congrArg (kleisliStep (h p.1) A p.2 >>= ·)
+          (funext fun s' => by rw [Function.comp_apply, pure_bind]; rfl)
+      _ = kleisliStep (h p.1) A p.2 >>= fun s' =>
+          (fun s'' => (p.1, s'')) <$> kleisliIterate (h p.1) A n s' :=
+        congrArg (kleisliStep (h p.1) A p.2 >>= ·)
+          (funext fun s' => ih (p.1, s'))
+      _ = (fun s' => (p.1, s')) <$> kleisliIterate (h p.1) A (n + 1) p.2 := by
+        rw [kleisliIterate]
+        simp only [map_eq_bind_pure_comp, bind_assoc]
+
+end OracleStrategy

--- a/VCVio/OracleComp/Coinductive/WiredRun.lean
+++ b/VCVio/OracleComp/Coinductive/WiredRun.lean
@@ -1,0 +1,118 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio.OracleComp.Coinductive.Machine
+import VCVio.OracleComp.Coinductive.Responder
+
+/-!
+# Wired Runs of Oracle Machines
+
+This file runs pointed oracle machines against stateful probabilistic responders and states the
+adjunction between machine interface wrapping and responder pullback.
+-/
+
+universe u
+
+open OracleSpec PFunctor
+
+variable {ι : Type u} {spec : OracleSpec.{u, u} ι} {α β : Type u}
+
+namespace OracleMachine
+
+/-- Run a machine against a stateful responder for at most `k` rounds. -/
+noncomputable def wireKRun (M : OracleMachine spec α β) (R : ProbResponder spec)
+    (k : ℕ) (p : R.State × M.State) : SPMF (Option β × R.State) :=
+  (M.runK R.toQueryImpl k p.2).run p.1
+
+@[simp] theorem wireKRun_zero (M : OracleMachine spec α β) (R : ProbResponder spec)
+    (r : R.State) (s : M.State) : M.wireKRun R 0 (r, s) = pure (M.output s, r) := rfl
+
+/-- A halted machine does not query or advance the responder. -/
+theorem wireKRun_of_output_eq_some (M : OracleMachine spec α β) (R : ProbResponder spec)
+    {s : M.State} {b : β} (hb : M.output s = some b) (k : ℕ) (r : R.State) :
+    M.wireKRun R k (r, s) = pure (some b, r) := by
+  rw [wireKRun, M.runK_of_output_eq_some R.toQueryImpl hb]
+  rfl
+
+/-- One unresolved machine round is one PolyFun-wired strategy step. -/
+theorem wireKRun_succ_of_output_eq_none (M : OracleMachine spec α β)
+    (R : ProbResponder spec) {s : M.State} (hb : M.output s = none) (k : ℕ)
+    (r : R.State) :
+    M.wireKRun R (k + 1) (r, s) =
+      OracleStrategy.wireKStep M.toDynSystem R (r, s) >>= fun p => M.wireKRun R k p :=
+  PointedMachine.runWith_run_succ_of_output_eq_none M R.toQueryImpl hb k r
+
+@[simp] theorem wireKRun_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
+    (M : OracleMachine spec α β) (k : ℕ) (s : M.State) (γ : Γ) :
+    M.wireKRun (.ofHandlerFamily h) k (γ, s) =
+      (fun ob => (ob, γ)) <$> M.runK (h γ) k s := by
+  induction k generalizing s with
+  | zero =>
+    simp only [wireKRun_zero, runK_zero, map_pure]
+    rfl
+  | succ k ih =>
+    cases hb : M.output s with
+    | some b =>
+      rw [M.wireKRun_of_output_eq_some _ hb, M.runK_of_output_eq_some (h γ) hb, map_pure]
+      rfl
+    | none =>
+      calc
+        M.wireKRun (.ofHandlerFamily h) (k + 1) (γ, s) =
+            ((fun s' => (γ, s')) <$> OracleStrategy.kleisliStep (h γ) M.toDynSystem s) >>=
+              fun p => M.wireKRun (.ofHandlerFamily h) k p := by
+          rw [M.wireKRun_succ_of_output_eq_none _ hb,
+            OracleStrategy.wireKStep_ofHandlerFamily]
+          rfl
+        _ = OracleStrategy.kleisliStep (h γ) M.toDynSystem s >>= fun s' =>
+            (fun ob => (ob, γ)) <$> M.runK (h γ) k s' := by
+          rw [bind_map_left]
+          exact bind_congr fun s' => ih s'
+        _ = (fun ob => (ob, γ)) <$> M.runK (h γ) (k + 1) s := by
+          rw [M.runK_succ_of_output_eq_none' _ hb, map_bind]
+
+variable {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+
+/-- Transport a machine along a lens, specialized back to the OracleSpec vocabulary. -/
+def wrapIface (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
+    (M : OracleMachine spec α β) : OracleMachine spec' α β where
+  State := M.State
+  expose s := w.toFunA (M.expose s)
+  update s a := M.update s (w.toFunB (M.expose s) a)
+  init := M.init
+  output := M.output
+
+/-- The OracleSpec wrapper is PolyFun's pointed-machine interface transport. -/
+theorem wrapIface_eq_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
+    (M : OracleMachine spec α β) : M.wrapIface w = M.wrap w := rfl
+
+/-- Running a machine wrapped along a lens is running it against the pulled-back responder. -/
+theorem runK_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
+    (M : OracleMachine spec α β) (R : ProbResponder spec') (k : ℕ) (s : M.State) :
+    (M.wrapIface w).runK R.toQueryImpl k s = M.runK (R.pullback w).toQueryImpl k s := by
+  induction k generalizing s with
+  | zero => rfl
+  | succ k ih =>
+    cases hb : M.output s with
+    | some b =>
+      rw [M.runK_of_output_eq_some (R.pullback w).toQueryImpl hb]
+      exact (M.wrapIface w).runK_of_output_eq_some R.toQueryImpl hb _
+    | none =>
+      rw [M.runK_succ_of_output_eq_none (R.pullback w).toQueryImpl hb,
+        (M.wrapIface w).runK_succ_of_output_eq_none R.toQueryImpl hb]
+      simp only [ih]
+      simp only [wrapIface, ProbResponder.toQueryImpl_pullback]
+      exact (bind_map_left (m := StateT R.State SPMF)
+        (fun a => w.toFunB (M.expose s) a) (R.toQueryImpl (w.toFunA (M.expose s)))
+        (fun r => M.runK (R.pullback w).toQueryImpl k (M.update s r))).symm
+
+/-- Wired-run form of the machine-wrap/responder-pullback adjunction. -/
+theorem wireKRun_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
+    (M : OracleMachine spec α β) (R : ProbResponder spec') (k : ℕ)
+    (r : R.State) (s : M.State) :
+    (M.wrapIface w).wireKRun R k (r, s) = M.wireKRun (R.pullback w) k (r, s) := by
+  rw [wireKRun, wireKRun, runK_wrap]
+  rfl
+
+end OracleMachine


### PR DESCRIPTION
## Stack

This PR is based on and should be reviewed after #482.

## Motivation

#482 supplies the machine/program correspondence. This PR exercises it on an existing
cryptographic construction without moving protocol semantics into VCVio-specific machine types.

The guiding principle is that cryptography in VCVio should be a thin probabilistic and
oracle-specific layer over PolyFun interaction. The existing cached IND-CPA oracle remains the
source of truth; this PR only gives it a PolyFun-compatible responder presentation via lenses.

## Probabilistic responders

The primitive data stored by `ProbResponder spec` is an actual PolyFun handler:

```lean
structure ProbResponder (spec : OracleSpec ι) where
  State : Type
  handler : PFunctor.Handler (StateT State SPMF) spec.toPFunctor
```

Thus a response is an effectful Mealy transition in the Kleisli category of `SPMF`: for a query it
jointly samples an answer and the next private responder state. `ProbResponder` contributes only
the existential state packaging and the specialization to VCVio's probability monad.

The new bridges include:

- `ofQueryImpl` for an existing `StateT σ SPMF` PolyFun handler;
- `ofStateQueryImpl` for an existing `StateT σ ProbComp` implementation, transported by
  `StateT.mapHom (MonadHom.ofLift ProbComp SPMF)`;
- `ofResponder` for a deterministic `PFunctor.Responder σ q`, using
  `Responder.toStateHandler` and the pure monad morphism;
- `pullback` along a `PFunctor.Lens`.

The distributional bridge is an instance of PolyFun fold naturality rather than a fresh induction
over `OracleComp`:

```lean
(simulateQ responder.toQueryImpl oa).run state =
  𝒟[(simulateQ impl oa).run state]
```

## Wired machine execution

The finite responder/strategy run is directly PolyFun's stateful Kleisli execution:

```lean
PFunctor.DynSystem.stepWith responder.toQueryImpl strategy
PFunctor.DynSystem.iterWith responder.toQueryImpl strategy
```

Similarly, pointed-machine execution is based on `PointedMachine.runWith`. The important
one-step law for an unresolved machine state is inherited from PolyFun:

```lean
wireKRun R (k + 1) (r, s) =
  wireKStep machine.toDynSystem R (r, s) >>= fun p =>
    wireKRun R k p
```

## Lenses as reductions

For a lens

```lean
w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor
```

wrapping the querying machine and pulling back the responder are observationally the same:

```lean
(machine.wrapIface w).wireKRun responder k (r, s) =
  machine.wireKRun (responder.pullback w) k (r, s)
```

This is the concrete reduction principle exercised by the IND-CPA example.

## IND-CPA application

The existing cached implementation

```lean
encAlg.IND_CPA_queryImpl' pk b :
  QueryImpl encAlg.IND_CPA_oracleSpec
    (StateT encAlg.IND_CPA_Cache ProbComp)
```

is wrapped as `encAlg.IND_CPA_responder pk b`. A machine satisfying

```lean
machine.Implements adversary k
```

then has the same joint result/cache distribution as the existing `simulateQ` execution. No
second IND-CPA semantics is introduced.

The left/right message transformation is represented by a PolyFun lens:

```lean
(m₀, m₁) ↦ (m₁, m₀)
```

It leaves uniform-sampling queries and oracle responses unchanged. The corresponding machine
reduction theorem is a one-line specialization of the generic wrap/pullback law, replacing a
protocol-specific run induction.

## Proposed PolyFun follow-up

The remaining existential wrapper points to a useful generic PolyFun notion:

```lean
structure KleisliResponder (m : Type u → Type v) (q : PFunctor) where
  State : Type u
  handler : PFunctor.Handler (StateT State m) q
```

Useful accompanying theory would include:

- pullback along `PFunctor.Lens`;
- transport along `MonadHom`;
- `stepWith` / `iterWith` laws;
- a responder homomorphism or state-simulation notion.

The last item would express conjugacies between responder states—for example, swapping the keys
of the cached IND-CPA oracle—without a VCVio-specific induction. Once this exists upstream,
`ProbResponder` can become an even thinner specialization or alias.

## Deliberately out of scope

- computational complexity and PolyTime;
- Cslib and concrete Turing machines;
- asymptotic security;
- a complete branch-flip/cache-conjugacy theorem, pending the generic responder-hom notion above.

## Review guide

- `VCVio/OracleComp/Coinductive/Responder.lean` — the thin handler-backed wrapper;
- `VCVio/OracleComp/Coinductive/WiredRun.lean` — generic machine/responder wiring;
- `VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean` — the existing-protocol application.

## Validation

- `lake build`
- `git diff --check dtumad/oracle-machine-implements..dtumad/polyfun-indcpa-responder`
- no new `sorry` declarations
- no Cslib, PolyTime, or asymptotic-complexity dependency

