### PR TITLE
fix(Falcon): reject non-canonical signature lengths

### DIFF
--- a/Extern/Falcon/FPRBridge.lean
+++ b/Extern/Falcon/FPRBridge.lean
@@ -135,10 +135,9 @@ theorem concrete_verify_eq_verify
         Falcon.verify p prims pk msg sig := by
   dsimp
   by_cases hcomp : sig.compressedS2 = []
-  · have hslen : sig.compressedS2.length < p.sbytelen := by
-      simpa [hcomp] using hsbytelen
-    have hdecomp : (verifyPrimitives p hn).decompress [] p.sbytelen = none := by
-      simp [verifyPrimitives, Falcon.Concrete.decompress, hsbytelen]
+  · have hdecomp : (verifyPrimitives p hn).decompress [] p.sbytelen = none := by
+      apply Falcon.Concrete.decompress_eq_none_of_length_ne
+      simpa using Nat.ne_of_lt hsbytelen
     have hleft :
         Falcon.Concrete.concreteVerify p ((verifyPrimitives p hn).publicKeyBytes pk.h) msg
           (Falcon.Concrete.sigEncode sig.salt [] p.logn) = false := by

--- a/LatticeCrypto/Falcon/Concrete/Encoding.lean
+++ b/LatticeCrypto/Falcon/Concrete/Encoding.lean
@@ -69,9 +69,12 @@ def compress (n : ℕ) (s : IntPoly n) (dlen : ℕ) : Option (List UInt8) := Id.
     out := out.push 0
   return some out.toList
 
-/-- Decompress a Falcon signature polynomial from its compressed byte representation. -/
+/-- Decompress a fixed-length Falcon signature polynomial.
+
+`compress` pads every successful output to exactly `dlen` bytes. Accordingly, this decoder
+accepts exactly that length; the optional unpadded Falcon representation is outside its format. -/
 def decompress (n : ℕ) (d : List UInt8) (dlen : ℕ) : Option (IntPoly n) := Id.run do
-  if d.length < dlen then return none
+  if d.length ≠ dlen then return none
   let bytes := d.toArray
   let mut acc : UInt32 := 0
   let mut accLen : UInt32 := 0
@@ -110,6 +113,10 @@ def decompress (n : ℕ) (d : List UInt8) (dlen : ℕ) : Option (IntPoly n) := I
     if bytes[j]! != 0 then return none
     j := j + 1
   return some (Vector.ofFn fun ⟨i, _⟩ => result.getD i 0)
+
+@[simp] theorem decompress_eq_none_of_length_ne (n d dlen) (h : d.length ≠ dlen) :
+    decompress n d dlen = none := by
+  simp [decompress, h]
 
 /-! ## Public key encoding (14 bits per coefficient) -/
 

--- a/LatticeCryptoTest/Falcon/Main.lean
+++ b/LatticeCryptoTest/Falcon/Main.lean
@@ -119,7 +119,9 @@ def main : IO Unit := do
     | some bytes =>
       match decompress n bytes 666 with
       | none => check st "decompress should succeed" false
-      | some s' => check st "decompress(compress(s)) = s" (s == s')
+      | some s' =>
+        check st "decompress(compress(s)) = s" (s == s')
+        check st "decompress rejects trailing bytes" ((decompress n (bytes ++ [0]) 666).isNone)
   IO.println ""
   -- ── 4. Public key encode/decode roundtrip ─────
   IO.println "4. Public key encode/decode roundtrip"


### PR DESCRIPTION
## Summary

- require compressed Falcon signature polynomials to have exactly the fixed padded length emitted by `compress`
- add a simp theorem recording that every mismatched length is rejected
- add a regression check for an otherwise-valid encoding with a trailing byte
- adapt the dependent abstract/concrete verifier bridge

This is the small, self-contained wire-format fix identified and originally implemented by @alexanderlhicks in #471 (commit `c2b876303ee85c96f7a6cedf9577e9eaa6558207`). Alexander is preserved as the commit author so the useful slice can be reviewed independently of that broader WIP branch.

## Correctness rationale

`sigDecode` returns every byte after the header and salt, while the previous `decompress` guard rejected only short inputs and its loop consumed at most `dlen` bytes. Appending any extra byte could therefore leave verification unchanged.

The repository models the fixed padded signature format: `compress` already pads successful output to exactly `dlen`. Exact-length rejection is consistent with the fixed-bitlength decoding requirement in Falcon v1.2 Algorithm 18 and with the fixed framing used by c-fn-dsa. The optional unpadded representation remains outside this decoder, as it already was when shorter inputs were rejected.

References:
- https://falcon-sign.info/falcon.pdf
- https://github.com/pornin/c-fn-dsa/blob/main/codec.c
- https://github.com/pornin/c-fn-dsa/blob/main/vrfy.c

## Validation

- `lake build LatticeCrypto Extern`
- `lake env lean LatticeCrypto/Falcon/Concrete/Encoding.lean`
- `lake env lean Extern/Falcon/FPRBridge.lean`
- `lake env lean LatticeCryptoTest/Falcon/Main.lean`

The full native `falcon_test` executable reached and compiled the Lean test module locally, then could not link because the optional `third_party` native backends are not checked out in this workspace.