### PR TITLE
fix(LatticeCrypto): bind SelfTargetMSIS solutions to their hashed preimage

### DIFF
--- a/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
+++ b/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
@@ -28,9 +28,13 @@ over a finite coefficient ring.
 ## SelfTargetMSIS
 
 The SelfTargetMSIS problem (introduced in the Dilithium security proof): given a random matrix
-`A` and access to a random oracle `H`, find `(c, z)` such that `Az = c*t + w` where `w` has
-high bits matching a specific target, and `z` is short. The "self-target" refers to the fact
-that the adversary must produce a hash preimage `c = H(...)` as part of the solution.
+`A` and access to a random oracle `H`, find a hash preimage `(μ, w)` and a short response `z`
+such that `c = H(μ, w)` and `Az = c*t + w'` where the recomputed commitment `w'` matches `w`.
+The "self-target" is this binding of the solution to its own hash preimage: `isValid` receives
+the preimage alongside the RO output `c`, and an instantiation must require the commitment it
+recomputes from the response to equal the commitment component `w` of the hashed preimage. The
+experiment enforces the RO side of the binding by looking the preimage up in the oracle's
+query cache.
 
 ## References
 
@@ -99,8 +103,9 @@ namespace SelfTargetMSIS
 
 The adversary receives a matrix `A` and a target vector `t`, and has access to a random
 oracle `H`. The adversary must produce `(hashInput, response)` such that:
-1. `c = H(hashInput)` (self-targeting: the adversary must have queried the RO on `hashInput`)
-2. `isValid(challenge, target, c, response)` holds (shortness bound + verification equation)
+1. `c = H(hashInput)` (RO consistency: the adversary must have queried the RO on `hashInput`)
+2. `isValid(challenge, target, hashInput, c, response)` holds (shortness bound + verification
+   equation binding the recomputed commitment to `hashInput`'s commitment component)
 
 The experiment enforces RO consistency by looking up `hashInput` in the RO's query cache.
 If the adversary never queried `H(hashInput)`, the check fails automatically.
@@ -109,8 +114,12 @@ This captures the core hardness assumption in the ML-DSA/Dilithium security proo
 structure Problem (Challenge Response Target HashInput HashOutput : Type) where
   /-- Sample the public parameters (matrix + target). -/
   sampleParams : ProbComp (Challenge × Target)
-  /-- Check whether a purported solution is valid, given the hash output from the RO. -/
-  isValid : Challenge → Target → HashOutput → Response → Bool
+  /-- Check whether a purported solution is valid, given the hash preimage the adversary
+  queried and the hash output the RO cached for it. Receiving the preimage is what makes the
+  problem *self-targeting*: an instantiation must require the commitment recomputed from the
+  response to equal the commitment component of the hashed preimage, binding the solution to
+  the very input hashed to produce the challenge. -/
+  isValid : Challenge → Target → HashInput → HashOutput → Response → Bool
 
 section Experiment
 
@@ -130,7 +139,7 @@ variable [DecidableEq HashInput] [SampleableType HashOutput]
 /-- The SelfTargetMSIS experiment in the ROM: sample parameters, run the adversary with
 uniform randomness and a lazy random oracle for `H`, then enforce:
 1. The adversary actually queried `H(hashInput)` (RO consistency check via the query cache)
-2. The solution passes `isValid` with the RO's cached output -/
+2. The solution passes `isValid` with the queried preimage and the RO's cached output -/
 noncomputable def experiment
     {problem : Problem Challenge Response Target HashInput HashOutput}
     (adv : Adversary problem) :
@@ -143,7 +152,7 @@ noncomputable def experiment
   let ((hashInput, response), cache) ←
     StateT.run (simulateQ (idImpl + ro) (adv.run params)) ∅
   match cache hashInput with
-  | some hashOutput => return problem.isValid params.1 params.2 hashOutput response
+  | some hashOutput => return problem.isValid params.1 params.2 hashInput hashOutput response
   | none => return false
 
 /-- Advantage of a SelfTargetMSIS adversary. -/

--- a/LatticeCrypto/MLDSA/SecurityNMA.lean
+++ b/LatticeCrypto/MLDSA/SecurityNMA.lean
@@ -421,10 +421,28 @@ noncomputable def mldsaSTMSIS (M : Type) :
   sampleParams := do
     let (pk, _) ← keygen1 p prims
     return (prims.expandA pk.rho, pk)
-  isValid := fun aHat pk cTilde (z, h) =>
-    -- Recover the commitment `w'` from `(pk, c̃, (z, h))` and run the identification verifier.
+  isValid := fun aHat pk hashInput cTilde (z, h) =>
+    -- Recover the commitment `w'` from `(pk, c̃, (z, h))`, bind it to the commitment component
+    -- of the hashed preimage (the self-target binding), and run the identification verifier.
     let w' := prims.useHintVec h (computeWApprox p prims aHat (prims.sampleInBall cTilde) z pk.t1)
-    (identificationScheme p prims).verify pk w' cTilde (z, h)
+    decide (hashInput.2 = w') && (identificationScheme p prims).verify pk w' cTilde (z, h)
+
+omit [DecidableEq M] [SampleableType (CommitHashBytes p)] in
+/-- **Self-target binding, made explicit.** An accepted `mldsaSTMSIS` solution is exactly the
+identification-verifier acceptance *and* the binding of the recovered commitment `w'` to the
+commitment component of the hashed preimage. Exposing the binding as its own conjunct keeps the
+self-target requirement visible and hard to drop from the tailored relation: an instantiation that
+silently ignored the preimage would fail this characterization. -/
+theorem mldsaSTMSIS_isValid_eq_true_iff (aHat : TqMatrix p.k p.l) (pk : PublicKey p prims)
+    (hashInput : M × Commitment p prims) (cTilde : CommitHashBytes p)
+    (z : RqVec p.l) (h : Vector prims.Hint p.k) :
+    (mldsaSTMSIS p prims M).isValid aHat pk hashInput cTilde (z, h) = true ↔
+      hashInput.2 = prims.useHintVec h
+          (computeWApprox p prims aHat (prims.sampleInBall cTilde) z pk.t1) ∧
+        (identificationScheme p prims).verify pk
+          (prims.useHintVec h (computeWApprox p prims aHat (prims.sampleInBall cTilde) z pk.t1))
+          cTilde (z, h) = true := by
+  simp only [mldsaSTMSIS, Bool.and_eq_true, decide_eq_true_iff]
 
 /-- **The SelfTargetMSIS extractor `C` (Lemma 7, Step 3).**
 
@@ -483,7 +501,8 @@ private theorem stmsis_tail_le
             ((extractorC p prims main).run (prims.expandA pk.rho, pk))).run ∅
         match cache hashInput with
         | some hashOutput =>
-            pure ((mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk hashOutput response)
+            pure ((mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk hashInput hashOutput
+              response)
         | none => pure false] := by
   classical
   -- Decompose both tails over the shared simulation of `main pk` from the empty cache.
@@ -528,15 +547,18 @@ private theorem stmsis_tail_le
         subst hu
         exact QueryCache.cacheQuery_self _ (msg, w') u
     rw [hcache]
-    -- An accepted NMA forgery is a valid STMSIS solution (commitment recoverability is exactly the
-    -- middle conjunct of `verify`, which `isValid` discharges by `decide (X = X)`).
+    -- An accepted NMA forgery is a valid STMSIS solution. The self-target binding
+    -- `hashInput.2 = w'` holds because the queried preimage is exactly `(msg, w')`, so the binding
+    -- reduces to `decide (w' = w') = true`; commitment recoverability is the middle conjunct of
+    -- `verify`, which `isValid` discharges by `decide (X = X)`.
     rw [probOutput_pure, probOutput_pure]
     by_cases hverify :
         (identificationScheme p prims).verify pk w' cc.1 (z, h) = true
     · -- Accepted: `isValid` recovers `w'` as the very `useHintVec …` value `verify` checks against,
-      -- so its middle conjunct is `decide (X = X) = true` and `isValid = true`.
+      -- and the preimage's commitment component `(msg, w').2` is `w'`, so both conjuncts hold.
       have hvalid :
-          (mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk cc.1 (z, h) = true := by
+          (mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk (msg, w') cc.1 (z, h)
+            = true := by
         simp only [mldsaSTMSIS, identificationScheme] at hverify ⊢
         revert hverify
         grind


### PR DESCRIPTION
Extracts the generic `SelfTargetMSIS` binding repair as a small, self-contained PR — step 1 of the decomposition @dtumad proposed on #467/#479. It is independently necessary (it closes a soundness gap in the tailored ML-DSA self-target problem) and it unblocks a sound review of #479.

## The soundness gap

`SelfTargetMSIS.Problem.isValid` received only `Challenge → Target → HashOutput → Response`, never the RO **preimage** the experiment looks up. So `mldsaSTMSIS.isValid` recomputed a commitment `w'` from `(pk, c̃, (z, h))` and verified against that same recomputed value, without ever requiring the commitment component of the *hashed* pair `(msg, w)` to equal `w'`. The relevant equality closed as `X = X`. That makes the tailored problem strictly easier than the literature relation — a zero-response / zero-hint solution wins after querying an unrelated commitment, subject only to the verifier norm gates.

## The repair

- **Generic** (`ShortIntegerSolution.lean`): `isValid : Challenge → Target → HashInput → HashOutput → Response → Bool`, and `experiment` now passes the cache-consistent `hashInput` (the same preimage it already looks up) into `isValid`. The structure's type parameters are unchanged, so abstract references to `SelfTargetMSIS.Problem …` elsewhere are unaffected.
- **ML-DSA binding** (`SecurityNMA.lean`): `mldsaSTMSIS.isValid` now additionally requires `hashInput.2 = w'` — the recovered commitment must equal the commitment component of the hashed preimage. On the accepting path the forger's own returned `(msg, w')` *is* the queried preimage, so the extraction proof discharges the binding for free (it reduces to `w' = w'`); the read-back proof (`stmsis_tail_le`) is updated accordingly.
- **Characterization** (`mldsaSTMSIS_isValid_eq_true_iff`): acceptance is exactly *verifier acceptance ∧ the binding conjunct*, stated explicitly so the self-target requirement stays visible — an instantiation that silently dropped the preimage would fail this lemma, making the regression hard to reintroduce.

## Scope (deliberately narrow)

This PR fixes **only** the SelfTargetMSIS binding. The other items from the #467 review are separate, larger pieces and are **not** in this PR:
- the short-secret MLWE model / exact short-key swap (the full-ring-uniform MLWE issue) — a focused model PR;
- the explicit reduction from this tailored verifier relation to the standard-STMSIS normal form (`H([I_m | A]·y, μ)` with the challenge as `y`'s final coefficient block) — the endpoint bridge;
- the generic CMA-to-NMA engine.

The characterization lemma here is the lightweight binding statement, not the full algebraic normal-form bridge (that lives with the standard-STMSIS reduction).

## Verification

Off current `main`. `lake build LatticeCrypto` (and the full CI library set) green on Lean v4.32.0; `mldsaSTMSIS_isValid_eq_true_iff` and the affected `nmaAdvantage_keygen1_le_stmsis` extraction kernel-check `[propext, Classical.choice, Quot.sound]`. No statement outside the three touched declarations changes.

https://claude.ai/code/session_01DaNGD9nDo3Grwk58nsjS77
