### PR TITLE
feat(coinductive): probabilistic responders, wired runs, and the IND-CPA responder presentation

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -104,6 +104,8 @@ import VCVio.OracleComp.Coercions.SubSpec
 import VCVio.OracleComp.Coinductive.Bridge
 import VCVio.OracleComp.Coinductive.DynSystem
 import VCVio.OracleComp.Coinductive.Machine
+import VCVio.OracleComp.Coinductive.Responder
+import VCVio.OracleComp.Coinductive.WiredRun
 import VCVio.OracleComp.Constructions.BitVec
 import VCVio.OracleComp.Constructions.Fork
 import VCVio.OracleComp.Constructions.GenerateSeed

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
@@ -5,6 +5,7 @@ Authors: Devon Tuma, Quang Dao
 -/
 import VCVio.CryptoFoundations.AsymmEncAlg.Defs
 import VCVio.OracleComp.Coercions.SubSpec
+import VCVio.OracleComp.Coinductive.WiredRun
 import VCVio.OracleComp.ProbComp
 import VCVio.OracleComp.QueryTracking.QueryBound
 import VCVio.OracleComp.SimSemantics.Append
@@ -81,6 +82,81 @@ def IND_CPA_queryImpl' (encAlg : AsymmEncAlg ProbComp M PK SK C)
   IND_CPA_queryImplFromChallenge encAlg
     (IND_CPA_cachedChallengeOracle encAlg pk
       (fun mm => if b then mm.1 else mm.2))
+
+/-- The cached left/right oracle as a probabilistic responder. This is a thin wrapper around
+`IND_CPA_queryImpl'`; the existing `StateT ProbComp` implementation remains the source of truth. -/
+@[reducible] noncomputable def IND_CPA_responder (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (pk : PK) (b : Bool) : ProbResponder encAlg.IND_CPA_oracleSpec :=
+  .ofStateQueryImpl (encAlg.IND_CPA_queryImpl' pk b)
+
+@[simp] theorem IND_CPA_responder_state (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (pk : PK) (b : Bool) : (encAlg.IND_CPA_responder pk b).State = encAlg.IND_CPA_Cache := rfl
+
+/-- Running a program against the responder is the evaluation distribution of the existing
+cached `StateT ProbComp` interpretation. -/
+theorem run_IND_CPA_responder_eq (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (pk : PK) (b : Bool) {γ : Type} (oa : OracleComp encAlg.IND_CPA_oracleSpec γ)
+    (cache : encAlg.IND_CPA_Cache) :
+    (simulateQ (encAlg.IND_CPA_responder pk b).toQueryImpl oa).run cache =
+      𝒟[(simulateQ (encAlg.IND_CPA_queryImpl' pk b) oa).run cache] :=
+  ProbResponder.run_simulateQ_toQueryImpl_ofStateQueryImpl
+    (encAlg.IND_CPA_queryImpl' pk b) oa cache
+
+/-- Machine-level reading of the existing IND-CPA oracle execution: any machine implementing
+the program adversary within fuel `k` has exactly the same joint output/cache distribution. -/
+theorem runAgainst_IND_CPA_responder_eq (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (adversary : encAlg.IND_CPA_adversary)
+    (machine : OracleMachine encAlg.IND_CPA_oracleSpec PK Bool) {k : ℕ}
+    (himp : machine.ImplementsWithin adversary k) (pk : PK) (b : Bool)
+    (cache : encAlg.IND_CPA_Cache) :
+    machine.runAgainst (encAlg.IND_CPA_responder pk b) k (cache, machine.init pk) =
+      (fun p => (some p.1, p.2)) <$>
+        𝒟[(simulateQ (encAlg.IND_CPA_queryImpl' pk b) (adversary pk)).run cache] :=
+  calc machine.runAgainst (encAlg.IND_CPA_responder pk b) k (cache, machine.init pk)
+      = (machine.runWithInput (encAlg.IND_CPA_responder pk b).toQueryImpl k pk).run cache :=
+        rfl
+    _ = (some <$> simulateQ (encAlg.IND_CPA_responder pk b).toQueryImpl
+          (adversary pk)).run cache := by
+        rw [himp.simulateQ_run_eq (encAlg.IND_CPA_responder pk b).toQueryImpl pk]
+    _ = (fun p => (some p.1, p.2)) <$>
+          𝒟[(simulateQ (encAlg.IND_CPA_queryImpl' pk b) (adversary pk)).run cache] := by
+        rw [StateT.run_map, run_IND_CPA_responder_eq]
+
+/-! ## Left/right message swapping as a PolyFun reduction -/
+
+/-- The interface lens that swaps the two messages in a challenge query. Responses are
+unchanged. -/
+def IND_CPA_swapChallengeLens :
+    PFunctor.Lens (M × M →ₒ C).toPFunctor (M × M →ₒ C).toPFunctor where
+  toFunA mm := (mm.2, mm.1)
+  toFunB _ := id
+
+/-- The IND-CPA interface reduction that leaves randomness queries alone and swaps the two
+messages at every challenge query. -/
+def IND_CPA_swapLens (encAlg : AsymmEncAlg ProbComp M PK SK C) :
+    PFunctor.Lens encAlg.IND_CPA_oracleSpec.toPFunctor
+      encAlg.IND_CPA_oracleSpec.toPFunctor :=
+  PFunctor.Lens.sumMap (PFunctor.Lens.id unifSpec.toPFunctor) IND_CPA_swapChallengeLens
+
+omit [DecidableEq M] in
+@[simp] theorem IND_CPA_swapLens_query_left (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (t : unifSpec.Domain) : encAlg.IND_CPA_swapLens.toFunA (.inl t) = .inl t := rfl
+
+omit [DecidableEq M] in
+@[simp] theorem IND_CPA_swapLens_query_right (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (mm : M × M) : encAlg.IND_CPA_swapLens.toFunA (.inr mm) = .inr (mm.2, mm.1) := rfl
+
+omit [DecidableEq M] in
+/-- Wrapping an IND-CPA machine with message swapping is exactly responder pullback along the
+same PolyFun lens: a one-line specialization of the generic wrap/pullback adjunction
+`OracleMachine.runAgainst_wrap`, with no protocol-specific run induction. -/
+theorem runAgainst_IND_CPA_swap (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (machine : OracleMachine encAlg.IND_CPA_oracleSpec PK Bool)
+    (R : ProbResponder encAlg.IND_CPA_oracleSpec) (k : ℕ) (r : R.State)
+    (s : machine.State) :
+    OracleMachine.runAgainst (machine.wrap encAlg.IND_CPA_swapLens) R k (r, s) =
+      machine.runAgainst (R.pullback encAlg.IND_CPA_swapLens) k (r, s) :=
+  OracleMachine.runAgainst_wrap encAlg.IND_CPA_swapLens machine R k r s
 
 /-- Oracle IND-CPA experiment with caching on the LR oracle. -/
 def IND_CPA_experiment {encAlg : AsymmEncAlg ProbComp M PK SK C}

--- a/VCVio/OracleComp/Coinductive/Machine.lean
+++ b/VCVio/OracleComp/Coinductive/Machine.lean
@@ -111,6 +111,54 @@ abbrev toMachine {α β : Type u} (program : α → OracleComp spec β) :
 
 end OracleComp
 
+namespace PFunctor.DynSystem.DynComputation
+
+/- Interface transport commutes with fuelled unrolling. Stated at the generic
+`DynComputation` level; an upstream candidate for `DynComputation/Bounded`. -/
+section UnrollWrap
+
+universe u' uA uB uA₂ uB₂ uα uβ
+
+variable {p : PFunctor.{uA, uB}} {q : PFunctor.{uA₂, uB₂}} {α : Type uα} {β : Type uβ}
+
+/-- Fuelled unrolling commutes with interface transport along a lens: the unrolled
+query tree of the wrapped machine is the lens-translated unrolled tree. The syntactic
+(`FreeM`-level) content of interface wrapping, from which handler-level wrapping laws
+follow by `FreeM.liftM` naturality without touching machine states. -/
+theorem unroll_wrap (M : DynComputation.{u'} p α β) (w : PFunctor.Lens p q)
+    (k : ℕ) (s : M.State) :
+    (M.wrap w).unroll k s = PFunctor.FreeM.mapLens w (M.unroll k s) := by
+  induction k generalizing s with
+  | zero =>
+    cases hview : M.view s with
+    | inl b =>
+      rw [M.unroll_return 0 s b hview,
+        (M.wrap w).unroll_return 0 s b (by simp [hview])]
+      rfl
+    | inr qq =>
+      obtain ⟨t, next⟩ := qq
+      rw [M.unroll_query_zero s t next hview,
+        (M.wrap w).unroll_query_zero s (w.toFunA t)
+          (fun d => next (w.toFunB t d)) (by simp [hview])]
+      rfl
+  | succ k ih =>
+    cases hview : M.view s with
+    | inl b =>
+      rw [M.unroll_return (k + 1) s b hview,
+        (M.wrap w).unroll_return (k + 1) s b (by simp [hview])]
+      rfl
+    | inr qq =>
+      obtain ⟨t, next⟩ := qq
+      rw [M.unroll_query_succ k s t next hview,
+        (M.wrap w).unroll_query_succ k s (w.toFunA t)
+          (fun d => next (w.toFunB t d)) (by simp [hview])]
+      exact congrArg (PFunctor.FreeM.liftBind (w.toFunA t))
+        (funext fun d => ih (next (w.toFunB t d)))
+
+end UnrollWrap
+
+end PFunctor.DynSystem.DynComputation
+
 namespace PFunctor.DynSystem.DynComputation.ImplementsWithin
 
 /- The `OracleSpec`/`simulateQ` readings of the fuelled implementation relation live in the

--- a/VCVio/OracleComp/Coinductive/Responder.lean
+++ b/VCVio/OracleComp/Coinductive/Responder.lean
@@ -1,0 +1,381 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio.OracleComp.Coinductive.DynSystem
+import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
+import PolyFun.PFunctor.Dynamical.Game
+
+/-!
+# Probabilistic Wiring: Adversary Strategies Against Stateful Responders
+
+`ProbResponder spec` is the challenger side of an interactive game presented as a
+coalgebra: a state set together with, for each query, a *joint* subdistribution over
+the answer and the next state — a Mealy machine in the Kleisli category of `SPMF`.
+Unbundled, it is exactly a stateful handler `QueryImpl spec (StateT State SPMF)`
+(`ProbResponder.toQueryImpl` / `ofQueryImpl` are definitional inverses): the bundled
+probabilistic sibling of PolyFun's deterministic Kleisli–Mealy bridge
+`PFunctor.Responder.equivStateHandler`.
+
+Wiring a responder against an adversary `OracleStrategy` is not a hand-rolled
+construction: `stepAgainst` / `iterateAgainst` are PolyFun's generic eval-wired runs
+`PFunctor.DynSystem.stepWith` / `iterWith` instantiated at `m := SPMF`, driven by the
+responder's stateful handler. The responder state comes first in the product state,
+matching the upstream handler-state-first convention and the challenger-first state of
+`PFunctor.DynSystem.closedGame`; a deterministic responder (`ProbResponder.ofDet`) wires
+to `pure` of the closed-game step (`stepAgainst_ofDet`). `transcriptAgainst` additionally
+records the exchanged queries and answers — `QueryLog` is VCVio vocabulary, so the
+transcript form lives here rather than upstream.
+
+Memoryless oracles embed as responders with trivial (`ProbResponder.ofHandler`) or
+constant (`ProbResponder.ofHandlerFamily`) state, and the wired run then collapses to
+the existing memoryless runs `OracleStrategy.kleisliStep` / `kleisliIterate`
+(`stepAgainst_ofHandler` and companions) — the setup-indexed family form of the upstream
+stateless collapses `PFunctor.DynSystem.stepWith_lift` / `iterWith_lift`. The
+per-run-sampled oracle of a one-shot security game is exactly the constant-state case.
+Genuinely stateful challengers enter through `ProbResponder.ofQueryImpl` (from a
+`QueryImpl` into `StateT σ SPMF`) or `ProbResponder.ofStateQueryImpl` (from a
+`QueryImpl` into `StateT σ ProbComp`, via its evaluation distribution): the lazy random
+oracle (`randomOracleResponder`) is the motivating instance, and cached LR encryption
+oracles fit the same constructor at the `CryptoFoundations` layer. The joint
+answer/state draw is essential for these — the cache entry a random oracle stores must
+be the very answer it returned.
+
+## Categorical view (Spivak–Niu)
+
+A *deterministic* responder is a dynamical system over the internal hom `[p, y]` of
+Spivak–Niu §4.5 (for `p` the interface polynomial `spec.toPFunctor`) — PolyFun's
+`PFunctor.Responder`, which embeds here as the Dirac case `ProbResponder.ofDet`.
+Closing an adversary against a responder is wiring along the evaluation map
+`eval : [p, y] ⊗ p → y`: `stepAgainst` keeps that wiring as deterministic combinatorial
+data and lets the *states* advance in the Kleisli category of the commutative monad
+`SPMF` — one synchronized step of the tensor system with the evaluation wiring applied,
+which is precisely the upstream `stepWith`. `ProbResponder` is strictly more general
+than a Kleisli lift of an `[p, y]`-system, because the answer and the next state are
+drawn jointly rather than the state first determining a handler. The UC layer's
+`processSemanticsOracle` is the heavyweight sibling of this construction (multi-party,
+scheduler-driven); this file is the minimal two-party core, and neither is derived from
+the other.
+
+Wired runs of machine adversaries (an `OracleMachine.runK` against a responder rather
+than a memoryless handler) live in `VCVio.OracleComp.Coinductive.WiredRun`.
+-/
+
+universe u v
+
+open OracleSpec
+
+variable {ι : Type u} {spec : OracleSpec.{u, u} ι} {S : Type u}
+
+/-! ## Probabilistic stateful responders -/
+
+/-- A probabilistic stateful responder: the challenger side of an interactive game, as
+a Mealy coalgebra in the Kleisli category of `SPMF`. From a state, each query yields a
+joint subdistribution over the answer and the successor state. The joint draw matters:
+a lazy random oracle's stored cache entry must be the very answer it returned, which no
+answer-then-state factorization expresses. -/
+structure ProbResponder {ι : Type u} (spec : OracleSpec.{u, u} ι) where
+  /-- The responder's internal state (the challenger's memory). -/
+  State : Type u
+  /-- Answer a query from a state, jointly drawing the successor state. -/
+  answer : State → (t : spec.Domain) → SPMF (spec.Range t × State)
+
+namespace ProbResponder
+
+/-- A responder as a stateful query implementation in `StateT State SPMF`: the
+bundled-to-unbundled direction of the Kleisli–Mealy identification, of which
+`PFunctor.Responder.equivStateHandler` is the deterministic (`Id`) sibling. -/
+def toQueryImpl (R : ProbResponder spec) : QueryImpl spec (StateT R.State SPMF) :=
+  fun t s => R.answer s t
+
+/-- A stateful query implementation as a responder; inverse to `toQueryImpl`. -/
+@[reducible] def ofQueryImpl {σ : Type u} (impl : QueryImpl spec (StateT σ SPMF)) :
+    ProbResponder spec where
+  State := σ
+  answer s t := impl t s
+
+@[simp] lemma toQueryImpl_ofQueryImpl {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) : (ofQueryImpl impl).toQueryImpl = impl :=
+  rfl
+
+@[simp] lemma ofQueryImpl_toQueryImpl (R : ProbResponder spec) :
+    ofQueryImpl R.toQueryImpl = R :=
+  rfl
+
+/-- A family of memoryless randomized oracles indexed by a fixed setup value, as a
+responder whose state is the setup and never changes: the per-run-sampled oracle of a
+one-shot security game (sample the setup, then answer memorylessly) is exactly this
+constant-state case. -/
+@[reducible] noncomputable def ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec) :
+    ProbResponder spec where
+  State := Γ
+  answer γ t := (fun r => (r, γ)) <$> h γ t
+
+/-- A memoryless randomized oracle as a (trivially) stateful responder. -/
+@[reducible] noncomputable def ofHandler (H : ProbHandler spec) : ProbResponder spec :=
+  ofHandlerFamily fun _ : PUnit => H
+
+/-- A deterministic responder — PolyFun's `PFunctor.Responder`, a dynamical system over
+the internal hom `spec.toPFunctor ⊸ X` — as a Dirac probabilistic responder: the answer
+and successor state it commits to, with probability one. Wiring against it recovers the
+upstream closed game (`OracleStrategy.stepAgainst_ofDet`). -/
+@[reducible] noncomputable def ofDet {σ : Type u} (C : PFunctor.Responder σ spec.toPFunctor) :
+    ProbResponder spec where
+  State := σ
+  answer s t := pure (C.answer s t, C.next s t)
+
+/-- Pull a responder back along an interface lens: translate each query forward through
+the lens, ask the target responder, and pull its answer back through the lens, keeping
+the target's state. This is the challenger side of interface wrapping — dual to
+installing an adversary forward along a lens (`OracleStrategy.reduce`).
+
+Reducible so that `(pullback w R).State` unfolds to `R.State` during unification:
+statements freely mix the two spellings, and keeping them interchangeable at
+reducible transparency is what lets `rw`/`simp` traverse such goals. -/
+@[reducible] noncomputable def pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec') :
+    ProbResponder spec where
+  State := R.State
+  answer s t := (fun q => (w.toFunB t q.1, q.2)) <$> R.answer s (w.toFunA t)
+
+/-- The pulled-back responder's handler translates each query forward and maps the
+target responder's answer back through the lens: `toQueryImpl` of `pullback w R` is the
+answer-post-composition of `R.toQueryImpl` along `w`. The handler-level form of the
+interface-wrapping adjunction. -/
+@[simp] theorem toQueryImpl_pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    (t : spec.toPFunctor.A) :
+    (pullback w R).toQueryImpl t =
+      (fun a => w.toFunB t a) <$> R.toQueryImpl (w.toFunA t) := by
+  funext s
+  rfl
+
+/-- **`FreeM.liftM` naturality for responder pullback**: interpreting a lens-translated
+program through a responder's handler is interpreting the original program through the
+pulled-back responder. The handler-level content of the interface-wrapping adjunction —
+machine-free, so run-level wrapping laws follow from it by pure congruence. -/
+theorem liftM_mapLens_pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    {γ : Type u} : ∀ oa : OracleComp spec γ,
+    PFunctor.FreeM.liftM R.toQueryImpl (PFunctor.FreeM.mapLens w oa) =
+      PFunctor.FreeM.liftM (pullback w R).toQueryImpl oa
+  | .pure x => rfl
+  | .liftBind t rest => by
+    change (R.toQueryImpl (w.toFunA t) >>= fun d =>
+        PFunctor.FreeM.liftM R.toQueryImpl (PFunctor.FreeM.mapLens w (rest (w.toFunB t d)))) =
+      (pullback w R).toQueryImpl t >>= fun a =>
+        PFunctor.FreeM.liftM (pullback w R).toQueryImpl (rest a)
+    rw [toQueryImpl_pullback]
+    simp only [bind_map_left]
+    exact bind_congr fun d => liftM_mapLens_pullback w R (rest (w.toFunB t d))
+
+/-- Lift a stateful `ProbComp` query implementation to a probabilistic responder via
+its evaluation distribution, pointwise in the state. This is the bridge along which
+existing stateful challengers (the lazy random oracle, cached LR encryption oracles)
+become responders. -/
+@[reducible] noncomputable def ofStateQueryImpl {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀}
+    {σ : Type} (impl : QueryImpl spec₀ (StateT σ ProbComp)) : ProbResponder spec₀ where
+  State := σ
+  answer s t := 𝒟[(impl t).run s]
+
+/-- **The stateful-responder probability bridge**: running an adversary against the
+responder built from a `StateT σ ProbComp` handler (`ofStateQueryImpl impl`) is exactly
+the evaluation distribution of running it against `impl` itself — the responder's `SPMF`
+program-run is `𝒟` of the `ProbComp` program-run, *jointly* in the returned value and the
+final state. This is the reusable bridge every stateful-responder consumer needs to move a
+game between its `ProbComp` presentation (where probability reasoning happens) and its
+`ProbResponder` presentation (the dynamical-systems wiring data).
+
+Structurally it is the naturality of `simulateQ` along the monad morphism
+`𝒟 : ProbComp →ᵐ SPMF`, transported through `StateT σ` — i.e. `𝒟 ∘ simulateQ impl =
+simulateQ (𝒟 ∘ impl)`. It is proved here by a bespoke `OracleComp` induction for want of a
+generic *naturality of the universal fold along a monad morphism* law: `simulateQ'` is
+already a bundled `OracleComp spec →ᵐ r`, but there is no `φ ∘ₘ simulateQ' impl =
+simulateQ' (φ ∘ impl)`, nor a `StateT`-functoriality lemma for `→ᵐ`, so this and its
+siblings (`evalDist_simulateQ_run'_eq_evalDist`, `evalDist_simulateQ_run_congr`) are each
+re-derived by hand. See the PolyFun Kleisli/handler pain-point ledger. -/
+theorem run_simulateQ_toQueryImpl_ofStateQueryImpl {ι₀ : Type}
+    {spec₀ : OracleSpec.{0, 0} ι₀} {σ α : Type}
+    (impl : QueryImpl spec₀ (StateT σ ProbComp)) (oa : OracleComp spec₀ α) (s : σ) :
+    (simulateQ (ofStateQueryImpl impl).toQueryImpl oa).run s =
+      𝒟[(simulateQ impl oa).run s] := by
+  induction oa generalizing s with
+  | pure x =>
+    change (simulateQ (ofStateQueryImpl impl).toQueryImpl (pure x)).run s =
+      𝒟[(simulateQ impl (pure x)).run s]
+    rw [simulateQ_pure, simulateQ_pure, StateT.run_pure, StateT.run_pure, evalDist_pure]
+  | queryBind t k ih =>
+    have hqb : ∀ {r : Type → Type} [Monad r] [LawfulMonad r] (impl' : QueryImpl spec₀ r),
+        simulateQ impl' (OracleComp.queryBind t k) =
+          impl' t >>= fun u => simulateQ impl' (k u) := by
+      intro r _ _ impl'
+      rw [show OracleComp.queryBind t k =
+        (liftM (spec₀.query t) : OracleComp spec₀ (spec₀.Range t)) >>= k from rfl,
+        simulateQ_bind, simulateQ_spec_query]
+    rw [hqb, hqb, StateT.run_bind, StateT.run_bind, evalDist_bind]
+    exact bind_congr fun p => ih p.1 p.2
+
+/-- The state set of a responder built from a stateful `ProbComp` handler is that handler's
+state; a `@[simp]` `rfl` bridge so `(ofStateQueryImpl impl).State` reduces to the concrete state
+type in downstream goals (the responder-`State` abbrev is otherwise opaque to `simp` and blocks
+`StateT` run-map / bind rewriting). -/
+@[simp] theorem ofStateQueryImpl_state {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀} {σ : Type}
+    (impl : QueryImpl spec₀ (StateT σ ProbComp)) : (ofStateQueryImpl impl).State = σ := rfl
+
+/-- The post-composed form of `run_simulateQ_toQueryImpl_ofStateQueryImpl`: mapping the returned
+value by `f` before running commutes with the bridge, pairing `f` on the value component. The
+form security games hit, where the adversary's result is wrapped in `some` before the judge sees
+it. -/
+theorem run_map_simulateQ_toQueryImpl_ofStateQueryImpl {ι₀ : Type}
+    {spec₀ : OracleSpec.{0, 0} ι₀} {σ α γ : Type}
+    (impl : QueryImpl spec₀ (StateT σ ProbComp)) (f : α → γ) (oa : OracleComp spec₀ α) (s : σ) :
+    (f <$> simulateQ (ofStateQueryImpl impl).toQueryImpl oa).run s =
+      (fun p => (f p.1, p.2)) <$> 𝒟[(simulateQ impl oa).run s] := by
+  rw [StateT.run_map, run_simulateQ_toQueryImpl_ofStateQueryImpl]
+
+end ProbResponder
+
+/-- The lazy random oracle as a probabilistic responder: the state is the query cache,
+and each fresh query jointly draws a uniform answer and the cache extended by it. The
+canonical example of a challenger whose answer and successor state must be drawn
+jointly. -/
+noncomputable def randomOracleResponder {ι₀ : Type} [DecidableEq ι₀]
+    {spec₀ : OracleSpec.{0, 0} ι₀} [∀ t : spec₀.Domain, SampleableType (spec₀.Range t)] :
+    ProbResponder spec₀ :=
+  .ofStateQueryImpl spec₀.randomOracle
+
+namespace OracleStrategy
+
+/-! ## Wired runs
+
+`stepAgainst` / `iterateAgainst` are the upstream eval-wired runs
+`PFunctor.DynSystem.stepWith` / `iterWith` at `m := SPMF`, driven by the responder's
+stateful handler `ProbResponder.toQueryImpl`. The responder state comes first in the
+product, mirroring the upstream handler-state-first convention (and the challenger-first
+state of `PFunctor.DynSystem.closedGame`). Likewise, the memoryless Kleisli runs of
+`VCVio.OracleComp.Coinductive.DynSystem` are the upstream stateless runs at `m := SPMF`:
+the step identification is definitional, the iterate agrees by fuel induction (the two
+equation-compiler recursions do not unify definitionally at a variable fuel). Regression
+guards below keep both identifications tight. -/
+
+example (H : ProbHandler spec) (A : OracleStrategy S spec) (s : S) :
+    kleisliStep H A s = PFunctor.DynSystem.kleisliStep H A s := rfl
+
+example (H : ProbHandler spec) (A : OracleStrategy S spec) (n : ℕ) (s : S) :
+    kleisliIterate H A n s = PFunctor.DynSystem.kleisliIterate H A n s := by
+  induction n generalizing s with
+  | zero => rfl
+  | succ n ih => exact congrArg (kleisliStep H A s >>= ·) (funext ih)
+
+/-- One wired round of an adversary strategy against a stateful responder: the
+responder answers the exposed query (jointly drawing its successor state), and the
+adversary advances along the answer. This is the upstream stateful-handler step
+`PFunctor.DynSystem.stepWith` at `m := SPMF`: the wiring itself is deterministic
+interface data; only the states advance stochastically. -/
+noncomputable def stepAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :
+    R.State × S → SPMF (R.State × S) :=
+  PFunctor.DynSystem.stepWith R.toQueryImpl A
+
+@[simp] theorem stepAgainst_apply (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (p : R.State × S) :
+    stepAgainst A R p =
+      (fun q => (q.2, A.update p.2 q.1)) <$> R.answer p.1 (A.expose p.2) := rfl
+
+/-- The `n`-round wired run: the Markov chain on the product state space generated by
+`stepAgainst` — the upstream `PFunctor.DynSystem.iterWith` at `m := SPMF`. -/
+noncomputable def iterateAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :
+    ℕ → R.State × S → SPMF (R.State × S) :=
+  PFunctor.DynSystem.iterWith R.toQueryImpl A
+
+@[simp] theorem iterateAgainst_zero (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (p : R.State × S) : iterateAgainst A R 0 p = pure p := rfl
+
+theorem iterateAgainst_succ (A : OracleStrategy S spec) (R : ProbResponder spec) (n : ℕ)
+    (p : R.State × S) :
+    iterateAgainst A R (n + 1) p = stepAgainst A R p >>= iterateAgainst A R n := rfl
+
+/-- The joint subdistribution over the length-`n` wired transcript and the final
+product state (responder state first, matching `stepAgainst`). `QueryLog` is VCVio
+vocabulary, so the transcript-recording run lives here rather than upstream. -/
+noncomputable def transcriptAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :
+    R.State × S → ℕ → SPMF (QueryLog spec × (R.State × S))
+  | p, 0 => pure ([], p)
+  | p, n + 1 => do
+      let q ← R.answer p.1 (A.expose p.2)
+      let rest ← transcriptAgainst A R (q.2, A.update p.2 q.1) n
+      pure (⟨A.expose p.2, q.1⟩ :: rest.1, rest.2)
+
+/-- The subdistribution over length-`n` wired transcripts. -/
+noncomputable def transcriptDistAgainst (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (p : R.State × S) (n : ℕ) : SPMF (QueryLog spec) :=
+  Prod.fst <$> transcriptAgainst A R p n
+
+/-! ## Deterministic recovery
+
+Against the Dirac lift of a deterministic responder, one wired step is `pure` of the
+upstream closed-game step: the state pairs agree on the nose because both put the
+responder/challenger state first. -/
+
+/-- Wiring against a deterministic responder is the (Dirac lift of the) upstream closed
+game `PFunctor.DynSystem.closedGame`. -/
+@[simp] theorem stepAgainst_ofDet (A : OracleStrategy S spec) {σ : Type u}
+    (C : PFunctor.Responder σ spec.toPFunctor) (p : σ × S) :
+    stepAgainst A (.ofDet C) p = pure ((PFunctor.DynSystem.closedGame C A).step p) := by
+  obtain ⟨r, s⟩ := p
+  simp [ProbResponder.ofDet]
+
+/-! ## Memoryless recovery
+
+Against a constant-state responder the wired run is the existing memoryless Kleisli
+run against the selected handler, with the setup carried along unchanged — the
+setup-indexed family form of the upstream `PFunctor.DynSystem.stepWith_lift` /
+`iterWith_lift` collapses (the family handler is state-dependent, so it is not literally
+a `StateT.lift`; the same induction applies). -/
+
+@[simp] theorem stepAgainst_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
+    (A : OracleStrategy S spec) (p : Γ × S) :
+    stepAgainst A (ProbResponder.ofHandlerFamily h) p =
+      (fun s' => (p.1, s')) <$> kleisliStep (h p.1) A p.2 := by
+  simp only [stepAgainst_apply, ProbResponder.ofHandlerFamily, kleisliStep, Functor.map_map]
+
+@[simp] theorem iterateAgainst_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
+    (A : OracleStrategy S spec) (n : ℕ) (p : Γ × S) :
+    iterateAgainst A (ProbResponder.ofHandlerFamily h) n p =
+      (fun s' => (p.1, s')) <$> kleisliIterate (h p.1) A n p.2 := by
+  induction n generalizing p with
+  | zero =>
+    simp only [iterateAgainst_zero, kleisliIterate, map_pure]
+  | succ n ih =>
+    calc iterateAgainst A (ProbResponder.ofHandlerFamily h) (n + 1) p
+        = ((fun s' => (p.1, s')) <$> kleisliStep (h p.1) A p.2) >>=
+            iterateAgainst A (ProbResponder.ofHandlerFamily h) n := by
+          rw [iterateAgainst_succ, stepAgainst_ofHandlerFamily]
+      _ = kleisliStep (h p.1) A p.2 >>= fun s' =>
+            iterateAgainst A (ProbResponder.ofHandlerFamily h) n (p.1, s') := by
+          rw [map_eq_bind_pure_comp, bind_assoc]
+          exact congrArg (kleisliStep (h p.1) A p.2 >>= ·)
+            (funext fun s' => by rw [Function.comp_apply, pure_bind])
+      _ = kleisliStep (h p.1) A p.2 >>= fun s' =>
+            (fun s'' => (p.1, s'')) <$> kleisliIterate (h p.1) A n s' :=
+          congrArg (kleisliStep (h p.1) A p.2 >>= ·)
+            (funext fun s' => ih (p.1, s'))
+      _ = (fun s' => (p.1, s')) <$> kleisliIterate (h p.1) A (n + 1) p.2 := by
+          rw [kleisliIterate]
+          simp only [map_eq_bind_pure_comp, bind_assoc]
+
+/-- Against a memoryless oracle the wired step is the memoryless Kleisli step. -/
+@[simp] theorem stepAgainst_ofHandler (H : ProbHandler spec) (A : OracleStrategy S spec)
+    (p : PUnit × S) :
+    stepAgainst A (ProbResponder.ofHandler H) p =
+      (fun s' => (p.1, s')) <$> kleisliStep H A p.2 :=
+  stepAgainst_ofHandlerFamily (fun _ => H) A p
+
+/-- Against a memoryless oracle the wired run is the memoryless Kleisli run. -/
+@[simp] theorem iterateAgainst_ofHandler (H : ProbHandler spec) (A : OracleStrategy S spec)
+    (n : ℕ) (p : PUnit × S) :
+    iterateAgainst A (ProbResponder.ofHandler H) n p =
+      (fun s' => (p.1, s')) <$> kleisliIterate H A n p.2 :=
+  iterateAgainst_ofHandlerFamily (fun _ => H) A n p
+
+end OracleStrategy

--- a/VCVio/OracleComp/Coinductive/WiredRun.lean
+++ b/VCVio/OracleComp/Coinductive/WiredRun.lean
@@ -1,0 +1,164 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+import VCVio.OracleComp.Coinductive.Machine
+import VCVio.OracleComp.Coinductive.Responder
+import PolyFun.PFunctor.Handler.Normalization
+
+/-!
+# Wired Machine Runs: Fuelled Machines Against Stateful Responders
+
+`OracleMachine.runAgainst` runs a machine adversary against a stateful probabilistic
+responder (`ProbResponder`): the machine's monad-parametric run `runWith` at
+`m := StateT R.State SPMF`, fed the responder's handler and run from the responder
+state (`runAgainst_eq_runWith_run` is the definitional canary). The responder state
+comes first in the input pair, matching `OracleStrategy.stepAgainst`; the output pair
+is `(readout, final responder state)` in `StateT.run` order, value first.
+
+The step theory is inherited from PolyFun's `DynComputation` bounded-execution
+lemmas rather than re-proven: a returned state is Dirac on its value at every fuel
+(`runAgainst_of_view_return`, from `runWith_return`), zero fuel cuts an unresolved
+query off (`runAgainst_zero_of_view_query`, from `runWith_query_zero`), and the wired
+step law `runAgainst_succ_of_view_query` is `runWith_query_succ_stateT` read at
+`m := SPMF`: one unit of fuel jointly samples the answer and next responder state,
+then continues. VCVio contributes the `SPMF` semantics; the constant-state collapse
+`runAgainst_ofHandlerFamily` recovers the memoryless run against the selected handler.
+
+`runAgainst` is deliberately *not* an image of `OracleStrategy.iterateAgainst` in
+general: early stopping matters. Against a stateful responder, running past the
+readout would keep advancing the responder's state — and, against lossy responders,
+shed mass — so the early-stopping run and the fixed-fuel iterate genuinely differ on
+machines that halt before the fuel is exhausted.
+
+Interface wrapping needs no bespoke machine transport: `DynComputation.wrap` moves a
+machine along a lens, and the **interface-wrapping adjunction** `runWith_wrap` /
+`runAgainst_wrap` states that wrapping the adversary forward equals pulling the
+responder back (`ProbResponder.pullback`) along the same lens. This is the run-level
+combinator behind same-interface security reductions (`OracleStrategy.reduce` is the
+sub-spec special case).
+-/
+
+universe u
+
+open OracleSpec PFunctor PFunctor.DynSystem
+
+namespace OracleComp.OracleMachine
+
+variable {ι : Type u} {spec : OracleSpec.{u, u} ι} {α β : Type u}
+
+/-! ## The wired run -/
+
+/-- The fuelled run of a machine against a stateful responder: the machine's
+monad-parametric run `runWith` at `m := StateT R.State SPMF`, fed the responder's
+handler and run from the responder state. Input pair is responder-state-first
+(matching `OracleStrategy.stepAgainst`); output pair is `(readout, final responder
+state)` in `StateT.run` order. Early stopping at the first returned value is
+inherited from `runWith`. -/
+noncomputable def runAgainst (M : OracleMachine spec α β) (R : ProbResponder spec)
+    (k : ℕ) (p : R.State × M.State) : SPMF (Option β × R.State) :=
+  (M.runWith R.toQueryImpl k p.2).run p.1
+
+/-- Regression canary: the wired run is definitionally the stateful `runWith` in
+`StateT.run` form. -/
+theorem runAgainst_eq_runWith_run (M : OracleMachine spec α β) (R : ProbResponder spec)
+    (k : ℕ) (r : R.State) (s : M.State) :
+    M.runAgainst R k (r, s) = (M.runWith R.toQueryImpl k s).run r := rfl
+
+/-- A returned machine state's wired run is Dirac on its value and the unchanged
+responder state, at every fuel. -/
+theorem runAgainst_of_view_return (M : OracleMachine spec α β) (R : ProbResponder spec)
+    {s : M.State} {b : β} (hview : M.view s = Sum.inl b) (k : ℕ) (r : R.State) :
+    M.runAgainst R k (r, s) = pure (some b, r) := by
+  rw [runAgainst_eq_runWith_run, M.runWith_return R.toQueryImpl k s b hview]
+  simp only [handler_nf]
+
+/-- Zero fuel cuts an unresolved query off with `none`, leaving the responder state
+unchanged. -/
+theorem runAgainst_zero_of_view_query (M : OracleMachine spec α β)
+    (R : ProbResponder spec) {s : M.State} {t : spec.Domain}
+    {next : spec.Range t → M.State} (hview : M.view s = Sum.inr ⟨t, next⟩)
+    (r : R.State) : M.runAgainst R 0 (r, s) = pure (none, r) := by
+  rw [runAgainst_eq_runWith_run, M.runWith_query_zero R.toQueryImpl s t next hview]
+  simp only [handler_nf]
+
+/-- **The wired step law**: on a querying state, one unit of fuel of the wired run
+jointly samples the responder's answer and next state, then continues — PolyFun's
+`runWith_query_succ_stateT` read at `m := SPMF`. -/
+theorem runAgainst_succ_of_view_query (M : OracleMachine spec α β)
+    (R : ProbResponder spec) {s : M.State} {t : spec.Domain}
+    {next : spec.Range t → M.State} (hview : M.view s = Sum.inr ⟨t, next⟩)
+    (k : ℕ) (r : R.State) :
+    M.runAgainst R (k + 1) (r, s) =
+      R.answer r t >>= fun q => M.runAgainst R k (q.2, next q.1) :=
+  M.runWith_query_succ_stateT R.toQueryImpl k s t next hview r
+
+/-! ## Memoryless recovery -/
+
+/-- Against a constant-state responder the wired run is the memoryless machine run
+against the selected handler, with the setup carried along unchanged: the machine-run
+form of `OracleStrategy.iterateAgainst_ofHandlerFamily`. -/
+@[simp] theorem runAgainst_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
+    (M : OracleMachine spec α β) (k : ℕ) (s : M.State) (γ : Γ) :
+    M.runAgainst (.ofHandlerFamily h) k (γ, s) =
+      (fun ob => (ob, γ)) <$> M.runWith (h γ) k s := by
+  induction k generalizing s with
+  | zero =>
+    cases hview : M.view s with
+    | inl b =>
+      rw [M.runAgainst_of_view_return _ hview, M.runWith_return (h γ) 0 s b hview,
+        map_pure]
+    | inr q =>
+      rw [M.runAgainst_zero_of_view_query _ hview,
+        M.runWith_query_zero (h γ) s q.1 q.2 hview, map_pure]
+  | succ k ih =>
+    cases hview : M.view s with
+    | inl b =>
+      rw [M.runAgainst_of_view_return _ hview, M.runWith_return (h γ) (k + 1) s b hview,
+        map_pure]
+    | inr q =>
+      obtain ⟨t, next⟩ := q
+      calc M.runAgainst (.ofHandlerFamily h) (k + 1) (γ, s)
+          = (ProbResponder.ofHandlerFamily h).answer γ t >>= fun p =>
+              M.runAgainst (.ofHandlerFamily h) k (p.2, next p.1) :=
+            M.runAgainst_succ_of_view_query (.ofHandlerFamily h) hview k γ
+        _ = h γ t >>= fun a =>
+              (fun ob => (ob, γ)) <$> M.runWith (h γ) k (next a) := by
+            simp only [ProbResponder.ofHandlerFamily, bind_map_left]
+            exact bind_congr fun a => ih (next a)
+        _ = (fun ob => (ob, γ)) <$> M.runWith (h γ) (k + 1) s := by
+            rw [M.runWith_query_succ (h γ) k s t next hview, map_bind]
+
+/-! ## Interface wrapping: reductions as lenses
+
+Installing an interface translation on a machine adversary is PolyFun's
+`DynComputation.wrap`, and it is *adjoint* to pulling the responder back along the
+same lens: wrapping the adversary forward equals pulling the challenger's responder
+back. -/
+
+variable {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+
+/-- **The run-level interface-wrapping adjunction**: running the wrapped machine
+against a `spec'`-responder equals running the original machine against the responder
+pulled back along `w`. Pure factoring, no fuel induction: `unroll_wrap` translates the
+unrolled query tree, and `ProbResponder.liftM_mapLens_pullback` re-reads the
+translation through the pulled-back handler. -/
+theorem runWith_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
+    (M : OracleMachine spec α β) (R : ProbResponder spec') (k : ℕ) (s : M.State) :
+    (M.wrap w).runWith R.toQueryImpl k s =
+      M.runWith (R.pullback w).toQueryImpl k s := by
+  simp only [DynComputation.runWith]
+  rw [M.unroll_wrap w k s]
+  exact ProbResponder.liftM_mapLens_pullback w R (M.unroll k s)
+
+/-- **The wired-run interface-wrapping adjunction**: the `runAgainst` form of
+`runWith_wrap`. This is the workhorse of same-interface reductions at the game
+level. -/
+theorem runAgainst_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
+    (M : OracleMachine spec α β) (R : ProbResponder spec') (k : ℕ) (r : R.State)
+    (s : M.State) :
+    runAgainst (M.wrap w) R k (r, s) = M.runAgainst (R.pullback w) k (r, s) := by
+  rw [runAgainst_eq_runWith_run, runAgainst_eq_runWith_run, runWith_wrap]
+
+end OracleComp.OracleMachine


### PR DESCRIPTION
## Motivation

Fresh implementation of the responder layer, replacing the closed reference draft #483. That
draft was stacked on the retired `PointedMachine` API; this version sits on the merged machine
layer (#498) and on PolyFun's current `Handler.Stateful`/`stepWith`/`iterWith` (PolyFun#101),
which delivered the generic stateful-handler theory the old draft had to hand-roll.

The guiding principle is unchanged: cryptography in VCVio is a thin probabilistic layer over
PolyFun interaction. The existing cached IND-CPA oracle remains the source of truth; this PR
gives it a PolyFun-compatible responder presentation via lenses.

## What this adds

**`Coinductive/Responder.lean`** — `ProbResponder spec`: stateful probabilistic challengers as
Mealy coalgebras in the Kleisli category of `SPMF` (a joint answer/next-state draw — essential
for lazily sampled oracles, where the cached entry must be the answer actually returned).
Definitionally interchangeable with `QueryImpl spec (StateT State SPMF)`; the deterministic
(`Id`) sibling of PolyFun's `Responder.equivStateHandler`. Constructors from handlers, handler
families, deterministic responders, and stateful `ProbComp` implementations (the lazy random
oracle is the motivating instance). Strategy wiring `stepAgainst`/`iterateAgainst` is PolyFun's
`stepWith`/`iterWith` at `m := SPMF`, plus `transcriptAgainst` on `QueryLog`.

**`Coinductive/WiredRun.lean`** — `OracleMachine.runAgainst`: fuelled machine-vs-responder
runs, definitionally `runWith` at `m := StateT R.State SPMF`. The step laws are inherited from
`DynComputation` bounded execution; the memoryless collapse recovers the plain handler run.
The **interface-wrapping adjunction** `runAgainst_wrap` — wrapping the adversary forward along
a lens equals pulling the responder back — is now a two-step factoring rather than a fuel
induction: `DynComputation.unroll_wrap` (added in `Machine.lean`; pure `FreeM`-level, an
upstream candidate) composed with `ProbResponder.liftM_mapLens_pullback` (handler-level
naturality, machine-free).

**`INDCPA/Oracle.lean`** — the cached LR oracle as `IND_CPA_responder` (a thin
`ofStateQueryImpl` wrapper; `IND_CPA_queryImpl'` stays the source of truth), the machine-level
distribution bridge `runAgainst_IND_CPA_responder_eq`, and left/right message swapping as a
PolyFun lens whose machine reduction `runAgainst_IND_CPA_swap` is a one-line instance of the
generic adjunction.

## Naming and API notes

- The legacy `wireK*` names are gone: they referenced the old `runK` (fuel-`k` run on the
  retired `PointedMachine`), which no longer exists. The run family is now
  `runAgainst`/`stepAgainst`/`iterateAgainst`/`transcriptAgainst`, matching the
  pattern-runs-on-matter vocabulary (`runAgainst` = run the adversary pattern against the
  challenger matter).
- Responder smart constructors are `@[reducible]`: statements freely mix `(pullback w R).State`
  with `R.State` (and similar), and keeping those interchangeable at reducible transparency is
  what lets `rw`/`simp` traverse such goals — the earlier draft needed trailing `rfl`s exactly
  where this was missing. Remaining handler-layer normalization uses PolyFun#103's
  `handler_nf` simp set.

## Proposed PolyFun follow-ups

- `DynComputation.unroll_wrap` (unrolling commutes with `wrap`) belongs next to the other
  bounded-execution lemmas.
- The generic form of `liftM_mapLens_pullback` — `FreeM.liftM h (FreeM.mapLens w f) =
  FreeM.liftM (fun t => w.toFunB t <$> h (w.toFunA t)) f` for any lawful monad — is
  `Handler`-level naturality with no responder content.

## Deliberately out of scope

- Computational complexity / PPT (returns as its own stack on the machine carrier).
- Branch-flip/cache-conjugacy for the IND-CPA cache (wants a responder-homomorphism notion —
  `PresentationHom` territory upstream).

## Validation

- `lake build` (3002 jobs, green; only pre-existing `sorry` warnings on `main`)
- `scripts/check-extern-isolation.sh`, `scripts/check-interop-isolation.sh`
- no new `sorry`/axioms; no linter warnings in the added files
