### PR TITLE
docs: rebrand project as VCVio

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # VCVio — AI Agent Guide
 
-Formally verified cryptography proofs in Lean 4, built on Mathlib.
+Machine-checked cryptographic proofs in Lean, built on Mathlib.
 
 ## Fast Start
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,4 @@
-# VCV-io — AI Agent Guide
+# VCVio — AI Agent Guide
 
 Formally verified cryptography proofs in Lean 4, built on Mathlib.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-# Contributing to VCV-io
+# Contributing to VCVio
 
 Thanks for contributing.
 

--- a/README.md
+++ b/README.md
@@ -1,17 +1,22 @@
-# Formally Verified Cryptography Proofs in Lean 4
+# VCVio
 
-This library aims to provide a foundational framework in Lean for reasoning about cryptographic protocols in the computational model. The core part of the framework provides:
+*Verifying Cryptography via Interactions and Oracles*
+
+VCVio is a Lean 4 library for machine-checked proofs about cryptographic games, primitives,
+protocols, and implementations. The core framework provides:
 
 * A monadic syntax for representing computations with oracle access (`OracleComp`), with probabilistic computations (`ProbComp`) as a special case of having uniform selection oracles.
 * A denotational semantics (`evalDist`) for assigning probability distributions to probabilistic computations, and tools for reasoning about the probabilities of particular outputs or events (`probOutput`/`probEvent`/`probFailure`).
 * An operational semantics (`simulateQ`) for implementing/simulating the behavior of a computation's oracles, including implementations of random oracles, query logging, reductions, etc.
 * A program logic with relational (pRHL-style) and unary (Hoare-style) proof modes, with interactive tactics for stepping through game-based proofs.
 
-It also provides definitions for cryptographic primitives such as symmetric/asymmetric encryption, signatures, $\Sigma$-protocols, and transforms like Fiat-Shamir and Fischlin.
+It also provides definitions for cryptographic primitives such as symmetric/asymmetric encryption,
+signatures, $\Sigma$-protocols, and transforms like Fiat-Shamir and Fischlin.
 
-On top of that generic framework, the repo now contains a dedicated `LatticeCrypto` library for
-ML-DSA, ML-KEM, and Falcon, including both proof-level abstractions and executable concrete
-implementations.
+On top of the generic framework, `LatticeCrypto` covers ML-DSA, ML-KEM, and Falcon, including
+proof-level abstractions and executable concrete implementations. `HashSig` covers SLH-DSA
+(SPHINCS+, FIPS 205), and the interaction layer supports computational interpretations of
+interactive and UC-style systems.
 
 Assuming Lean 4 and lake are already installed, the project can be built by just running:
 
@@ -27,18 +32,22 @@ only times the smoke module separately with `lake env lean VCVioTest/Smoke.lean`
 
 Mathematical foundations such as probability theory, computational complexity, and algebraic structures are based on or written to the Mathlib project (see [MATHLIB4](REFERENCES.md#mathlib4)), making all of that library usable in constructions and proofs.
 
-Generally the project aims to enable proof complexity comparable to that found in Mathlib.
-It's most well suited to proving concrete security bounds for reductions, and for establishing the security of individual cryptographic primitives.
-It allows for fully foundational proofs of things like forking/rewinding adversaries and Fiat-Shamir style transforms, but has less support for composing a large number of primitives into complex protocols.
-Asymptotic reasoning is also supported, but tooling and automation for this is currently limited.
-Computational complexity is not considered.
+The project aims to enable proof effort comparable to that found in Mathlib. It is particularly
+well suited to concrete security bounds for reductions and to the security of individual
+cryptographic primitives. It supports foundational arguments about forking and rewinding
+adversaries, Fiat-Shamir-style transforms, interactive systems, and UC-style composition.
+Asymptotic security and query-cost and expected-cost reasoning are also supported. Polynomial-time
+infrastructure and some tooling and automation remain under active development.
 
 ## Repository Map
 
 - `VCVio/` contains the oracle-computation framework, probability semantics, program logic, and generic crypto abstractions.
 - `LatticeCrypto/` contains lattice algebra, hardness assumptions, ML-DSA, ML-KEM, Falcon, and their concrete implementations.
+- `HashSig/` contains hash-based signatures, including proof-level specifications and security for SLH-DSA.
 - `LatticeCryptoTest/` contains ACVP vectors, regression tests, and differential checks against native backends.
+- `HashSigTest/` contains hash-signature test and validation modules.
 - `Examples/` contains compact framework proofs including OneTimePad, ElGamal, and Schnorr.
+- `Interop/` contains experimental bridges to Rust verification frontends such as hax and Aeneas.
 - `csrc/` contains C FFI bridges for the native ML-DSA, ML-KEM, and Falcon implementations used in tests.
 - `third_party/` contains the vendored native backends used by the FFI layer.
 - `ToMathlib/` contains supporting constructions that may eventually move to a separate project.
@@ -139,8 +148,15 @@ Predicates and tools for computations:
 * `IsQueryBound` - bound the number of queries a computation makes (with per-index variant `IsPerIndexQueryBound`)
 * `QueryImpl.withLogging`/`withCaching`/`withPregen` - modifiers that wrap a query implementation with logging, caching, or pre-generated answers
 
-## Trivia
+## Name
 
-`VCV-io` is inspired by FCF (see [FCF-REPO](REFERENCES.md#fcf-repo) and [FCF14](REFERENCES.md#fcf14)), a foundational framework for verified cryptography in Coq. Similar to FCF, we formalize the notion of oracle computations as central to modeling cryptographic games, primitives, and protocols. In contrast to FCF, our handling of oracles is much more refined — we allow for an *indexed* family of oracles via polynomial functors, and build significant infrastructure for combining and simulation of oracles.
+**VCVio** stands for **Verifying Cryptography via Interactions and Oracles**.
 
-The name `VCV` is reverse of `FCF` under the involution `F <=> V` (same number of characters going from the beginning, versus the end, of the English alphabet). One backronym for the name is "Verified Cryptography via Indexed Oracles".
+Interactions arise between protocol participants, between computations and their oracle
+environments, and between specifications and implementations through simulation and effect
+handlers. Oracles provide a common abstraction for cryptographic games, reductions,
+probabilistic semantics, and executable interpretations.
+
+VCVio is inspired by FCF (see [FCF-REPO](REFERENCES.md#fcf-repo) and
+[FCF14](REFERENCES.md#fcf14)), the Foundational Cryptography Framework for Coq, whose
+foundational approach influenced VCVio's machine-checked cryptographic security proofs.

--- a/README.md
+++ b/README.md
@@ -157,6 +157,9 @@ their oracle environments, and between specifications and implementations throug
 effect handlers; oracles provide a common abstraction for cryptographic games, reductions,
 probabilistic semantics, and executable interpretations.
 
-VCVio is inspired by FCF (see [FCF-REPO](REFERENCES.md#fcf-repo) and
-[FCF14](REFERENCES.md#fcf14)), the Foundational Cryptography Framework for Rocq (formerly Coq).
-FCF's foundational approach influenced VCVio's machine-checked cryptographic security proofs.
+VCVio's framework is inspired by FCF (see [FCF-REPO](REFERENCES.md#fcf-repo) and
+[FCF14](REFERENCES.md#fcf14)), the Foundational Cryptography Framework for Rocq (formerly Coq),
+particularly its use of embedded probabilistic and oracle-aided computations with semantic models
+and derived rules for game-based reasoning. Where FCF gives each computation a single oracle
+interface, VCVio uses indexed oracle families represented by polynomial functors and provides
+compositional infrastructure for combining, simulating, and interpreting them.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
-# VCVio
+# Machine-Checked Cryptographic Proofs in Lean
 
-*Verifying Cryptography via Interactions and Oracles*
-
-VCVio is a Lean 4 library for machine-checked proofs about cryptographic games, primitives,
+VCVio is a Lean library for machine-checked proofs about cryptographic games, primitives,
 protocols, and implementations. The core framework provides:
 
 * A monadic syntax for representing computations with oracle access (`OracleComp`), with probabilistic computations (`ProbComp`) as a special case of having uniform selection oracles.
@@ -18,7 +16,7 @@ proof-level abstractions and executable concrete implementations. `HashSig` cove
 (SPHINCS+, FIPS 205), and the interaction layer supports computational interpretations of
 interactive and UC-style systems.
 
-Assuming Lean 4 and lake are already installed, the project can be built by just running:
+Assuming Lean and Lake are already installed, the project can be built by just running:
 
 ```
 lake exe cache get && lake build
@@ -152,11 +150,13 @@ Predicates and tools for computations:
 
 **VCVio** stands for **Verifying Cryptography via Interactions and Oracles**.
 
-Interactions arise between protocol participants, between computations and their oracle
-environments, and between specifications and implementations through simulation and effect
-handlers. Oracles provide a common abstraction for cryptographic games, reductions,
+The initials **VCV** also admit the Latin motto *Veritas cryptographica vincit*
+(“cryptographic truth prevails”). The **io** suffix reflects the interactions and oracles at the
+heart of the library: interactions arise between protocol participants, between computations and
+their oracle environments, and between specifications and implementations through simulation and
+effect handlers; oracles provide a common abstraction for cryptographic games, reductions,
 probabilistic semantics, and executable interpretations.
 
 VCVio is inspired by FCF (see [FCF-REPO](REFERENCES.md#fcf-repo) and
-[FCF14](REFERENCES.md#fcf14)), the Foundational Cryptography Framework for Coq, whose
-foundational approach influenced VCVio's machine-checked cryptographic security proofs.
+[FCF14](REFERENCES.md#fcf14)), the Foundational Cryptography Framework for Rocq (formerly Coq).
+FCF's foundational approach influenced VCVio's machine-checked cryptographic security proofs.

--- a/VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean
+++ b/VCVio/CryptoFoundations/HardnessAssumptions/CollisionResistance.lean
@@ -129,7 +129,7 @@ term `(t+2) * (t+1) / (2 * |Y|)` — a `(t+2)`-query game once the two
 verification queries are accounted for.
 
 Closes one of the layers requested in
-[Verified-zkEVM/VCV-io#284](https://github.com/Verified-zkEVM/VCV-io/issues/284).
+[Verified-zkEVM/VCVio#284](https://github.com/Verified-zkEVM/VCVio/issues/284).
 -/
 
 /-- The random-oracle spec with domain `X` and range `Y`, as seen by the

--- a/VCVio/CryptoFoundations/HashCommitment.lean
+++ b/VCVio/CryptoFoundations/HashCommitment.lean
@@ -23,7 +23,7 @@ A binding adversary outputting two openings `(c, m₁, s₁, m₂, s₂)` with
 `bindingAdvantage H.toCommitment A ≤ keyedCRAdvantage H (bindingAdv_toCRAdv A)`.
 
 This is the standard-model layer of the
-[#284](https://github.com/Verified-zkEVM/VCV-io/issues/284) consolidation
+[#284](https://github.com/Verified-zkEVM/VCVio/issues/284) consolidation
 chain `binding ≤ keyed-CR ≤ birthday`.
 
 ## Main Definitions

--- a/VCVio/OracleComp/QueryTracking/WriterCost.lean
+++ b/VCVio/OracleComp/QueryTracking/WriterCost.lean
@@ -198,7 +198,7 @@ of its cost marginal.
 
 This expectation is computed over the base monad's subdistribution semantics on `oa.costs`. In
 particular, if the underlying computation can fail, the missing mass contributes `0`, exactly as
-for other `wp`-style expectations in VCV-io. -/
+for other `wp`-style expectations in VCVio. -/
 noncomputable def expectedCost
     (oa : AddWriterT ω m α) (val : ω → ENNReal) : ENNReal :=
   ∑' w : ω, Pr[= w | oa.costs] * val w

--- a/docs/agents/interaction.md
+++ b/docs/agents/interaction.md
@@ -1,6 +1,6 @@
 # Interaction Integration
 
-VCV-io depends on PolyFun for the generic interaction framework.
+VCVio depends on PolyFun for the generic interaction framework.
 Do not duplicate PolyFun's interaction guide here.
 Use this page for VCV-specific runtime, computational, and example integration only.
 
@@ -13,11 +13,11 @@ Generic protocol theory lives in PolyFun:
 - Generic UC interfaces, open processes, structural boundary traces, open theory, notation, environment actions, and leakage scaffolding: `PolyFun.Interaction.UC.*`
 
 For conceptual background, read PolyFun's `docs/wiki/interaction.md` and the module docstrings in the PolyFun dependency.
-VCV-io should only document how those generic APIs are instantiated with probabilistic semantics, oracle computations, and crypto examples.
+VCVio should only document how those generic APIs are instantiated with probabilistic semantics, oracle computations, and crypto examples.
 
 ## VCV-Specific Layers
 
-VCV-io retains the computational and runtime interpretation of PolyFun's generic UC layer:
+VCVio retains the computational and runtime interpretation of PolyFun's generic UC layer:
 
 | File | Purpose |
 |------|---------|
@@ -25,8 +25,8 @@ VCV-io retains the computational and runtime interpretation of PolyFun's generic
 | `VCVio/Interaction/UC/Runtime.lean` | Synchronous runtime semantics for closed open processes, including `processSemantics`, `processSemanticsProbComp`, and `processSemanticsOracle`. |
 | `VCVio/Interaction/UC/AsyncRuntime.lean` | Asynchronous runtime semantics with process ticks and environment events. |
 | `VCVio/Interaction/UC/AsyncSecurity.lean` | Fair-PPT security wrappers for asynchronous env-open executions. |
-| `VCVio/Interaction/UC/Standard.lean` | Standard VCV-io UC imports and conveniences. |
-| `VCVio/Interaction/UC/StdDoBridge.lean` | Bridges from VCV-io program-logic/Std.Do idioms into the UC runtime layer. |
+| `VCVio/Interaction/UC/Standard.lean` | Standard VCVio UC imports and conveniences. |
+| `VCVio/Interaction/UC/StdDoBridge.lean` | Bridges from VCVio program-logic/Std.Do idioms into the UC runtime layer. |
 
 These files may import PolyFun interaction modules.
 Generic interaction modules should not be reintroduced under `VCVio/Interaction` or `ToMathlib`.
@@ -34,8 +34,8 @@ Generic interaction modules should not be reintroduced under `VCVio/Interaction`
 ## Runtime Semantics
 
 `OpenProcess m Party Δ` comes from PolyFun and carries its per-step `Spec.Sampler m` intrinsically.
-VCV-io's runtime layer interprets a closed process by running those samplers and then observing the resulting state in a probabilistic semantics.
-Use PolyFun's `OpenStep.boundaryTrace` when you need to read the emitted output packets from a completed open-step transcript; routing and probabilistic interpretation remain VCV-io runtime concerns.
+VCVio's runtime layer interprets a closed process by running those samplers and then observing the resulting state in a probabilistic semantics.
+Use PolyFun's `OpenStep.boundaryTrace` when you need to read the emitted output packets from a completed open-step transcript; routing and probabilistic interpretation remain VCVio runtime concerns.
 
 Use the synchronous entry points in `VCVio/Interaction/UC/Runtime.lean`:
 
@@ -76,7 +76,7 @@ Important definitions:
 - `Execution T` is the distributional experiment consumed by paper-level `Standard.UCSecure`.
 
 The generic equivalence-style UC judgments live in PolyFun.
-The VCV-io layer gives them a crypto-facing distributional interpretation.
+The VCVio layer gives them a crypto-facing distributional interpretation.
 Use the `Observed*` definitions when you intentionally work relative to a chosen observer.
 Use `Standard.UCSecure exec ε π F` when stating textbook UC security for a fixed execution experiment; `Execution.ofSemantics` is an explicit bridge from an observer to such an execution.
 
@@ -107,4 +107,4 @@ import VCVio.Interaction.UC.Computational
 import VCVio.Interaction.UC.Standard
 ```
 
-When editing VCV-io, prefer importing the specific PolyFun module you need rather than re-exporting large generic surfaces through VCV-io.
+When editing VCVio, prefer importing the specific PolyFun module you need rather than re-exporting large generic surfaces through VCVio.

--- a/scripts/extract-doc-fragments.py
+++ b/scripts/extract-doc-fragments.py
@@ -1,5 +1,5 @@
 #!/usr/bin/env python3
-"""Extract structured documentation fragments from the VCV-io codebase.
+"""Extract structured documentation fragments from the VCVio codebase.
 
 Generates markdown tables for:
 1. Tactic declarations (from ProgramLogic/)


### PR DESCRIPTION
## Summary

- standardize the public project name as `VCVio` without changing Lean namespaces or imports
- introduce the expansion “Verifying Cryptography via Interactions and Oracles”
- refresh the README to cover lattice cryptography, hash signatures, interactions, UC, and complexity infrastructure
- update first-party prose and issue links to the canonical `Verified-zkEVM/VCVio` identity

## Impact

This is a compatibility-preserving documentation rebrand. Package names, module paths, library targets, and imports remain unchanged.

## Validation

- `git diff --check`
- `python3 scripts/check-agent-docs.py`
- verified no first-party occurrences of `VCV-io`, the old backronym, or the old alphabet explanation remain outside vendored code
