### PR TITLE
feat(MLDSA): short-secret MLWE model and the exact NMA key-swap hop

### DIFF
--- a/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
+++ b/LatticeCrypto/HardnessAssumptions/ShortIntegerSolution.lean
@@ -28,9 +28,13 @@ over a finite coefficient ring.
 ## SelfTargetMSIS
 
 The SelfTargetMSIS problem (introduced in the Dilithium security proof): given a random matrix
-`A` and access to a random oracle `H`, find `(c, z)` such that `Az = c*t + w` where `w` has
-high bits matching a specific target, and `z` is short. The "self-target" refers to the fact
-that the adversary must produce a hash preimage `c = H(...)` as part of the solution.
+`A` and access to a random oracle `H`, find a hash preimage `(μ, w)` and a short response `z`
+such that `c = H(μ, w)` and `Az = c*t + w'` where the recomputed commitment `w'` matches `w`.
+The "self-target" is this binding of the solution to its own hash preimage: `isValid` receives
+the preimage alongside the RO output `c`, and an instantiation must require the commitment it
+recomputes from the response to equal the commitment component `w` of the hashed preimage. The
+experiment enforces the RO side of the binding by looking the preimage up in the oracle's
+query cache.
 
 ## References
 
@@ -99,8 +103,9 @@ namespace SelfTargetMSIS
 
 The adversary receives a matrix `A` and a target vector `t`, and has access to a random
 oracle `H`. The adversary must produce `(hashInput, response)` such that:
-1. `c = H(hashInput)` (self-targeting: the adversary must have queried the RO on `hashInput`)
-2. `isValid(challenge, target, c, response)` holds (shortness bound + verification equation)
+1. `c = H(hashInput)` (RO consistency: the adversary must have queried the RO on `hashInput`)
+2. `isValid(challenge, target, hashInput, c, response)` holds (shortness bound + verification
+   equation binding the recomputed commitment to `hashInput`'s commitment component)
 
 The experiment enforces RO consistency by looking up `hashInput` in the RO's query cache.
 If the adversary never queried `H(hashInput)`, the check fails automatically.
@@ -109,8 +114,12 @@ This captures the core hardness assumption in the ML-DSA/Dilithium security proo
 structure Problem (Challenge Response Target HashInput HashOutput : Type) where
   /-- Sample the public parameters (matrix + target). -/
   sampleParams : ProbComp (Challenge × Target)
-  /-- Check whether a purported solution is valid, given the hash output from the RO. -/
-  isValid : Challenge → Target → HashOutput → Response → Bool
+  /-- Check whether a purported solution is valid, given the hash preimage the adversary
+  queried and the hash output the RO cached for it. Receiving the preimage is what makes the
+  problem *self-targeting*: an instantiation must require the commitment recomputed from the
+  response to equal the commitment component of the hashed preimage, binding the solution to
+  the very input hashed to produce the challenge. -/
+  isValid : Challenge → Target → HashInput → HashOutput → Response → Bool
 
 section Experiment
 
@@ -130,7 +139,7 @@ variable [DecidableEq HashInput] [SampleableType HashOutput]
 /-- The SelfTargetMSIS experiment in the ROM: sample parameters, run the adversary with
 uniform randomness and a lazy random oracle for `H`, then enforce:
 1. The adversary actually queried `H(hashInput)` (RO consistency check via the query cache)
-2. The solution passes `isValid` with the RO's cached output -/
+2. The solution passes `isValid` with the queried preimage and the RO's cached output -/
 noncomputable def experiment
     {problem : Problem Challenge Response Target HashInput HashOutput}
     (adv : Adversary problem) :
@@ -143,7 +152,7 @@ noncomputable def experiment
   let ((hashInput, response), cache) ←
     StateT.run (simulateQ (idImpl + ro) (adv.run params)) ∅
   match cache hashInput with
-  | some hashOutput => return problem.isValid params.1 params.2 hashOutput response
+  | some hashOutput => return problem.isValid params.1 params.2 hashInput hashOutput response
   | none => return false
 
 /-- Advantage of a SelfTargetMSIS adversary. -/

--- a/LatticeCrypto/MLDSA/Scheme.lean
+++ b/LatticeCrypto/MLDSA/Scheme.lean
@@ -125,6 +125,45 @@ noncomputable def validKeyPair (pk : PublicKey p prims) (sk : SecretKey p) : Boo
       ∃ seed : Bytes 32, keyGenFromSeed p prims seed = (pk, sk) := by
   simp [validKeyPair]
 
+/-! ### Short-secret idealized key validity
+
+The idealized proof-level ML-DSA model samples the short secrets `(s₁, s₂)` directly on the
+`η`-bounded box rather than deriving them deterministically from a seed. `validKeyPairShort`
+is the ∃-material analogue of `validKeyPair` that such key generators satisfy by construction;
+it is the key relation carried by `identificationSchemeShort` and the short-model security
+statements. -/
+
+/-- A key pair is *short-valid* when it is built from bounded key material: there are seeds
+`ρ`, `K` and `η`-bounded short vectors `(s₁, s₂)` such that the pair is exactly the key
+assembled from that material — `t = ExpandA(ρ) · s₁ + s₂` split by `Power2Round` into the
+published `t₁` and withheld `t₀`, with `tr = H(ρ, t₁)`. This is the ∃-material analogue of the
+∃-seed `validKeyPair`: it captures the algebraic key relationship (`t = A·s₁ + s₂`,
+`(t₁, t₀) = Power2Round(t)`, `s₁, s₂` bounded by `η`) without tying the material to a
+deterministic seed derivation, so it holds for idealized key generators that sample the
+material directly (e.g. `(s₁, s₂)` uniform on the `η`-bounded box). The predicate is decidable
+because all material spaces are finite; the instance is supplied classically. -/
+noncomputable def validKeyPairShort (pk : PublicKey p prims) (sk : SecretKey p) : Bool :=
+  @decide _ <| Classical.propDecidable
+    (∃ (rho key : Bytes 32) (s1 : RqVec p.l) (s2 : RqVec p.k),
+    polyVecBounded s1 p.eta ∧ polyVecBounded s2 p.eta ∧
+    ((⟨rho, (prims.power2RoundVec (prims.expandA rho * s1 + s2)).1⟩,
+      ⟨rho, key,
+        prims.hashPublicKey rho (prims.power2RoundVec (prims.expandA rho * s1 + s2)).1,
+        s1, s2, (prims.power2RoundVec (prims.expandA rho * s1 + s2)).2⟩) :
+      PublicKey p prims × SecretKey p) = (pk, sk))
+
+@[simp] theorem validKeyPairShort_eq_true_iff (pk : PublicKey p prims) (sk : SecretKey p) :
+    validKeyPairShort p prims pk sk = true ↔
+      ∃ (rho key : Bytes 32) (s1 : RqVec p.l) (s2 : RqVec p.k),
+        polyVecBounded s1 p.eta ∧ polyVecBounded s2 p.eta ∧
+        ((⟨rho, (prims.power2RoundVec (prims.expandA rho * s1 + s2)).1⟩,
+          ⟨rho, key,
+            prims.hashPublicKey rho (prims.power2RoundVec (prims.expandA rho * s1 + s2)).1,
+            s1, s2, (prims.power2RoundVec (prims.expandA rho * s1 + s2)).2⟩) :
+          PublicKey p prims × SecretKey p) = (pk, sk) := by
+  unfold validKeyPairShort
+  exact @decide_eq_true_iff _ (Classical.propDecidable _)
+
 /-! ### Identification Scheme -/
 
 /-- The core identification scheme with aborts for ML-DSA.
@@ -174,6 +213,23 @@ def identificationScheme
     decide (polyVecNorm z < p.gamma1 - p.beta) &&
     decide (w1' = w1) &&
     decide (prims.hintWeight h ≤ p.omega)
+
+/-- The core ML-DSA identification scheme with aborts, tagged at the material-based key
+relation `validKeyPairShort`. The commit / respond / verify algorithms are exactly those of
+`identificationScheme` — the relation is only a type-level index of `IdenSchemeWithAbort`,
+never consumed by the operations — so every per-key fact about the operations transports
+between the two scheme constants. This is the scheme used by the idealized short-key security
+statements, whose key generators produce material-valid rather than seed-derived pairs. -/
+def identificationSchemeShort
+    [DecidableEq prims.High] [SampleableType (RqVec p.l)] :
+    IdenSchemeWithAbort
+      (PublicKey p prims) (SecretKey p)
+      (Commitment p prims) (SigningState p)
+      (CommitHashBytes p) (Response p prims)
+      (validKeyPairShort p prims) :=
+  ⟨(identificationScheme p prims).commit,
+    (identificationScheme p prims).respond,
+    (identificationScheme p prims).verify⟩
 
 /-! ### Key Generation Algebraic Properties -/
 

--- a/LatticeCrypto/MLDSA/SecurityNMA.lean
+++ b/LatticeCrypto/MLDSA/SecurityNMA.lean
@@ -108,6 +108,124 @@ theorem keyFromMaterial_eq (seed : Bytes 32) :
       keyGenFromSeed p prims seed := by
   simp only [keyFromMaterial, keyGenFromSeed]
 
+/-! ### Short-secret sampling and the idealized key generators
+
+The FIPS key generator derives everything deterministically from one seed
+(`keygen0` above). The idealized proof-level model instead samples the matrix
+seed `ρ`, the signing key `K`, and the short secrets `(s₁, s₂)` independently,
+with `(s₁, s₂)` uniform on the `η`-bounded box `S_η^ℓ × S_η^k` — the
+distribution the Module-LWE assumption for ML-DSA is stated over. The key-swap
+hop is then an exact monad identity against `mldsaMLWEShort` (no statistical
+slack); the deterministic-XOF derivation is not part of this hop and is handled
+separately by a named XOF-replacement assumption. -/
+
+/-- `polyVecBounded` is a decidable predicate: it is a `≤` test on the computed
+centered infinity norm. -/
+instance {k b : ℕ} : DecidablePred (fun v : RqVec k => polyVecBounded v b) := fun _ => by
+  unfold polyVecBounded
+  exact Nat.decLe _ _
+
+omit nttOps in
+/-- The zero vector lies in every `η`-bounded box. -/
+lemma polyVecBounded_zero (k b : ℕ) : polyVecBounded (0 : RqVec k) b := by
+  unfold polyVecBounded polyVecNorm
+  rw [LatticeCrypto.PolyVec.cInfNorm_le_iff]
+  intro j
+  have hz : (0 : RqVec k).get j = (0 : Rq) := by
+    change (0 : Vector Rq k).get j = 0
+    simp [Vector.get]
+  rw [hz]
+  have h0 : polyNorm (0 : Rq) = 0 := by
+    simp only [polyNorm, normOps, LatticeCrypto.zmodPolyNormOps,
+      LatticeCrypto.normOpsOfCenteredView, LatticeCrypto.cInfNormOf]
+    simp only [vectorNegacyclicRing_backend, vectorBackend_coeff, Finset.sup_eq_zero,
+      Finset.mem_univ, Int.natAbs_eq_zero, forall_const]
+    intro i
+    have hci : Vector.get (0 : Rq) i = (0 : Coeff) :=
+      LatticeCrypto.NegacyclicRing.coeff_zero coeffRing i
+    rw [hci]
+    simp only [LatticeCrypto.zmodCenteredCoeffView, LatticeCrypto.centeredRepr, ZMod.val_zero,
+      Int.natCast_zero]
+    split <;> omega
+  calc normOps.cInfNorm (0 : Rq) = polyNorm (0 : Rq) := rfl
+    _ = 0 := h0
+    _ ≤ b := Nat.zero_le b
+
+/-- **Uniform sampling from the `η`-bounded box.** The uniform distribution on
+`S_b^k = { v : RqVec k | ‖v‖∞ ≤ b }`, i.e. every coefficient of every component
+uniform on the centered interval `[-b, b]`. This is the secret/error
+distribution of the Module-LWE assumption used by ML-DSA (`η ∈ {2, 4}` for the
+approved parameter sets). -/
+noncomputable def sampleShortVec (k b : ℕ) [SampleableType (RqVec k)] : ProbComp (RqVec k) :=
+  letI : Fintype {v : RqVec k // polyVecBounded v b} := .ofFinite _
+  letI : Nonempty {v : RqVec k // polyVecBounded v b} := ⟨0, polyVecBounded_zero k b⟩
+  letI : SampleableType {v : RqVec k // polyVecBounded v b} := .ofFintype _
+  Subtype.val <$> ($ᵗ {v : RqVec k // polyVecBounded v b})
+
+/-- **Idealized key generation (real `t`).** Sample the matrix seed `ρ`, the
+signing key `K`, and the short secrets `(s₁, s₂)` independently — `(s₁, s₂)`
+uniform on the `η`-bounded box — and form `t = ExpandA(ρ) · s₁ + s₂`. This is
+the honestly-sampled key distribution of the idealized proof-level ML-DSA
+model; the deterministic seed-expanded `keygen0` is related to it by a separate
+XOF-replacement assumption. -/
+noncomputable def keygenShort : ProbComp (PublicKey p prims × SecretKey p) := do
+  let key ← $ᵗ (Bytes 32)
+  let rho ← $ᵗ (Bytes 32)
+  let s1 ← sampleShortVec p.l p.eta
+  let s2 ← sampleShortVec p.k p.eta
+  let t := prims.expandA rho * s1 + s2
+  return keyFromMaterial p prims rho key s1 s2 t
+
+/-- **Idealized key generation (uniform `t`).** Identical to `keygenShort`
+except the public vector `t` is sampled uniformly. The gap between the two is
+exactly the `mldsaMLWEShort` distinguishing advantage of the induced
+distinguisher (`nma_keyswap_hop_short`). -/
+noncomputable def keygenShort1 : ProbComp (PublicKey p prims × SecretKey p) := do
+  let key ← $ᵗ (Bytes 32)
+  let rho ← $ᵗ (Bytes 32)
+  let s1 ← sampleShortVec p.l p.eta
+  let s2 ← sampleShortVec p.k p.eta
+  let t ← $ᵗ (RqVec p.k)
+  return keyFromMaterial p prims rho key s1 s2 t
+
+omit nttOps in
+/-- Every output of `sampleShortVec k b` lies in the `b`-bounded box: the sampler draws from
+the subtype `{v // polyVecBounded v b}` and projects out the value, so support membership
+carries the bound. -/
+lemma mem_support_sampleShortVec {k b : ℕ} [SampleableType (RqVec k)] {v : RqVec k}
+    (hv : v ∈ support (sampleShortVec k b)) : polyVecBounded v b := by
+  simp only [sampleShortVec, support_map] at hv
+  obtain ⟨u, -, rfl⟩ := hv
+  exact u.property
+
+/-- The generable relation carried by the idealized short-key model: the generator is
+`keygenShort`, and every generated pair is material-valid. Each pair drawn by `keygenShort`
+is literally `keyFromMaterial ρ K s₁ s₂ (ExpandA(ρ)·s₁ + s₂)` for uniform `ρ`, `K` and
+box-sampled `(s₁, s₂)`, and `sampleShortVec` outputs are `η`-bounded on their support
+(`mem_support_sampleShortVec`) — exactly the witness `validKeyPairShort` asks for. This
+inhabits the `hGen` hypothesis of the short-model security headlines
+(`keygenShort_generable`). -/
+noncomputable def hrShort :
+    GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims) :=
+  ⟨keygenShort p prims, fun pk sk hmem => by
+    rw [validKeyPairShort_eq_true_iff]
+    simp only [keygenShort, mem_support_bind_iff] at hmem
+    obtain ⟨key, -, rho, -, s1, hs1, s2, hs2, hpure⟩ := hmem
+    refine ⟨rho, key, s1, s2, mem_support_sampleShortVec hs1,
+      mem_support_sampleShortVec hs2, ?_⟩
+    simpa only [keyFromMaterial] using (eq_of_mem_support_pure _ hpure).symm⟩
+
+omit [DecidableEq prims.High] in
+/-- **Satisfiability certificate for the short-model `hGen` hypothesis.** Some generable
+relation over `validKeyPairShort` has `keygenShort` as its generator — witnessed by
+`hrShort`. The short-model security statements hypothesize such a relation via
+`hGen : hr.gen = keygenShort p prims`; this theorem records that the hypothesis pair
+`(hr, hGen)` is inhabited, so those statements have non-vacuous instances. -/
+theorem keygenShort_generable :
+    ∃ hr : GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims),
+      hr.gen = keygenShort p prims :=
+  ⟨hrShort p prims, rfl⟩
+
 end KeyGen
 
 section Game
@@ -149,6 +267,40 @@ noncomputable def nmaAdvantage
       OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
         (M × Option (Commitment p prims × Response p prims))) : ℝ≥0∞ :=
   Pr[= true | nmaGame p prims hr maxAttempts keygen main]
+
+/-! ### Short-model EUF-NMA game -/
+
+/-- The EUF-NMA game over the idealized short-key scheme: identical to `nmaGame` except the
+signature scheme is `FiatShamirWithAbort` over `identificationSchemeShort`, whose key relation
+`validKeyPairShort` is the material-based one that `keygenShort` generates (`hrShort`). The
+observed runtime, the forging interface, and the verify recomputation are unchanged. -/
+noncomputable def nmaGameShort
+    (hr : GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims))
+    (maxAttempts : ℕ)
+    (keygen : ProbComp (PublicKey p prims × SecretKey p))
+    (main : PublicKey p prims →
+      OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
+        (M × Option (Commitment p prims × Response p prims))) :
+    SPMF Bool :=
+  (FiatShamirWithAbort.runtime (Commit := Commitment p prims)
+    (Chal := CommitHashBytes p) M).evalDist do
+      let (pk, _) ← (FiatShamirWithAbort.runtime (Commit := Commitment p prims)
+        (Chal := CommitHashBytes p) M).liftProbComp keygen
+      let (msg, σ) ← main pk
+      (FiatShamirWithAbort (identificationSchemeShort p prims) hr M maxAttempts).verify pk msg σ
+
+/-- The advantage of the short-model NMA game with key generator `keygen` is its
+`true`-probability. The exact short hop identifies
+`|nmaAdvantageShort keygenShort − nmaAdvantageShort keygenShort1|` with the `mldsaMLWEShort`
+advantage of `distinguisherBShort`. -/
+noncomputable def nmaAdvantageShort
+    (hr : GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims))
+    (maxAttempts : ℕ)
+    (keygen : ProbComp (PublicKey p prims × SecretKey p))
+    (main : PublicKey p prims →
+      OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
+        (M × Option (Commitment p prims × Response p prims))) : ℝ≥0∞ :=
+  Pr[= true | nmaGameShort p prims hr maxAttempts keygen main]
 
 end Game
 
@@ -231,6 +383,192 @@ noncomputable def distinguisherB
     simulateToProbComp p prims (M := M) do
       let (msg, σ) ← main pk
       (FiatShamirWithAbort (identificationScheme p prims) hr M maxAttempts).verify pk msg σ
+
+/-! ### Short-secret MLWE problems and the seed-to-matrix bridge
+
+The idealized short-key model states its Module-LWE assumption over short `(s₁, s₂)`
+(`mldsaMLWEShort`, seed-based; `mldsaMatrixMLWE`, uniform-matrix form). The seed-based problem
+reduces to the standard matrix form under the `expandAIdealization` XOF assumption
+(`advantage_mldsaMLWEShort_le_matrix`), and `distinguisherBShort` is the induced distinguisher
+whose advantage the short key-swap hop bounds. -/
+
+/-- **The short-secret Module-LWE problem for ML-DSA** (seed-based form). The public
+challenge is the matrix seed `ρ` itself (uniform), the secret `s₁` and the additive
+error `s₂` are uniform on the `η`-bounded box (`sampleShortVec`), and the decision
+target is `t = ExpandA(ρ) · s₁ + s₂` versus uniform `t`. This is the distribution the
+ML-DSA literature states its MLWE assumption over; unlike a uniform-error variant it
+is not information-theoretically trivial, since `ExpandA(ρ) · s₁ + s₂` with short
+`(s₁, s₂)` is far from uniform. Bridging the seed-based challenge to the standard
+uniform-matrix form is `advantage_mldsaMLWEShort_le_matrix`, under the explicit
+`expandAIdealization` assumption. -/
+noncomputable def mldsaMLWEShort (p : Params) (prims : Primitives p)
+    [SampleableType (RqVec p.l)] [SampleableType (RqVec p.k)] :
+    LearningWithErrors.Problem (Bytes 32) (RqVec p.l) (RqVec p.k) where
+  sampleChallenge := $ᵗ (Bytes 32)
+  sampleSecret := sampleShortVec p.l p.eta
+  sampleError := sampleShortVec p.k p.eta
+  noiseless := fun s1 rho => prims.expandA rho * s1
+  sampleUniform := $ᵗ (RqVec p.k)
+
+/-- **The matrix-based short Module-LWE problem for ML-DSA.** The standard form: the
+public challenge is a uniform matrix `A`, the secret and error are uniform on the
+`η`-bounded box, and the decision target is `A · s₁ + s₂` versus uniform. This is the
+literature-facing hardness assumption; `mldsaMLWEShort` reduces to it under
+`expandAIdealization` (`advantage_mldsaMLWEShort_le_matrix`). -/
+noncomputable def mldsaMatrixMLWE (p : Params)
+    [SampleableType (TqMatrix p.k p.l)]
+    [SampleableType (RqVec p.l)] [SampleableType (RqVec p.k)] :
+    LearningWithErrors.Problem (TqMatrix p.k p.l) (RqVec p.l) (RqVec p.k) where
+  sampleChallenge := $ᵗ (TqMatrix p.k p.l)
+  sampleSecret := sampleShortVec p.l p.eta
+  sampleError := sampleShortVec p.k p.eta
+  noiseless := fun s1 A => A * s1
+  sampleUniform := $ᵗ (RqVec p.k)
+
+/-- **ExpandA idealization (quantified XOF-as-random-matrix step).** For every
+distinguisher `D` receiving both the seed and the matrix, the pair
+`(ρ, ExpandA(ρ))` for uniform `ρ` is `εA`-indistinguishable from `(ρ, A)` with `A`
+uniform and independent of `ρ`.
+
+This is the standard random-oracle reading of `ExpandA` (Dilithium's `A = ExpandA(ρ)`
+with `ExpandA` modeled as a random function), stated once with inspectable content
+rather than supplied per-reduction. For a fixed deterministic `prims.expandA` the
+unrestricted-quantifier form is only satisfiable at large `εA` (a distinguisher may
+recompute `ExpandA(ρ)` and compare); pending the cost-model infrastructure (#460) it
+should be read computationally, against bounded distinguishers, where it is the
+assumption that SHAKE-based expansion yields a pseudorandom matrix. -/
+def expandAIdealization (p : Params) (prims : Primitives p)
+    [SampleableType (TqMatrix p.k p.l)] (εA : ℝ) : Prop :=
+  ∀ [IsUniformSpec unifSpec] (D : Bytes 32 → TqMatrix p.k p.l → ProbComp Bool),
+    |(Pr[= true | do
+        let rho ← $ᵗ (Bytes 32)
+        D rho (prims.expandA rho)]).toReal -
+      (Pr[= true | do
+        let rho ← $ᵗ (Bytes 32)
+        let A ← $ᵗ (TqMatrix p.k p.l)
+        D rho A]).toReal| ≤ εA
+
+/-- The short-model MLWE distinguisher: form `pk = (ρ, Power2Round(t).1)` from the challenge
+`(ρ, t)`, run the NMA forging strategy
+`main` on `pk`, simulate the random oracle to verify the returned forgery, and output the
+validity bit — typed against the short-secret problem `mldsaMLWEShort` and the short-key
+scheme `identificationSchemeShort`. When `(ρ, t)` is real it reproduces
+`nmaGameShort … keygenShort`; when `t` is uniform it reproduces `nmaGameShort … keygenShort1`
+(`nma_keyswap_hop_short`). -/
+noncomputable def distinguisherBShort
+    (hr : GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims))
+    (maxAttempts : ℕ)
+    (main : PublicKey p prims →
+      OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
+        (M × Option (Commitment p prims × Response p prims))) :
+    LearningWithErrors.Adversary (mldsaMLWEShort p prims) :=
+  fun (challenge : Bytes 32 × RqVec p.k) =>
+    let rho := challenge.1
+    let t := challenge.2
+    let pk : PublicKey p prims := ⟨rho, (prims.power2RoundVec t).1⟩
+    simulateToProbComp p prims (M := M) do
+      let (msg, σ) ← main pk
+      (FiatShamirWithAbort (identificationSchemeShort p prims) hr M maxAttempts).verify pk msg σ
+
+/-- Lift a seed-based short-MLWE adversary to the uniform-matrix problem: run it on a
+freshly sampled seed and the challenged target vector, discarding the matrix. -/
+noncomputable def matrixLift
+    (B : LearningWithErrors.Adversary (mldsaMLWEShort p prims)) :
+    LearningWithErrors.Adversary (mldsaMatrixMLWE p) :=
+  fun c => do
+    let rho ← $ᵗ (Bytes 32)
+    B (rho, c.2)
+
+omit [DecidableEq prims.High] [DecidableEq (Commitment p prims)]
+  [SampleableType (CommitHashBytes p)] [IsUniformSpec unifSpec] in
+/-- **Seed-to-matrix bridge.** Under `expandAIdealization`, any adversary against the
+seed-based short problem yields one against the standard uniform-matrix problem: the
+matrix adversary runs the seed adversary on a freshly sampled seed and the challenged
+target vector. The uniform branches agree exactly (both present an independent uniform
+`t`), and the real branches differ by one application of the idealization at the
+distinguisher `D ρ A := s₁ ← S_η^ℓ; s₂ ← S_η^k; B (ρ, A·s₁ + s₂)`.
+
+Proof recipe: rewrite both advantages via `advantage_eq_game_boolDistAdvantage` and
+`ProbComp.boolDistAdvantage`; the `game1` branches are identified by stripping the
+unused matrix draw (`probOutput_bind_const`, with `Pr[⊥ | $ᵗ _] = 0`) and commuting
+the independent uniform draws (`evalDist_bind_bind_swap`); the `game0` branches
+are `≤ εA` by `hA` applied at `D` above, after `bind_assoc` normalization. Conclude
+by the triangle inequality. -/
+lemma advantage_mldsaMLWEShort_le_matrix {εA : ℝ}
+    (hA : expandAIdealization p prims εA)
+    (B : LearningWithErrors.Adversary (mldsaMLWEShort p prims)) :
+    LearningWithErrors.advantage (mldsaMLWEShort p prims) B ≤
+      LearningWithErrors.advantage (mldsaMatrixMLWE p) (matrixLift p prims B) + εA := by
+  set Bm : LearningWithErrors.Adversary (mldsaMatrixMLWE p) :=
+    matrixLift p prims B with hBm
+  set D : Bytes 32 → TqMatrix p.k p.l → ProbComp Bool :=
+    (fun rho A => do
+      let s1 ← sampleShortVec p.l p.eta
+      let s2 ← sampleShortVec p.k p.eta
+      B (rho, A * s1 + s2)) with hD
+  -- Local copy of the generic `advantage = boolDistAdvantage` bridge (its named form lives later
+  -- in the file, in the `Hop` section, so it is not yet in scope here).
+  have hadv : ∀ {S Sec O : Type} [Add O] (problem : LearningWithErrors.Problem S Sec O)
+      (adv : LearningWithErrors.Adversary problem),
+      LearningWithErrors.advantage problem adv =
+        (LearningWithErrors.game0 problem adv).boolDistAdvantage
+          (LearningWithErrors.game1 problem adv) := by
+    intro S Sec O _ problem adv
+    rw [LearningWithErrors.advantage,
+      show LearningWithErrors.experiment problem adv = (do
+        let b ← ($ᵗ Bool)
+        let z ← if b then LearningWithErrors.game0 problem adv
+                      else LearningWithErrors.game1 problem adv
+        pure (b == z)) by
+        simp only [LearningWithErrors.experiment, LearningWithErrors.game0,
+          LearningWithErrors.game1, bind_assoc]]
+    exact ProbComp.boolBiasAdvantage_eq_boolDistAdvantage_uniformBool_branch _ _
+  rw [hadv (mldsaMLWEShort p prims) B, hadv (mldsaMatrixMLWE p) Bm,
+    ProbComp.boolDistAdvantage, ProbComp.boolDistAdvantage]
+  have h1 : Pr[= true | LearningWithErrors.game1 (mldsaMLWEShort p prims) B] =
+      Pr[= true | LearningWithErrors.game1 (mldsaMatrixMLWE p) Bm] := by
+    simp only [LearningWithErrors.game1, LearningWithErrors.uniformDistr, mldsaMLWEShort,
+      mldsaMatrixMLWE, hBm, matrixLift, bind_assoc, pure_bind]
+    -- Strip the unused leading matrix draw on the right, then commute the two uniform draws.
+    rw [probOutput_bind_const, probFailure_uniformSample]
+    simp only [tsub_zero, one_mul]
+    rw [probOutput_def, probOutput_def,
+      evalDist_bind_bind_swap
+        ($ᵗ (Bytes 32)) ($ᵗ (RqVec p.k)) (fun rho t => B (rho, t))]
+  have h0 : |(Pr[= true | LearningWithErrors.game0 (mldsaMLWEShort p prims) B]).toReal -
+      (Pr[= true | LearningWithErrors.game0 (mldsaMatrixMLWE p) Bm]).toReal| ≤ εA := by
+    have hreal : Pr[= true | LearningWithErrors.game0 (mldsaMLWEShort p prims) B] =
+        Pr[= true | do let rho ← $ᵗ (Bytes 32); D rho (prims.expandA rho)] := by
+      simp only [LearningWithErrors.game0, LearningWithErrors.distr, mldsaMLWEShort, hD,
+        bind_assoc, pure_bind]
+    have hunif : Pr[= true | LearningWithErrors.game0 (mldsaMatrixMLWE p) Bm] =
+        Pr[= true | do
+          let rho ← $ᵗ (Bytes 32)
+          let A ← $ᵗ (TqMatrix p.k p.l)
+          D rho A] := by
+      simp only [LearningWithErrors.game0, LearningWithErrors.distr, mldsaMatrixMLWE, hBm,
+        matrixLift, hD,
+        bind_assoc, pure_bind]
+      -- Commute the trailing `ρ` draw to the front (three independent-draw transpositions).
+      rw [probOutput_def, probOutput_def]
+      congr 1
+      refine Eq.trans (evalDist_bind_congr' _ (fun A => evalDist_bind_congr' _ (fun s1 =>
+        evalDist_bind_bind_swap (sampleShortVec p.k p.eta) ($ᵗ (Bytes 32))
+          (fun s2 rho => B (rho, A * s1 + s2))))) ?_
+      refine Eq.trans (evalDist_bind_congr' _ (fun A =>
+        evalDist_bind_bind_swap (sampleShortVec p.l p.eta) ($ᵗ (Bytes 32))
+          (fun s1 rho => sampleShortVec p.k p.eta >>= fun s2 => B (rho, A * s1 + s2)))) ?_
+      exact evalDist_bind_bind_swap
+        ($ᵗ (TqMatrix p.k p.l)) ($ᵗ (Bytes 32))
+        (fun A rho => sampleShortVec p.l p.eta >>= fun s1 =>
+          sampleShortVec p.k p.eta >>= fun s2 => B (rho, A * s1 + s2))
+    rw [hreal, hunif]
+    exact hA D
+  rw [h1]
+  refine le_trans (abs_sub_le _
+    (Pr[= true | LearningWithErrors.game0 (mldsaMatrixMLWE p) Bm].toReal) _) ?_
+  rw [add_comm]
+  exact add_le_add le_rfl h0
 
 end Distinguisher
 
@@ -393,6 +731,101 @@ theorem nma_keyswap_hop (h_laws : Primitives.Laws prims nttOps)
           ⟨rho, (prims.power2RoundVec (prims.expandA rho * s1 + s2)).1⟩ d.1 d.2)))
   -- The hop is in fact an *equality* modulo (H0)/(H1): after rewriting both NMA games into the
   -- matching MLWE games the bound becomes `|x - y| = |x - y|`, closed by reflexivity.
+  rw [hH0, hH1]
+
+/-! ### The exact short-model key-swap hop -/
+
+omit [SampleableType (RqVec p.k)] in
+/-- Short-model NMA-game / distinguisher plumbing: the `nmaGame_eq_keygen_bind` rewrite at the
+short scheme. Pushing the `keygen` sampling out of the Fiat-Shamir-with-aborts runtime, the
+`Pr[= true]` of `nmaGameShort … keygen` equals that of first sampling `(pk, _) ← keygen` in
+plain `ProbComp` and then running the forge-and-verify tail through `simulateToProbComp` —
+exactly the body of `distinguisherBShort` evaluated at `pk`. -/
+theorem nmaGameShort_eq_keygen_bind
+    (hr : GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims))
+    (maxAttempts : ℕ)
+    (keygen : ProbComp (PublicKey p prims × SecretKey p))
+    (main : PublicKey p prims →
+      OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
+        (M × Option (Commitment p prims × Response p prims))) :
+    nmaGameShort p prims hr maxAttempts keygen main =
+      𝒟[(do
+        let (pk, _) ← keygen
+        simulateToProbComp p prims (M := M) (do
+          let (msg, σ) ← main pk
+          (FiatShamirWithAbort (identificationSchemeShort p prims) hr M maxAttempts).verify
+            pk msg σ))] := by
+  classical
+  let ro : QueryImpl (M × Commitment p prims →ₒ CommitHashBytes p)
+      (StateT ((M × Commitment p prims →ₒ CommitHashBytes p).QueryCache) ProbComp) := randomOracle
+  let impl : QueryImpl (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
+      (StateT ((M × Commitment p prims →ₒ CommitHashBytes p).QueryCache) ProbComp) :=
+    unifFwdImpl (M × Commitment p prims →ₒ CommitHashBytes p) + ro
+  let rest : PublicKey p prims →
+      OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p)) Bool := fun pk => do
+    let (msg, σ) ← main pk
+    (FiatShamirWithAbort (identificationSchemeShort p prims) hr M maxAttempts).verify pk msg σ
+  unfold nmaGameShort FiatShamirWithAbort.runtime ProbCompRuntime.evalDist
+    ProbCompRuntime.liftProbComp SPMFSemantics.evalDist SemanticsVia.denote
+  change 𝒟[(simulateQ impl (liftM keygen >>= fun pk => rest pk.1)).run' ∅] =
+    𝒟[keygen >>= fun pk => simulateToProbComp p prims (rest pk.1)]
+  rw [simulateQ_bind,
+    roSim.run'_liftM_bind (ro := ro) (oa := keygen)
+      (rest := fun pk => simulateQ impl (rest pk.1)) (s := ∅)]
+  rw [evalDist_bind, evalDist_bind]
+  simp only [simulateToProbComp, roImpl]
+  rfl
+
+/-- **The exact short-model key-swap hop.** Against the idealized key generators
+`keygenShort` / `keygenShort1`, the short-model NMA-game gap **is** the `mldsaMLWEShort`
+distinguishing advantage of `distinguisherBShort` — both branch identifications are pure
+monad-rewriting identities, with no statistical slack: the key generators sample
+`ρ`, `K`, `s₁`, `s₂` independently, exactly as the problem's `distr`/`uniformDistr`
+do (the unused `K` draw strips off, being the leading draw).
+
+Proof recipe: both branches follow the same shape: `rw [nmaGameShort_eq_keygen_bind]`,
+`simp only [LearningWithErrors.game0/1, LearningWithErrors.distr/uniformDistr,
+distinguisherBShort, mldsaMLWEShort, keygenShort/1, keyFromMaterial, bind_assoc, pure_bind]`,
+strip the leading `K` draw with `probOutput_bind_const` (`Pr[⊥ | $ᵗ (Bytes 32)] = 0`), and
+close with `probOutput_def`/`SPMF.evalDist_def`. -/
+theorem nma_keyswap_hop_short
+    (hr : GenerableRelation (PublicKey p prims) (SecretKey p) (validKeyPairShort p prims))
+    (maxAttempts : ℕ)
+    (main : PublicKey p prims →
+      OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
+        (M × Option (Commitment p prims × Response p prims))) :
+    |(nmaAdvantageShort p prims hr maxAttempts (keygenShort p prims) main).toReal -
+        (nmaAdvantageShort p prims hr maxAttempts (keygenShort1 p prims) main).toReal| ≤
+      LearningWithErrors.advantage (mldsaMLWEShort p prims)
+        (distinguisherBShort p prims hr maxAttempts main) := by
+  set B := distinguisherBShort p prims hr maxAttempts main (M := M) with hB
+  -- `Pr[= true | 𝒟[Y]] = Pr[= true | Y]` holds definitionally (the SPMF self-lift is `id`).
+  have peel : ∀ (Y : ProbComp Bool), Pr[= true | 𝒟[Y]] = Pr[= true | Y] := fun _ => rfl
+  have hkey : Pr[⊥ | ($ᵗ (Bytes 32) : ProbComp (Bytes 32))] = 0 := probFailure_uniformSample _
+  have hss : ∀ (k b : ℕ) [SampleableType (RqVec k)], Pr[⊥ | sampleShortVec k b] = 0 := by
+    intro k b _
+    simp only [sampleShortVec, probFailure_map, probFailure_uniformSample]
+  rw [advantage_eq_game_boolDistAdvantage (mldsaMLWEShort p prims) B,
+    ProbComp.boolDistAdvantage, nmaAdvantageShort, nmaAdvantageShort]
+  have hH1 : Pr[= true | nmaGameShort p prims hr maxAttempts (keygenShort1 p prims) main] =
+      Pr[= true | LearningWithErrors.game1 (mldsaMLWEShort p prims) B] := by
+    rw [nmaGameShort_eq_keygen_bind]
+    simp only [LearningWithErrors.game1, LearningWithErrors.uniformDistr, hB,
+      distinguisherBShort, mldsaMLWEShort, keygenShort1, keyFromMaterial, bind_assoc, pure_bind]
+    -- Strip the unused leading `key` draw, then the unused `s₁`, `s₂` draws under `ρ`.
+    rw [peel, probOutput_bind_const, hkey]
+    simp only [tsub_zero, one_mul]
+    refine probOutput_bind_congr' _ true (fun rho => ?_)
+    rw [probOutput_bind_const, hss, probOutput_bind_const, hss]
+    simp only [tsub_zero, one_mul]
+  have hH0 : Pr[= true | nmaGameShort p prims hr maxAttempts (keygenShort p prims) main] =
+      Pr[= true | LearningWithErrors.game0 (mldsaMLWEShort p prims) B] := by
+    rw [nmaGameShort_eq_keygen_bind]
+    simp only [LearningWithErrors.game0, LearningWithErrors.distr, hB, distinguisherBShort,
+      mldsaMLWEShort, keygenShort, keyFromMaterial, bind_assoc, pure_bind]
+    -- Only the leading `key` draw is unused here (`s₁`, `s₂` build `t`).
+    rw [peel, probOutput_bind_const, hkey]
+    simp only [tsub_zero, one_mul]
   rw [hH0, hH1]
 
 end Hop

--- a/LatticeCrypto/MLDSA/SecurityNMA.lean
+++ b/LatticeCrypto/MLDSA/SecurityNMA.lean
@@ -421,10 +421,28 @@ noncomputable def mldsaSTMSIS (M : Type) :
   sampleParams := do
     let (pk, _) ← keygen1 p prims
     return (prims.expandA pk.rho, pk)
-  isValid := fun aHat pk cTilde (z, h) =>
-    -- Recover the commitment `w'` from `(pk, c̃, (z, h))` and run the identification verifier.
+  isValid := fun aHat pk hashInput cTilde (z, h) =>
+    -- Recover the commitment `w'` from `(pk, c̃, (z, h))`, bind it to the commitment component
+    -- of the hashed preimage (the self-target binding), and run the identification verifier.
     let w' := prims.useHintVec h (computeWApprox p prims aHat (prims.sampleInBall cTilde) z pk.t1)
-    (identificationScheme p prims).verify pk w' cTilde (z, h)
+    decide (hashInput.2 = w') && (identificationScheme p prims).verify pk w' cTilde (z, h)
+
+omit [DecidableEq M] [SampleableType (CommitHashBytes p)] in
+/-- **Self-target binding, made explicit.** An accepted `mldsaSTMSIS` solution is exactly the
+identification-verifier acceptance *and* the binding of the recovered commitment `w'` to the
+commitment component of the hashed preimage. Exposing the binding as its own conjunct keeps the
+self-target requirement visible and hard to drop from the tailored relation: an instantiation that
+silently ignored the preimage would fail this characterization. -/
+theorem mldsaSTMSIS_isValid_eq_true_iff (aHat : TqMatrix p.k p.l) (pk : PublicKey p prims)
+    (hashInput : M × Commitment p prims) (cTilde : CommitHashBytes p)
+    (z : RqVec p.l) (h : Vector prims.Hint p.k) :
+    (mldsaSTMSIS p prims M).isValid aHat pk hashInput cTilde (z, h) = true ↔
+      hashInput.2 = prims.useHintVec h
+          (computeWApprox p prims aHat (prims.sampleInBall cTilde) z pk.t1) ∧
+        (identificationScheme p prims).verify pk
+          (prims.useHintVec h (computeWApprox p prims aHat (prims.sampleInBall cTilde) z pk.t1))
+          cTilde (z, h) = true := by
+  simp only [mldsaSTMSIS, Bool.and_eq_true, decide_eq_true_iff]
 
 /-- **The SelfTargetMSIS extractor `C` (Lemma 7, Step 3).**
 
@@ -483,7 +501,8 @@ private theorem stmsis_tail_le
             ((extractorC p prims main).run (prims.expandA pk.rho, pk))).run ∅
         match cache hashInput with
         | some hashOutput =>
-            pure ((mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk hashOutput response)
+            pure ((mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk hashInput hashOutput
+              response)
         | none => pure false] := by
   classical
   -- Decompose both tails over the shared simulation of `main pk` from the empty cache.
@@ -528,15 +547,18 @@ private theorem stmsis_tail_le
         subst hu
         exact QueryCache.cacheQuery_self _ (msg, w') u
     rw [hcache]
-    -- An accepted NMA forgery is a valid STMSIS solution (commitment recoverability is exactly the
-    -- middle conjunct of `verify`, which `isValid` discharges by `decide (X = X)`).
+    -- An accepted NMA forgery is a valid STMSIS solution. The self-target binding
+    -- `hashInput.2 = w'` holds because the queried preimage is exactly `(msg, w')`, so the binding
+    -- reduces to `decide (w' = w') = true`; commitment recoverability is the middle conjunct of
+    -- `verify`, which `isValid` discharges by `decide (X = X)`.
     rw [probOutput_pure, probOutput_pure]
     by_cases hverify :
         (identificationScheme p prims).verify pk w' cc.1 (z, h) = true
     · -- Accepted: `isValid` recovers `w'` as the very `useHintVec …` value `verify` checks against,
-      -- so its middle conjunct is `decide (X = X) = true` and `isValid = true`.
+      -- and the preimage's commitment component `(msg, w').2` is `w'`, so both conjuncts hold.
       have hvalid :
-          (mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk cc.1 (z, h) = true := by
+          (mldsaSTMSIS p prims M).isValid (prims.expandA pk.rho) pk (msg, w') cc.1 (z, h)
+            = true := by
         simp only [mldsaSTMSIS, identificationScheme] at hverify ⊢
         revert hverify
         grind


### PR DESCRIPTION
Step 2 of the #467 decomposition @dtumad proposed: the corrected short-secret MLWE model and the exact NMA key-swap hop, as a focused, purely additive PR.

**Stacked on #503** (the SelfTargetMSIS binding repair) — until #503 lands, its diff shows here too; this PR's own content is the ~489 additive lines in `SecurityNMA.lean` + `Scheme.lean`. The two are independent in content (MLWE leg vs SelfTargetMSIS leg); the stacking is just to keep the decomposition ordered.

## What this adds

The MLWE leg of the ML-DSA NMA reduction, modelled over the **η-bounded box** rather than the full ring — fixing the information-theoretically-zero-advantage issue of the earlier full-ring-uniform `mldsaMLWE`:

- **`sampleShortVec`** (uniform on the η-box), **`keygenShort`/`keygenShort1`** (idealized key generation sampling ρ, K, and short (s₁, s₂) independently).
- **`validKeyPairShort`** (the ∃-material key relation) + **`identificationSchemeShort`**, with the satisfiability certificate **`keygenShort_generable`** (`⟨hrShort, rfl⟩`) — so the relation/pinning hypotheses these introduce are inhabited, not vacuous.
- **`mldsaMLWEShort`** (seed-based short-secret MLWE) and **`mldsaMatrixMLWE`** (the standard uniform-matrix form), with **`expandAIdealization`** (the named XOF-as-random-matrix assumption, computational reading disclosed) and the proven seed→matrix bridge **`advantage_mldsaMLWEShort_le_matrix`** via **`matrixLift`**.
- **`nma_keyswap_hop_short`** — the headline: the NMA-game gap between the real and uniform-`t` short key generators is bounded by the `mldsaMLWEShort` distinguishing advantage of `distinguisherBShort`, as an **exact identity** — no `idealGap`/`hSlack` statistical-slack term (the earlier `honestSamplingSlack` stopgap is not used).

## Scope

Purely additive — no existing declaration is modified or removed. The old `mldsaMLWE`/`nma_security` chain on the base is untouched here; it is retired when the NMA headline moves over (a later step). The SelfTargetMSIS/extraction/headline development (`mldsaSTMSISShort`, `nma_security_short/fips`, ...) is **not** in this PR — it is steps 3–4.

## Verification

Off current main (v4.32.0). `lake build ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets` green. `nma_keyswap_hop_short`, `advantage_mldsaMLWEShort_le_matrix`, and `keygenShort_generable` all kernel-check `[propext, Classical.choice, Quot.sound]`. Both touched files CI-lint clean.

https://claude.ai/code/session_01DaNGD9nDo3Grwk58nsjS77
