### PR TITLE
refactor(SigmaProtocol): split the interaction out as ChallengeVerifyProtocol

### DIFF
--- a/Examples/Schnorr/SigmaProtocol.lean
+++ b/Examples/Schnorr/SigmaProtocol.lean
@@ -100,7 +100,7 @@ omit [Fintype F] [DecidableEq F] in
 /-- Perfect completeness: an honest prover with a valid witness always produces
 an accepting transcript. Follows from `add_smul` and `mul_smul`. -/
 theorem sigma_complete (g : G) :
-    PerfectlyComplete (sigma F G g) := by
+    (sigma F G g).PerfectlyComplete := by
   intro pk sk h
   have h_eq : sk • g = pk := of_decide_eq_true h
   simp only [sigma, monad_norm]
@@ -140,7 +140,7 @@ omit [Fintype F] [DecidableEq F] in
 The proof swaps sampling order and uses uniformity of `F` to reindex via the bijection
 `r ↦ r + c * sk`. -/
 theorem sigma_hvzk (g : G) [Finite F] :
-    PerfectHVZK (sigma F G g) (simTranscript F G g) := by
+    (sigma F G g).PerfectHVZK (simTranscript F G g) := by
   let _ : Fintype F := Fintype.ofFinite F
   intro pk sk h_sk
   have h_eq : sk • g = pk := of_decide_eq_true h_sk
@@ -150,7 +150,7 @@ theorem sigma_hvzk (g : G) [Finite F] :
     let c ← ($ᵗ F)
     let r ← ($ᵗ F)
     pure (((r + c * sk) • g - c • pk, c, r + c * sk) : G × F × F)]
-  · simp only [SigmaProtocol.realTranscript, sigma]
+  · simp only [ChallengeVerifyProtocol.realTranscript, sigma]
     vcstep rw
     simp [h_eq, add_smul, mul_smul, add_sub_cancel_right]
   · show _ = Pr[= t | simTranscript F G g pk]
@@ -174,12 +174,12 @@ distribution of `(r • g, c, r + c * sk)` where `r, c ← $ᵗ F` are sampled *
 This is the form in which the commitment `r • g` and the challenge `c` are literally
 independent (by sampling order), making conditional uniformity trivial. -/
 private lemma realTranscript_eq_indep (g : G) (pk : G) (sk : F) :
-    SigmaProtocol.realTranscript (sigma F G g) pk sk =
+    (sigma F G g).realTranscript pk sk =
       (do
         let r ← $ᵗ F
         let c ← $ᵗ F
         pure ((r • g, c, r + c * sk) : G × F × F)) := by
-  simp only [SigmaProtocol.realTranscript, sigma, monad_norm]
+  simp only [ChallengeVerifyProtocol.realTranscript, sigma, monad_norm]
 
 omit [DecidableEq F] in
 /-- **Simulator commit-predictability for Schnorr.** With the standard bijection
@@ -198,7 +198,7 @@ on `G` when `z ← $ᵗ F`. Averaging over `c ← $ᵗ F` preserves uniformity, 
 on `G` gives probability `1/|G| = 1/|F|` for any specific output. -/
 theorem sigma_simCommitPredictability (g : G)
     (hg : Function.Bijective (· • g : F → G)) :
-    SigmaProtocol.simCommitPredictability (sigma F G g) (simTranscript F G g)
+    (sigma F G g).simCommitPredictability (simTranscript F G g)
       ((Fintype.card F : ℝ≥0∞)⁻¹) := by
   classical
   letI : Fintype G := Fintype.ofBijective _ hg
@@ -246,7 +246,7 @@ challenge is uniform on `F`. The proof reduces to the explicit independent produ
 closed form `realTranscript_eq_indep`; in that form the commit `r • g` and challenge
 `c` are literally independent (by sampling order), so the factoring is immediate. -/
 theorem sigma_simChalUniformGivenCommit (g : G) :
-    simChalUniformGivenCommit (sigma F G g) (simTranscript F G g) := by
+    (sigma F G g).simChalUniformGivenCommit (simTranscript F G g) := by
   classical
   intro pk sk hsk c₀ ch₀
   have hHVZK := sigma_hvzk F G g pk sk hsk

--- a/Examples/Schnorr/Signature.lean
+++ b/Examples/Schnorr/Signature.lean
@@ -208,7 +208,7 @@ theorem signature_euf_cma (g : G)
     (by intro ω₁ p₁ ω₂ p₂; simp [Schnorr.sigma])
     (Schnorr.simTranscript F G g)
     (ζ_zk := 0) le_rfl
-    ((SigmaProtocol.perfectHVZK_iff_hvzk_zero _ _).mp (Schnorr.sigma_hvzk F G g))
+    ((ChallengeVerifyProtocol.perfectHVZK_iff_hvzk_zero _ _).mp (Schnorr.sigma_hvzk F G g))
     (β := (Fintype.card F : ℝ≥0∞)⁻¹)
     (Schnorr.sigma_simCommitPredictability F G g hg)
     adv qS qH hQ

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean
@@ -658,7 +658,7 @@ private lemma cmaRealSignGhost_public_evalDist_eq_publicDist
       cmaRealSignGhostDist M Commit Chal σ hr m s] =
     𝒟[cmaRealSignPublicDist M Commit Chal σ hr s] := by
   rcases s with ⟨log, cache, keypair⟩
-  simp only [cmaRealSignGhostDist, cmaRealSignPublicDist, SigmaProtocol.realTranscript,
+  simp only [cmaRealSignGhostDist, cmaRealSignPublicDist, ChallengeVerifyProtocol.realTranscript,
     cmaSignPublicOfTranscript, evalDist_bind, evalDist_map, map_bind, bind_pure_comp,
     Functor.map_map]
   refine bind_congr fun key => ?_

--- a/VCVio/CryptoFoundations/SigmaProtocol.lean
+++ b/VCVio/CryptoFoundations/SigmaProtocol.lean
@@ -10,11 +10,28 @@ public import VCVio.EvalDist.TVDist
 public import VCVio.CryptoFoundations.IdenSchemeWithAbort
 
 /-!
-# Sigma Protocol
+# Challenge-Verify Protocols and Sigma Protocols
 
-This file defines a structure type for Σ-protocols, along with standard
-security properties: completeness, special soundness, and honest-verifier
-zero-knowledge (HVZK).
+This file defines two structure types, along with standard security properties:
+completeness, special soundness, and honest-verifier zero-knowledge (HVZK).
+
+`ChallengeVerifyProtocol` is the bare commit–challenge–response interaction: the prover commits,
+the verifier replies with a single challenge drawn from its own randomness, the prover responds,
+and the verifier deterministically accepts or rejects. It carries no witness-extraction or
+simulation data, so it is the right interface for consumers that only run the protocol.
+
+`SigmaProtocol` extends it with `sim` and `extract` fields, packaging a Σ-protocol together with
+the simulator and the witness extractor that special soundness refers to. Both conventions appear
+in the literature — Damgård's canonical treatment leaves the extractor existentially quantified
+inside the special soundness property, whereas bundling it as data lets consumers such as the
+Fischlin transform and the Fiat-Shamir Σ-layer name and run it. Splitting the two records supports
+both readings: use `ChallengeVerifyProtocol` when the extractor is irrelevant, `SigmaProtocol`
+when it is needed.
+
+Properties that only concern the interaction — `PerfectlyComplete`, `HVZK`, `PerfectHVZK`,
+`UniqueResponses`, and the transcript distribution `realTranscript` — are stated on
+`ChallengeVerifyProtocol`, and are available on a `SigmaProtocol` through the parent projection.
+`SpeciallySound` lives on `SigmaProtocol`, since it is the property that consumes `extract`.
 
 ## Type Parameters
 
@@ -28,8 +45,8 @@ zero-knowledge (HVZK).
 
 ## Coercion to `IdenSchemeWithAbort`
 
-Every `SigmaProtocol` can be viewed as a non-aborting `IdenSchemeWithAbort` via
-`SigmaProtocol.toIdenSchemeWithAbort`, which wraps `respond` with `some`.
+Every `ChallengeVerifyProtocol` can be viewed as a non-aborting `IdenSchemeWithAbort` via
+`ChallengeVerifyProtocol.toIdenSchemeWithAbort`, which wraps `respond` with `some`.
 -/
 
 @[expose] public section
@@ -38,14 +55,17 @@ universe u v
 
 open OracleSpec OracleComp
 
-/-- A sigma protocol for statements in `Stmt` and witnesses in `Wit`,
-where `rel : Stmt → Wit → Bool` is the proposition proven by the Σ-protocol.
-Commitments are split into a public part `Commit` (revealed to the verifier) and a
-private part `PrvState` (retained by the prover). Verifier challenges are drawn uniformly
-from `Chal`. Prover responses are in `Resp`.
+/-- A commit–challenge–response protocol for statements in `Stmt` and witnesses in `Wit`, where
+`rel : Stmt → Wit → Bool` is the proposition proven by the protocol.
 
-We leave properties like special soundness as separate definitions for better modularity. -/
-structure SigmaProtocol
+Commitments are split into a public part `Commit` (revealed to the verifier) and a private part
+`PrvState` (retained by the prover). The verifier sends a single challenge, drawn uniformly from
+`Chal`; since that challenge is its only message, the protocol is public-coin. Prover responses
+are in `Resp`, and verification is deterministic.
+
+This is the interaction alone. A Σ-protocol additionally carries a witness extractor; see
+`SigmaProtocol`, which extends this structure. -/
+structure ChallengeVerifyProtocol
     (Stmt Wit Commit PrvState Chal Resp : Type) (rel : Stmt → Wit → Bool) where
   /-- Generate a commitment to prove knowledge of a valid witness. -/
   commit (stmt : Stmt) (wit : Wit) : ProbComp (Commit × PrvState)
@@ -53,12 +73,23 @@ structure SigmaProtocol
   respond (stmt : Stmt) (wit : Wit) (prvState : PrvState) (chal : Chal) : ProbComp Resp
   /-- Deterministic verification: check that the response satisfies the challenge. -/
   verify (stmt : Stmt) (commit : Commit) (chal : Chal) (resp : Resp) : Bool
+
+/-- A Σ-protocol: a `ChallengeVerifyProtocol` together with the simulator and the witness
+extractor that special soundness refers to (`SigmaProtocol.SpeciallySound`).
+
+The extractor is bundled as data rather than existentially quantified so that consumers can run
+it — the Fischlin transform and the Fiat-Shamir Σ-layer both do. Consumers that need neither it
+nor `sim` should take a `ChallengeVerifyProtocol` instead; every `SigmaProtocol` provides one
+through its parent projection. -/
+structure SigmaProtocol
+    (Stmt Wit Commit PrvState Chal Resp : Type) (rel : Stmt → Wit → Bool)
+    extends ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel where
   /-- Simulate public commitment generation while only knowing the statement. -/
   sim (stmt : Stmt) : ProbComp Commit
   /-- Extract a witness to the statement from two accepting transcripts. -/
   extract (chal₁ : Chal) (resp₁ : Resp) (chal₂ : Chal) (resp₂ : Resp) : ProbComp Wit
 
-namespace SigmaProtocol
+namespace ChallengeVerifyProtocol
 
 variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
 
@@ -66,9 +97,9 @@ section complete
 
 variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
-/-- A Σ-protocol is perfectly complete if the honest prover always convinces the verifier
+/-- A protocol is perfectly complete if the honest prover always convinces the verifier
 on valid statement-witness pairs. -/
-def PerfectlyComplete (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel) : Prop :=
+def PerfectlyComplete (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel) : Prop :=
   ∀ x w, rel x w = true →
     Pr[= true | do
       let (pc, sc) ← σ.commit x w
@@ -77,6 +108,12 @@ def PerfectlyComplete (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel
       return σ.verify x pc ω π] = 1
 
 end complete
+
+end ChallengeVerifyProtocol
+
+namespace SigmaProtocol
+
+variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
 
 section speciallySound
 
@@ -105,12 +142,18 @@ theorem extract_sound_of_speciallySoundAt
 
 end speciallySound
 
+end SigmaProtocol
+
+namespace ChallengeVerifyProtocol
+
+variable {Stmt Wit Commit PrvState Chal Resp : Type} {rel : Stmt → Wit → Bool}
+
 section hvzk
 
 variable [SampleableType Chal] [IsUniformSpec unifSpec]
 
-/-- The honest prover's transcript distribution for a Σ-protocol. -/
-def realTranscript (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+/-- The honest prover's transcript distribution. -/
+def realTranscript (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (x : Stmt) (w : Wit) :
     ProbComp (Commit × Chal × Resp) := do
   let (pc, sc) ← σ.commit x w
@@ -126,15 +169,15 @@ The simulated transcript is produced by `simTranscript` given only the statement
 
 Note: the `sim` field of `SigmaProtocol` only produces a public commitment. For HVZK we need
 a full transcript simulator `Stmt → ProbComp (Commit × Chal × Resp)`. We parameterize by this
-simulator. -/
-def HVZK (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+simulator, which also keeps the property available on a bare `ChallengeVerifyProtocol`. -/
+def HVZK (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) (ζ_zk : ℝ) : Prop :=
   ∀ x w, rel x w = true →
     tvDist (σ.realTranscript x w) (simTranscript x) ≤ ζ_zk
 
 /-- Exact honest-verifier zero-knowledge: the real transcript distribution equals the
 simulated one. -/
-def PerfectHVZK (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+def PerfectHVZK (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) : Prop :=
   ∀ x w, rel x w = true →
     𝒟[σ.realTranscript x w] = 𝒟[simTranscript x]
@@ -142,7 +185,7 @@ def PerfectHVZK (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
 /-- The perfect HVZK property is equivalent to the approximate HVZK property with `ζ_zk = 0`. -/
 @[grind =]
 lemma perfectHVZK_iff_hvzk_zero
-    (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+    (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) :
     σ.PerfectHVZK simTranscript ↔ σ.HVZK simTranscript 0 := by
   refine ⟨fun h x w hx => ?_, fun h x w hx => ?_⟩
@@ -162,7 +205,7 @@ The `_σ : SigmaProtocol …` argument is dummy (the predicate only depends on
 `simTranscript` and `β`); it is present to enable field-notation usage like
 `σ.simCommitPredictability simTranscript β`. -/
 def simCommitPredictability
-    (_σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+    (_σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) (β : ℝ≥0∞) : Prop :=
   ∀ x : Stmt, ∀ c₀ : Commit, probOutput (Prod.fst <$> simTranscript x) c₀ ≤ β
 
@@ -190,7 +233,7 @@ satisfy this when `pk` admits a witness (the proof uses a witness-indexed biject
 response variable); for statements outside the relation's image, the simulator's joint may
 have any structure. -/
 def simChalUniformGivenCommit [Fintype Chal]
-    (_σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+    (_σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) : Prop :=
   ∀ (pk : Stmt) (sk : Wit), rel pk sk = true →
     ∀ (c₀ : Commit) (ch₀ : Chal),
@@ -202,10 +245,10 @@ end hvzk
 
 section uniqueResponses
 
-/-- A Σ-protocol has unique responses if for any statement, commitment, and challenge,
+/-- A protocol has unique responses if for any statement, commitment, and challenge,
 there is at most one valid response. This property is required by the Fischlin transform
 and holds for most common Σ-protocols (Schnorr, Guillou-Quisquater, etc.). -/
-def UniqueResponses (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel) : Prop :=
+def UniqueResponses (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel) : Prop :=
   ∀ x pc ω p₁ p₂,
     σ.verify x pc ω p₁ = true → σ.verify x pc ω p₂ = true → p₁ = p₂
 
@@ -213,19 +256,18 @@ end uniqueResponses
 
 section toIdenSchemeWithAbort
 
-/-- Every `SigmaProtocol` can be viewed as a non-aborting `IdenSchemeWithAbort` by wrapping
-the response in `some`. The `sim` and `extract` fields are not part of
-`IdenSchemeWithAbort` and are dropped. -/
-def toIdenSchemeWithAbort (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel) :
+/-- Every `ChallengeVerifyProtocol` can be viewed as a non-aborting `IdenSchemeWithAbort` by
+wrapping the response in `some`. -/
+def toIdenSchemeWithAbort (σ : ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel) :
     IdenSchemeWithAbort Stmt Wit Commit PrvState Chal Resp rel where
   commit := σ.commit
   respond := fun stmt wit prvState chal => some <$> σ.respond stmt wit prvState chal
   verify := σ.verify
 
-instance : Coe (SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
+instance : Coe (ChallengeVerifyProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (IdenSchemeWithAbort Stmt Wit Commit PrvState Chal Resp rel) :=
   ⟨toIdenSchemeWithAbort⟩
 
 end toIdenSchemeWithAbort
 
-end SigmaProtocol
+end ChallengeVerifyProtocol


### PR DESCRIPTION
Human summary: This PR is to split out the simulation/extraction component of the SigmaProtocol structure as an extension of a simpler class of protocols that may not have these features.

----


Addresses @dtumad's review point on #450: rather than a parallel protocol hierarchy, factor the shared interaction out of `SigmaProtocol` so both #450 and #418 can build on one record.

## What changes

Adds `ChallengeVerifyProtocol` — the bare commit–challenge–response interaction (`commit` / `respond` / `verify`) — and makes `SigmaProtocol` extend it with the existing `sim` and `extract` fields. Consumers that only run a protocol can take the base record; those that extract keep taking `SigmaProtocol`.

Properties concerning the interaction alone move to the base: `PerfectlyComplete`, `realTranscript`, `HVZK`, `PerfectHVZK`, `perfectHVZK_iff_hvzk_zero`, `simCommitPredictability`, `simChalUniformGivenCommit`, `UniqueResponses`, and `toIdenSchemeWithAbort` with its `Coe`. `SpeciallySoundAt` / `SpeciallySound` / `extract_sound_of_speciallySoundAt` stay on `SigmaProtocol`, since they consume `extract`.

No fields are removed and no proofs change — this is purely a restructuring.

## Why the churn is small

Lean's dot notation resolves through the parent projection, so `σ.commit`, `σ.HVZK`, `σ.simCommitPredictability` and friends keep working unchanged on a `SigmaProtocol`. Fischlin, the whole Fiat-Shamir Σ-layer (`CmaToNma`, `Fork`, `Reductions`, `Security`, `Chain`), and every `variable (σ : SigmaProtocol ...)` site are untouched. Only explicitly qualified references needed updating:

- one `simp` lemma name in `FiatShamir/Sigma/Stateful/Hops.lean`
- unqualified references in the Schnorr example, switched to dot notation

## Scope

Deliberately kept minimal and on `ProbComp`:

- **not** generalizing over a monad — that stays #418, which rebases onto this
- **not** removing the currently-unused `sim` field — separable cleanup
- **not** adding new properties — #450 adds its soundness notions to the base on rebase

Then #450 can delete its own parallel copy of this structure and instantiate the shared one.

## Verification

`lake build VCVio Examples` passes: 0 errors, no new warnings, no new `sorry`s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)