### PR TITLE
feat(ToMathlib): subprobability measures, and the countability BitVec discreteness needs

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -39,6 +39,7 @@ public import ToMathlib.MeasureTheory.MeasurableSpace.Except
 public import ToMathlib.MeasureTheory.MeasurableSpace.Option
 public import ToMathlib.MeasureTheory.Measure.Monotone
 public import ToMathlib.MeasureTheory.Measure.Option
+public import ToMathlib.MeasureTheory.Measure.Subprobability
 public import ToMathlib.OrderEnrichedCategory
 public import ToMathlib.Probability.NegativeHypergeometric
 public import ToMathlib.Probability.ProbabilityMassFunction.Measure

--- a/ToMathlib/MeasureTheory/DiscreteInstances.lean
+++ b/ToMathlib/MeasureTheory/DiscreteInstances.lean
@@ -28,6 +28,17 @@ exactly as upstream does it.
 
 public section
 
+/-- `BitVec n` is finite, hence countable.
+
+Mathlib does not carry this instance, and `ToMathlib.General` supplies only a `Fintype` one. It is
+restated here so that this module stands alone: without `Countable` in scope,
+`MeasurableSingletonClass.toDiscreteMeasurableSpace` does not fire, and the discrete structure
+below fails to propagate to products and function types — which is exactly what cryptographic
+sampling statements are built from. `Finite` is `Prop`-valued, so this cannot conflict with the
+`Fintype` instance elsewhere. -/
+instance BitVec.instFinite (n : ℕ) : Finite (BitVec n) :=
+  Finite.of_injective BitVec.toFin fun _ _ h => BitVec.toFin_inj.mp h
+
 instance BitVec.instMeasurableSpace (n : ℕ) : MeasurableSpace (BitVec n) := ⊤
 
 instance BitVec.instMeasurableSingletonClass (n : ℕ) :

--- a/ToMathlib/MeasureTheory/Measure/Subprobability.lean
+++ b/ToMathlib/MeasureTheory/Measure/Subprobability.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.GiryMonad
+public import Mathlib.MeasureTheory.Measure.Typeclasses.Probability
+
+/-!
+# Subprobability measures
+
+`IsSubprobabilityMeasure μ` states that `μ Set.univ ≤ 1`. It is the mass discipline of a
+computation that may fail to return: the defect `1 - μ Set.univ` is the mass that never reached a
+value, so a returned result and a failure stay distinguishable without an `Option` wrapper.
+
+Mathlib has no such class. `IsZeroOrProbabilityMeasure` is a different condition — it admits only
+total mass `0` or `1`, and so cannot describe a computation that fails with probability strictly
+between the two.
+
+The class is closed under the Giry operations that build denotations: `dirac`, `map` along a
+measurable function, and `bind` against a subprobability family. The `bind` statement carries its
+almost-everywhere measurability hypothesis explicitly rather than being an instance, matching the
+Giry monad's own API.
+-/
+
+@[expose] public section
+
+open scoped ENNReal
+
+namespace MeasureTheory
+
+variable {α β : Type*} [MeasurableSpace α] [MeasurableSpace β]
+
+/-- A measure with total mass at most one. -/
+class IsSubprobabilityMeasure (μ : Measure α) : Prop where
+  /-- The total mass of a subprobability measure is at most one. -/
+  measure_univ_le' : μ Set.univ ≤ 1
+
+section
+
+variable (μ : Measure α) [IsSubprobabilityMeasure μ]
+
+/-- The total mass of a subprobability measure is at most one. -/
+theorem measure_univ_le : μ Set.univ ≤ 1 := IsSubprobabilityMeasure.measure_univ_le'
+
+/-- Every set has measure at most one under a subprobability measure. -/
+theorem measure_le_one (s : Set α) : μ s ≤ 1 :=
+  le_trans (measure_mono (Set.subset_univ s)) (measure_univ_le μ)
+
+instance (priority := 100) IsSubprobabilityMeasure.toIsFiniteMeasure : IsFiniteMeasure μ :=
+  ⟨lt_of_le_of_lt (measure_univ_le μ) ENNReal.one_lt_top⟩
+
+/-- The mass a subprobability measure does not assign to any value. -/
+noncomputable def Measure.defect : ℝ≥0∞ := 1 - μ Set.univ
+
+@[simp]
+theorem Measure.defect_add_measure_univ : μ.defect + μ Set.univ = 1 :=
+  tsub_add_cancel_of_le (measure_univ_le μ)
+
+end
+
+instance (priority := 100) IsProbabilityMeasure.toIsSubprobabilityMeasure (μ : Measure α)
+    [IsProbabilityMeasure μ] : IsSubprobabilityMeasure μ :=
+  ⟨le_of_eq (measure_univ (μ := μ))⟩
+
+instance : IsSubprobabilityMeasure (0 : Measure α) := ⟨by simp⟩
+
+instance (a : α) : IsSubprobabilityMeasure (Measure.dirac a) := inferInstance
+
+/-- Pushing a subprobability measure forward along a measurable function preserves its mass
+bound. Stated as a theorem because the measurability hypothesis cannot be synthesised. -/
+theorem isSubprobabilityMeasure_map (μ : Measure α) [IsSubprobabilityMeasure μ] {f : α → β}
+    (hf : Measurable f) : IsSubprobabilityMeasure (μ.map f) :=
+  ⟨by rw [Measure.map_apply hf MeasurableSet.univ, Set.preimage_univ]; exact measure_univ_le μ⟩
+
+/-- Giry bind of a subprobability family against a subprobability measure stays a
+subprobability measure. The measurability hypothesis is the one `Measure.bind_apply` needs. -/
+theorem isSubprobabilityMeasure_bind {μ : Measure α} [IsSubprobabilityMeasure μ]
+    {f : α → Measure β} (hf : AEMeasurable f μ)
+    [hsub : ∀ a, IsSubprobabilityMeasure (f a)] :
+    IsSubprobabilityMeasure (μ.bind f) := by
+  refine ⟨?_⟩
+  rw [Measure.bind_apply MeasurableSet.univ hf]
+  calc ∫⁻ a, f a Set.univ ∂μ
+      ≤ ∫⁻ _, 1 ∂μ := lintegral_mono fun a => measure_univ_le (f a)
+    _ = μ Set.univ := by simp
+    _ ≤ 1 := measure_univ_le μ
+
+end MeasureTheory


### PR DESCRIPTION
## Stack

- base: #531 (`dtumad/measure-semantics`)
- roadmap: #532

First of the follow-ups that convert the measure denotation into a working probability layer.

## `IsSubprobabilityMeasure`

`μ Set.univ ≤ 1` — the mass discipline of a computation that may fail to return, where the defect
`1 - μ Set.univ` is the mass that never reached a value. Mathlib has no such class:
`IsZeroOrProbabilityMeasure` admits only total mass `0` or `1`, so it cannot describe failure with
probability strictly between them.

Closed under the Giry operations denotations are built from — `dirac`, `map` along a measurable
function, and `bind` against a subprobability family. `map` and `bind` are theorems rather than
instances because their measurability hypotheses cannot be synthesised, which is the same choice
the Giry monad's own API makes.

## A gap in the discrete instances

`DiscreteInstances` already gave `BitVec n` the discrete σ-algebra, but without `Countable` in
scope `MeasurableSingletonClass.toDiscreteMeasurableSpace` never fires, so that structure did
**not** propagate to products or function types — which is what cryptographic sampling statements
are actually built from. `DiscreteMeasurableSpace (BitVec n × Bool)` now synthesises.

`Finite` is `Prop`-valued, so the instance cannot conflict with the `Fintype` one in
`ToMathlib.General`; it is restated here so the module stands alone rather than pulling in that
grab-bag.

## Not done here

No `SampleSpace`-style bundling of `MeasurableSpace` + `MeasurableSingletonClass` +
`DiscreteMeasurableSpace`. It would be redundant — `DiscreteMeasurableSpace` already implies
`MeasurableSingletonClass` upstream at priority 100, and `Measurable.of_discrete` is already
`@[fun_prop]` — and it would risk the instance loop Mathlib warns about in
`MeasurableSpace/Defs.lean`.

`Vector`, `List.Vector` and `Matrix` still have no `MeasurableSpace` at all. Deferred until the
use sites can settle whether the right choice is the σ-algebra induced from `Fin n → α`, which
also works for continuous `α`, or simply `⊤`.

## Validation

- `lake build ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets VCVioTest`
- `lake exe axiomsweep --check`
- `bash scripts/check-pmf-boundary.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)