### PR TITLE
fix(Falcon): round berExp's argument reduction toward -infinity

### DIFF
--- a/Extern/Falcon/SamplerZ.lean
+++ b/Extern/Falcon/SamplerZ.lean
@@ -163,9 +163,31 @@ instance : Inhabited F := ⟨FloatLike.zero⟩
 private def log2Const : F := FloatLike.scaled (6243314768165359 : Int64) (-53 : Int32)
 private def invLog2Const : F := FloatLike.scaled (6497320848556798 : Int64) (-52 : Int32)
 
+/-- Reduce `x ≥ 0` modulo `log 2`, returning `(si, r)` with `si` a nonnegative integer and
+`r` in `[0, log 2)` such that `x = si * log 2 + r` up to rounding.
+
+The quotient is rounded toward negative infinity, which is what places `r` on the nonnegative
+side. That side matters to the caller: `FloatLike.expm_p63` reads only its argument's
+magnitude, so it evaluates a negative `r` as `exp (|r|)` rather than `exp (-r)`. The reference
+rounds toward zero, which agrees with `floor_` on the `x ≥ 0` its caller guarantees. -/
+def berExpReduce (x : F) : Int64 × F :=
+  let si := FloatLike.floor_ (FloatLike.mul x (invLog2Const (F := F)))
+  (si, FloatLike.sub x (FloatLike.mul (FloatLike.ofInt si) (log2Const (F := F))))
+
+/-- Sample a bit with probability `ccs * exp (-x)`, for `x ≥ 0`.
+
+Writing `x = si * log 2 + r` via `berExpReduce` factors `ccs * exp (-x)` as
+`ccs * exp (-r) / 2 ^ si`: `FloatLike.expm_p63` supplies the first factor on the reduced
+range and `si` becomes a right shift. `si ≥ 64` is saturated to 63, a bias the reference
+bounds by `2 ^ (-96)`.
+
+`x ≥ 0` is a genuine precondition rather than a convenience. The saturation
+`s ||| (63 - s) >>> 26` detects `si ≥ 64` through the borrow bit and has no negative branch,
+so a negative `si` truncates to `63 + si` and the shift drives the acceptance weight to
+zero — where the correct weight for `x < 0` is above one. `samplerZLoop` is what supplies the
+precondition; see its docstring for what that rests on. -/
 def berExp (s : PRNGState) (x ccs : F) : Bool × PRNGState := Id.run do
-  let si := FloatLike.rint (FloatLike.mul x (invLog2Const (F := F)))
-  let r := FloatLike.sub x (FloatLike.mul (FloatLike.ofInt si) (log2Const (F := F)))
+  let (si, r) := berExpReduce x
   let mut sShift := si.toUInt64.toUInt32
   sShift := sShift ||| (((63 : UInt32) - sShift) >>> 26)
   sShift := sShift &&& 63
@@ -221,6 +243,14 @@ private def sigmaMinConsts : Array F := #[
   | some sigmaMin => sigmaMin
   | none => panic! s!"Falcon samplerZ does not support logn={logn}"
 
+/-- One rejection round: draw `z` from the bimodal half-Gaussian and keep it with probability
+`ccs * exp (-x)`, where `x = (z - r) ^ 2 / (2 * σ ^ 2) - z0 ^ 2 / (2 * σ₀ ^ 2)`.
+
+The `x ≥ 0` that `berExp` requires holds because `|z - r| ≥ z0` for either value of `b` when `r`
+is in `[0, 1)`, together with `σ ≤ σ₀`. That second half is a key-generation invariant rather
+than anything checked here, and in floating point it is tight: at the representable `1 / σ`
+nearest `1 / σ₀` from above, `r = 0` and `b = 0` give `x = 0` exactly, while one ulp further —
+`σ` just past `σ₀` — gives `x < 0`. -/
 partial def samplerZLoop (state : PRNGState) (sInt : Int64)
     (r dss ccs : F) : Int32 × PRNGState :=
   let (z0, s') := gaussian0 state

--- a/LatticeCryptoTest/Falcon/Main.lean
+++ b/LatticeCryptoTest/Falcon/Main.lean
@@ -291,6 +291,43 @@ def runFalconProtocolTests (st : IO.Ref TestState) : IO Unit := do
     let prng2 := PRNGState.init seed
     let (accept1, _) := berExp prng2 zero half
     check st s!"berExp(zero, half) likely accepts (got {accept1})" accept1
+    -- `berExpReduce` must land `r` in `[0, log 2)`: `expm_p63` reads only `|r|`, so a
+    -- negative `r` is evaluated as `exp |r|` and inflates the acceptance weight by up to
+    -- `2x`. Rounding the quotient to nearest instead of toward `-∞` puts `r` below zero for
+    -- about half of all inputs, and `k / 32` catches it at 100 of the 199 points below.
+    let log2Bound : FPR := 0x3FE62E42FEFA39F7  -- `log 2`, rounded up by 8 ulp
+    let mut redBad : Nat := 0
+    let mut redCount : Nat := 0
+    for k in [1:200] do
+      let (_, r) := berExpReduce (scaled (Int64.ofNat k) (-5))
+      if (r >>> 63) != 0 || r > log2Bound then
+        redBad := if redBad == 0 then k else redBad
+        redCount := redCount + 1
+    check st s!"berExpReduce(k/32) ∈ [0, log 2] for k < 200" (redCount == 0)
+      s!"{redCount} of 199 outside, first at k={redBad}"
+    check st "berExpReduce(0) = (0, 0)"
+      (berExpReduce (F := FPR) zero == (0, zero))
+    -- `berExp` needs `x ≥ 0`, and `samplerZLoop` supplies it from the key-generation
+    -- invariant `σ ≤ σ₀`. In floating point that margin is exactly zero, so pin both sides:
+    -- `isigmaHi` is the representable `1/σ` just above `1/σ₀`, and `isigmaLo` is one ulp
+    -- down, where `σ` passes `σ₀` and `x` goes negative. The pair is what makes this a test
+    -- rather than a restatement.
+    let inv2s0 : FPR := scaled 5435486223186882 (-55)
+    let isigmaHi : FPR := scaled 4947651334655860 (-53)  -- σ = 1.8204999999999998 ≤ σ₀
+    let isigmaLo : FPR := scaled 4947651334655859 (-53)  -- σ = 1.8205000000000002 > σ₀
+    let xAt (isig : FPR) (z0 : Nat) : FPR :=
+      let dss := mul (mul isig isig) half
+      let diff := sub zero (ofInt (Int64.ofNat z0))  -- z = -z0 for b = 0, centre r = 0
+      sub (mul (mul diff diff) dss) (mul (ofInt (Int64.ofNat (z0 * z0))) inv2s0)
+    let mut hiNeg : Nat := 0
+    let mut loNeg : Nat := 0
+    for z0 in [0:26] do
+      if (xAt isigmaHi z0) >>> 63 != 0 then hiNeg := hiNeg + 1
+      if (xAt isigmaLo z0) >>> 63 != 0 then loNeg := loNeg + 1
+    check st "samplerZ x ≥ 0 for σ ≤ σ₀ (berExp's precondition)" (hiNeg == 0)
+      s!"{hiNeg} of 26 negative"
+    check st "samplerZ x < 0 one ulp past σ₀ (the margin is exactly zero)" (loNeg > 0)
+      s!"{loNeg} of 26 negative"
   IO.println ""
   -- ── 13. Falcon-1024 FFI end-to-end ─────────────
   IO.println "13. Falcon-1024 FFI end-to-end"


### PR DESCRIPTION
Split out of #514 at @dtumad's suggestion — that PR is about the FPR error bounds, this is a runtime conformance fix, and they should not ride together.

## The bug

`berExp` reduces `x` modulo `log 2` before handing the remainder to `expm_p63`. It rounded the quotient with `rint` (round to nearest). The reference truncates:

```c
/* c-fn-dsa/sign_sampler.c:874 */
int32_t si = (int32_t)fpr_trunc(fpr_mul(x, INV_LOG2));
/* Reduce x modulo log(2): x = s*log(2) + r, with s an integer, and
   0 <= r < log(2). We can use fpr_trunc() because x >= 0 */
```

On `x ≥ 0` truncation is floor, so `r` belongs in `[0, log 2)`. Rounding to nearest centres `r` on zero instead and puts it **below** zero for about half of all inputs — 100 of the 199 points `x = k/32, k < 200`, and 49.8% over a uniform sweep of the range Falcon reaches.

## Why the sign matters

`expm_p63` reaches its argument only through `mtwop63`, which reads the significand and the exponent field and **never bit 63**. So it computes `exp(-|r|)`, and a negative `r` yields `exp(r)` where the algorithm needs `exp(-r)` — an acceptance weight wrong by `exp(2r)`, up to 2×. That is the Bernoulli step which shapes `samplerZ`'s output, so the error lands on the discrete Gaussian itself.

The sign-blindness is proved rather than asserted, in #514: `mtwop63_neg`, `expm_p63_neg`, and `expm_p63_error_abs` (the error bound over the symmetric domain, against `exp(-|x|)`). Those are bounds work and stay there; this PR is the one-line behavioural change and its tests, and does not depend on them.

## Why it survived

The Lean sampler is never cross-checked against the reference — every signing test signs via **FFI** and only *verifies* in Lean. The one `berExp` test used `x = 0`, where the two roundings agree.

## The precondition, and why the tests come in pairs

`floor_` is right precisely on `x ≥ 0`, and strictly worse without it. At `x = -0.01, ccs = 0.5`, against a correct weight of `0.50503`:

| | `si` | `sShift` | weight/2^64 |
|---|---|---|---|
| `rint` | 0 | 0 | 0.49503 (2% off, right by accident) |
| `floor_` | −1 | 63 | 0 (always reject) |

`rint` lands near the right answer because `si = 0` leaves `r = x` and sign-blindness reads `exp(-|x|)`. The saturation `s ||| (63 - s) >>> 26` detects `si ≥ 64` through the borrow bit and has no negative branch, so a negative `si` truncates to `63 + si`.

`x ≥ 0` follows from `|z − r| ≥ z0` together with `σ ≤ σ₀` — the latter a key-generation invariant, not something the sampler checks. In floating point its margin is **exactly zero**, because `dss` is computed from `isigma` while `inv2σ0` is a hardcoded constant, so the two can disagree by an ulp at `σ = σ₀`:

- at the representable `1/σ` just **above** `1/σ₀` (`σ = 1.8204999999999998 ≤ σ₀`): `x = 0` exactly, for `r = 0, b = 0`, at every `z0 ∈ [0,25]`
- one ulp **down** (`σ = 1.8205000000000002 > σ₀`): `x < 0` for 25 of those 26
- 2M draws with `σ ∈ [σ_min, σ₀]`: min `x = 8.5e-13 > 0`

So the tests pin **both** sides. Testing only `σ ≤ σ₀` would not distinguish a real invariant from a coincidence.

## Open question for the reviewer

@dtumad's point stands and I have not resolved it: `samplerZ`'s public `isigma` is unrestricted, the margin is one ulp, and the failure mode past it is silent — a wrong sampling distribution rather than a crash. This PR documents the invariant and tests its boundary; it does not *enforce* it. Carrying it in the caller's type or checking defensively at the entry point are both live options, and I would rather agree the shape here than pick one unilaterally, since a defensive check would be the first deliberate divergence from bit-exactness with the C.

## Verification

Builds standalone off `main`. Reduction and boundary values checked against the bit-exact `FPR` emulation in Lean, not only against an IEEE model: `floor_` gives 0 violations over the `k/32` sweep, `rint` gives 100.
