### PR TITLE
docs(CostModel): drop stale PolyTime entries from the module docstring

### DIFF
--- a/VCVio/OracleComp/QueryTracking/CostModel.lean
+++ b/VCVio/OracleComp/QueryTracking/CostModel.lean
@@ -28,15 +28,12 @@ Uses `AddWriterT` (defined in `ToMathlib.Control.WriterT`) for additive cost acc
 - `costDist oa cm`: Joint distribution of `(output, totalCost)`.
 - `expectedCost oa cm val`: Expected total cost `E[val(cost)]`, computed via `wp`.
 - `WorstCaseCostBound`, `ExpectedCostBound`: Cost bound predicates.
-- `WorstCasePolyTime`, `ExpectedPolyTime`: Asymptotic polynomial-time predicates for computation
-  families indexed by a security parameter.
 
 ## Key Results
 
 - `fst_map_costDist`: Cost instrumentation doesn't change the output distribution.
 - `expectedCost_pure`: Expected cost of a pure computation is `0`.
 - `probEvent_cost_gt_le_expectedCost_div`: Markov's inequality for cost distributions.
-- `WorstCasePolyTime.toExpectedPolyTime`: Strict polynomial time implies expected polynomial time.
 -/
 
 @[expose] public section


### PR DESCRIPTION
The module docstring of `VCVio/OracleComp/QueryTracking/CostModel.lean` still advertises `WorstCasePolyTime` and `ExpectedPolyTime` under **Main Definitions**, and `WorstCasePolyTime.toExpectedPolyTime` under **Key Results**.

Those declarations — along with the whole `section PolyTime` and `WorstCasePolyTime.toPolyQueries_unit` — were deleted as dead code in #264 (518e01b9); only the docstring lines survived. They are currently the only occurrences of those names anywhere in the repo, so a reader following the header goes looking for definitions that do not exist.

This removes the three stale lines. Every other name the header lists still resolves to a live declaration in the file. No code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)