### PR TITLE
feat(OracleComp+CryptoFoundations): make the simulation and replay-fork pipeline executable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -191,6 +191,8 @@ jobs:
         run: lake env lean VCVioTest/RoundByRound/OneRound.lean
       - name: Check Merkle batch-opening canaries
         run: lake env lean VCVioTest/MerkleTreeBatch.lean
+      - name: Check simulation/fork pipeline computability lock
+        run: lake env lean VCVioTest/Computability.lean
       - name: Run SLH-DSA-SHA2-128-24 differential KAT
         run: lake exe slhdsa_kat
       - name: Run SLH-DSA-C13 differential KAT

--- a/Examples/PRGfromPRF.lean
+++ b/Examples/PRGfromPRF.lean
@@ -198,7 +198,7 @@ private lemma run'_bind_liftM {σ β γ : Type} (N : StateT σ ProbComp β)
 
 /-- The output distribution that the ideal PRF reduction feeds to the PRG adversary:
 sample an initial seed, then read `n` output blocks off the lazy random oracle chain. -/
-noncomputable def idealOutputs (n : ℕ) : ProbComp (List.Vector O n) := do
+def idealOutputs (n : ℕ) : ProbComp (List.Vector O n) := do
   let seed ← $ᵗ S
   (simulateQ (prfIdealQueryImpl (D := S) (R := S × O)) (oracleOutputs n seed)).run' ∅
 
@@ -227,13 +227,13 @@ lemma prfIdealExp_prfReduction_eq (adv : PRGAdversary (List.Vector O n)) :
 /-- The per-seed output distribution: run the lazy random oracle chain for `n` rounds from a
 fixed initial state `seed`, collecting the output blocks. Averaging over `seed ← $ᵗ S` gives
 `idealOutputs`. -/
-noncomputable def seedOutputs (n : ℕ) (seed : S) : ProbComp (List.Vector O n) :=
+def seedOutputs (n : ℕ) (seed : S) : ProbComp (List.Vector O n) :=
   (simulateQ (prfIdealQueryImpl (D := S) (R := S × O)) (oracleOutputs n seed)).run' ∅
 
 /-- The per-seed collision experiment: run the lazy random oracle chain for `n` rounds from a
 fixed initial state `seed`, and test whether any queried state repeats. Averaging over
 `seed ← $ᵗ S` gives `idealCollisionExp`. -/
-noncomputable def seedCollisionExp (n : ℕ) (seed : S) : ProbComp Bool := do
+def seedCollisionExp (n : ℕ) (seed : S) : ProbComp Bool := do
   let states ←
     (simulateQ (prfIdealQueryImpl (D := S) (R := S × O))
       (oracleVisitedStates n seed)).run' ∅
@@ -257,7 +257,7 @@ random oracle chain for `N` rounds from state `s`, the bad event is that the cha
 state (`¬ Nodup`) or revisits a state already present in `c`. For `c = ∅` this reduces to
 `seedCollisionExp`. The generalized cache is the induction vehicle: each fresh step extends
 `c` by the just-visited state. -/
-noncomputable def genCollisionExp (N : ℕ) (s : S) (c : (S →ₒ S × O).QueryCache) :
+def genCollisionExp (N : ℕ) (s : S) (c : (S →ₒ S × O).QueryCache) :
     ProbComp Bool := do
   let states ←
     (simulateQ (prfIdealQueryImpl (D := S) (R := S × O)) (oracleVisitedStates N s)).run' c

--- a/LatticeCrypto/MLDSA/SecurityNMA.lean
+++ b/LatticeCrypto/MLDSA/SecurityNMA.lean
@@ -321,7 +321,7 @@ variable {M : Type} [DecidableEq M] [DecidableEq (Commitment p prims)]
 inside `StateT QueryCache ProbComp`. Running an oracle computation through this implementation and
 projecting away the final cache turns it into a plain `ProbComp`, which is what the MLWE
 distinguisher must return. -/
-noncomputable def roImpl :
+def roImpl :
     QueryImpl (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
       (StateT ((M × Commitment p prims →ₒ CommitHashBytes p).QueryCache) ProbComp) :=
   unifFwdImpl (M × Commitment p prims →ₒ CommitHashBytes p) +
@@ -332,7 +332,7 @@ noncomputable def roImpl :
 empty cache and discarding the final cache state. This is exactly the `ProbComp` underlying
 `FiatShamirWithAbort.runtime.evalDist` (see `BundledSemantics.withStateOracle`), exposed so the
 MLWE distinguisher — which must inhabit `… → ProbComp Bool` — can run the NMA game internally. -/
-noncomputable def simulateToProbComp {α : Type}
+def simulateToProbComp {α : Type}
     (mx : OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p)) α) :
     ProbComp α :=
   StateT.run' (simulateQ (roImpl p prims (M := M)) mx) ∅
@@ -354,7 +354,7 @@ The matrix never appears as a free challenge: phrasing the MLWE instance over se
 ROM modeling of Dilithium with `ExpandA` a random oracle, and it makes the distinguisher `B` total
 (no `ExpandA`-surjectivity assumption). Relating an abstract matrix-based MLWE problem to this
 concrete seed-based one is a statement-level bridge obligation. -/
-noncomputable def mldsaMLWE (p : Params) (prims : Primitives p)
+def mldsaMLWE (p : Params) (prims : Primitives p)
     [SampleableType (RqVec p.l)] [SampleableType (RqVec p.k)] :
     LearningWithErrors.Problem (Bytes 32) (RqVec p.l) (RqVec p.k) where
   sampleChallenge := do
@@ -478,7 +478,7 @@ noncomputable def distinguisherBShort
 
 /-- Lift a seed-based short-MLWE adversary to the uniform-matrix problem: run it on a
 freshly sampled seed and the challenged target vector, discarding the matrix. -/
-noncomputable def matrixLift
+def matrixLift
     (B : LearningWithErrors.Adversary (mldsaMLWEShort p prims)) :
     LearningWithErrors.Adversary (mldsaMatrixMLWE p) :=
   fun c => do
@@ -772,7 +772,7 @@ solution.
 
 The `sampleParams` draws the same seed-based key as `keygen1`/`mldsaMLWE`: it samples `ρ` through
 `ExpandSeed`, a uniform `t`, and publishes `(ExpandA(ρ), pk)` with `pk = ⟨ρ, Power2Round(t).1⟩`. -/
-noncomputable def mldsaSTMSIS (M : Type) :
+def mldsaSTMSIS (M : Type) :
     SelfTargetMSIS.Problem (TqMatrix p.k p.l) (Response p prims) (PublicKey p prims)
       (M × Commitment p prims) (CommitHashBytes p) where
   sampleParams := do
@@ -812,7 +812,7 @@ check rejects. The matrix in `params.1` is ignored by `C` (it equals `ExpandA(pa
 The STMSIS experiment then looks up `c̃ = H(msg, w')` in the oracle cache and checks
 `mldsaSTMSIS.isValid Â pk c̃ (z, h)`, which recomputes `w'` from `(pk, c̃, (z, h))` and runs the
 identification verifier — exactly what the NMA `verify` does after querying `H(msg, w')`. -/
-noncomputable def extractorC [Inhabited (Commitment p prims)] [Inhabited (Response p prims)]
+def extractorC [Inhabited (Commitment p prims)] [Inhabited (Response p prims)]
     (main : PublicKey p prims →
       OracleComp (unifSpec + (M × Commitment p prims →ₒ CommitHashBytes p))
         (M × Option (Commitment p prims × Response p prims))) :

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/CmaToNma.lean
@@ -55,7 +55,7 @@ abbrev cmaOracleSpec (M Commit Chal Resp : Type) :
     OracleSpec ((ℕ ⊕ (M × Commit)) ⊕ M) :=
   fsRoSpec M Commit Chal + (M →ₒ (Commit × Resp))
 
-noncomputable def simulatedNmaFwd
+def simulatedNmaFwd
     [DecidableEq M] [DecidableEq Commit] :
     QueryImpl (fsRoSpec M Commit Chal)
       (StateT (fsRoSpec M Commit Chal).QueryCache
@@ -63,14 +63,14 @@ noncomputable def simulatedNmaFwd
   (HasQuery.toQueryImpl (spec := fsRoSpec M Commit Chal)
     (m := OracleComp (fsRoSpec M Commit Chal))).liftTarget _
 
-noncomputable def simulatedNmaUnifSim
+def simulatedNmaUnifSim
     [DecidableEq M] [DecidableEq Commit] :
     QueryImpl unifSpec
       (StateT (fsRoSpec M Commit Chal).QueryCache
         (OracleComp (fsRoSpec M Commit Chal))) :=
   fun n => simulatedNmaFwd (M := M) (Commit := Commit) (Chal := Chal) (.inl n)
 
-noncomputable def simulatedNmaRoSim
+def simulatedNmaRoSim
     [DecidableEq M] [DecidableEq Commit] :
     QueryImpl (M × Commit →ₒ Chal)
       (StateT (fsRoSpec M Commit Chal).QueryCache
@@ -82,7 +82,7 @@ noncomputable def simulatedNmaRoSim
       let v ← simulatedNmaFwd (M := M) (Commit := Commit) (Chal := Chal) (.inr mc)
       modifyGet fun cache => (v, cache.cacheQuery (.inr mc) v)
 
-noncomputable def simulatedNmaBaseSim
+def simulatedNmaBaseSim
     [DecidableEq M] [DecidableEq Commit] :
     QueryImpl (fsRoSpec M Commit Chal)
       (StateT (fsRoSpec M Commit Chal).QueryCache
@@ -90,7 +90,7 @@ noncomputable def simulatedNmaBaseSim
   simulatedNmaUnifSim (M := M) (Commit := Commit) (Chal := Chal) +
     simulatedNmaRoSim (M := M) (Commit := Commit) (Chal := Chal)
 
-noncomputable def simulatedNmaSigSim
+def simulatedNmaSigSim
     [DecidableEq M] [DecidableEq Commit]
     [Finite Chal] [SampleableType Chal]
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
@@ -105,7 +105,7 @@ noncomputable def simulatedNmaSigSim
     | some _ => ((c, s), cache)
     | none => ((c, s), cache.cacheQuery (.inr (msg, c)) ω)
 
-noncomputable def simulatedNmaImpl
+def simulatedNmaImpl
     [DecidableEq M] [DecidableEq Commit]
     [Finite Chal] [SampleableType Chal]
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
@@ -126,7 +126,7 @@ queries by sampling from `simTranscript` and programming the cache,
 and returns the final cache together with the forgery.
 
 This is the concrete-interface reduction entering the replay-forking lemma. -/
-noncomputable def simulatedNmaAdv
+def simulatedNmaAdv
     [DecidableEq M] [DecidableEq Commit]
     [Finite Chal] [SampleableType Chal]
     (simTranscript : Stmt → ProbComp (Commit × Chal × Resp))

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Reductions.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Reductions.lean
@@ -143,7 +143,7 @@ variable [SampleableType Wit] [SampleableType Chal]
 /-- The branch the NMA extractor takes on a forking-lemma result: from two traces sharing a
 commitment whose distinct cached challenges accept, run `σ.extract`; otherwise resample. This is
 the post-`contextFork` continuation of `nmaForkExtract`. -/
-private noncomputable def nmaForkExtractBranch :
+private def nmaForkExtractBranch :
     Option (Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal) ×
       Fork.Trace (M := M) (Commit := Commit) (Resp := Resp) (Chal := Chal)) →
       OracleComp (unifSpec + (Unit →ₒ Chal)) Wit
@@ -163,7 +163,7 @@ private noncomputable def nmaForkExtractBranch :
 
 /-- Witness-extraction computation used by the NMA reduction: replay the forking lemma, then
 take the `nmaForkExtractBranch` continuation on the resulting trace pair. -/
-private noncomputable def nmaForkExtract
+private def nmaForkExtract
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qH : ℕ) (pk : Stmt) :
@@ -174,7 +174,7 @@ private noncomputable def nmaForkExtract
 
 /-- NMA reduction for `nma_to_hard_relation_bound`: simulate the challenge oracle of
 `nmaForkExtract` down to `ProbComp`. -/
-private noncomputable def nmaReduction
+private def nmaReduction
     (nmaAdv : SignatureAlg.managedRoNmaAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (qH : ℕ) : Stmt → ProbComp Wit := fun pk =>

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Bridge.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Bridge.lean
@@ -58,7 +58,7 @@ abbrev SourceCmaComp (α : Type) :=
 /-! ## Adversary wrappers -/
 
 /-- Candidate-producing part of the CMA adversary after the public key is fixed. -/
-@[reducible, fs_simp] noncomputable def postKeygenCandidateAdv
+@[reducible, fs_simp] def postKeygenCandidateAdv
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt)
@@ -68,7 +68,7 @@ abbrev SourceCmaComp (α : Type) :=
       (M × (Commit × Resp)))
 
 /-- Candidate-producing adversary with the public key fetched from the game. -/
-@[reducible, fs_simp] noncomputable def candidateAdv
+@[reducible, fs_simp] def candidateAdv
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt)
       (Stmt × (M × (Commit × Resp))) := do
@@ -79,7 +79,7 @@ abbrev SourceCmaComp (α : Type) :=
   pure (pk, out)
 
 /-- Lift a CMA-style Fiat-Shamir adversary into the named CMA game interface. -/
-@[reducible, fs_simp] noncomputable def signedAdv
+@[reducible, fs_simp] def signedAdv
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt)
       ((M × (Commit × Resp)) × Bool) := do
@@ -95,7 +95,7 @@ abbrev SourceCmaComp (α : Type) :=
   pure ((msg, sig), verified)
 
 /-- Log signing queries while forwarding every query to the surrounding CMA interface. -/
-@[reducible, fs_simp] noncomputable def cmaSignLogImpl :
+@[reducible, fs_simp] def cmaSignLogImpl :
     QueryImpl (cmaSpec M Commit Chal Resp Stmt)
       (StateT (List M) (OracleComp (cmaSpec M Commit Chal Resp Stmt)))
   | .unif n => do
@@ -118,7 +118,7 @@ abbrev SourceCmaComp (α : Type) :=
       pure pk
 
 /-- Log signing queries while producing the final candidate, before verification. -/
-@[reducible, fs_simp] noncomputable def signedCandidateAdv
+@[reducible, fs_simp] def signedCandidateAdv
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt)
       ((Stmt × (M × (Commit × Resp))) × List M) := do
@@ -126,7 +126,7 @@ abbrev SourceCmaComp (α : Type) :=
     (Resp := Resp) (Stmt := Stmt)) (candidateAdv σ hr M adv)).run []
 
 /-- Freshness and verification check attached after candidate production. -/
-@[reducible, fs_simp] noncomputable def verifyFreshComp
+@[reducible, fs_simp] def verifyFreshComp
     (p : (Stmt × (M × (Commit × Resp))) × List M) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt) Bool := do
   let pk := p.1.1
@@ -139,7 +139,7 @@ abbrev SourceCmaComp (α : Type) :=
   pure (!decide (out.1 ∈ signed) && verified)
 
 /-- Freshness-preserving Boolean adversary for the direct stateful CMA chain. -/
-@[reducible, fs_simp] noncomputable def signedFreshAdv
+@[reducible, fs_simp] def signedFreshAdv
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt) Bool :=
   signedCandidateAdv σ hr M adv >>= verifyFreshComp (σ := σ) (hr := hr)
@@ -149,7 +149,7 @@ abbrev SourceCmaComp (α : Type) :=
 
 /-- The public post-keygen adversary/verification computation before it is
 interpreted by the explicit random-oracle cache runtime. -/
-@[fs_simp] noncomputable def postKeygenAdvBase (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
+@[fs_simp] def postKeygenAdvBase (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) : SourceCmaComp (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp)
       ((M × (Commit × Resp)) × Bool) := do
   let (msg, sig) ← adv.main pk
@@ -159,7 +159,7 @@ interpreted by the explicit random-oracle cache runtime. -/
   pure ((msg, sig), verified)
 
 /-- Verification suffix attached after the fixed-key adversary produces a candidate. -/
-noncomputable def postVerifyComp (pk : Stmt) (x : M × (Commit × Resp)) :
+def postVerifyComp (pk : Stmt) (x : M × (Commit × Resp)) :
     OracleComp (cmaSpec M Commit Chal Resp Stmt) ((M × (Commit × Resp)) × Bool) := do
   let verified ← (liftM
     ((SourceSigAlg (σ := σ) (hr := hr) (M := M)).verify
@@ -168,7 +168,7 @@ noncomputable def postVerifyComp (pk : Stmt) (x : M × (Commit × Resp)) :
   pure (x, verified)
 
 /-- Fixed-key adversary and verification computation over the named CMA interface. -/
-@[fs_simp] noncomputable def postKeygenAdv (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
+@[fs_simp] def postKeygenAdv (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) : OracleComp (cmaSpec M Commit Chal Resp Stmt) ((M × (Commit × Resp)) × Bool) :=
   (postKeygenCandidateAdv (σ := σ) (hr := hr) (M := M)
     (Commit := Commit) (Chal := Chal) (Resp := Resp) adv pk) >>=
@@ -204,7 +204,7 @@ lemma runtimeWithCache_evalDist_eq_fsBaseImpl
 The keypair is installed before the adversary runs, and the final freshness
 check reads the signed-message log from the resulting `CmaState`. This is the
 canonical normal form used by the stateful CMA chain. -/
-@[fs_simp] noncomputable def postKeygenFreshProb (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
+@[fs_simp] def postKeygenFreshProb (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (pk : Stmt) (sk : Wit) : ProbComp Bool :=
   (simulateQ (cmaRealSourceFullSum M Commit Chal σ hr)
       (postKeygenAdvBase (σ := σ) (hr := hr) (M := M)
@@ -221,7 +221,7 @@ canonical normal form used by the stateful CMA chain. -/
 /-- Run the direct stateful `cmaReal` game against `signedAdv` and pack the
 forgery, verification bit, and signed-message log into one probability
 computation. -/
-@[fs_simp] noncomputable def cmaRealRun (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
+@[fs_simp] def cmaRealRun (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) :
     ProbComp ((M × (Commit × Resp)) × Bool × List M) := do
   let p ← (cmaReal M Commit Chal σ hr).runState
     (cmaInit M Commit Chal Stmt Wit) (signedAdv σ hr M adv)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Chain.lean
@@ -55,7 +55,7 @@ noncomputable local instance instIsUniformSpecChalSingleton [Fintype Chal] :
 /-! ## CMA-to-NMA adversary -/
 
 /-- The CMA-to-NMA reduction at the managed random-oracle interface. -/
-noncomputable def nmaAdvFromCma
+def nmaAdvFromCma
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     SignatureAlg.managedRoNmaAdv
@@ -89,7 +89,7 @@ on this wrapper at slot parameter `qH`: `Fork.forkPoint qH` indexes
 `Fin (qH + 1)`, which is exactly the right number of slots for `qH + 1`
 queries (the framework's structural `+1` is precisely the wrapper's verifier
 slot). The replay-forking denominator is therefore `qH + 1`, not `qH + 2`. -/
-noncomputable def nmaAdvFromCmaWithFinalQuery
+def nmaAdvFromCmaWithFinalQuery
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     SignatureAlg.managedRoNmaAdv
@@ -127,7 +127,7 @@ private abbrev ForkBaseState (M Commit Chal : Type)
     [DecidableEq M] [DecidableEq Commit] :=
   (fsRoSpec M Commit Chal).QueryCache × Fork.SimState M Commit Chal
 
-@[fs_simp] private noncomputable def forkBaseImpl
+@[fs_simp] private def forkBaseImpl
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
     QueryImpl (cmaOracleSpec M Commit Chal Resp)
       (StateT (ForkBaseState M Commit Chal) (OracleComp (Fork.wrappedSpec Chal))) :=
@@ -146,7 +146,7 @@ private abbrev ForkBaseState (M Commit Chal : Type)
   | .inl _ => signed
   | .inr m => signed ++ [m]
 
-@[fs_simp] private noncomputable def forkLoggedImpl
+@[fs_simp] private def forkLoggedImpl
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
     QueryImpl (cmaOracleSpec M Commit Chal Resp)
       (StateT (ForkBaseState M Commit Chal × List M)
@@ -161,7 +161,7 @@ private abbrev SimLoggedState (M Commit Chal : Type)
     [DecidableEq M] [DecidableEq Commit] :=
   (fsRoSpec M Commit Chal).QueryCache × List M
 
-@[fs_simp] private noncomputable def simLoggedVerifyFreshComp
+@[fs_simp] private def simLoggedVerifyFreshComp
     (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (pk : Stmt) (x : M × (Commit × Resp))
     (s : SimLoggedState M Commit Chal) : ProbComp Bool := do
@@ -174,12 +174,12 @@ private abbrev SimLoggedState (M Commit Chal : Type)
       let ch ← ($ᵗ Chal : ProbComp Chal)
       pure (!decide (msg ∈ s.2) && σ.verify pk c ch resp)
 
-@[fs_simp] private noncomputable def fsUniformImpl :
+@[fs_simp] private def fsUniformImpl :
     QueryImpl (fsRoSpec M Commit Chal) ProbComp :=
   QueryImpl.ofLift unifSpec ProbComp +
     (uniformSampleImpl (spec := (M × Commit →ₒ Chal)))
 
-@[fs_simp] private noncomputable def simulatedNmaLoggedProbImpl
+@[fs_simp] private def simulatedNmaLoggedProbImpl
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
     QueryImpl (cmaOracleSpec M Commit Chal Resp)
       (StateT (SimLoggedState M Commit Chal) ProbComp) :=
@@ -190,7 +190,7 @@ private abbrev SimLoggedState (M Commit Chal : Type)
     (cmaOracleSignLogAux (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp))
 
-@[fs_simp] private noncomputable def cmaSimLoggedImpl
+@[fs_simp] private def cmaSimLoggedImpl
     (hr : GenerableRelation Stmt Wit rel)
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     QueryImpl (cmaSpec M Commit Chal Resp Stmt)
@@ -199,7 +199,7 @@ private abbrev SimLoggedState (M Commit Chal : Type)
     (cmaSignLogImpl (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp) (Stmt := Stmt))).flattenStateT
 
-@[fs_simp] private noncomputable def cmaSimLoggedLeftImpl
+@[fs_simp] private def cmaSimLoggedLeftImpl
     (hr : GenerableRelation Stmt Wit rel)
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     QueryImpl (cmaOracleSpec M Commit Chal Resp)
@@ -904,12 +904,12 @@ private lemma forkPoint_isSome_of_mem_verified_length {qH : ℕ}
     (Chal := Chal) (Resp := Resp) trace hverified hmem ?_
   exact (List.findIdx_lt_length_of_exists ⟨trace.target, hmem, by simp⟩).le.trans hlen
 
-@[fs_simp] private noncomputable def forkWrappedUniformImpl [Fintype Chal] :
+@[fs_simp] private def forkWrappedUniformImpl [Fintype Chal] :
     QueryImpl (Fork.wrappedSpec Chal) ProbComp :=
   QueryImpl.ofLift unifSpec ProbComp +
     (uniformSampleImpl (spec := (Unit →ₒ Chal)))
 
-@[fs_simp] private noncomputable def forkVerifyFreshComp
+@[fs_simp] private def forkVerifyFreshComp
     (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (pk : Stmt) (x : M × (Commit × Resp))
     (s : ForkBaseState M Commit Chal × List M) :
@@ -941,7 +941,7 @@ private lemma forkVerifyFreshComp_project
     simp [forkVerifyFreshComp, simLoggedVerifyFreshComp, forkLoggedProj,
       forkWrappedUniformImpl, hcache] <;> rfl
 
-private noncomputable def forkFinalQueryTrace
+private def forkFinalQueryTrace
     (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (pk : Stmt) (x : M × (Commit × Resp))
     (s : ForkBaseState M Commit Chal × List M) :
@@ -1116,7 +1116,7 @@ private lemma forkBase_finalQuery_runTrace_eq
   obtain ⟨⟨msg, c, resp⟩, advCache, liveCache, queryLog⟩ := z
   cases hcache : liveCache (msg, c) <;> simp [Fork.roImpl, hcache]
 
-@[fs_simp] private noncomputable def forkLoggedProbImpl [Fintype Chal]
+@[fs_simp] private def forkLoggedProbImpl [Fintype Chal]
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :
     QueryImpl (cmaOracleSpec M Commit Chal Resp)
       (StateT (ForkBaseState M Commit Chal × List M) ProbComp) :=
@@ -1326,7 +1326,7 @@ private lemma probOutput_simulateQ_forkWrappedUniformImpl [Fintype Chal]
       Pr[= x | oa] :=
   congrFun (congrArg DFunLike.coe (evalDist_simulateQ_forkWrappedUniformImpl oa)) x
 
-private noncomputable def forkH5Body
+private def forkH5Body
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
@@ -1338,7 +1338,7 @@ private noncomputable def forkH5Body
   forkVerifyFreshComp (M := M) (Commit := Commit) (Chal := Chal)
     (Resp := Resp) σ pk z.1 z.2
 
-private noncomputable def forkLoggedVerifyBody
+private def forkLoggedVerifyBody
     (adv : SignatureAlg.unforgeableAdv
       (FiatShamir (m := OracleComp (unifSpec + (M × Commit →ₒ Chal))) σ hr M))
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) (pk : Stmt) :

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Compatibility.lean
@@ -62,7 +62,7 @@ noncomputable def statefulPostKeygenFreshAdvantage
 
 This packages `cmaRealRun` with the same final freshness predicate as the
 post-keygen normal form. -/
-noncomputable def statefulCmaFreshExperiment
+def statefulCmaFreshExperiment
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) : ProbComp Bool := do
   let z ← cmaRealRun σ hr M adv
   let out := z.1
@@ -165,7 +165,7 @@ theorem statefulCmaFreshAdvantage_eq_statefulPostKeygenFreshAdvantage
 /-! ## Public WriterT compatibility -/
 
 /-- Fixed-key public signing-query handler in the generic `appendInputLog` form. -/
-@[reducible, fs_simp] private noncomputable def postKeygenAppendImpl (pk : Stmt) (sk : Wit) :
+@[reducible, fs_simp] private def postKeygenAppendImpl (pk : Stmt) (sk : Wit) :
     QueryImpl (SourceCmaSpec (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp))
       (StateT (List M) (StateT (RoCache M Commit Chal) ProbComp)) := by
   letI : HasQuery (unifSpec + roSpec M Commit Chal)
@@ -184,7 +184,7 @@ private abbrev postKeygenState (M Commit Chal : Type) := List M × RoCache M Com
 
 /-- Product-state version of `postKeygenAppendImpl`, used to compare with the
 full `CmaState` handler by projection. -/
-@[fs_simp] private noncomputable def postKeygenAppendProdImpl (pk : Stmt) (sk : Wit) :
+@[fs_simp] private def postKeygenAppendProdImpl (pk : Stmt) (sk : Wit) :
     QueryImpl (SourceCmaSpec (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp))
       (StateT (postKeygenState M Commit Chal) ProbComp) := fun t =>
   StateT.mk fun (signed, cache) =>
@@ -334,7 +334,7 @@ private lemma postKeygenAppendProdImpl_eq_flattenStateT
 
 /-- Fixed-key public post-keygen experiment after WriterT logging has been
 converted to an input log. This is split at the candidate/log boundary. -/
-private noncomputable def postKeygenFreshAppendProb
+private def postKeygenFreshAppendProb
     (adv : SourceAdv (σ := σ) (hr := hr) (M := M)) (pk : Stmt) (sk : Wit) : ProbComp Bool :=
   letI : HasQuery (roSpec M Commit Chal) (StateT (RoCache M Commit Chal) ProbComp) :=
     (randomOracle : QueryImpl (roSpec M Commit Chal) _).toHasQuery
@@ -428,14 +428,14 @@ private theorem postKeygenFreshAppendProb_eq_statefulPostKeygenFreshProb
   | Sum.inl _ => signed
   | Sum.inr m => signed ++ [m]
 
-@[fs_simp] private noncomputable def cmaRealAppendProdImpl :
+@[fs_simp] private def cmaRealAppendProdImpl :
     QueryImpl (SourceCmaSpec (M := M) (Commit := Commit) (Chal := Chal) (Resp := Resp))
       (StateT (List M × CmaState M Commit Chal Stmt Wit) ProbComp) :=
   QueryImpl.extendStateLeft (cmaRealSourceFullSum M Commit Chal σ hr)
     (cmaRealAppendAux (M := M) (Commit := Commit) (Chal := Chal)
       (Resp := Resp) (Stmt := Stmt) (Wit := Wit))
 
-@[fs_simp] private noncomputable def cmaRealLoggedProdImpl :
+@[fs_simp] private def cmaRealLoggedProdImpl :
     QueryImpl (cmaSpec M Commit Chal Resp Stmt)
       (StateT (List M × CmaState M Commit Chal Stmt Wit) ProbComp) :=
   ((cmaReal M Commit Chal σ hr).mapStateTBase

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Games.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Games.lean
@@ -40,7 +40,7 @@ variable {Resp PrvState : Type}
 /-- Public part of the no-message-attack game.
 
 State: random-oracle cache, lazily sampled keypair, and bad flag. -/
-@[fs_simp] noncomputable def nmaPublic
+@[fs_simp] def nmaPublic
     (hr : GenerableRelation Stmt Wit rel) :
     QueryImpl.Stateful unifSpec (cmaPublicSpec M Commit Chal Stmt)
       (NmaState M Commit Chal Stmt Wit)
@@ -62,7 +62,7 @@ State: random-oracle cache, lazily sampled keypair, and bad flag. -/
           pure (pk, (s.1, some (pk, sk), s.2.2))
 
 /-- Programmable random-oracle part of the no-message-attack game. -/
-@[fs_simp] noncomputable def nmaProgram :
+@[fs_simp] def nmaProgram :
     QueryImpl.Stateful unifSpec (progSpec M Commit Chal)
       (NmaState M Commit Chal Stmt Wit)
   | mch => StateT.mk fun s =>
@@ -74,7 +74,7 @@ State: random-oracle cache, lazily sampled keypair, and bad flag. -/
       | none => pure ((), (cache.cacheQuery mc ch, s.2.1, s.2.2))
 
 /-- The no-message-attack game as a direct stateful handler. -/
-@[fs_simp] noncomputable def nma
+@[fs_simp] def nma
     (hr : GenerableRelation Stmt Wit rel) :
     QueryImpl.Stateful unifSpec (nmaSpec M Commit Chal Stmt)
       (NmaState M Commit Chal Stmt Wit)
@@ -90,7 +90,7 @@ State: random-oracle cache, lazily sampled keypair, and bad flag. -/
 This component has no private state. Its imports are intentionally the same
 ambient `nmaSpec` used by the signing simulator, so adversarial RO queries and
 programming queries interact through one inner random-oracle cache. -/
-@[fs_simp] noncomputable def cmaPublicForward :
+@[fs_simp] def cmaPublicForward :
     QueryImpl.Stateful (nmaSpec M Commit Chal Stmt) (cmaPublicSpec M Commit Chal Stmt) PUnit
   | .unif n => StateT.mk fun u => do
       let r ← (((nmaSpec M Commit Chal Stmt).query (.unif n)) :
@@ -109,7 +109,7 @@ programming queries interact through one inner random-oracle cache. -/
 
 State: signed-message log. Signing queries sample the HVZK simulator and
 program the random oracle through the shared NMA interface. -/
-@[fs_simp] noncomputable def cmaSignSim
+@[fs_simp] def cmaSignSim
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     QueryImpl.Stateful (nmaSpec M Commit Chal Stmt) (signSpec M Commit Resp)
       (OuterState M)
@@ -126,7 +126,7 @@ program the random oracle through the shared NMA interface. -/
 Public queries are forwarded to the NMA interface; signing queries are handled
 by the simulator component that owns the signed-message log. Both paths share
 the same `nmaSpec` imports on purpose. -/
-@[fs_simp] noncomputable def cmaToNma
+@[fs_simp] def cmaToNma
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     QueryImpl.Stateful (nmaSpec M Commit Chal Stmt) (cmaSpec M Commit Chal Resp Stmt)
       (OuterState M)
@@ -147,7 +147,7 @@ the same `nmaSpec` imports on purpose. -/
 /-! ## `cmaSim`: simulated CMA game -/
 
 /-- The simulated CMA game, linked through the direct CMA frame. -/
-@[fs_simp] noncomputable abbrev cmaSim
+@[fs_simp] abbrev cmaSim
     (hr : GenerableRelation Stmt Wit rel)
     (simT : Stmt → ProbComp (Commit × Chal × Resp)) :
     QueryImpl.Stateful unifSpec (cmaSpec M Commit Chal Resp Stmt)
@@ -161,14 +161,14 @@ the same `nmaSpec` imports on purpose. -/
 
 This handler is shared by the fixed-key public post-keygen experiment and the
 direct named CMA game. -/
-@[reducible, fs_simp] noncomputable def fsBaseImpl :
+@[reducible, fs_simp] def fsBaseImpl :
     QueryImpl (unifSpec + roSpec M Commit Chal)
       (StateT (RoCache M Commit Chal) ProbComp) :=
   unifFwdImpl (roSpec M Commit Chal) +
     (randomOracle : QueryImpl (roSpec M Commit Chal) _)
 
 /-- Fixed-key real Fiat-Shamir signing over the shared random-oracle cache. -/
-@[reducible, fs_simp] noncomputable def cmaRealFixedSign
+@[reducible, fs_simp] def cmaRealFixedSign
     (sigma : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (hr : GenerableRelation Stmt Wit rel)
     (pk : Stmt) (sk : Wit) :
@@ -181,7 +181,7 @@ direct named CMA game. -/
     pk sk
 
 /-- Source-query part of the real CMA game over the full direct CMA state. -/
-@[fs_simp] noncomputable def cmaRealSourceFull
+@[fs_simp] def cmaRealSourceFull
     (sigma : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (hr : GenerableRelation Stmt Wit rel) :
     QueryImpl.Stateful unifSpec (cmaSourceSpec M Commit Chal Resp)
@@ -229,7 +229,7 @@ direct named CMA game. -/
 
 /-- Source-query part of the real CMA game over the concrete sum interface used
 by `SignatureAlg.unforgeableAdv`. -/
-@[fs_simp] noncomputable def cmaRealSourceFullSum
+@[fs_simp] def cmaRealSourceFullSum
     (sigma : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (hr : GenerableRelation Stmt Wit rel) :
     QueryImpl.Stateful unifSpec
@@ -243,7 +243,7 @@ by `SignatureAlg.unforgeableAdv`. -/
 
 On signing queries, this runs the real Sigma protocol and appends the message
 to the signed log. The bad flag is preserved and never set by real signing. -/
-@[fs_simp] noncomputable def cmaReal
+@[fs_simp] def cmaReal
     (sigma : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (hr : GenerableRelation Stmt Wit rel) :
     QueryImpl.Stateful unifSpec (cmaSpec M Commit Chal Resp Stmt)

--- a/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean
+++ b/VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean
@@ -487,7 +487,7 @@ private def CmaRealSignGhost.public
   challenge := x.challenge
   response := x.ghostResponse
 
-private noncomputable def cmaSignKeySource
+private def cmaSignKeySource
     (hr : GenerableRelation Stmt Wit rel)
     (s : CmaData M Commit Chal Stmt Wit) :
     ProbComp (Stmt × Wit) :=
@@ -503,7 +503,7 @@ private def cmaSignKeyedData
   | some _ => s
   | none => (s.1, s.2.1, some (pk, sk))
 
-private noncomputable def cmaRealSignGhostDist
+private def cmaRealSignGhostDist
     (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (hr : GenerableRelation Stmt Wit rel)
     (m : M)
@@ -524,7 +524,7 @@ private noncomputable def cmaRealSignGhostDist
         pk := pk, sk := sk, commit := c, privateState := prv,
         challenge := ch, ghostResponse := ghostResp, actualResponse := ghostResp }
 
-private noncomputable def cmaRealSignPublicDist
+private def cmaRealSignPublicDist
     (σ : SigmaProtocol Stmt Wit Commit PrvState Chal Resp rel)
     (hr : GenerableRelation Stmt Wit rel)
     (s : CmaData M Commit Chal Stmt Wit) :
@@ -532,7 +532,7 @@ private noncomputable def cmaRealSignPublicDist
   let (pk, sk) ← cmaSignKeySource M Commit Chal hr s
   cmaSignPublicOfTranscript pk sk <$> σ.realTranscript pk sk
 
-private noncomputable def cmaSimSignPublicDist
+private def cmaSimSignPublicDist
     (hr : GenerableRelation Stmt Wit rel)
     (simT : Stmt → ProbComp (Commit × Chal × Resp))
     (s : CmaData M Commit Chal Stmt Wit) :

--- a/VCVio/CryptoFoundations/Fischlin/Completeness.lean
+++ b/VCVio/CryptoFoundations/Fischlin/Completeness.lean
@@ -254,7 +254,7 @@ private lemma fischlinUnifSearch_probEvent_minGt_le
 /-- The full simulation implementation (`unifFwdImpl + randomOracle`) interpreting the Fischlin
 random-oracle world into `StateT QueryCache ProbComp`. This is definitionally the implementation
 used by the bundled `withStateOracle` runtime. -/
-@[reducible] noncomputable def fischlinImpl :
+@[reducible] def fischlinImpl :
     QueryImpl (unifSpec + fischlinROSpec Stmt Commit Chal Resp ρ b M)
       (StateT (fischlinROSpec Stmt Commit Chal Resp ρ b M).QueryCache ProbComp) :=
   unifFwdImpl (fischlinROSpec Stmt Commit Chal Resp ρ b M)
@@ -292,7 +292,7 @@ Mirrors `keygen >>= sign >>= verify`, but the prover's per-repetition search use
 `fischlinUnifSearch` (fresh uniform draws) and the verifier reads the kept hash value
 directly from the search result instead of re-querying the random oracle. Returns the verdict
 `allVerified && (hashSum ≤ S)`. -/
-private noncomputable def modelGame : ProbComp Bool := do
+private def modelGame : ProbComp Bool := do
   let (pk, sk) ← hr.gen
   let commits : Fin ρ → Commit × PrvState ← Fin.mOfFn ρ fun _ => σ.commit pk sk
   let comVec : Fin ρ → Commit := fun i => (commits i).1

--- a/VCVio/CryptoFoundations/Fischlin/KnowledgeSoundness.lean
+++ b/VCVio/CryptoFoundations/Fischlin/KnowledgeSoundness.lean
@@ -73,7 +73,7 @@ The key property enabling this extractor is `UniqueResponses`: given the same
 `(statement, commitment, challenge)`, there is at most one valid response.
 So finding a second valid query at a different challenge gives a proper
 input pair for the Σ-protocol extractor. -/
-noncomputable def onlineExtract
+def onlineExtract
     (x : Stmt) (π : FischlinProof Commit Chal Resp ρ)
     (log : QueryLog (fischlinROSpec Stmt Commit Chal Resp ρ b M)) : ProbComp (Option Wit) :=
   let comList := List.ofFn fun i => (π i).1
@@ -243,7 +243,7 @@ output is either `none` or an invalid witness.
 
 The `prover` argument is the raw function rather than `KnowledgeSoundnessAdv`
 to keep type inference tractable. -/
-noncomputable def knowledgeSoundnessExp
+def knowledgeSoundnessExp
     (prover : Stmt → M →
       OracleComp (unifSpec + fischlinROSpec Stmt Commit Chal Resp ρ b M)
         (FischlinProof Commit Chal Resp ρ))
@@ -266,7 +266,7 @@ noncomputable def knowledgeSoundnessExp
 
 /-- The verification step of `knowledgeSoundnessExp`, as a standalone computation
 (definitionally the same term). -/
-private noncomputable def ksVerify (x : Stmt) (msg : M) (π : FischlinProof Commit Chal Resp ρ)
+private def ksVerify (x : Stmt) (msg : M) (π : FischlinProof Commit Chal Resp ρ)
     (cache : (fischlinROSpec Stmt Commit Chal Resp ρ b M).QueryCache) :
     ProbComp (Bool × (fischlinROSpec Stmt Commit Chal Resp ρ b M).QueryCache) :=
   let roSpec := fischlinROSpec Stmt Commit Chal Resp ρ b M
@@ -279,7 +279,7 @@ private noncomputable def ksVerify (x : Stmt) (msg : M) (π : FischlinProof Comm
 
 /-- The sampling phase of `knowledgeSoundnessExp` (prover run + verification), keeping the proof,
 the random-oracle log, and the verdict, but discarding the extractor. -/
-private noncomputable def ksSample
+private def ksSample
     (prover : Stmt → M →
       OracleComp (unifSpec + fischlinROSpec Stmt Commit Chal Resp ρ b M)
         (FischlinProof Commit Chal Resp ρ))
@@ -369,20 +369,20 @@ private lemma knowledgeSoundnessExp_bad_le_misses
 
 /-- The lifted `unifSpec` forwarder on the logging stack, exactly as in
 `knowledgeSoundnessExp`. -/
-private noncomputable def idImplW {ι : Type} (hashSpec : OracleSpec ι) :
+private def idImplW {ι : Type} (hashSpec : OracleSpec ι) :
     QueryImpl unifSpec (WriterT (QueryLog hashSpec) (StateT hashSpec.QueryCache ProbComp)) :=
   (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (WriterT (QueryLog hashSpec) (StateT hashSpec.QueryCache ProbComp))
 
 /-- The logged random oracle, exactly as in `knowledgeSoundnessExp`. -/
-private noncomputable def loggedROW {ι : Type} (hashSpec : OracleSpec ι) [DecidableEq ι]
+private def loggedROW {ι : Type} (hashSpec : OracleSpec ι) [DecidableEq ι]
     [hashSpec.DecidableEq] [∀ t : hashSpec.Domain, SampleableType (hashSpec.Range t)] :
     QueryImpl hashSpec (WriterT (QueryLog hashSpec) (StateT hashSpec.QueryCache ProbComp)) :=
   (hashSpec.randomOracle).withLogging
 
 /-- The combined logging implementation, exactly the `idImpl + loggedRO` of
 `knowledgeSoundnessExp` and `ksSample`. -/
-private noncomputable def compositeW {ι : Type} (hashSpec : OracleSpec ι) [DecidableEq ι]
+private def compositeW {ι : Type} (hashSpec : OracleSpec ι) [DecidableEq ι]
     [hashSpec.DecidableEq] [∀ t : hashSpec.Domain, SampleableType (hashSpec.Range t)] :
     QueryImpl (unifSpec + hashSpec)
       (WriterT (QueryLog hashSpec) (StateT hashSpec.QueryCache ProbComp)) :=
@@ -1431,7 +1431,7 @@ private lemma EP_bind_le_const {α β : Type} {mx : ProbComp α} {my : α → Pr
 
 /-- The lazy random-oracle simulation for a constant-range hash spec: forward `unifSpec`
 queries, lazily sample-and-cache hash queries. Abstract analogue of `fischlinImpl`. -/
-@[reducible] private noncomputable def roImpl (b' : ℕ) (T : Type) [DecidableEq T] :
+@[reducible] private def roImpl (b' : ℕ) (T : Type) [DecidableEq T] :
     QueryImpl (unifSpec + (T →ₒ Fin (2 ^ b')))
       (StateT (T →ₒ Fin (2 ^ b')).QueryCache ProbComp) :=
   unifFwdImpl (T →ₒ Fin (2 ^ b')) + randomOracle (spec := T →ₒ Fin (2 ^ b'))

--- a/VCVio/CryptoFoundations/MacFromPRF.lean
+++ b/VCVio/CryptoFoundations/MacFromPRF.lean
@@ -89,7 +89,7 @@ def prfFuncQuery (msg : D) :
 
 /-- Oracle implementation for the reduction: forwards `unifSpec` queries transparently
 and forwards `(D →ₒ R)` queries to the ambient oracle while logging them. -/
-noncomputable def macToPRFQueryImpl :
+def macToPRFQueryImpl :
     QueryImpl (unifSpec + (D →ₒ R))
       (WriterT (QueryLog (D →ₒ R)) (OracleComp (unifSpec + (D →ₒ R)))) :=
   let fwdTag : QueryImpl (D →ₒ R) (OracleComp (unifSpec + (D →ₒ R))) :=
@@ -103,7 +103,7 @@ noncomputable def macToPRFQueryImpl :
 logged-and-forwarded oracles, then verifies the forgery via one additional oracle query.
 If the forger makes Q tagging queries, the reduction makes Q + 1 oracle queries total;
 this can be tracked separately via `IsTotalQueryBound`. -/
-noncomputable def macToPRFReduction (prf : PRFScheme K D R)
+def macToPRFReduction (prf : PRFScheme K D R)
     (adversary : (prf.toMacAlg).UF_CMA_Adversary) :
     PRFAdversary D R :=
   ((simulateQ (macToPRFQueryImpl (D := D) (R := R)) adversary.main).run >>=

--- a/VCVio/CryptoFoundations/ReplayFork.lean
+++ b/VCVio/CryptoFoundations/ReplayFork.lean
@@ -427,7 +427,7 @@ def contextForkViewCollision (main : OracleComp spec α) (qb : ι → ℕ) (i : 
 /-- Per-path continuation of `contextForkCollision`. Locate occurrence `s` on `path`; if it is
 present, resample the focused answer and report `some s` exactly when the fresh answer collides
 with the first completion's answer and the path already selected `s`. -/
-noncomputable def contextForkCollisionCont (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+def contextForkCollisionCont (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) (path : PFunctor.FreeM.Path main) :
     OracleComp spec (Option (Fin (qb i + 1))) :=
   match PFunctor.FreeM.Cursor.locateAt? (P := spec.toPFunctor) i main path s with
@@ -439,7 +439,7 @@ noncomputable def contextForkCollisionCont (main : OracleComp spec α) (qb : ι 
 
 /-- Equal focused answers form the sole collision branch removed by
 `guardedContextFork`. -/
-noncomputable def contextForkCollision (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+def contextForkCollision (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
     (cf : α → Option (Fin (qb i + 1))) (s : Fin (qb i + 1)) :
     OracleComp spec (Option (Fin (qb i + 1))) :=
   PFunctor.FreeM.withPath main >>= contextForkCollisionCont main qb i cf s

--- a/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
+++ b/VCVio/OracleComp/QueryTracking/LoggingOracle.lean
@@ -55,7 +55,7 @@ variable {ω : Type u} [EmptyCollection ω] [Append ω]
 
 /-- Push an outer oracle interpretation through the base monad of a
 `WriterT`-valued query implementation. -/
-noncomputable def writerTMapBase
+def writerTMapBase
     (outer : QueryImpl spec₁ m₁)
     (inner : QueryImpl spec₀ (WriterT ω (OracleComp spec₁))) :
     QueryImpl spec₀ (WriterT ω m₁) := fun t =>

--- a/VCVio/OracleComp/QueryTracking/RandomOracle/Simulation.lean
+++ b/VCVio/OracleComp/QueryTracking/RandomOracle/Simulation.lean
@@ -43,7 +43,7 @@ variable {ι : Type} {hashSpec : OracleSpec ι}
 /-- The identity forwarding implementation for `unifSpec` queries, lifted to
 `StateT hashSpec.QueryCache ProbComp`. Each uniform query passes through to the underlying
 `ProbComp` without touching the cache state. -/
-noncomputable def unifFwdImpl (hashSpec : OracleSpec ι) :
+def unifFwdImpl (hashSpec : OracleSpec ι) :
     QueryImpl unifSpec (StateT hashSpec.QueryCache ProbComp) :=
   (HasQuery.toQueryImpl (spec := unifSpec) (m := ProbComp)).liftTarget
     (StateT hashSpec.QueryCache ProbComp)

--- a/VCVio/OracleComp/SimSemantics/StateT/Basic.lean
+++ b/VCVio/OracleComp/SimSemantics/StateT/Basic.lean
@@ -27,7 +27,7 @@ namespace QueryImpl
 
 /-- Push an outer oracle interpretation through the base monad of a
 `StateT`-valued query implementation. -/
-noncomputable def mapStateTBase {ι₀ ι₁ : Type _}
+def mapStateTBase {ι₀ ι₁ : Type _}
     {spec₀ : OracleSpec ι₀} {spec₁ : OracleSpec ι₁}
     {m : Type u → Type v} [Monad m] {σ : Type u}
     (outer : QueryImpl spec₁ m)

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,5 +1,6 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
+public import VCVioTest.Computability
 public import VCVioTest.GrindFailFast
 public import VCVioTest.LongChainPrograms
 public import VCVioTest.MerkleTreeBatch

--- a/VCVioTest/Computability.lean
+++ b/VCVioTest/Computability.lean
@@ -1,0 +1,112 @@
+/-
+Copyright (c) 2026 Alexander Hicks. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Alexander Hicks
+-/
+
+module
+public import VCVio
+
+/-!
+# Computability Regression Test
+
+Compile-time lock on the computability of the oracle-simulation and replay-fork pipeline.
+Every declaration below is a plain `def`: the test is that each one elaborates *without*
+`noncomputable`, so code generation succeeds for the whole pipeline. If a refactor
+accidentally makes any ingredient noncomputable (e.g. by routing a program-layer definition
+through `PMF`, `Classical.decEq`, or `Fintype.ofFinite`), this file fails to compile.
+
+The dividing line this file locks is: *programs* (`OracleComp` values, `QueryImpl` handlers,
+`StateT`/`WriterT` simulators, `ProbComp` runs) are computable, while *semantics*
+(`evalDist`, `Pr[⋯]`, `SPMF`, expected costs) remain noncomputable. Executability lets
+library users smoke-test security reductions by actually running them via
+`OracleComp.runIO`, turning "efficient by inspection" into inspection plus execution.
+
+No `#eval` is used: outputs are random, so any runtime assertion would be flaky. The lock
+is compilation itself.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace VCVioTest.Computability
+
+/-! ## Lazy random-oracle simulation pipeline
+
+Locks `unifFwdImpl`, `randomOracle`, and their sum: the standard interpretation of a
+`unifSpec + hashSpec` computation into `StateT QueryCache ProbComp`. -/
+
+/-- The lazy-RO simulation pipeline used throughout the Fiat-Shamir and Fischlin layers. -/
+def roSimPipeline :
+    QueryImpl (unifSpec + (ℕ →ₒ Bool))
+      (StateT ((ℕ →ₒ Bool) : OracleSpec ℕ).QueryCache ProbComp) :=
+  unifFwdImpl (ℕ →ₒ Bool) +
+    (randomOracle : QueryImpl ((ℕ →ₒ Bool) : OracleSpec ℕ) _)
+
+/-- A toy random-oracle computation: query two hash points and combine the answers. -/
+def roToy : OracleComp (unifSpec + (ℕ →ₒ Bool)) Bool := do
+  let b₁ ← (unifSpec + (ℕ →ₒ Bool)).query (Sum.inr 0)
+  let b₂ ← (unifSpec + (ℕ →ₒ Bool)).query (Sum.inr 1)
+  pure (b₁ != b₂)
+
+/-- The toy computation run through the pipeline from the empty cache, as a `ProbComp`. -/
+def roToyProb : ProbComp Bool :=
+  (simulateQ roSimPipeline roToy).run' ∅
+
+/-! ## Replay fork
+
+Locks `contextFork` and `contextForkCollision` on a minimal main computation, plus their
+interpretation down to `ProbComp` (via `uniformSampleImpl`) and `IO` (via `runIO`). -/
+
+/-- A minimal forkable main computation: one focused oracle query. -/
+def toyMain : OracleComp (unifSpec + (Unit →ₒ Bool)) Bool := do
+  let b ← (unifSpec + (Unit →ₒ Bool)).query (Sum.inr ())
+  pure b
+
+/-- Query budget for `toyMain`: one query at the focused index, none elsewhere. -/
+def toyBudget : ℕ ⊕ Unit → ℕ
+  | .inl _ => 0
+  | .inr () => 1
+
+/-- The replay fork of `toyMain` at the focused query. -/
+def toyFork : OracleComp (unifSpec + (Unit →ₒ Bool)) (Option (Bool × Bool)) :=
+  contextFork toyMain toyBudget (Sum.inr ()) (fun b => if b then some 0 else none)
+
+/-- The collision branch of the replay fork on `toyMain`. -/
+def toyForkCollision : OracleComp (unifSpec + (Unit →ₒ Bool)) (Option (Fin 2)) :=
+  contextForkCollision toyMain toyBudget (Sum.inr ())
+    (fun b => if b then some 0 else none) 0
+
+/-- The replay fork interpreted into `ProbComp` by uniform sampling. -/
+def toyForkProb : ProbComp (Option (Bool × Bool)) :=
+  simulateQ (QueryImpl.ofLift unifSpec ProbComp +
+    uniformSampleImpl (spec := ((Unit →ₒ Bool) : OracleSpec Unit))) toyFork
+
+/-- The replay fork as an executable `IO` action. -/
+def toyForkIO : IO (Option (Bool × Bool)) :=
+  OracleComp.runIO toyForkProb
+
+/-! ## Base-monad mapping combinators
+
+Locks `QueryImpl.mapStateTBase` and `QueryImpl.writerTMapBase`, the combinators that push an
+outer interpreter through a stateful or logging handler. -/
+
+/-- A stateful handler over `ProbComp` that records each sampled answer. -/
+def toyTrackingInner : QueryImpl (Unit →ₒ Bool) (StateT (List Bool) ProbComp) :=
+  fun (_ : Unit) => do
+    let b ← liftM ($ᵗ Bool)
+    modifyGet fun log => (b, b :: log)
+
+/-- `toyTrackingInner` with its base `ProbComp` mapped through the identity forwarder. -/
+def toyMappedState : QueryImpl (Unit →ₒ Bool) (StateT (List Bool) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).mapStateTBase toyTrackingInner
+
+/-- A logging handler with its base `ProbComp` mapped through the identity forwarder. -/
+def toyMappedWriter :
+    QueryImpl (Unit →ₒ Bool)
+      (WriterT (QueryLog ((Unit →ₒ Bool) : OracleSpec Unit)) ProbComp) :=
+  (QueryImpl.ofLift unifSpec ProbComp).writerTMapBase
+    (uniformSampleImpl (spec := ((Unit →ₒ Bool) : OracleSpec Unit))).withLogging
+
+end VCVioTest.Computability


### PR DESCRIPTION
## Summary

Makes the oracle-simulation and replay-fork pipeline *executable* by removing `noncomputable` markers that are demonstrably unnecessary, and adds a compile-time regression test that locks the property.

Security reductions built on VCVio — e.g. the rewinding collision reduction in b-wagn/fv-pq-da — are, today, executable programs *except* for inherited `noncomputable` markers. During a review of that project we ran its fork-and-extract reduction end-to-end via `OracleComp.runIO` on a toy instance and observed the expected behavior (fork succeeds ~1/2 of the time at |L|=2, always with distinct resampled challenges). Executability lets library users smoke-test reductions by running them, turning "efficient by inspection" claims into inspection plus execution. Removing a marker is non-breaking for all downstream code.

The dividing line: **programs** (`OracleComp` values, `QueryImpl` handlers, `StateT`/`WriterT` simulators, `ProbComp` runs) become computable; **semantics** (`evalDist`, `Pr[⋯]`, `SPMF`, `ProbCompRuntime`, advantages, expected costs) stay `noncomputable`.

## Changes

**Core pipeline** (the five markers verified removable by re-elaboration probes against `ea9916db`):
- `unifFwdImpl` (`OracleComp/QueryTracking/RandomOracle/Simulation.lean`)
- `contextForkCollisionCont`, `contextForkCollision` (`CryptoFoundations/ReplayFork.lean`) — the surrounding `quantitative` section already carries `[spec.DecidableEq]`, so the `if` condition elaborates with a real decidability instance; no signature change was needed
- `QueryImpl.mapStateTBase` (`OracleComp/SimSemantics/StateT/Basic.lean`)
- `QueryImpl.writerTMapBase` (`OracleComp/QueryTracking/LoggingOracle.lean`)

**Downstream sweep** (markers that existed only because of the above; each file verified with a targeted build):
- FiatShamir: `Sigma/CmaToNma.lean` (7 defs), `Sigma/Stateful/{Games,Bridge,Chain,Compatibility,Hops}.lean` (program/handler defs), `Sigma/Reductions.lean` (`nmaForkExtractBranch`, `nmaForkExtract`, `nmaReduction` — the fork-and-extract reduction itself)
- Fischlin: `Completeness.lean` (`fischlinImpl`, `modelGame`), `KnowledgeSoundness.lean` (`onlineExtract`, `knowledgeSoundnessExp`, `ksVerify`, `ksSample`, `idImplW`, `loggedROW`, `compositeW`, `roImpl`)
- `MacFromPRF.lean` (`macToPRFQueryImpl`, `macToPRFReduction`)
- `Examples/PRGfromPRF.lean` (`idealOutputs`, `seedOutputs`, `seedCollisionExp`, `genCollisionExp`)
- `LatticeCrypto/MLDSA/SecurityNMA.lean` (`roImpl`, `simulateToProbComp`, `mldsaMLWE`, `matrixLift`, `mldsaSTMSIS`, `extractorC`)

**Kept noncomputable** (each for a concrete reason, not conservatism):
- Everything semantics-valued: `runtime`/`runtimeWithCache`, `challengeSpaceInv`, advantages, `completenessError`/`knowledgeSoundnessError`/`slotPsi`/`Phi`/`EP`, `cmaSignEps*`, `nmaGame`/`nmaGameShort` (SPMF), `unforgeableExp*` (SPMF), `avgBadM`/`postStep*M`
- `postKeygenFreshWriterComp`/`postKeygenFreshWriterProb` (Compatibility.lean): bodies use `Classical.decEq`
- `distinguisherB`/`distinguisherBShort` (SecurityNMA.lean): depend on `validKeyPair`/`validKeyPairShort`, which are noncomputable upstream
- `sampleShortVec` and its dependents `keygenShort`/`keygenShort1`/`hrShort`/`mldsaMLWEShort`/`mldsaMatrixMLWE` (SecurityNMA.lean): `Fintype.ofFinite` in the sampler

**Regression test** `VCVioTest/Computability.lean` (new): plain `def`s covering the lazy-RO simulation pipeline (`unifFwdImpl + randomOracle` into `StateT QueryCache ProbComp`), `contextFork`/`contextForkCollision` on a toy main, their interpretation down to `ProbComp` and `IO`, and instantiations of `mapStateTBase`/`writerTMapBase`. Compile-only (outputs are random, so no `#eval` assertion); wired into CI as a `lake env lean` step in `build.yml` alongside the existing per-file test checks.

`noncomputable` on a computable body is legal Lean, so nothing forces markers to be minimal — the regression test is the only durable lock.

## Verification

- Every touched module rebuilt with a targeted `lake build` after each file's edit; full `lake build` passes.
- Zero proof edits, zero signature changes, zero renames: every removed line contained `noncomputable` and every added line is the same line minus the marker (plus the new test file, its umbrella import, and the CI step).

## Follow-ups (out of scope here, from the same review)

- Make `contextFork_eq_contextForkByClassify` (`ReplayFork.lean`, currently `private`) public: fv-pq-da re-proves it locally (`contextFork_eq_filterMap`) and that duplication breaks silently on refactor.
- Adopt fv-pq-da's `probEvent_focusPredicate_ofFreeM_fork_le` as the generalization of `probEvent_focusCollision_ofFreeM_fork_le` (`Constructions/Fork.lean`); the specialization is recovered with `Q x a := (firstAnswer = a)`, `δ := (card (spec.Range i))⁻¹`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
