### PR TITLE
feat(lattice): expose vector and encoding laws

### DIFF
--- a/Extern/MLDSA/Sampling.lean
+++ b/Extern/MLDSA/Sampling.lean
@@ -239,7 +239,7 @@ def sampleInBall (p : Params) (seed : CommitHashBytes p) : Rq :=
   let coeffs : Array Coeff :=
     sampleInBallLoop stream signs ringDegree p.tau (ringDegree - p.tau)
       (Array.replicate ringDegree 0) 8 0
-  Vector.ofFn fun i => coeffs.getD i.val 0
+  LatticeCrypto.Poly.ofPi fun i => coeffs.getD i.val 0
 
 /-! ## Structural output bounds for the rejection samplers
 
@@ -311,7 +311,7 @@ theorem sampleInBall_coeff_mem (p : Params) (seed : CommitHashBytes p) (i : Fin 
     (sampleInBall p seed).get i = 0 ∨ (sampleInBall p seed).get i = 1 ∨
       (sampleInBall p seed).get i = -1 := by
   unfold sampleInBall
-  simp only [Vector.get_ofFn]
+  rw [LatticeCrypto.Poly.get_ofPi]
   apply sampleInBallLoop_mem
   intro j
   left
@@ -471,15 +471,16 @@ private theorem countNZ_replicate_zero : countNZ (Array.replicate ringDegree (0 
 
 /-- The `ℓ₁` norm of a polynomial materialized by `Vector.ofFn` from a defaulted-array lookup is the
 nonzero count of that array. -/
-private theorem l1Norm_ofFn_eq_countNZ (coeffs : Array Coeff) :
-    LatticeCrypto.l1Norm (Vector.ofFn (fun i : Fin ringDegree => coeffs.getD i.val 0))
+private theorem l1Norm_ofPi_eq_countNZ (coeffs : Array Coeff) :
+    LatticeCrypto.l1Norm (LatticeCrypto.Poly.ofPi
+      (fun i : Fin ringDegree => coeffs.getD i.val 0))
       = countNZ coeffs := by
   rw [LatticeCrypto.l1Norm_eq_sum]
   unfold countNZ
   rw [Finset.sum_range (fun j => (LatticeCrypto.centeredRepr (coeffs.getD j 0)).natAbs)]
   apply Finset.sum_congr rfl
   intro i _
-  rw [Vector.get_ofFn]
+  rw [LatticeCrypto.Poly.get_ofPi]
 
 set_option maxRecDepth 4000 in
 /-- The challenge loop, run from the all-zero accumulator over `[ringDegree - τ, ringDegree)`,
@@ -504,7 +505,7 @@ coefficients). This is the count needed for the challenge-product bound `‖c ·
 theorem sampleInBall_l1Norm (p : Params) (seed : CommitHashBytes p) :
     LatticeCrypto.l1Norm (sampleInBall p seed) ≤ p.tau := by
   unfold sampleInBall
-  rw [l1Norm_ofFn_eq_countNZ]
+  rw [l1Norm_ofPi_eq_countNZ]
   exact countNZ_sampleInBallLoop_le _ _ p
 
 /-- After a `push`, the defaulted lookup at any index is either the pushed value or the prior

--- a/LatticeCrypto/MLDSA/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Encoding.lean
@@ -90,6 +90,26 @@ private def unpackNatArray (count width : Nat) (bytes : ByteArray) : Array Nat :
   Array.ofFn fun idx : Fin count =>
     Nat.ofDigits 2 <| List.ofFn fun j : Fin width => bits.getD (idx.val * width + j.val) 0
 
+private theorem bytesToBits_size (bytes : ByteArray) :
+    (bytesToBits bytes).size = bytes.size * 8 := by
+  simp [bytesToBits]
+
+private theorem bytesToBits_getElem (bytes : ByteArray) (i : Nat)
+    (hi : i < (bytesToBits bytes).size) :
+    (bytesToBits bytes)[i]'hi = bitOf (getByteD bytes (i / 8)) (i % 8) := by
+  simp only [bytesToBits, Array.getElem_ofFn]
+
+private theorem unpackNatArray_size (count width : Nat) (bytes : ByteArray) :
+    (unpackNatArray count width bytes).size = count := by
+  simp [unpackNatArray]
+
+private theorem unpackNatArray_getElem (count width : Nat) (bytes : ByteArray) (i : Nat)
+    (hi : i < (unpackNatArray count width bytes).size) :
+    (unpackNatArray count width bytes)[i]'hi =
+      Nat.ofDigits 2 (List.ofFn fun j : Fin width =>
+        (bytesToBits bytes).getD (i * width + j.val) 0) := by
+  simp only [unpackNatArray, Array.getElem_ofFn]
+
 /-- FIPS 204 Algorithm 16 on a single polynomial. -/
 def simpleBitPackPoly (f : Rq) (b : Nat) : ByteArray :=
   let width := simpleWidth b
@@ -137,8 +157,7 @@ private theorem bytesToBits_getD_lt_two (bytes : ByteArray) (i : Nat) :
     (bytesToBits bytes).getD i 0 < 2 := by
   by_cases hi : i < (bytesToBits bytes).size
   · rw [array_getD_eq_getElem (a := bytesToBits bytes) (i := i) (fallback := 0) hi]
-    unfold bytesToBits
-    rw [Array.getElem_ofFn]
+    rw [bytesToBits_getElem]
     exact bitOf_lt_two _ _
   · rw [Array.getD_eq_getD_getElem?, Array.getElem?_eq_none (by omega)]
     norm_num
@@ -149,9 +168,8 @@ private theorem unpackNatArray_getD_lt (count width : Nat) (bytes : ByteArray) (
     (unpackNatArray count width bytes).getD i 0 < 2 ^ width := by
   by_cases hi : i < (unpackNatArray count width bytes).size
   · rw [array_getD_eq_getElem (a := unpackNatArray count width bytes) (i := i) (fallback := 0) hi]
-    unfold unpackNatArray
-    rw [Array.getElem_ofFn]
-    set idx : Fin count := ⟨i, by simpa [unpackNatArray] using hi⟩ with hidx
+    rw [unpackNatArray_getElem]
+    set idx : Fin count := ⟨i, by simpa [unpackNatArray_size] using hi⟩ with hidx
     calc Nat.ofDigits 2 (List.ofFn fun j : Fin width =>
             (bytesToBits bytes).getD (idx.val * width + j.val) 0)
         < 2 ^ (List.ofFn fun j : Fin width =>
@@ -336,8 +354,7 @@ private theorem bytesToBits_bitsToBytes_getD {bits : Array Nat} {i : Nat}
   have hilt : i < (bytesToBits (bitsToBytes bits)).size := by
     simp only [bytesToBits, Array.size_ofFn, hbsize]; omega
   rw [array_getD_eq_getElem (a := bytesToBits (bitsToBytes bits)) 0 hilt]
-  unfold bytesToBits
-  rw [Array.getElem_ofFn]
+  rw [bytesToBits_getElem]
   have hbyte : i / 8 < (bits.size + 7) / 8 := by omega
   have hbit : i % 8 < 8 := Nat.mod_lt _ (by decide)
   have hindex : 8 * (i / 8) + i % 8 = i := by omega

--- a/LatticeCrypto/MLDSA/Concrete/Rounding.lean
+++ b/LatticeCrypto/MLDSA/Concrete/Rounding.lean
@@ -704,8 +704,9 @@ theorem concreteRounding_useHint_bound_of_isApproved (p : Params)
     (hp : p.isApproved) (r : Rq) (h : Hint) :
     cInfNorm (r - highBitsShift p (useHint p h r)) ≤ 2 * p.gamma2 + 1 := by
   refine cInfNorm_le_iff.mpr fun j => ?_
-  simp only [Rq.get_sub, highBitsShift, Nat.cast_mul, Nat.cast_ofNat, useHint, Vector.map_ofFn,
-      Vector.get_ofFn, Function.comp_apply]
+  rw [Rq.get_sub]
+  simp only [highBitsShift, Nat.cast_mul, Nat.cast_ofNat, useHint, Vector.map_ofFn,
+    Vector.get_ofFn, Function.comp_apply]
   simpa using useHintCoeff_shift_sub_le
     (BalancedDecomp.ofApproved hp) (h.get j) (r.get j)
 

--- a/LatticeCrypto/MLDSA/SecurityHVZK.lean
+++ b/LatticeCrypto/MLDSA/SecurityHVZK.lean
@@ -201,7 +201,6 @@ theorem evalDist_honest_pregate (sk : SecretKey p) {γ : Type}
 
 /-! ### Public recovery of the withheld key part `t₀` -/
 
-open Classical in
 /-- Noncomputable recovery of the withheld key part `t₀` from the public key alone: pick any
 seed that key generation maps to `pk` and return its `t₀` (or `0` if `pk` is not honestly
 generated). On valid key pairs this agrees with the actual secret `t₀` exactly under the
@@ -209,9 +208,12 @@ key-generation collision-freeness law `Primitives.Laws.keyVector_t0_determined`
 (`recoverT0_eq`). The HVZK simulator may use it because it is a function of the statement
 only; cryptographically this corresponds to treating the full `t = t₁·2^d + t₀` as public. -/
 noncomputable def recoverT0 (pk : PublicKey p prims) : RqVec p.k :=
-  if h : ∃ seed : Bytes 32, (keyGenFromSeed p prims seed).1 = pk then
-    (keyGenFromSeed p prims (Classical.choose h)).2.t0
-  else 0
+  by
+    letI : Decidable (∃ seed : Bytes 32, (keyGenFromSeed p prims seed).1 = pk) :=
+      Classical.propDecidable _
+    exact if h : ∃ seed : Bytes 32, (keyGenFromSeed p prims seed).1 = pk then
+      (keyGenFromSeed p prims (Classical.choose h)).2.t0
+    else 0
 
 omit [SampleableType (RqVec p.l)] [SampleableType (CommitHashBytes p)]
   [DecidableEq prims.High] in

--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -820,6 +820,10 @@ private theorem byteDecodeVec_byteEncodeVec_of_bound {d k : Nat} (hd : 0 < d) (v
       simp only [Array.getElem_ofFn]
       rw [getByteD_byteEncodeVec (hd := hd) (v := v) (poly := i) (j := j) hi hj]
       rw [getByteD_eq_getElem hjEnc, ByteArray.getElem_eq_getElem_data]
+      exact getElem_congr
+        (c := (byteEncode d (v[i]'hi)).data)
+        (d := (byteEncode d (v[i]'hi)).data)
+        (i := j) (j := j) (by simp) (by simp) hj2
   simp only [byteDecodeVec, Vector.getElem_ofFn]
   rw [hbytes]
   exact byteDecode_byteEncode_of_bound hd (f := v[i]'hi) (hbound := hbound ⟨i, hi⟩)
@@ -915,7 +919,9 @@ private theorem messageToArray_ofByteArray (ba : ByteArray) (hsize : ba.size = 3
   · intro i hi1 hi2
     have hi : i < ba.size := by simpa [hsize] using hi1
     rw [Array.getElem_ofFn]
-    simp [hi, ByteArray.getElem_eq_getElem_data]
+    calc
+      ba[i]! = ba[i]'hi := getElem!_pos ba i hi
+      _ = ba.data[i]'hi2 := ByteArray.getElem_eq_getElem_data
 
 private theorem toArray_byteEncode1Msg (f : Rq) :
     (byteEncode1Msg f).toArray = (byteEncode 1 f).data := by

--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -5,6 +5,7 @@ Authors: Quang Dao
 -/
 
 module
+import Batteries.Data.ByteArray
 import all Mathlib.Data.Nat.Digits.Lemmas
 public import LatticeCrypto.MLKEM.Encoding
 public import Mathlib.Data.List.GetD
@@ -71,13 +72,18 @@ private theorem array_getD_eq_getElem {α : Type} (a : Array α) {i : Nat}
     a.getD i fallback = a[i] := by
   simp [Array.getD, hi]
 
+private theorem array_getD_eq_fallback {α : Type} (a : Array α) {i : Nat}
+    {fallback : α} (hi : ¬i < a.size) :
+    a.getD i fallback = fallback := by
+  simp [Array.getD, hi]
+
 /-- Total byte lookup with zero fallback. -/
 private def getByteD (bytes : ByteArray) (i : Nat) : UInt8 :=
   (bytes[i]?).getD 0
 
 /-- Pack an array of individual bits (0/1 as `Nat`) into bytes, little-endian bit order. -/
 private def bitsToBytes (bits : Array Nat) : ByteArray :=
-  ByteArray.mk <| Array.ofFn fun idx : Fin (bits.size / 8) =>
+  ByteArray.ofFn fun idx : Fin (bits.size / 8) =>
     packByte fun j => bits.getD (8 * idx.val + j.val) 0
 
 /-- Unpack bytes into individual bits, little-endian bit order. -/
@@ -93,8 +99,25 @@ private def bytesToBits (bytes : ByteArray) : Array Nat :=
 
 private theorem bitsToBytes_size (bits : Array Nat) :
     (bitsToBytes bits).size = bits.size / 8 := by
-  have h : (bitsToBytes bits).data.size = bits.size / 8 := by simp [bitsToBytes]
-  simpa [ByteArray.size_data] using h
+  simp [bitsToBytes]
+
+private theorem bitsToBytes_getElem (bits : Array Nat) (i : Nat)
+    (hi : i < (bitsToBytes bits).size) :
+    (bitsToBytes bits)[i]'hi =
+      packByte fun j => bits.getD (8 * i + j.val) 0 := by
+  simp only [bitsToBytes, ByteArray.getElem_ofFn]
+
+private theorem bytesToBits_size (bytes : ByteArray) :
+    (bytesToBits bytes).size = bytes.size * 8 := by
+  simp [bytesToBits]
+
+private theorem bytesToBits_getElem (bytes : ByteArray) (i : Nat)
+    (hi : i < (bytesToBits bytes).size) :
+    (bytesToBits bytes)[i]'hi =
+      bitOf (bytes[i / 8]'(Nat.div_lt_of_lt_mul (by
+        have : i < bytes.size * 8 := by simpa [bytesToBits_size] using hi
+        simpa [Nat.mul_comm] using this))) (i % 8) := by
+  simp only [bytesToBits, Array.getElem_ofFn]
 
 private theorem bytesToBits_bitsToBytes_getElem {bits : Array Nat} {i : Nat}
     (hsize : bits.size % 8 = 0)
@@ -132,24 +155,18 @@ private theorem bytesToBits_bitsToBytes_getElem {bits : Array Nat} {i : Nat}
   have hindex : 8 * byteIdx + bitIdx = i := by
     dsimp [byteIdx, bitIdx]
     simpa [Nat.add_comm] using (Nat.mod_add_div i 8)
-  unfold bytesToBits bitsToBytes
-  rw [Array.getElem_ofFn]
-  simp only
-  rw [ByteArray.getElem_eq_getElem_data]
-  rw [Array.getElem_ofFn]
+  rw [bytesToBits_getElem, bitsToBytes_getElem]
   rw [hpacked, hindex]
   simp [hi]
 
 private theorem bitsToBytes_bytesToBits (bytes : ByteArray) :
     bitsToBytes (bytesToBits bytes) = bytes := by
-  apply ByteArray.ext
-  apply Array.ext
-  · simp [bitsToBytes, bytesToBits, ByteArray.size_data]
+  apply ByteArray.ext_getElem
+  · simp [bitsToBytes, bytesToBits]
   · intro i hi1 hi2
     have hi : i < bytes.size := by
-      simpa [bitsToBytes, bytesToBits, ByteArray.size_data] using hi1
-    unfold bitsToBytes
-    rw [Array.getElem_ofFn]
+      simpa [bitsToBytes, bytesToBits] using hi1
+    rw [bitsToBytes_getElem]
     have hbitsEq :
         (fun j : Fin 8 => (bytesToBits bytes).getD (8 * i + j.val) 0) =
           fun j : Fin 8 => bitOf (bytes[i]'hi) j.val := by
@@ -159,8 +176,7 @@ private theorem bitsToBytes_bytesToBits (bytes : ByteArray) :
           omega
         simpa [bytesToBits, Nat.mul_comm] using this
       rw [array_getD_eq_getElem (a := bytesToBits bytes) (i := 8 * i + j.val) (fallback := 0) hij]
-      unfold bytesToBits
-      rw [Array.getElem_ofFn]
+      rw [bytesToBits_getElem]
       have hdiv : (8 * i + j.val) / 8 = i := by
         calc
           (8 * i + j.val) / 8 = (j.val + i * 8) / 8 := by ac_rfl
@@ -177,15 +193,13 @@ private theorem bitsToBytes_bytesToBits (bytes : ByteArray) :
           packByte (fun j => bitOf (bytes[i]'hi) j.val) := by
       simpa using congrArg packByte hbitsEq
     rw [hpack, packByte_bitOf_byte]
-    rw [ByteArray.getElem_eq_getElem_data]
-    rfl
 
 private theorem bytesToBits_getD_lt_two (bytes : ByteArray) (i : Nat) :
     (bytesToBits bytes).getD i 0 < 2 := by
   by_cases hi : i < (bytesToBits bytes).size
   · rw [array_getD_eq_getElem (a := bytesToBits bytes) (i := i) (fallback := 0) hi]
-    unfold bytesToBits
-    rw [Array.getElem_ofFn]
+    have hi' : i < bytes.size * 8 := by simpa [bytesToBits_size] using hi
+    rw [bytesToBits_getElem bytes i hi]
     let byteIdx := i / 8
     let bitIdx := i % 8
     have hbit : bitIdx < 8 := by
@@ -194,10 +208,11 @@ private theorem bytesToBits_getD_lt_two (bytes : ByteArray) (i : Nat) :
     simpa [byteIdx, bitIdx] using
       bitOf_lt_two_fin (b := bytes[byteIdx]'(by
         dsimp [byteIdx]
-        have : i < 8 * bytes.size := by simpa [bytesToBits, Nat.mul_comm] using hi
+        have : i < 8 * bytes.size := by simpa [Nat.mul_comm] using hi'
         exact Nat.div_lt_of_lt_mul this))
         (j := ⟨bitIdx, hbit⟩)
-  · simp [Array.getD, hi]
+  · rw [array_getD_eq_fallback (bytesToBits bytes) hi]
+    decide
 
 private theorem ofDigits_digitsAppend_two {d n : Nat} (hn : n < 2 ^ d) :
     Nat.ofDigits 2 (Nat.digitsAppend 2 d n) = n := by
@@ -577,7 +592,6 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
         (getByteD (byteEncode12Poly f) (3 * pair)).toNat = a % 256 := by
       rw [getByteD_byteEncode12Poly (f := f) (j := 3 * pair) (by omega)]
       simp [byteEncode12PolyByte, a, hdiv0, hmod0]
-      rfl
     have hb1 :
         (getByteD (byteEncode12Poly f) (3 * pair + 1)).toNat = a / 256 + 16 * (b % 16) := by
       have hab' :
@@ -609,7 +623,6 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
               apply Fin.ext
               exact hidx
             simp [hidx', a]
-            rfl
     · have hmod : idx.val % 2 = 1 := by
         have hlt : idx.val % 2 < 2 := Nat.mod_lt _ (by decide)
         omega
@@ -628,7 +641,6 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
               apply Fin.ext
               exact hidx
             simp [hidx', b]
-            rfl
   apply LatticeCrypto.TransformPoly.ext
   apply Vector.toArray_inj.mp
   unfold byteDecode12Poly
@@ -648,10 +660,10 @@ private theorem byteDecode12Poly_byteEncode12Poly (f : Tq) :
             congrArg Array.ofFn hfun
     _ = f.coeffs.toArray := by
       apply Array.ext
-      · simp
+      · exact Array.size_ofFn.trans (Vector.size_toArray f.coeffs).symm
       · intro i hi1 hi2
         rw [Array.getElem_ofFn]
-        rfl
+        exact (Vector.getElem_toArray hi2).symm
 
 private theorem getByteD_byteEncode12Vec_eq_byteEncode12Poly
     {k : Nat} (v : TqVec k) {poly j : Nat} (hpoly : poly < k) (hj : j < 384) :
@@ -808,7 +820,6 @@ private theorem byteDecodeVec_byteEncodeVec_of_bound {d k : Nat} (hd : 0 < d) (v
       simp only [Array.getElem_ofFn]
       rw [getByteD_byteEncodeVec (hd := hd) (v := v) (poly := i) (j := j) hi hj]
       rw [getByteD_eq_getElem hjEnc, ByteArray.getElem_eq_getElem_data]
-      rfl
   simp only [byteDecodeVec, Vector.getElem_ofFn]
   rw [hbytes]
   exact byteDecode_byteEncode_of_bound hd (f := v[i]'hi) (hbound := hbound ⟨i, hi⟩)
@@ -905,7 +916,6 @@ private theorem messageToArray_ofByteArray (ba : ByteArray) (hsize : ba.size = 3
     have hi : i < ba.size := by simpa [hsize] using hi1
     rw [Array.getElem_ofFn]
     simp [hi, ByteArray.getElem_eq_getElem_data]
-    rfl
 
 private theorem toArray_byteEncode1Msg (f : Rq) :
     (byteEncode1Msg f).toArray = (byteEncode 1 f).data := by

--- a/LatticeCrypto/MLKEM/Concrete/Encoding.lean
+++ b/LatticeCrypto/MLKEM/Concrete/Encoding.lean
@@ -818,12 +818,13 @@ private theorem byteDecodeVec_byteEncodeVec_of_bound {d k : Nat} (hd : 0 < d) (v
       have hjEnc : j < (byteEncode d (v[i]'hi)).size := by
         simpa [byteEncode_size] using hj
       simp only [Array.getElem_ofFn]
-      rw [getByteD_byteEncodeVec (hd := hd) (v := v) (poly := i) (j := j) hi hj]
-      rw [getByteD_eq_getElem hjEnc, ByteArray.getElem_eq_getElem_data]
-      exact getElem_congr
-        (c := (byteEncode d (v[i]'hi)).data)
-        (d := (byteEncode d (v[i]'hi)).data)
-        (i := j) (j := j) (by simp) (by simp) hj2
+      calc
+        getByteD (byteEncodeVec d v) (i * (32 * d) + j) =
+            getByteD (byteEncode d (v[i]'hi)) j :=
+          getByteD_byteEncodeVec (hd := hd) (v := v) (poly := i) (j := j) hi hj
+        _ = (byteEncode d (v[i]'hi))[j]'hjEnc := getByteD_eq_getElem hjEnc
+        _ = (byteEncode d (v[i]'hi)).data[j]'hj2 :=
+          ByteArray.getElem_eq_getElem_data
   simp only [byteDecodeVec, Vector.getElem_ofFn]
   rw [hbytes]
   exact byteDecode_byteEncode_of_bound hd (f := v[i]'hi) (hbound := hbound ⟨i, hi⟩)

--- a/LatticeCrypto/Ring/Core.lean
+++ b/LatticeCrypto/Ring/Core.lean
@@ -46,7 +46,7 @@ variable {P : Type u} {k : Nat}
 
 /-- View a vector as a `Fin k → P` function. -/
 def toPi (v : PolyVec P k) : Fin k → P :=
-  fun i => v.get i
+  fun i => v[i.1]
 
 /-- Build a vector from a `Fin k → P` function. -/
 def ofPi (f : Fin k → P) : PolyVec P k :=
@@ -55,13 +55,13 @@ def ofPi (f : Fin k → P) : PolyVec P k :=
 @[simp] theorem toPi_ofPi (f : Fin k → P) :
     toPi (ofPi f) = f := by
   funext i
-  simp [toPi, ofPi, Vector.get]
+  simp [toPi, ofPi]
 
 @[simp] theorem ofPi_toPi (v : PolyVec P k) :
     ofPi (toPi v) = v := by
   apply Vector.ext
   intro i hi
-  simp [toPi, ofPi, Vector.get]
+  simp [toPi, ofPi]
 
 end PolyVec
 
@@ -71,7 +71,7 @@ variable {P : Type u} {rows cols : Nat}
 
 /-- View a row-major matrix as a Mathlib `Matrix`. -/
 def toMatrix (A : PolyMatrix P rows cols) : Matrix (Fin rows) (Fin cols) P :=
-  fun i j => (A.get i).get j
+  fun i j => A[i.1][j.1]
 
 /-- Build a row-major matrix from a Mathlib `Matrix`. -/
 def ofMatrix (A : Matrix (Fin rows) (Fin cols) P) : PolyMatrix P rows cols :=
@@ -80,7 +80,7 @@ def ofMatrix (A : Matrix (Fin rows) (Fin cols) P) : PolyMatrix P rows cols :=
 @[simp] theorem toMatrix_ofMatrix (A : Matrix (Fin rows) (Fin cols) P) :
     toMatrix (ofMatrix A) = A := by
   funext i j
-  simp [toMatrix, ofMatrix, Vector.get]
+  simp [toMatrix, ofMatrix]
 
 @[simp] theorem ofMatrix_toMatrix (A : PolyMatrix P rows cols) :
     ofMatrix (toMatrix A) = A := by
@@ -88,7 +88,7 @@ def ofMatrix (A : Matrix (Fin rows) (Fin cols) P) : PolyMatrix P rows cols :=
   intro i hi
   apply Vector.ext
   intro j hj
-  simp [toMatrix, ofMatrix, Vector.get]
+  simp [ofMatrix, toMatrix]
 
 end PolyMatrix
 

--- a/LatticeCrypto/Ring/Norms.lean
+++ b/LatticeCrypto/Ring/Norms.lean
@@ -344,11 +344,8 @@ omit [NeZero q] in
 component coefficient functions. -/
 private theorem mul_get_eq_convCoeff (f g : (vectorNegacyclicRing (ZMod q) n).Poly) (i : Fin n) :
     (f * g).get i = negacyclicConvCoeff f.get g.get i := by
-  have h1 : (f * g) = (vectorNegacyclicRing (ZMod q) n).mul f g := rfl
-  rw [h1, vectorNegacyclicRing_mul]
-  have h2 : (negacyclicMulPure (vectorKernel (ZMod q) n) f g).get i
-      = (vectorBackend (ZMod q) n).coeff (negacyclicMulPure (vectorKernel (ZMod q) n) f g) i := rfl
-  rw [h2, negacyclicMulPure_coeff]; rfl
+  rw [vectorRing_mul_apply]
+  exact vectorKernel_mul_get f g i
 
 /-- **Negacyclic-convolution infinity-norm bound.** For coefficient-domain polynomials in
 `ℤ_q[X] / (X^n + 1)`, the centered `ℓ∞` norm of the product is bounded by the `ℓ₁` norm of the

--- a/LatticeCrypto/Ring/SchoolbookCert.lean
+++ b/LatticeCrypto/Ring/SchoolbookCert.lean
@@ -211,11 +211,7 @@ private theorem vectorNegacyclicSemantics_one_sound
         (vectorNegacyclicRing Coeff n).one = 1 := by
   simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial,
              PolyBackend.toPolynomial]
-  have hcoeff : ∀ i : Fin n, (vectorBackend Coeff n).coeff (vectorNegacyclicRing Coeff n).one i =
-      if i.val = 0 then 1 else 0 := fun i => by
-    change (vectorNegacyclicRing Coeff n).one.get i = if i.val = 0 then 1 else 0
-    simp [vectorNegacyclicRing, Vector.get, Array.getElem_ofFn]
-  simp only [hcoeff, map_sum]
+  simp only [map_sum]
   rw [Finset.sum_eq_single_of_mem ⟨0, hn⟩ (Finset.mem_univ _)]
   · simp [Polynomial.monomial_zero_left, map_one]
   · intro ⟨j, hj⟩ _ hne
@@ -233,28 +229,24 @@ noncomputable def vectorNegacyclicSemantics (Coeff : Type*) [CommRing Coeff]
   quotientOf := NegacyclicQuotient.ofBackend (vectorBackend Coeff n)
   zero_sound := by
     unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
-    simp [vectorBackend_coeff, Finset.sum_const_zero, map_zero]
-    rfl
+    simp [Finset.sum_const_zero, map_zero]
   one_sound := by exact vectorNegacyclicSemantics_one_sound Coeff hn
   add_sound f g := by
     have hpoly : (vectorBackend Coeff n).toPolynomial ((vectorNegacyclicRing Coeff n).add f g) =
         (vectorBackend Coeff n).toPolynomial f + (vectorBackend Coeff n).toPolynomial g := by
-      simp [PolyBackend.toPolynomial, vectorNegacyclicRing, vectorBackend,
-            Vector.get, Finset.sum_add_distrib]
+      simp [PolyBackend.toPolynomial, vectorRing_add_get, Finset.sum_add_distrib]
     simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial, hpoly]
     exact map_add (Ideal.Quotient.mk _) _ _
   sub_sound f g := by
     have hpoly : (vectorBackend Coeff n).toPolynomial ((vectorNegacyclicRing Coeff n).sub f g) =
         (vectorBackend Coeff n).toPolynomial f - (vectorBackend Coeff n).toPolynomial g := by
-      simp [PolyBackend.toPolynomial, vectorNegacyclicRing, vectorBackend,
-            Vector.get, map_sub, Finset.sum_sub_distrib]
+      simp [PolyBackend.toPolynomial, vectorRing_sub_get, map_sub, Finset.sum_sub_distrib]
     simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial, hpoly]
     exact map_sub (Ideal.Quotient.mk _) _ _
   neg_sound f := by
     have hpoly : (vectorBackend Coeff n).toPolynomial ((vectorNegacyclicRing Coeff n).neg f) =
         -(vectorBackend Coeff n).toPolynomial f := by
-      simp [PolyBackend.toPolynomial, vectorNegacyclicRing, vectorBackend,
-            Vector.get, map_neg, Finset.sum_neg_distrib]
+      simp [PolyBackend.toPolynomial, vectorRing_neg_get, map_neg, Finset.sum_neg_distrib]
     simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial, hpoly]
     exact map_neg (Ideal.Quotient.mk _) _
   mul_sound f g := negacyclicMulPure_sound (vectorBackend Coeff n) (vectorKernel Coeff n) f g

--- a/LatticeCrypto/Ring/Smoke.lean
+++ b/LatticeCrypto/Ring/Smoke.lean
@@ -33,7 +33,7 @@ namespace LatticeCrypto
 namespace Smoke
 
 /-- Function-backed alternative `PolyBackend` using `Fin n → Coeff` as carrier. -/
-def piBackend (Coeff : Type*) (n : Nat) : PolyBackend Coeff where
+abbrev piBackend (Coeff : Type*) (n : Nat) : PolyBackend Coeff where
   Poly := Fin n → Coeff
   degree := n
   coeff := fun p i => p i
@@ -52,7 +52,7 @@ def piKernel (Coeff : Type*) [Zero Coeff] (n : Nat) :
   ofArray := fun a i => a.getD i.val 0
   toArray_size := by
     intro p
-    simp [piBackend]
+    exact Array.size_ofFn
   coeff_ofArray := by
     intro a h i
     have hi : i.val < a.size := Nat.lt_of_lt_of_eq i.isLt h.symm
@@ -60,10 +60,11 @@ def piKernel (Coeff : Type*) [Zero Coeff] (n : Nat) :
   ofArray_toArray := by
     intro p
     funext i
-    simp
+    rw [Array.getD_eq_getD_getElem?, Array.getElem?_ofFn]
+    rw [dif_pos i.isLt, Option.getD_some]
 
 /-- Bundled negacyclic ring over the function-backed backend. -/
-def piRing (Coeff : Type*) [CommRing Coeff] (n : Nat) :
+abbrev piRing (Coeff : Type*) [CommRing Coeff] (n : Nat) :
     NegacyclicRing Coeff where
   backend := piBackend Coeff n
   kernel := piKernel Coeff n
@@ -86,34 +87,33 @@ noncomputable def piSemantics (Coeff : Type*) [CommRing Coeff] {n : Nat} (hn : 0
   zero_sound := by
     unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
     simp [piBackend, piRing, Finset.sum_const_zero, map_zero]
-    rfl
   one_sound := by
     simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial,
                PolyBackend.toPolynomial]
-    have hcoeff : ∀ i : Fin n, (piBackend Coeff n).coeff (piRing Coeff n).one i =
-        if i.val = 0 then 1 else 0 := fun i => by simp [piBackend, piRing]
-    simp only [hcoeff, map_sum]
+    simp only [map_sum]
     rw [Finset.sum_eq_single_of_mem ⟨0, hn⟩ (Finset.mem_univ _)]
-    · simp only [Polynomial.monomial_zero_left]
-      exact map_one _
+    · simp [Polynomial.monomial_zero_left, map_one]
     · intro ⟨j, _⟩ _ hne
       simp only [Fin.mk.injEq, ne_eq] at hne
       simp [hne, map_zero]
-  add_sound := by
-    intro f g
-    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
-    simp only [piBackend, piRing, Finset.sum_add_distrib, map_add]
-    rfl
-  sub_sound := by
-    intro f g
-    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
-    simp only [piBackend, piRing, Finset.sum_sub_distrib, map_sub]
-    rfl
-  neg_sound := by
-    intro f
-    unfold NegacyclicQuotient.ofBackend NegacyclicQuotient.ofPolynomial PolyBackend.toPolynomial
-    simp only [piBackend, piRing, Finset.sum_neg_distrib, map_neg]
-    rfl
+  add_sound f g := by
+    have hpoly : (piBackend Coeff n).toPolynomial ((piRing Coeff n).add f g) =
+        (piBackend Coeff n).toPolynomial f + (piBackend Coeff n).toPolynomial g := by
+      simp [PolyBackend.toPolynomial, piBackend, Finset.sum_add_distrib]
+    simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial, hpoly]
+    exact map_add (Ideal.Quotient.mk _) _ _
+  sub_sound f g := by
+    have hpoly : (piBackend Coeff n).toPolynomial ((piRing Coeff n).sub f g) =
+        (piBackend Coeff n).toPolynomial f - (piBackend Coeff n).toPolynomial g := by
+      simp [PolyBackend.toPolynomial, piBackend, Finset.sum_sub_distrib]
+    simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial, hpoly]
+    exact map_sub (Ideal.Quotient.mk _) _ _
+  neg_sound f := by
+    have hpoly : (piBackend Coeff n).toPolynomial ((piRing Coeff n).neg f) =
+        -(piBackend Coeff n).toPolynomial f := by
+      simp [PolyBackend.toPolynomial, piBackend, Finset.sum_neg_distrib]
+    simp only [NegacyclicQuotient.ofBackend, NegacyclicQuotient.ofPolynomial, hpoly]
+    exact map_neg (Ideal.Quotient.mk _) _
   mul_sound := by
     intro f g
     exact negacyclicMulPure_sound (piBackend Coeff n) (piKernel Coeff n) f g
@@ -128,7 +128,7 @@ noncomputable def piQuotientRoundtrip {n : Nat} (hn : 0 < n) (f : (piRing (ZMod 
     NegacyclicRingSemantics.Quotient (piSemantics (ZMod 17) hn) :=
   (piSemantics (ZMod 17) hn).quotientOf f
 
-def piNegacyclicRoundtrip (n : Nat) (f g : (piRing (ZMod 17) n).Poly) :
+noncomputable def piNegacyclicRoundtrip (n : Nat) (f g : (piRing (ZMod 17) n).Poly) :
     (piRing (ZMod 17) n).Poly :=
   (piRing (ZMod 17) n).mul f g
 

--- a/LatticeCrypto/Ring/VectorBackend.lean
+++ b/LatticeCrypto/Ring/VectorBackend.lean
@@ -55,10 +55,23 @@ def toPi (p : Poly Coeff n) : Fin n → Coeff :=
 def ofPi (f : Fin n → Coeff) : Poly Coeff n :=
   Vector.ofFn f
 
+@[simp] theorem get_ofPi (f : Fin n → Coeff) (i : Fin n) :
+    (ofPi f).get i = f i := by
+  change (Vector.ofFn f)[i.val] = f i
+  rw [Vector.getElem_ofFn]
+
+/-- `Vector.get` after `Vector.ofFn`, stated at the concrete carrier boundary.
+Lean's core `ofFn` API is phrased using `GetElem`; this bridge keeps proof casts
+out of users of the polynomial representation. -/
+@[simp] theorem get_vectorOfFn (f : Fin n → Coeff) (i : Fin n) :
+    (Vector.ofFn f).get i = f i := by
+  change (Vector.ofFn f)[i.val] = f i
+  rw [Vector.getElem_ofFn]
+
 @[simp] theorem toPi_ofPi (f : Fin n → Coeff) :
     toPi (ofPi f) = f := by
   funext i
-  simp [toPi, ofPi, Vector.get]
+  exact get_ofPi f i
 
 /-- Pointwise extensionality for `Poly`: two vector-backed polynomials with
 equal `Fin`-indexed entries are equal. Bridges core `Vector.ext` (stated in
@@ -69,7 +82,19 @@ theorem ext_get_eq {p q : Poly Coeff n}
 
 @[simp] theorem ofPi_toPi (p : Poly Coeff n) :
     ofPi (toPi p) = p :=
-  ext_get_eq fun i => by simp [toPi, ofPi, Vector.get]
+  ext_get_eq fun i => get_ofPi (toPi p) i
+
+/-- Reading a pointwise combination reads the corresponding entries. This is the
+`Fin`-indexed boundary lemma used by the concrete ring operations. -/
+@[simp] theorem get_zipWith (f : Coeff → Coeff → Coeff) (p q : Poly Coeff n)
+    (i : Fin n) : (Vector.zipWith f p q).get i = f (p.get i) (q.get i) := by
+  exact Vector.getElem_zipWith (f := f) (as := (show Vector Coeff n from p))
+    (bs := (show Vector Coeff n from q)) i.isLt
+
+/-- Reading a mapped polynomial reads and maps the corresponding entry. -/
+@[simp] theorem get_map (f : Coeff → Coeff) (p : Poly Coeff n) (i : Fin n) :
+    (Vector.map f p).get i = f (p.get i) := by
+  exact Vector.getElem_map (xs := (show Vector Coeff n from p)) f i.isLt
 
 end Poly
 
@@ -102,18 +127,28 @@ instance [Inhabited Coeff] : Inhabited (Poly Coeff n) :=
 instance [Repr Coeff] : Repr (Poly Coeff n) :=
   inferInstanceAs (Repr (Vector Coeff n))
 
-/-- The canonical vector-backed semantic backend. -/
-def vectorBackend (Coeff : Type u) (n : Nat) : PolyBackend Coeff where
+@[simp] theorem Poly.get_add [Add Coeff] (f g : Poly Coeff n) (i : Fin n) :
+    (f + g).get i = f.get i + g.get i := by
+  exact Vector.getElem_add f g i.val i.isLt
+
+@[simp] theorem Poly.get_sub [Sub Coeff] (f g : Poly Coeff n) (i : Fin n) :
+    (f - g).get i = f.get i - g.get i := by
+  exact Vector.getElem_sub f g i.val i.isLt
+
+/-- The canonical vector-backed semantic backend. Its carrier projection is used in
+dependent types throughout the lattice layer, so that projection remains available
+to implicit elaboration while the backend operations stay behind named laws. -/
+abbrev vectorBackend (Coeff : Type u) (n : Nat) : PolyBackend Coeff where
   Poly := Poly Coeff n
   degree := n
   coeff := fun p i => p.get i
   build := Vector.ofFn
   coeff_build := by
     intro f i
-    simp [Vector.get]
+    exact Poly.get_ofPi f i
   build_coeff := by
     intro p
-    exact Poly.ext_get_eq fun _ => by simp [Vector.get]
+    exact Poly.ofPi_toPi p
 
 /-- The canonical vector/array executable kernel. -/
 def vectorKernel (Coeff : Type u) [Zero Coeff] (n : Nat) :
@@ -124,15 +159,29 @@ def vectorKernel (Coeff : Type u) [Zero Coeff] (n : Nat) :
     intro p
     exact p.size_toArray
   coeff_ofArray := by
+    simp only [vectorBackend]
     intro a h i
     have hi : i.val < a.size := Nat.lt_of_lt_of_eq i.isLt h.symm
-    simp [vectorBackend, hi, Vector.get]
+    rw [Poly.get_vectorOfFn]
+    simp [hi]
   ofArray_toArray := by
+    simp only [vectorBackend]
     intro p
-    exact Poly.ext_get_eq fun _ => by simp
+    exact Poly.ext_get_eq fun i => by
+      rw [Poly.get_vectorOfFn]
+      have hi : i.val < ((p : Vector Coeff n)).toArray.size := by
+        exact Nat.lt_of_lt_of_eq i.isLt
+          (Vector.size_toArray (show Vector Coeff n from p)).symm
+      rw [Array.getD_eq_getD_getElem?, Array.getD_getElem?]
+      split
+      · exact Vector.getElem_toArray (xs := (show Vector Coeff n from p))
+          hi
+      · rename_i h
+        exact (h hi).elim
 
-/-- The canonical bundled negacyclic ring over the vector backend. -/
-def vectorNegacyclicRing (Coeff : Type u) [CommRing Coeff] (n : Nat) :
+/-- The canonical bundled negacyclic ring over the vector backend. Its carrier and degree
+projections occur in dependent client types, so they remain available to implicit elaboration. -/
+@[implicit_reducible] def vectorNegacyclicRing (Coeff : Type u) [CommRing Coeff] (n : Nat) :
     NegacyclicRing Coeff where
   backend := vectorBackend Coeff n
   kernel := vectorKernel Coeff n
@@ -142,12 +191,12 @@ def vectorNegacyclicRing (Coeff : Type u) [CommRing Coeff] (n : Nat) :
   sub := Vector.zipWith (· - ·)
   neg := Vector.map Neg.neg
   mul := negacyclicMulPure (vectorKernel Coeff n)
-  add_coeff f g i := by simp [vectorBackend, Vector.get]
-  sub_coeff f g i := by simp [vectorBackend, Vector.get]
-  neg_coeff f i   := by simp [vectorBackend, Vector.get]
+  add_coeff f g i := Poly.get_zipWith (· + ·) f g i
+  sub_coeff f g i := Poly.get_zipWith (· - ·) f g i
+  neg_coeff f i   := Poly.get_map Neg.neg f i
   zero_coeff i    := by
-    change (0 : Vector Coeff n).get i = 0
-    simp [Vector.get]
+    change (0 : Vector Coeff n)[i.val] = 0
+    exact Vector.getElem_zero i.val i.isLt
 
 section VectorRingSimp
 
@@ -162,16 +211,19 @@ omit [CommRing Coeff] in
 
 omit [CommRing Coeff] in
 @[simp] theorem Poly.get_zero [Zero Coeff] (i : Fin n) : (0 : Poly Coeff n).get i = 0 := by
-  change (0 : Vector Coeff n).get i = 0
-  simp [Vector.get]
+  change (0 : Vector Coeff n)[i.val] = 0
+  exact Vector.getElem_zero i.val i.isLt
 
 @[simp] theorem vectorRing_zero :
     (vectorNegacyclicRing Coeff n).zero = (0 : Poly Coeff n) := rfl
 
 @[simp] theorem vectorRing_zero_get (i : Fin n) :
     ((vectorNegacyclicRing Coeff n).zero).get i = (0 : Coeff) := by
-  change (0 : Vector Coeff n).get i = 0
-  simp [Vector.get]
+  exact Poly.get_zero i
+
+@[simp] theorem vectorRing_one_get (i : Fin n) :
+    ((vectorNegacyclicRing Coeff n).one).get i = if i.val = 0 then 1 else 0 := by
+  exact Poly.get_vectorOfFn (fun i : Fin n => if i.val = 0 then 1 else 0) i
 
 @[simp] theorem vectorNegacyclicRing_mul :
     (vectorNegacyclicRing Coeff n).mul = negacyclicMulPure (vectorKernel Coeff n) := rfl
@@ -179,14 +231,22 @@ omit [CommRing Coeff] in
 @[simp] theorem vectorNegacyclicRing_backend :
     (vectorNegacyclicRing Coeff n).backend = vectorBackend Coeff n := rfl
 
+@[simp] theorem vectorRing_mul_apply (f g : (vectorNegacyclicRing Coeff n).Poly) :
+    f * g = negacyclicMulPure (vectorKernel Coeff n) f g := rfl
+
+/-- Concrete `Vector.get` form of the pure negacyclic multiplication law. -/
+@[simp] theorem vectorKernel_mul_get (f g : Poly Coeff n) (i : Fin n) :
+    (negacyclicMulPure (vectorKernel Coeff n) f g).get i =
+      negacyclicConvCoeff f.get g.get i := by
+  exact negacyclicMulPure_coeff (vectorKernel Coeff n) f g i
+
 /-- Coefficient of a sum through the concrete vector backend (`Vector.instAdd`).
 Paired with `vectorNegacyclicRing_backend` so that both variants of `+` on
 `Poly Coeff n` are handled after the backend is normalised. -/
 @[simp] theorem vectorBackend_add_coeff (f g : Poly Coeff n) (i : Fin n) :
     (vectorBackend Coeff n).coeff (f + g) i =
       (vectorBackend Coeff n).coeff f i + (vectorBackend Coeff n).coeff g i := by
-  simp only [vectorBackend_coeff]
-  exact Vector.getElem_add f g i.val i.isLt
+  exact Poly.get_add f g i
 
 /-- Coefficient of a ring-`+` sum through the vector backend, where `+` comes from
 `NegacyclicRing.instAddPoly`. Fires in downstream files where the carrier is spelled
@@ -199,34 +259,38 @@ as `(vectorNegacyclicRing ...).Poly` rather than `Poly Coeff n`. -/
 
 theorem vectorRing_mul_add_right (f g h : Poly Coeff n) :
     (vRing Coeff n).mul f (g + h) = (vRing Coeff n).mul f g + (vRing Coeff n).mul f h := by
-  apply PolyBackend.ext_coeff; intro k
-  -- Split the outer ring addition first, before vectorNegacyclicRing_backend fires.
-  simp only [NegacyclicRing.coeff_add]
-  simp only [vectorNegacyclicRing_mul, vectorNegacyclicRing_backend,
-             vectorBackend_add_coeff, negacyclicMulPure_coeff, negacyclicConvCoeff]
+  apply Poly.ext_get_eq
+  intro k
+  change (negacyclicMulPure (vectorKernel Coeff n) f (g + h)).get k =
+    (negacyclicMulPure (vectorKernel Coeff n) f g +
+      negacyclicMulPure (vectorKernel Coeff n) f h).get k
+  simp only [vectorKernel_mul_get, Poly.get_add, negacyclicConvCoeff]
   rw [← Finset.sum_add_distrib]; congr 1; ext ij
   split_ifs <;> ring
 
 @[simp] theorem vectorBackend_sub_coeff (f g : Poly Coeff n) (i : Fin n) :
     (vectorBackend Coeff n).coeff (f - g) i =
       (vectorBackend Coeff n).coeff f i - (vectorBackend Coeff n).coeff g i := by
-  simp only [vectorBackend_coeff]
-  exact Vector.getElem_sub f g i.val i.isLt
+  exact Poly.get_sub f g i
 
 theorem vectorRing_mul_sub_right (f g h : Poly Coeff n) :
     (vRing Coeff n).mul f (g - h) = (vRing Coeff n).mul f g - (vRing Coeff n).mul f h := by
-  apply PolyBackend.ext_coeff; intro k
-  simp only [NegacyclicRing.coeff_sub]
-  simp only [vectorNegacyclicRing_mul, vectorNegacyclicRing_backend,
-             vectorBackend_sub_coeff, negacyclicMulPure_coeff, negacyclicConvCoeff]
+  apply Poly.ext_get_eq
+  intro k
+  change (negacyclicMulPure (vectorKernel Coeff n) f (g - h)).get k =
+    (negacyclicMulPure (vectorKernel Coeff n) f g -
+      negacyclicMulPure (vectorKernel Coeff n) f h).get k
+  simp only [vectorKernel_mul_get, Poly.get_sub, negacyclicConvCoeff]
   rw [← Finset.sum_sub_distrib]; congr 1; ext ij
   split_ifs <;> ring
 
 theorem vectorRing_mul_comm (f g : Poly Coeff n) :
     (vRing Coeff n).mul f g = (vRing Coeff n).mul g f := by
-  apply PolyBackend.ext_coeff; intro k
-  simp only [vectorNegacyclicRing_mul, vectorNegacyclicRing_backend,
-             negacyclicMulPure_coeff, negacyclicConvCoeff]
+  apply Poly.ext_get_eq
+  intro k
+  change (negacyclicMulPure (vectorKernel Coeff n) f g).get k =
+    (negacyclicMulPure (vectorKernel Coeff n) g f).get k
+  simp only [vectorKernel_mul_get, negacyclicConvCoeff]
   let bn := vectorBackend Coeff n
   let n' := bn.degree
   let ff := fun (a b : Fin n') (f g: Poly Coeff n) => if (a.val + b.val) % n = k.val then
@@ -244,27 +308,22 @@ theorem vectorRing_mul_comm (f g : Poly Coeff n) :
 
 @[simp] theorem vectorRing_add_get (f g : Poly Coeff n) (i : Fin n) :
     ((vectorNegacyclicRing Coeff n).add f g).get i = f.get i + g.get i := by
-  change (Vector.zipWith (· + ·) f g)[i] = f[i] + g[i]
-  simp only [Fin.getElem_fin, Vector.getElem_zipWith]
-  rfl
+  exact Poly.get_zipWith (· + ·) f g i
 
 @[simp] theorem vectorRing_sub_get (f g : Poly Coeff n) (i : Fin n) :
     ((vectorNegacyclicRing Coeff n).sub f g).get i = f.get i - g.get i := by
-  change (Vector.zipWith (· - ·) f g)[i] = f[i] - g[i]
-  simp only [Fin.getElem_fin, Vector.getElem_zipWith]
-  rfl
+  exact Poly.get_zipWith (· - ·) f g i
 
 @[simp] theorem vectorRing_neg_get (f : Poly Coeff n) (i : Fin n) :
     ((vectorNegacyclicRing Coeff n).neg f).get i = -f.get i := by
-  change (Vector.map Neg.neg f)[i] = Neg.neg f[i]
-  simp [Fin.getElem_fin, Vector.getElem_map]
-  rfl
+  exact Poly.get_map Neg.neg f i
 
 omit [CommRing Coeff] in
 /-- Coefficient-wise negation lemma for abstract `Poly` (not tied to a specific ring). -/
 @[simp] theorem Poly.get_neg [Neg Coeff] (f : Poly Coeff n) (i : Fin n) :
-    (-f).get i = -f.get i :=
-  Vector.getElem_map (xs := (f : Vector Coeff n)) (- ·) i.isLt
+    (-f).get i = -f.get i := by
+  change (-(f : Vector Coeff n))[i.val] = -((f : Vector Coeff n))[i.val]
+  exact Vector.getElem_neg f i.val i.isLt
 
 end VectorRingSimp
 


### PR DESCRIPTION
## Summary

- expose stable carrier/get/map/zip/add/sub laws for the lattice vector backend
- name the vector-backed negacyclic multiplication law used by concrete schemes
- expose ML-KEM/ML-DSA encoding size and element laws
- migrate adjacent ring, norm, schoolbook, rounding, and encoding proofs to those laws
- express ML-KEM byte-array extensionality through explicit lookup equalities, compatible with Lean 4.32 and 4.33

## Motivation

The current lattice backend works well computationally but downstream proofs repeatedly unfold its representation. This PR makes those representation boundaries explicit and reusable without broad reducer exposure.

## Stack

- depends on #519
- this is the second PR in the pre-4.33 stack
- the Lean 4.33/module-system migration follows this PR

## Validation

- `lake build LatticeCrypto Extern` (3,060 jobs on Lean 4.32)
- the same lattice surface is included in the green Lean 4.33 aggregate build
- no terminal `rfl` repair was added for the cross-version byte proofs
- no new `sorry`/`admit`

## Review notes

`vectorNegacyclicRing` remains narrowly `@[implicit_reducible]`: making it an `abbrev` was tested and breaks dependent `Mul` instance synthesis. The new named laws keep ordinary consumers away from that representation boundary.
