### PR TITLE
feat(scripts): kernel-level axiom sweep with committed regression baseline

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -192,16 +192,15 @@ jobs:
       # tool build breakage) always fail so the soak cannot silently rot.
       # Sweeps the non-test libraries; Interop (the declared TCB) is bounded by
       # its import-isolation gate instead.
-      - name: Axiom sweep (report-only)
-        run: |
-          status=0
-          lake exe axiomsweep --check || status=$?
-          if [ "$status" -eq 1 ]; then
-            echo "::warning::axiomsweep found new axiom/sorry taint (report-only during soak)"
-          elif [ "$status" -ne 0 ]; then
-            echo "::error::axiomsweep infrastructure failure (exit $status) — not a taint verdict"
-            exit "$status"
-          fi
+      # Exercise the sweep against its own fixtures before trusting its verdict on the
+      # library: the fixtures carry synthetic taint of each shape the tool reasons about
+      # (direct and transitive `sorryAx`, an axiom occurring only in a type, a mutual
+      # family whose taint crosses the cycle, generated `._native.` name shapes), plus
+      # the exit-code matrix CI depends on.
+      - name: Test the axiom sweep tool
+        run: ./scripts/test-axiomsweep.sh
+      - name: Axiom sweep
+        run: lake exe axiomsweep --check
       - name: Check round-by-round extraction regression
         run: lake env lean VCVioTest/RoundByRound/OneRound.lean
       - name: Check Merkle batch-opening canaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,6 +187,14 @@ jobs:
         run: |
           bash scripts/build_timing_report.sh run test_path "$BUILD_TIMING_RESULTS" -- \
             bash -eo pipefail -c 'lake env lean VCVioTest/Smoke.lean'
+      # Report-only during the initial soak; flip to enforcing by dropping the
+      # trailing `|| echo ...` once the baseline has survived a few PRs.
+      # Sweeps the non-test libraries; Interop (the declared TCB) is bounded by
+      # its import-isolation gate instead.
+      - name: Axiom sweep (report-only)
+        run: |
+          lake exe axiomsweep --check || \
+            echo "::warning::axiomsweep found new axiom/sorry taint (report-only during soak)"
       - name: Check round-by-round extraction regression
         run: lake env lean VCVioTest/RoundByRound/OneRound.lean
       - name: Check Merkle batch-opening canaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -187,14 +187,21 @@ jobs:
         run: |
           bash scripts/build_timing_report.sh run test_path "$BUILD_TIMING_RESULTS" -- \
             bash -eo pipefail -c 'lake env lean VCVioTest/Smoke.lean'
-      # Report-only during the initial soak; flip to enforcing by dropping the
-      # trailing `|| echo ...` once the baseline has survived a few PRs.
+      # Taint findings are report-only during the initial soak (flip to enforcing by
+      # failing on exit 1 too); infrastructure failures (exit != 1: missing baseline,
+      # tool build breakage) always fail so the soak cannot silently rot.
       # Sweeps the non-test libraries; Interop (the declared TCB) is bounded by
       # its import-isolation gate instead.
       - name: Axiom sweep (report-only)
         run: |
-          lake exe axiomsweep --check || \
+          status=0
+          lake exe axiomsweep --check || status=$?
+          if [ "$status" -eq 1 ]; then
             echo "::warning::axiomsweep found new axiom/sorry taint (report-only during soak)"
+          elif [ "$status" -ne 0 ]; then
+            echo "::error::axiomsweep infrastructure failure (exit $status) — not a taint verdict"
+            exit "$status"
+          fi
       - name: Check round-by-round extraction regression
         run: lake env lean VCVioTest/RoundByRound/OneRound.lean
       - name: Check Merkle batch-opening canaries

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,14 +201,22 @@ The timing report parses per-file build times only for that same set.
 Test libraries and test executables are not part of the timed build; CI only
 times the smoke module separately with `lake env lean VCVioTest/Smoke.lean`.
 
-After the build, CI runs `lake exe axiomsweep --check` (report-only during its
-initial soak): kernel-level axiom/`sorry` accounting for every declaration in
-the non-test libraries, gated against the committed baseline
-`scripts/axiom_baseline.json`. It fails only on *new* `sorryAx` or
-non-standard-axiom taint; after intentionally adding or closing a `sorry`, run
+After the build, CI runs `./scripts/test-axiomsweep.sh` and then
+`lake exe axiomsweep --check`: kernel-level axiom/`sorry` accounting for every
+declaration in the non-test libraries, gated against the committed baseline
+`scripts/axiom_baseline.json`. It fails on *new* `sorryAx` or non-standard-axiom
+taint; after intentionally adding or closing a `sorry`, run
 `lake exe axiomsweep --update-baseline` and commit the diff. `Interop` (the
 declared TCB) is excluded — its boundary is enforced by the import-isolation
 gate instead.
+
+The baseline is an allowlist for `sorryAx` debt only. Native trust
+(`native_decide`, which mints per-declaration `._native.` axioms) is held to a
+zero-debt rule: anything outside the explicit `grandfatheredNativeTrust` list in
+`scripts/AxiomSweep.lean` fails `--check` and cannot be greened by editing the
+baseline, since accepting it would widen the trusted computing base. The
+`AxiomSweepTestFixtures` library carries synthetic taint for the tool's own
+tests and is deliberately excluded from every aggregate.
 
 After adding new `.lean` files: `./scripts/update-lib.sh`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,6 +201,15 @@ The timing report parses per-file build times only for that same set.
 Test libraries and test executables are not part of the timed build; CI only
 times the smoke module separately with `lake env lean VCVioTest/Smoke.lean`.
 
+After the build, CI runs `lake exe axiomsweep --check` (report-only during its
+initial soak): kernel-level axiom/`sorry` accounting for every declaration in
+the non-test libraries, gated against the committed baseline
+`scripts/axiom_baseline.json`. It fails only on *new* `sorryAx` or
+non-standard-axiom taint; after intentionally adding or closing a `sorry`, run
+`lake exe axiomsweep --update-baseline` and commit the diff. `Interop` (the
+declared TCB) is excluded — its boundary is enforced by the import-isolation
+gate instead.
+
 After adding new `.lean` files: `./scripts/update-lib.sh`
 
 Lean toolchain and Mathlib must stay in sync (both currently `v4.32.2`). Keep files

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -381,3 +381,13 @@ lean_exe axiomsweep where
   srcDir := "scripts"
   root := `AxiomSweep
   supportInterpreter := true
+
+/-- Isolated fixtures for the axiom-sweep mutation matrix, exercised by
+`scripts/test-axiomsweep.sh`. Not a default target, and deliberately carrying synthetic
+kernel taint: `sorryAx` reached directly and transitively, an axiom occurring only in a
+type, a mutual-inductive family whose taint crosses the cycle, and names that imitate the
+generated `._native.` suffix. Kept out of every aggregate so the taint stays quarantined
+from the swept libraries. -/
+lean_lib AxiomSweepTestFixtures where
+  srcDir := "scripts"
+  globs := #[.submodules `AxiomSweepTestFixtures]

--- a/lakefile.lean
+++ b/lakefile.lean
@@ -371,3 +371,13 @@ lean_exe slhdsa_kat where
 /-- C13 known-answer test: pure-Lean keccak256 concrete verify vs the reference signer vector. -/
 lean_exe slhdsa_c13_kat where
   root := `HashSigTest.SLHDSA.C13KAT
+
+/-- Kernel-level axiom / `sorry` accounting across the non-test libraries, with a
+committed regression baseline (`scripts/axiom_baseline.json`). Complements the Interop
+TCB-isolation gate: that gate bounds imports, this one accounts for the axioms every
+declaration ultimately rests on. Runtime-imports built oleans, so run it after
+`lake build`. See `scripts/AxiomSweep.lean`. -/
+lean_exe axiomsweep where
+  srcDir := "scripts"
+  root := `AxiomSweep
+  supportInterpreter := true

--- a/scripts/AxiomSweep.lean
+++ b/scripts/AxiomSweep.lean
@@ -44,10 +44,19 @@ The committed baseline (`scripts/axiom_baseline.json`) records the currently-kno
 `sorryAx`-tainted declarations and any declarations depending on non-standard axioms
 (anything beyond `propext`, `Classical.choice`, `Quot.sound` — so native trust axioms
 surface here too: `native_decide`-style tactics mint per-declaration
-`…._native.<tactic>.ax_*` axioms, recorded under their owning declaration). `--check`
-fails exactly when a declaration is tainted that the baseline does not cover. When gaps
-are closed, `--check` reports them and stays green; run `--update-baseline` to shrink the
-file in the same PR.
+`…._native.<tactic>.ax_<number>_<number>` axioms, recorded under their owning
+declaration). `--check` fails exactly when a declaration is tainted that the baseline
+does not cover. When gaps are closed, `--check` reports them and stays green; run
+`--update-baseline` to shrink the file in the same PR.
+
+The baseline is an allowlist for `sorryAx` debt only. Native trust is held to PolyFun's
+zero-debt rule instead: `neverAllowlistable` rejects any `._native.` axiom outside the
+explicit `grandfatheredNativeTrust` list, so no baseline edit can widen the trusted
+computing base. Exit codes are a contract with CI — `1` is a taint verdict, anything else
+an infrastructure failure — which is why `main` traps uncaught exceptions into `2`.
+
+`scripts/test-axiomsweep.sh` exercises all of this against the `AxiomSweepTestFixtures`
+library, whose fixtures carry synthetic taint of each shape this file reasons about.
 -/
 
 open Lean
@@ -65,11 +74,35 @@ def defaultRoots : Array Name :=
 /-- Axioms that carry no extra trust assumptions beyond Lean's standard foundation. -/
 def standardAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
 
-/-- Axioms that may never be baselined: bare native-compiler trust. A baseline edit
-cannot green these — remove the dependency instead. (Zero hits today; this floor keeps
-the baseline from ever becoming a second, laxer policy.) -/
+/-- Whether `a` names native-compiler trust: either a bare compiler axiom, or one of the
+per-declaration axioms `native_decide`-style tactics mint, which this toolchain names
+`Owner._native.<tactic>.ax_<n>_<n>` rather than routing through `Lean.ofReduceBool`. -/
+def isNativeTrust (a : String) : Bool :=
+  a == "Lean.ofReduceBool" || a == "Lean.trustCompiler" || (a.splitOn "._native.").length > 1
+
+/-- The native trust this repository has already accepted, listed by full axiom name so
+the acceptance is auditable in source rather than hidden in a JSON allowlist. Both come
+from the ML-DSA / ML-KEM NTT inversion certificates, whose loop kernels the kernel cannot
+unfold in principle (`while` → `Loop.forIn` → `partial`); see the burndown note in
+`LatticeCrypto/{MLDSA,MLKEM}/Concrete/NTT.lean`.
+
+Fails closed: if a private-name index or module path shifts, the entry stops matching and
+`--check` goes red until someone consciously re-accepts it. -/
+def grandfatheredNativeTrust : List String :=
+  ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide",
+   "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]
+
+/-- Axioms that may never be baselined: native-compiler trust beyond what
+`grandfatheredNativeTrust` already accepts. Unlike `sorryAx` debt — honest work in
+progress, which the baseline is allowed to track — new native trust is a widening of the
+trusted computing base, so no baseline edit can green it; remove the dependency instead.
+
+This is the counterpart of PolyFun's zero-debt gate. PolyFun refuses a nonempty baseline
+outright; VCVio cannot, since it carries genuine `sorryAx` debt, so the floor applies the
+same "cannot pre-authorize future taint" rule to the part of the baseline where widening
+the TCB is at stake. -/
 def neverAllowlistable (a : String) : Bool :=
-  a == "Lean.ofReduceBool" || a == "Lean.trustCompiler"
+  isNativeTrust a && !grandfatheredNativeTrust.contains a
 
 /-- Phase 1: DFS. Compute, for every constant reachable from the work list, an
 under-approximation of the set of axioms it transitively depends on, memoised across
@@ -152,14 +185,28 @@ structure Baseline where
   nonstandard : Array NonstandardEntry
   deriving FromJson, ToJson
 
-/-- Collapse the volatile counter suffix of native trust axioms
+/-- Whether `s` is a nonempty string of ASCII decimal digits. -/
+def isDecimal (s : String) : Bool :=
+  !s.isEmpty && s.toList.all fun c => '0' ≤ c && c ≤ '9'
+
+/-- Collapse exactly the generated counter suffix of native trust axioms
 (`Foo._native.native_decide.ax_1_1` → `Foo._native.native_decide`), so baselines key by
-owning declaration rather than a rebuild-volatile counter. -/
+owning declaration rather than a rebuild-volatile counter. Names that merely contain
+`._native.` or resemble a generated suffix are preserved: collapsing them would let two
+distinct axioms share one baseline key, so real taint could hide behind an accepted
+entry. -/
 def normalizeAxiomName (s : String) : String :=
   match s.splitOn "._native." with
   | [owner, tail] =>
     match tail.splitOn "." with
-    | tactic :: _ => owner ++ "._native." ++ tactic
+    | [tactic, counter] =>
+      match counter.splitOn "_" with
+      | ["ax", major, minor] =>
+        if !owner.isEmpty && !tactic.isEmpty && isDecimal major && isDecimal minor then
+          owner ++ "._native." ++ tactic
+        else
+          s
+      | _ => s
     | _ => s
   | _ => s
 
@@ -288,6 +335,22 @@ def runCheck (cur : Baseline) (basePath : String) : IO UInt32 := do
   IO.println "axiomsweep: check passed (no new axiom/sorry taint)."
   return 0
 
+/-- Rewrite the baseline from the current build. Refuses while never-allowlistable taint
+is present: `--check` would reject the result anyway (the floor is enforced there, not
+here), so writing it would only produce a baseline that looks authoritative and is not.
+Recording new `sorryAx` debt is fine — that is what the baseline is for. -/
+def runUpdate (cur : Baseline) (basePath : String) : IO UInt32 := do
+  let floor := cur.nonstandard.filter fun e => e.axioms.any neverAllowlistable
+  if !floor.isEmpty then
+    IO.eprintln s!"axiomsweep: refusing to update {basePath} while \
+      {floor.size} declaration(s) depend on never-allowlistable axioms:"
+    for e in floor do IO.eprintln s!"  {e.name} : {e.axioms.filter neverAllowlistable}"
+    IO.eprintln "axiomsweep: remove the dependency; the baseline cannot pre-authorize it."
+    return 1
+  IO.FS.writeFile basePath ((toJson cur).pretty ++ "\n")
+  IO.println s!"axiomsweep: wrote baseline to {basePath}"
+  return 0
+
 structure Config where
   roots : Array Name := #[]
   out? : Option String := none
@@ -310,7 +373,10 @@ def parseArgs : List String → Config → Except String Config
 end AxiomSweep
 
 open AxiomSweep in
-unsafe def main (args : List String) : IO UInt32 := do
+/-- Tool body. Exit codes are a contract with CI, which reads `1` as a taint verdict and
+anything else as an infrastructure failure; `main` wraps this so an uncaught exception
+cannot masquerade as the former. -/
+unsafe def run (args : List String) : IO UInt32 := do
   let cfg ← match parseArgs args {} with
     | .ok cfg => pure cfg
     | .error e => IO.eprintln e; return 2
@@ -346,9 +412,15 @@ unsafe def main (args : List String) : IO UInt32 := do
     IO.FS.writeFile out (report.pretty ++ "\n")
     IO.println s!"axiomsweep: wrote report to {out}"
   if cfg.update then
-    IO.FS.writeFile cfg.baseline ((toJson cur).pretty ++ "\n")
-    IO.println s!"axiomsweep: wrote baseline to {cfg.baseline}"
-    return 0
+    return (← runUpdate cur cfg.baseline)
   if cfg.check then
     return (← runCheck cur cfg.baseline)
   return 0
+
+open AxiomSweep in
+unsafe def main (args : List String) : IO UInt32 := do
+  try
+    run args
+  catch e =>
+    IO.eprintln s!"axiomsweep: internal error: {e}"
+    return 2

--- a/scripts/AxiomSweep.lean
+++ b/scripts/AxiomSweep.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 VCVio Contributors. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: VCVio Contributors
+Authors: Alexander Hicks
 -/
 import Lean
 
@@ -14,10 +14,22 @@ declaration in the non-test libraries (`VCVio`, `ToMathlib`, `Extern`, `LatticeC
 depend on — the same information as `#print axioms`, for the whole library at once.
 
 Because this reads elaborated `.olean` data rather than source text, it sees exactly what
-the kernel accepted: private declarations, macro-generated declarations, and instances are
-all included, and no source-level heuristics are involved. This complements the Interop
-TCB-isolation gate: that gate bounds *imports*; this one accounts for the *axioms* every
-declaration ultimately rests on.
+the kernel accepted: private declarations and instances are reported, compiler-generated
+auxiliaries are traversed (their taint surfaces on the parent declaration), and no
+source-level heuristics are involved. This complements the Interop TCB-isolation gate:
+that gate bounds *imports*; this one accounts for the *axioms* every declaration
+ultimately rests on. The sweep covers what the root
+modules transitively import — pair it with the repo's import-completeness gate so every
+source file is actually in scope; an unimported file is invisible to any kernel-level
+census.
+
+Known blind spots, shared with `#print axioms` (all environment-walking tools):
+* structure-field **default values** and autoparams (`:= by sorry`) are re-elaborated at
+  each use site and attach to no swept constant of the defining module;
+* `example`s never enter the environment;
+* files not transitively imported by the swept roots are invisible (pair with the repo's
+  import-completeness gate).
+A source-level `sorry` grep is the complementary check for the first two.
 
 Modes (run after `lake build`):
 
@@ -30,8 +42,9 @@ lake exe axiomsweep --update-baseline   # rewrite the baseline from the current 
 
 The committed baseline (`scripts/axiom_baseline.json`) records the currently-known
 `sorryAx`-tainted declarations and any declarations depending on non-standard axioms
-(anything beyond `propext`, `Classical.choice`, `Quot.sound` — so `Lean.ofReduceBool` and
-`Lean.trustCompiler` from native-trusting tactics surface here too). `--check`
+(anything beyond `propext`, `Classical.choice`, `Quot.sound` — so native trust axioms
+surface here too: `native_decide`-style tactics mint per-declaration
+`…._native.<tactic>.ax_*` axioms, recorded under their owning declaration). `--check`
 fails exactly when a declaration is tainted that the baseline does not cover. When gaps
 are closed, `--check` reports them and stays green; run `--update-baseline` to shrink the
 file in the same PR.
@@ -52,38 +65,70 @@ def defaultRoots : Array Name :=
 /-- Axioms that carry no extra trust assumptions beyond Lean's standard foundation. -/
 def standardAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
 
-/-- Compute, for every constant reachable from the work list, the set of axioms it
-transitively depends on, memoised across roots via `memo` (so sweeping thousands of
-declarations shares one traversal of the environment).
+/-- Axioms that may never be baselined: bare native-compiler trust. A baseline edit
+cannot green these — remove the dependency instead. (Zero hits today; this floor keeps
+the baseline from ever becoming a second, laxer policy.) -/
+def neverAllowlistable (a : String) : Bool :=
+  a == "Lean.ofReduceBool" || a == "Lean.trustCompiler"
 
-`gray` marks constants whose dependencies are still being expanded. Cycles — which the
-kernel only permits inside mutual inductive families, where no axioms hide — are broken by
-treating back-edges as axiom-free. -/
+/-- Phase 1: DFS. Compute, for every constant reachable from the work list, an
+under-approximation of the set of axioms it transitively depends on, memoised across
+roots via `memo`. Also records the finalisation order — a topological order of the
+dependency graph except inside mutual-inductive cycles.
+
+`gray` marks constants whose dependencies are still being expanded. Back-edges (cycles,
+which the kernel only permits inside mutual inductive families) contribute nothing in
+this phase; `repair` below propagates to the true fixpoint. An axiom contributes itself
+plus anything reachable through its *type* (matching Lean's own `CollectAxioms`). -/
 partial def collect (env : Environment) (stack : List Name) (gray : Std.HashSet Name)
-    (memo : Std.HashMap Name (Array Name)) : Std.HashMap Name (Array Name) :=
+    (memo : Std.HashMap Name (Array Name)) (order : Array Name) :
+    Std.HashMap Name (Array Name) × Array Name :=
   match stack with
-  | [] => memo
+  | [] => (memo, order)
   | n :: rest =>
     if memo.contains n then
-      collect env rest gray memo
+      collect env rest gray memo order
     else match env.find? n with
-      | none => collect env rest gray (memo.insert n #[])
+      | none => collect env rest gray (memo.insert n #[]) order
       | some ci =>
-        if ci matches .axiomInfo _ then
-          collect env rest gray (memo.insert n #[n])
+        let deps := ci.getUsedConstantsAsSet.toList
+        if gray.contains n then
+          let seed : Array Name := if ci matches .axiomInfo _ then #[n] else #[]
+          let axs := deps.foldl (init := seed) fun acc d =>
+            match memo[d]? with
+            | some as => as.foldl (init := acc) fun acc a =>
+                if acc.contains a then acc else acc.push a
+            | none => acc
+          collect env rest gray (memo.insert n axs) (order.push n)
         else
-          let deps := ci.getUsedConstantsAsSet.toList
-          if gray.contains n then
-            -- All children are memoised (or lie on a cycle): finalise this constant.
-            let axs := deps.foldl (init := #[]) fun acc d =>
-              match memo[d]? with
-              | some as => as.foldl (init := acc) fun acc a =>
-                  if acc.contains a then acc else acc.push a
-              | none => acc
-            collect env rest gray (memo.insert n axs)
-          else
-            let pending := deps.filter fun d => !memo.contains d && !gray.contains d
-            collect env (pending ++ stack) (gray.insert n) memo
+          let pending := deps.filter fun d => !memo.contains d && !gray.contains d
+          collect env (pending ++ stack) (gray.insert n) memo order
+
+/-- Phase 2: propagate to fixpoint. The DFS under-approximates inside mutual-inductive
+cycles (a member's taint may not reach its siblings), and — because `memo` persists
+across roots — anything finalised after reading such a member inherits the error.
+Re-deriving every set in finalisation order until nothing changes computes the least
+fixpoint of the closure equations: the true kernel-level axiom dependency set. This is
+strictly more accurate than `#print axioms`, whose `CollectAxioms` has the same
+mutual-family blind spot this phase repairs. Sets grow monotonically and are bounded,
+so termination is immediate; in practice one or two passes suffice. -/
+partial def repair (env : Environment) (order : Array Name)
+    (memo : Std.HashMap Name (Array Name)) : Std.HashMap Name (Array Name) :=
+  let (memo', changed) := order.foldl (init := (memo, false)) fun (memo, changed) n =>
+    match env.find? n with
+    | none => (memo, changed)
+    | some ci =>
+      let deps := ci.getUsedConstantsAsSet.toList
+      let seed : Array Name := if ci matches .axiomInfo _ then #[n] else #[]
+      let axs := deps.foldl (init := seed) fun acc d =>
+        match memo[d]? with
+        | some as => as.foldl (init := acc) fun acc a =>
+            if acc.contains a then acc else acc.push a
+        | none => acc
+      let old := (memo[n]?.getD #[]).size
+      if axs.size == old then (memo, changed)
+      else (memo.insert n axs, true)
+  if changed then repair env order memo' else memo'
 
 /-- One row of the per-declaration report. -/
 structure Entry where
@@ -107,6 +152,22 @@ structure Baseline where
   nonstandard : Array NonstandardEntry
   deriving FromJson, ToJson
 
+/-- Collapse the volatile counter suffix of native trust axioms
+(`Foo._native.native_decide.ax_1_1` → `Foo._native.native_decide`), so baselines key by
+owning declaration rather than a rebuild-volatile counter. -/
+def normalizeAxiomName (s : String) : String :=
+  match s.splitOn "._native." with
+  | [owner, tail] =>
+    match tail.splitOn "." with
+    | tactic :: _ => owner ++ "._native." ++ tactic
+    | _ => s
+  | _ => s
+
+/-- Sort and deduplicate (normalisation can identify adjacent names). -/
+def dedupSort (a : Array String) : Array String :=
+  (a.qsort (· < ·)).foldl (init := #[]) fun acc x =>
+    if acc.back? == some x then acc else acc.push x
+
 def kindOf : ConstantInfo → String
   | .axiomInfo _ => "axiom"
   | .defnInfo _ => "def"
@@ -118,9 +179,10 @@ def kindOf : ConstantInfo → String
   | .recInfo _ => "recursor"
 
 /-- Whether to report a constant: skip compiler-internal auxiliaries (`_proof_*`,
-`match_*`, equation lemmas, …), whose axiom footprint is inherited by their parent
-declaration anyway, but keep `private` declarations (checked under their user-facing
-name, since the `_private` mangling would otherwise look internal). -/
+`match_*`, numbered equation lemmas, …), whose axiom footprint is inherited by their
+parent declaration, but keep `private` declarations (checked under their user-facing
+name, since the `_private` mangling would otherwise look internal). On-demand aux
+lemmas with symbolic names (`.eq_def`, `.congr_simp`) are reported. -/
 def isReportable (n : Name) : Bool :=
   !n.hasMacroScopes && !((privateToUserName? n).getD n).isInternalDetail
 
@@ -129,15 +191,21 @@ compute their axiom closures. -/
 def buildEntries (roots : Array Name) : CoreM (Array Entry × Nat) := do
   let env ← getEnv
   let mut targets : Array (Name × Name) := #[]
+  let mut seen : Std.HashSet Name := {}
   let mut moduleCount := 0
   for (mname, mdata) in env.header.moduleNames.zip env.header.moduleData do
     if roots.any (·.isPrefixOf mname) then
       moduleCount := moduleCount + 1
       for c in mdata.constNames do
-        if isReportable c then
+        -- A realised constant (e.g. `.congr_simp`) can appear in several modules'
+        -- `constNames`; report it once, under the first module that carries it.
+        if isReportable c && !seen.contains c then
+          seen := seen.insert c
           targets := targets.push (c, mname)
-  let memo := targets.foldl (init := ({} : Std.HashMap Name (Array Name)))
-    fun memo (c, _) => collect env [c] {} memo
+  let (memo0, order) :=
+    targets.foldl (init := (({} : Std.HashMap Name (Array Name)), (#[] : Array Name)))
+      fun (memo, order) (c, _) => collect env [c] {} memo order
+  let memo := repair env order memo0
   let mut entries : Array Entry := #[]
   for (c, mname) in targets do
     let some ci := env.find? c | continue
@@ -147,7 +215,7 @@ def buildEntries (roots : Array Name) : CoreM (Array Entry × Nat) := do
       module := mname.toString
       kind := kindOf ci
       line := line
-      axioms := ((memo[c]?.getD #[]).map toString).qsort (· < ·) }
+      axioms := dedupSort ((memo[c]?.getD #[]).map (normalizeAxiomName ·.toString)) }
   return (entries.qsort (fun a b => a.name < b.name), moduleCount)
 
 def isStandard (a : String) : Bool :=
@@ -187,8 +255,16 @@ def runCheck (cur : Baseline) (basePath : String) : IO UInt32 := do
     | none => true
     | some b => e.axioms.any (!b.axioms.contains ·)
   let fixedNonstd := base.nonstandard.filter fun b =>
-    (cur.nonstandard.find? (·.name == b.name)).isNone
+    match cur.nonstandard.find? (·.name == b.name) with
+    | none => true
+    | some c => b.axioms.any (!c.axioms.contains ·)
   let mut failed := false
+  let floor := cur.nonstandard.filter fun e => e.axioms.any neverAllowlistable
+  if !floor.isEmpty then
+    failed := true
+    IO.eprintln s!"axiomsweep: {floor.size} declaration(s) depend on never-allowlistable \
+      axioms (bare native-compiler trust) — the baseline cannot green these:"
+    for e in floor do IO.eprintln s!"  {e.name} : {e.axioms.filter neverAllowlistable}"
   if !newSorry.isEmpty then
     failed := true
     IO.eprintln s!"axiomsweep: {newSorry.size} declaration(s) newly depend on sorryAx \
@@ -229,7 +305,7 @@ def parseArgs : List String → Config → Except String Config
     parseArgs rest { cfg with roots := cfg.roots.push mod.toName }
   | arg :: _, _ => .error s!"axiomsweep: unknown or incomplete argument: {arg}\n\
       usage: lake exe axiomsweep [--out FILE] [--check] [--update-baseline] \
-      [--baseline FILE] [--root MOD]*"
+      [--baseline FILE] [--root MOD]*\n      (--check and --update-baseline are mutually exclusive)"
 
 end AxiomSweep
 
@@ -238,11 +314,20 @@ unsafe def main (args : List String) : IO UInt32 := do
   let cfg ← match parseArgs args {} with
     | .ok cfg => pure cfg
     | .error e => IO.eprintln e; return 2
+  if cfg.check && cfg.update then
+    IO.eprintln "axiomsweep: --check and --update-baseline are mutually exclusive"
+    return 2
   let roots := if cfg.roots.isEmpty then defaultRoots else cfg.roots
   initSearchPath (← findSysroot)
   enableInitializersExecution
-  let env ← importModules (roots.map ({ module := · })) {} (trustLevel := 1024)
-    (loadExts := true)
+  let env ← try
+      importModules (roots.map ({ module := · })) {} (trustLevel := 1024)
+        (loadExts := true)
+    catch e =>
+      IO.eprintln s!"axiomsweep: cannot import root modules {roots}: {e.toString}\n\
+        (roots must be importable modules — glob-based libs without an umbrella \
+        module cannot be swept by library name)"
+      return (2 : UInt32)
   let ((entries, moduleCount), _) ← (buildEntries roots).toIO
     { fileName := "<axiomsweep>", fileMap := default } { env }
   let cur := currentBaseline entries

--- a/scripts/AxiomSweep.lean
+++ b/scripts/AxiomSweep.lean
@@ -1,0 +1,269 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: VCVio Contributors
+-/
+import Lean
+
+/-!
+# Axiom sweep: whole-library kernel-level axiom and `sorry` accounting
+
+Walks the compiled environment (the same data the kernel checked) and computes, for every
+declaration in the non-test libraries (`VCVio`, `ToMathlib`, `Extern`, `LatticeCrypto`,
+`HashSig`, `Examples`, `VCVioWidgets`), the set of axioms its statement and proof ultimately
+depend on — the same information as `#print axioms`, for the whole library at once.
+
+Because this reads elaborated `.olean` data rather than source text, it sees exactly what
+the kernel accepted: private declarations, macro-generated declarations, and instances are
+all included, and no source-level heuristics are involved. This complements the Interop
+TCB-isolation gate: that gate bounds *imports*; this one accounts for the *axioms* every
+declaration ultimately rests on.
+
+Modes (run after `lake build`):
+
+```
+lake exe axiomsweep                     # summary only
+lake exe axiomsweep --out report.json   # also write the full per-declaration report
+lake exe axiomsweep --check             # gate against scripts/axiom_baseline.json
+lake exe axiomsweep --update-baseline   # rewrite the baseline from the current build
+```
+
+The committed baseline (`scripts/axiom_baseline.json`) records the currently-known
+`sorryAx`-tainted declarations and any declarations depending on non-standard axioms
+(anything beyond `propext`, `Classical.choice`, `Quot.sound` — so `Lean.ofReduceBool` and
+`Lean.trustCompiler` from native-trusting tactics surface here too). `--check`
+fails exactly when a declaration is tainted that the baseline does not cover. When gaps
+are closed, `--check` reports them and stays green; run `--update-baseline` to shrink the
+file in the same PR.
+-/
+
+open Lean
+
+namespace AxiomSweep
+
+/-- Root modules swept when no `--root` is given.
+
+`Interop` is deliberately excluded: it is the declared TCB (bounded by the import
+isolation gate), sits outside the certified surface this sweep accounts for, and is not
+built by the main CI build job. Sweep it explicitly with `--root Interop` if needed. -/
+def defaultRoots : Array Name :=
+  #[`VCVio, `ToMathlib, `Extern, `LatticeCrypto, `HashSig, `Examples, `VCVioWidgets]
+
+/-- Axioms that carry no extra trust assumptions beyond Lean's standard foundation. -/
+def standardAxioms : List Name := [``propext, ``Classical.choice, ``Quot.sound]
+
+/-- Compute, for every constant reachable from the work list, the set of axioms it
+transitively depends on, memoised across roots via `memo` (so sweeping thousands of
+declarations shares one traversal of the environment).
+
+`gray` marks constants whose dependencies are still being expanded. Cycles — which the
+kernel only permits inside mutual inductive families, where no axioms hide — are broken by
+treating back-edges as axiom-free. -/
+partial def collect (env : Environment) (stack : List Name) (gray : Std.HashSet Name)
+    (memo : Std.HashMap Name (Array Name)) : Std.HashMap Name (Array Name) :=
+  match stack with
+  | [] => memo
+  | n :: rest =>
+    if memo.contains n then
+      collect env rest gray memo
+    else match env.find? n with
+      | none => collect env rest gray (memo.insert n #[])
+      | some ci =>
+        if ci matches .axiomInfo _ then
+          collect env rest gray (memo.insert n #[n])
+        else
+          let deps := ci.getUsedConstantsAsSet.toList
+          if gray.contains n then
+            -- All children are memoised (or lie on a cycle): finalise this constant.
+            let axs := deps.foldl (init := #[]) fun acc d =>
+              match memo[d]? with
+              | some as => as.foldl (init := acc) fun acc a =>
+                  if acc.contains a then acc else acc.push a
+              | none => acc
+            collect env rest gray (memo.insert n axs)
+          else
+            let pending := deps.filter fun d => !memo.contains d && !gray.contains d
+            collect env (pending ++ stack) (gray.insert n) memo
+
+/-- One row of the per-declaration report. -/
+structure Entry where
+  name : String
+  module : String
+  kind : String
+  line : Option Nat
+  axioms : Array String
+  deriving ToJson
+
+/-- A declaration depending on axioms beyond the standard foundation (and `sorryAx`,
+which is tracked separately). -/
+structure NonstandardEntry where
+  name : String
+  axioms : Array String
+  deriving FromJson, ToJson
+
+/-- The committed regression baseline. -/
+structure Baseline where
+  «sorry» : Array String
+  nonstandard : Array NonstandardEntry
+  deriving FromJson, ToJson
+
+def kindOf : ConstantInfo → String
+  | .axiomInfo _ => "axiom"
+  | .defnInfo _ => "def"
+  | .thmInfo _ => "theorem"
+  | .opaqueInfo _ => "opaque"
+  | .quotInfo _ => "quot"
+  | .inductInfo _ => "inductive"
+  | .ctorInfo _ => "constructor"
+  | .recInfo _ => "recursor"
+
+/-- Whether to report a constant: skip compiler-internal auxiliaries (`_proof_*`,
+`match_*`, equation lemmas, …), whose axiom footprint is inherited by their parent
+declaration anyway, but keep `private` declarations (checked under their user-facing
+name, since the `_private` mangling would otherwise look internal). -/
+def isReportable (n : Name) : Bool :=
+  !n.hasMacroScopes && !((privateToUserName? n).getD n).isInternalDetail
+
+/-- Enumerate the reportable declarations of every module under one of `roots` and
+compute their axiom closures. -/
+def buildEntries (roots : Array Name) : CoreM (Array Entry × Nat) := do
+  let env ← getEnv
+  let mut targets : Array (Name × Name) := #[]
+  let mut moduleCount := 0
+  for (mname, mdata) in env.header.moduleNames.zip env.header.moduleData do
+    if roots.any (·.isPrefixOf mname) then
+      moduleCount := moduleCount + 1
+      for c in mdata.constNames do
+        if isReportable c then
+          targets := targets.push (c, mname)
+  let memo := targets.foldl (init := ({} : Std.HashMap Name (Array Name)))
+    fun memo (c, _) => collect env [c] {} memo
+  let mut entries : Array Entry := #[]
+  for (c, mname) in targets do
+    let some ci := env.find? c | continue
+    let line := (← findDeclarationRanges? c).map (·.range.pos.line)
+    entries := entries.push {
+      name := c.toString
+      module := mname.toString
+      kind := kindOf ci
+      line := line
+      axioms := ((memo[c]?.getD #[]).map toString).qsort (· < ·) }
+  return (entries.qsort (fun a b => a.name < b.name), moduleCount)
+
+def isStandard (a : String) : Bool :=
+  standardAxioms.any (toString · == a)
+
+def sorryAxName : String := "sorryAx"
+
+/-- Non-standard axioms of an entry: everything beyond the standard foundation, with
+`sorryAx` tracked separately. -/
+def nonstandardOf (e : Entry) : Array String :=
+  e.axioms.filter fun a => !isStandard a && a != sorryAxName
+
+/-- Project the current build's taint sets into baseline form (deterministically
+sorted, since `entries` is sorted by name). -/
+def currentBaseline (entries : Array Entry) : Baseline where
+  «sorry» := (entries.filter (·.axioms.contains sorryAxName)).map (·.name)
+  nonstandard := entries.filterMap fun e =>
+    let bad := nonstandardOf e
+    if bad.isEmpty then none else some { name := e.name, axioms := bad }
+
+/-- Compare the current taint sets against the committed baseline. Returns the exit
+code: `1` iff there is a regression (new taint not covered by the baseline). -/
+def runCheck (cur : Baseline) (basePath : String) : IO UInt32 := do
+  if !(← System.FilePath.pathExists basePath) then
+    IO.eprintln s!"axiomsweep: baseline {basePath} not found; \
+      create it with `lake exe axiomsweep --update-baseline`"
+    return 2
+  let base ← match Json.parse (← IO.FS.readFile basePath) >>= fromJson? (α := Baseline) with
+    | .ok b => pure b
+    | .error e =>
+      IO.eprintln s!"axiomsweep: cannot parse baseline {basePath}: {e}"
+      return 2
+  let newSorry := cur.«sorry».filter (!base.«sorry».contains ·)
+  let fixedSorry := base.«sorry».filter (!cur.«sorry».contains ·)
+  let newNonstd := cur.nonstandard.filter fun e =>
+    match base.nonstandard.find? (·.name == e.name) with
+    | none => true
+    | some b => e.axioms.any (!b.axioms.contains ·)
+  let fixedNonstd := base.nonstandard.filter fun b =>
+    (cur.nonstandard.find? (·.name == b.name)).isNone
+  let mut failed := false
+  if !newSorry.isEmpty then
+    failed := true
+    IO.eprintln s!"axiomsweep: {newSorry.size} declaration(s) newly depend on sorryAx \
+      (not in {basePath}):"
+    for n in newSorry do IO.eprintln s!"  {n}"
+  if !newNonstd.isEmpty then
+    failed := true
+    IO.eprintln s!"axiomsweep: {newNonstd.size} declaration(s) newly depend on \
+      non-standard axioms (not in {basePath}):"
+    for e in newNonstd do IO.eprintln s!"  {e.name} : {e.axioms}"
+  if failed then
+    IO.eprintln s!"axiomsweep: if intentional (new tagged sorry), refresh the baseline \
+      with `lake exe axiomsweep --update-baseline` and commit the diff."
+    return 1
+  if !fixedSorry.isEmpty || !fixedNonstd.isEmpty then
+    IO.println s!"axiomsweep: good news — {fixedSorry.size + fixedNonstd.size} baseline \
+      entr(y/ies) no longer tainted; run `lake exe axiomsweep --update-baseline` to shrink \
+      the baseline:"
+    for n in fixedSorry do IO.println s!"  {n}"
+    for e in fixedNonstd do IO.println s!"  {e.name}"
+  IO.println "axiomsweep: check passed (no new axiom/sorry taint)."
+  return 0
+
+structure Config where
+  roots : Array Name := #[]
+  out? : Option String := none
+  check : Bool := false
+  update : Bool := false
+  baseline : String := "scripts/axiom_baseline.json"
+
+def parseArgs : List String → Config → Except String Config
+  | [], cfg => .ok cfg
+  | "--check" :: rest, cfg => parseArgs rest { cfg with check := true }
+  | "--update-baseline" :: rest, cfg => parseArgs rest { cfg with update := true }
+  | "--out" :: path :: rest, cfg => parseArgs rest { cfg with out? := some path }
+  | "--baseline" :: path :: rest, cfg => parseArgs rest { cfg with baseline := path }
+  | "--root" :: mod :: rest, cfg =>
+    parseArgs rest { cfg with roots := cfg.roots.push mod.toName }
+  | arg :: _, _ => .error s!"axiomsweep: unknown or incomplete argument: {arg}\n\
+      usage: lake exe axiomsweep [--out FILE] [--check] [--update-baseline] \
+      [--baseline FILE] [--root MOD]*"
+
+end AxiomSweep
+
+open AxiomSweep in
+unsafe def main (args : List String) : IO UInt32 := do
+  let cfg ← match parseArgs args {} with
+    | .ok cfg => pure cfg
+    | .error e => IO.eprintln e; return 2
+  let roots := if cfg.roots.isEmpty then defaultRoots else cfg.roots
+  initSearchPath (← findSysroot)
+  enableInitializersExecution
+  let env ← importModules (roots.map ({ module := · })) {} (trustLevel := 1024)
+    (loadExts := true)
+  let ((entries, moduleCount), _) ← (buildEntries roots).toIO
+    { fileName := "<axiomsweep>", fileMap := default } { env }
+  let cur := currentBaseline entries
+  let distinctNonstd := cur.nonstandard.foldl (init := (#[] : Array String)) fun acc e =>
+    e.axioms.foldl (init := acc) fun acc a => if acc.contains a then acc else acc.push a
+  IO.println s!"axiomsweep: {entries.size} declarations across {moduleCount} modules \
+    under {roots}"
+  IO.println s!"  sorryAx-tainted: {cur.«sorry».size}"
+  IO.println s!"  non-standard-axiom-tainted: {cur.nonstandard.size} \
+    (axioms: {distinctNonstd})"
+  if let some out := cfg.out? then
+    let report := Json.mkObj [
+      ("roots", toJson (roots.map (·.toString))),
+      ("declarationCount", toJson entries.size),
+      ("declarations", toJson entries)]
+    IO.FS.writeFile out (report.pretty ++ "\n")
+    IO.println s!"axiomsweep: wrote report to {out}"
+  if cfg.update then
+    IO.FS.writeFile cfg.baseline ((toJson cur).pretty ++ "\n")
+    IO.println s!"axiomsweep: wrote baseline to {cfg.baseline}"
+    return 0
+  if cfg.check then
+    return (← runCheck cur cfg.baseline)
+  return 0

--- a/scripts/AxiomSweepTestFixtures/Clean.lean
+++ b/scripts/AxiomSweepTestFixtures/Clean.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Clean executable fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Clean
+
+def base : Nat := 7
+
+def transitive : Nat := base + 1
+
+end AxiomSweepTestFixtures.Clean

--- a/scripts/AxiomSweepTestFixtures/Tainted.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted.lean
@@ -1,0 +1,13 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+import AxiomSweepTestFixtures.Tainted.AxiomInType
+import AxiomSweepTestFixtures.Tainted.DirectSorry
+import AxiomSweepTestFixtures.Tainted.Mutual
+import AxiomSweepTestFixtures.Tainted.NativeNames
+
+/-! # Imported taint fixture root for axiomsweep -/

--- a/scripts/AxiomSweepTestFixtures/Tainted/AxiomInType.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/AxiomInType.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Axiom-in-type fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted
+
+axiom typeIndex : Nat
+
+axiom axiomInType : Fin (typeIndex + 1)
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Tainted/DirectSorry.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/DirectSorry.lean
@@ -1,0 +1,18 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Direct and transitive `sorryAx` fixtures for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted
+
+opaque directSorry : Nat := sorryAx Nat true
+
+def transitiveSorry : Nat := directSorry
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Tainted/Mutual.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/Mutual.lean
@@ -1,0 +1,25 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Mutual-inductive fixpoint fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted
+
+axiom mutualAxiom : True
+
+mutual
+  inductive MutualLeft : Type where
+    | fromRight : MutualRight → MutualLeft
+    | tainted : True.intro = mutualAxiom → MutualLeft
+
+  inductive MutualRight : Type where
+    | fromLeft : MutualLeft → MutualRight
+end
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Tainted/NativeNames.lean
+++ b/scripts/AxiomSweepTestFixtures/Tainted/NativeNames.lean
@@ -1,0 +1,42 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Native-axiom name-normalization fixtures for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Tainted.Generated._native.native_decide
+
+axiom ax_12_34 : True
+
+end AxiomSweepTestFixtures.Tainted.Generated._native.native_decide
+
+namespace AxiomSweepTestFixtures.Tainted.Collision._native.native_decide
+
+axiom ax_12_extra : True
+axiom ax_x_34 : True
+
+namespace ax_12_34
+
+axiom extra : True
+
+end ax_12_34
+
+end AxiomSweepTestFixtures.Tainted.Collision._native.native_decide
+
+namespace AxiomSweepTestFixtures.Tainted
+
+theorem generatedNativeUser : True := Generated._native.native_decide.ax_12_34
+
+theorem collisionUser : True := Collision._native.native_decide.ax_12_extra
+
+theorem collisionNondecimalUser : True := Collision._native.native_decide.ax_x_34
+
+theorem collisionExtraSegmentUser : True :=
+  Collision._native.native_decide.ax_12_34.extra
+
+end AxiomSweepTestFixtures.Tainted

--- a/scripts/AxiomSweepTestFixtures/Unimported.lean
+++ b/scripts/AxiomSweepTestFixtures/Unimported.lean
@@ -1,0 +1,16 @@
+/-
+Copyright (c) 2026 VCVio Contributors. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+module
+
+/-! # Deliberately unimported `sorryAx` fixture for axiomsweep -/
+
+public section
+
+namespace AxiomSweepTestFixtures.Unimported
+
+opaque hiddenSorry : Nat := sorryAx Nat true
+
+end AxiomSweepTestFixtures.Unimported

--- a/scripts/axiom_baseline.json
+++ b/scripts/axiom_baseline.json
@@ -53,71 +53,71 @@
  "nonstandard":
  [{"name": "MLDSA.Concrete.concreteNTTRingLaws",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLDSA.Concrete.concrete_sampleInBall_smul_bound",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLDSA.Concrete.concrete_transform",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLDSA.Concrete.invNTT_ntt",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLDSA.Concrete.ntt_invNTT",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLDSA.mldsa_laws_inhabited",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLDSA.seedRevealingPrims_laws",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLKEM.Concrete.concreteNTTRingLaws",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLKEM.Concrete.invNTT_ntt",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name": "MLKEM.Concrete.ntt_invNTT",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTT_add",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTT_sub",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.ntt_injective",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.ntt_surjective",
    "axioms":
-   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTT_add",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTT_sub",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.ntt_injective",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]},
   {"name":
    "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.ntt_surjective",
    "axioms":
-   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]}]}
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide"]}]}

--- a/scripts/axiom_baseline.json
+++ b/scripts/axiom_baseline.json
@@ -1,0 +1,123 @@
+{"sorry":
+ ["BR93.br93AsymmEnc.cpaGame_gap_le_badEvent",
+  "BR93.br93AsymmEnc.indcpa_bound",
+  "CategoryTheory.EnrichedCategory.Hom_def",
+  "CategoryTheory.EnrichedCategory.RelativeMonad.inducedFunctor",
+  "CategoryTheory.EnrichedCategory.RelativeMonad.inducedFunctor_map",
+  "CategoryTheory.EnrichedCategory.RelativeMonad.inducedFunctor_obj",
+  "CategoryTheory.EnrichedCategory.comp_def",
+  "CategoryTheory.EnrichedCategory.id_def",
+  "CategoryTheory.EnrichedCategory.instProduct",
+  "Falcon.Concrete.FPRBridge.add_error",
+  "Falcon.Concrete.FPRBridge.div_error",
+  "Falcon.Concrete.FPRBridge.expm_p63_error",
+  "Falcon.Concrete.FPRBridge.mul_error",
+  "Falcon.Concrete.FPRBridge.sqrt_error",
+  "Falcon.Concrete.KeyGen.keyGen",
+  "Falcon.Concrete.NTRUSolver.FXR.sqr",
+  "Falcon.Concrete.NTRUSolver.check_ortho_norm",
+  "Falcon.Concrete.NTRUSolver.solve_NTRU",
+  "Falcon.Concrete.NTRUSolver.solve_NTRU_depth0",
+  "Falcon.Concrete.NTRUSolver.solve_NTRU_intermediate",
+  "Falcon.euf_cma_security",
+  "Falcon.euf_cma_security_bytes40",
+  "Falcon.keyGenFromSeed",
+  "Falcon.sign",
+  "Falcon.verify_sign_correct",
+  "FiatShamirWithAbort.euf_cma_bound",
+  "FiatShamirWithAbort.euf_cma_bound_perfectHVZK",
+  "FujisakiOkamoto.IND_CCA_bound",
+  "GPVHashAndSign.euf_cma_collision_bound",
+  "GPVHashAndSign.euf_cma_split_bound",
+  "GPVHashAndSign.forgery_yields_collision",
+  "GPVHashAndSign.forgery_yields_collision_or_exact_match",
+  "GPVHashAndSign.programmedPreimageReduction",
+  "GPVHashAndSign.reduction",
+  "MLDSA.euf_cma_security",
+  "MLKEM.ind_cca_security",
+  "MLKEM.kpke_delta_correct",
+  "MLKEM.kpke_ind_cpa_security",
+  "PMF.etvDist_sq_le_of_renyiDiv",
+  "SLHDSA.slhdsa_euf_cma_security",
+  "TTransform.OW_PCVA_bound",
+  "UTransform.IND_CCA_bound",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.liftIntermediateLevels",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.poly_big_to_small",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_FFT",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_adj_fft",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_iFFT",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_invnorm_fft",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_mul_realconst",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_mul_selfadj_fft",
+  "_private.LatticeCrypto.Falcon.Concrete.NTRUSolver.0.Falcon.Concrete.NTRUSolver.vect_set"],
+ "nonstandard":
+ [{"name": "MLDSA.Concrete.concreteNTTRingLaws",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLDSA.Concrete.concrete_sampleInBall_smul_bound",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLDSA.Concrete.concrete_transform",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLDSA.Concrete.invNTT_ntt",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLDSA.Concrete.ntt_invNTT",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLDSA.mldsa_laws_inhabited",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLDSA.seedRevealingPrims_laws",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLKEM.Concrete.concreteNTTRingLaws",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLKEM.Concrete.invNTT_ntt",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name": "MLKEM.Concrete.ntt_invNTT",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTT_add",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTT_sub",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.ntt_injective",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.ntt_surjective",
+   "axioms":
+   ["_private.LatticeCrypto.MLDSA.Concrete.NTT.0.MLDSA.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTT_add",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTT_sub",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.ntt_injective",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]},
+  {"name":
+   "_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.ntt_surjective",
+   "axioms":
+   ["_private.LatticeCrypto.MLKEM.Concrete.NTT.0.MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_1_1"]}]}

--- a/scripts/test-axiomsweep.sh
+++ b/scripts/test-axiomsweep.sh
@@ -1,0 +1,178 @@
+#!/usr/bin/env bash
+
+# Execute falsifiable fixtures for the kernel-level axiom sweep.
+#
+# Ported from PolyFun's `scripts/test-axiomsweep.sh`, with the exit-code matrix adapted
+# to VCVio's policy: the baseline is an allowlist for `sorryAx` debt (PolyFun forbids a
+# nonempty baseline outright; VCVio carries genuine work in progress), while native trust
+# is held to the same zero-debt rule through `neverAllowlistable`.
+
+set -euo pipefail
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+FIXTURE_TMP="$(mktemp -d "${TMPDIR:-/tmp}/vcvio-axiomsweep.XXXXXX")"
+trap 'rm -rf -- "$FIXTURE_TMP"' EXIT
+
+expect_status() {
+  local expected="$1"
+  local label="$2"
+  shift 2
+  local log="$FIXTURE_TMP/${label}.log"
+  local actual=0
+  "$@" >"$log" 2>&1 || actual=$?
+  if [[ "$actual" -ne "$expected" ]]; then
+    echo "ERROR: $label returned $actual; expected $expected" >&2
+    sed -n '1,160p' "$log" >&2
+    return 1
+  fi
+}
+
+EMPTY_BASELINE="$FIXTURE_TMP/empty.json"
+INVALID_BASELINE="$FIXTURE_TMP/invalid.json"
+MISSING_BASELINE="$FIXTURE_TMP/missing.json"
+COVERING_BASELINE="$FIXTURE_TMP/covering.json"
+CLEAN_REPORT="$FIXTURE_TMP/clean.json"
+TAINTED_REPORT="$FIXTURE_TMP/tainted.json"
+TAINTED_REPORT_2="$FIXTURE_TMP/tainted-2.json"
+UNIMPORTED_REPORT="$FIXTURE_TMP/unimported.json"
+
+printf '{"sorry": [], "nonstandard": []}\n' >"$EMPTY_BASELINE"
+printf '{not-json}\n' >"$INVALID_BASELINE"
+
+lake build AxiomSweepTestFixtures
+lake exe axiomsweep --root AxiomSweepTestFixtures.Clean --out "$CLEAN_REPORT"
+lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted --out "$TAINTED_REPORT"
+lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted --out "$TAINTED_REPORT_2"
+lake exe axiomsweep --root AxiomSweepTestFixtures.Unimported --out "$UNIMPORTED_REPORT"
+
+# The sweep must be deterministic: same build, byte-identical report.
+cmp "$TAINTED_REPORT" "$TAINTED_REPORT_2"
+
+python3 - "$CLEAN_REPORT" "$TAINTED_REPORT" "$UNIMPORTED_REPORT" "$COVERING_BASELINE" <<'PY'
+import json
+import sys
+
+clean_path, tainted_path, unimported_path, covering_path = sys.argv[1:]
+
+with open(clean_path, encoding="utf-8") as stream:
+    clean = json.load(stream)
+with open(tainted_path, encoding="utf-8") as stream:
+    tainted = json.load(stream)
+with open(unimported_path, encoding="utf-8") as stream:
+    unimported = json.load(stream)
+
+clean_entries = {entry["name"]: entry for entry in clean["declarations"]}
+tainted_entries = {entry["name"]: entry for entry in tainted["declarations"]}
+unimported_entries = {entry["name"]: entry for entry in unimported["declarations"]}
+
+assert clean_entries
+assert all(not entry["axioms"] for entry in clean_entries.values())
+
+prefix = "AxiomSweepTestFixtures.Tainted."
+
+# `sorryAx` reached directly, and through an intervening definition.
+assert "sorryAx" in tainted_entries[prefix + "directSorry"]["axioms"]
+assert "sorryAx" in tainted_entries[prefix + "transitiveSorry"]["axioms"]
+
+# An axiom occurring only in a *type* still counts, matching Lean's `CollectAxioms`.
+assert prefix + "typeIndex" in tainted_entries[prefix + "axiomInType"]["axioms"]
+
+# The fixpoint repair pass: `MutualRight` never mentions the axiom itself, and inherits it
+# only across the mutual-inductive cycle. This is the witness for the `repair` phase.
+assert prefix + "mutualAxiom" in tainted_entries[prefix + "MutualRight"]["axioms"]
+
+all_axioms = {axiom for entry in tainted_entries.values() for axiom in entry["axioms"]}
+
+# A well-formed generated suffix collapses to its owning declaration...
+generated = prefix + "Generated._native.native_decide"
+assert generated in all_axioms
+assert generated + ".ax_12_34" not in all_axioms
+
+# ...and nothing else does. Collapsing these would let distinct axioms share one baseline
+# key, so real taint could hide behind an accepted entry.
+assert prefix + "Collision._native.native_decide.ax_12_extra" in all_axioms
+assert prefix + "Collision._native.native_decide.ax_x_34" in all_axioms
+assert prefix + "Collision._native.native_decide.ax_12_34.extra" in all_axioms
+
+# A file no root transitively imports is invisible to any environment-walking census.
+hidden = "AxiomSweepTestFixtures.Unimported.hiddenSorry"
+assert hidden not in tainted_entries
+assert hidden in unimported_entries
+assert "sorryAx" in unimported_entries[hidden]["axioms"]
+
+# A baseline that covers every tainted declaration of the fixture root, used below to
+# check that full coverage is accepted and that native trust is refused even so.
+covering = {
+    "sorry": sorted(n for n, e in tainted_entries.items() if "sorryAx" in e["axioms"]),
+    "nonstandard": [
+        {"name": n, "axioms": sorted(a for a in e["axioms"]
+                                     if a != "sorryAx"
+                                     and a not in ("propext", "Classical.choice", "Quot.sound"))}
+        for n, e in sorted(tainted_entries.items())
+        if any(a != "sorryAx" and a not in ("propext", "Classical.choice", "Quot.sound")
+               for a in e["axioms"])
+    ],
+}
+with open(covering_path, "w", encoding="utf-8") as stream:
+    json.dump(covering, stream)
+PY
+
+# --- gate directions -------------------------------------------------------------------
+
+expect_status 0 clean-check \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --baseline "$EMPTY_BASELINE"
+expect_status 1 uncovered-taint \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted \
+    --check --baseline "$EMPTY_BASELINE"
+
+# Full coverage still fails: the fixtures mint `._native.` axioms outside
+# `grandfatheredNativeTrust`, and no baseline edit may green those.
+expect_status 1 native-trust-floor \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted \
+    --check --baseline "$COVERING_BASELINE"
+grep -q "never-allowlistable" "$FIXTURE_TMP/native-trust-floor.log"
+
+# --- infrastructure failures must never read as a taint verdict ------------------------
+
+expect_status 2 missing-baseline \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --baseline "$MISSING_BASELINE"
+expect_status 2 invalid-baseline \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --baseline "$INVALID_BASELINE"
+expect_status 2 conflicting-flags \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --check --update-baseline --baseline "$EMPTY_BASELINE"
+expect_status 2 unknown-flag \
+  lake exe axiomsweep --bogus
+expect_status 2 bad-root \
+  lake exe axiomsweep --root NoSuchModule --check --baseline "$EMPTY_BASELINE"
+expect_status 2 unwritable-out \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --out "$FIXTURE_TMP/no-such-dir/report.json"
+
+# --- baseline writing -------------------------------------------------------------------
+
+# Shrinking is allowed once the debt is gone.
+cp "$COVERING_BASELINE" "$FIXTURE_TMP/shrink.json"
+expect_status 0 shrink-baseline \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Clean \
+    --update-baseline --baseline "$FIXTURE_TMP/shrink.json"
+python3 -c "
+import json,sys
+b=json.load(open(sys.argv[1]))
+assert b['sorry'] == [] and b['nonstandard'] == [], b
+" "$FIXTURE_TMP/shrink.json"
+
+# Pre-authorizing native trust is not, and the file must be left untouched.
+cp "$EMPTY_BASELINE" "$FIXTURE_TMP/growth.json"
+cp "$FIXTURE_TMP/growth.json" "$FIXTURE_TMP/growth-before.json"
+expect_status 1 reject-native-trust-growth \
+  lake exe axiomsweep --root AxiomSweepTestFixtures.Tainted \
+    --update-baseline --baseline "$FIXTURE_TMP/growth.json"
+cmp "$FIXTURE_TMP/growth-before.json" "$FIXTURE_TMP/growth.json"
+
+echo "✓ Axiom sweep executable fixture matrix passed."


### PR DESCRIPTION
## What

Adds `lake exe axiomsweep`: kernel-level axiom / `sorry` accounting for the whole library, with a committed regression baseline.

The tool loads the built `.olean` environment (the same data the kernel checked) and computes, for every declaration under the swept root modules, the set of axioms it transitively depends on — i.e. the `#print axioms` information, library-wide, in one pass. Because it reads elaborated data rather than source text, it sees exactly what the kernel accepted: private declarations, macro-generated declarations, and instances included; no regex heuristics.

## Why

VCV-io already treats trust boundaries as first-class (the Interop TCB-isolation gate, the no-submodules consumer job), but had no kernel-level accounting of what its theorems actually rest on. The sweep's first run surfaced a real, previously-invisible dependency: **20 declarations in the concrete ML-DSA/ML-KEM path rest on `native_decide` trust axioms** (`Lean.ofReduceBool`), inherited through two *private* NTT matrix lemmas that no source scan or manual review would flag. Downstream reviews (ArkLib) have also repeatedly traced `sorryAx` inheritance chains by hand; this makes both mechanical.

Scope note: `Interop` (the declared TCB) is deliberately excluded from the default sweep — its boundary is enforced by the import-isolation gate; this tool accounts for the axioms everything *outside* it rests on. Sweep it explicitly with `--root Interop` if desired.

## How

- **`scripts/AxiomSweep.lean`** (+ `lean_exe axiomsweep` in the lakefile): memoised traversal of the compiled environment; only imports core `Lean`, runtime-imports the built oleans, so it needs a completed `lake build` and adds no dependencies. Runs in seconds.
- **`scripts/axiom_baseline.json`**: the currently-known `sorryAx`-tainted declarations (and any non-standard-axiom dependents). `--check` fails **iff a declaration is tainted that the baseline does not list**; closing gaps stays green and prints a nudge to shrink the baseline via `--update-baseline`.
- **CI**: one report-only step after the build (`::warning` on regression). Flip to enforcing by deleting the `|| echo` once the baseline has soaked for a few PRs.
- Docs updated in the same PR.

## Modes

```
lake exe axiomsweep                     # summary
lake exe axiomsweep --out report.json   # full per-declaration report (name, module, kind, line, axioms)
lake exe axiomsweep --check             # regression gate against scripts/axiom_baseline.json
lake exe axiomsweep --update-baseline   # refresh the baseline; commit the diff
lake exe axiomsweep --root Foo          # override the swept root modules (repeatable)
```

## Baseline at this commit

- **13,985 declarations across 438 modules** in the seven non-test libraries; sweep runs in seconds on a built tree.
- **51 sorryAx-tainted declarations** (honest WIP, now pinned by name).
- **20 declarations resting on `native_decide` trust axioms** — all inherited from `_private.…MLDSA/MLKEM.Concrete.invNTTMatrix_nttMatrix_entry._native.native_decide.ax_*`. Recorded in the baseline; it doubles as the burndown list.

### Burndown feasibility (measured)

Kernel-checking these two lemmas was probed empirically before this PR:
- The loop kernels (`loopNTT`/`loopInvNTT`) use `while` loops → `Loop.forIn` → `partial`, so the kernel **cannot unfold them in principle** — this, not speed, is why the in-file comment says `decide`/`rfl` gets stuck. Any burndown needs a structural (e.g. `Vector.ofFn`/`Fin.foldl`) re-derivation of the transform matrices on the certificate side, keeping the loop kernels via the existing `@[implemented_by]` pattern.
- The dense 256×256×256 product identity costs ~180µs per modular multiply-add in the kernel (measured: 1M ops = 182 s) → **~49 min naive**, optimistically 5–15 min with an engineered Nat-packed certificate + sharded per-row lemmas. A real project, not a cleanup.
- The durable fix is the file comment's own option 2: prove the kernels implement the Vandermonde transform and derive inversion from ~256 geometric-sum identities (`∑ ζ^{jk} = 0`) instead of 16.7M multiplications.

Proposed as a follow-up issue; this PR only makes the trust dependency visible and gates against new ones.
- Spot-checked both directions against `#print axioms` (`MLDSA.Concrete.concreteNTTRingLaws` → native trust axiom present; `BR93.br93AsymmEnc.indcpa_bound` → `sorryAx` present); `--check` exit codes verified.
- Works fine with the module system (`module`/`public` sources).

## Notes

- Same tool as ArkLib's `alh/axiom-sweep` branch (multi-root variant); the copies are intentionally self-contained per repo, mirroring how other scripts are shared across the org. If it proves its keep everywhere, extracting a shared home is a possible follow-up.
- `lean4export` was considered and deliberately not used: it targets external kernel checking, has no source positions, and would add a per-toolchain pinned dependency; walking the environment yields the same information with line numbers and zero new deps.
- The per-declaration report is not committed anywhere; only the baseline is tracked.


## Adversarial review

Five independent adversarial reviewers (one per repo deployment) attacked the tool, wiring, and baselines before this PR was opened. Everything they confirmed is fixed in the follow-up commit on this branch:

- **Collector defect (HIGH, confirmed in 4 repos)**: the one-pass DFS finalized self-referencing constants (every inductive/ctor pair) prematurely, producing per-declaration rows that diverged from `#print axioms` in both directions, with constructible shapes where a new `sorry` passed `--check`. Fixed with a fixpoint-repair phase computing the true kernel closure (now strictly *more* accurate than `#print axioms`, whose own `CollectAxioms` wobbles inside mutual families). Post-fix rows spot-verified against ground truth; sorry-sets unchanged everywhere.
- Axiom *types* now traversed (`CollectAxioms` parity); duplicate `constNames` rows deduped; `native_decide` axiom names normalized to their owning declaration (the `ax_N_M` counters are `Elab.async`/toolchain-volatile); `--check`/`--update-baseline` mutually exclusive; bare `Lean.ofReduceBool`/`Lean.trustCompiler` are never baselinable (floor).
- CI steps now distinguish taint findings (report-only during soak) from infrastructure failures (always fail).
- Known blind spots documented: structure-field defaults and `example`s never enter any environment walk (`#print axioms` included); unimported files are invisible — paired with each repo's import-completeness gate.

What survived attack unchanged: baseline determinism (byte-identical regeneration), all headline numbers, spot-checks vs `#print axioms`, gate exit-code semantics, and the CI/step placement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
