### PR TITLE
feat(EvalDist): identify `expectedValue` with a Lebesgue integral

### DIFF
--- a/ToMathlib/MeasureTheory/Measure/Option.lean
+++ b/ToMathlib/MeasureTheory/Measure/Option.lean
@@ -55,6 +55,19 @@ theorem dropNone_dirac_some (x : α) :
     dropNone (Measure.dirac (some x)) = Measure.dirac x := by
   rw [dropNone, Measure.dirac_bind measurable_dropNoneKernel]
 
+/-- The success mass at `x` is the original mass at `some x`.
+
+This is the computation rule that carries a pointwise mass statement across `dropNone`. -/
+theorem dropNone_apply_singleton [DiscreteMeasurableSpace α] (μ : Measure (Option α)) (x : α) :
+    dropNone μ {x} = μ {some x} := by
+  rw [dropNone, Measure.bind_apply MeasurableSet.of_discrete
+    measurable_dropNoneKernel.aemeasurable]
+  refine Eq.trans (lintegral_congr (g := Set.indicator {some x} 1) ?_) ?_
+  · rintro (_ | y)
+    · simp
+    · by_cases hy : y = x <;> simp [hy]
+  · exact lintegral_indicator_one MeasurableSet.of_discrete
+
 /-- Discarding `none` cannot increase the total mass. -/
 theorem dropNone_apply_univ_le (μ : Measure (Option α)) :
     dropNone μ Set.univ ≤ μ Set.univ := by

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -86,6 +86,7 @@ public import VCVio.EvalDist.Defs.Semantics
 public import VCVio.EvalDist.Defs.Support
 public import VCVio.EvalDist.Divergence.KLDivergence
 public import VCVio.EvalDist.Expectation
+public import VCVio.EvalDist.ExpectationMeasure
 public import VCVio.EvalDist.Fintype
 public import VCVio.EvalDist.IndepProduct
 public import VCVio.EvalDist.Inequalities

--- a/VCVio/EvalDist/ExpectationMeasure.lean
+++ b/VCVio/EvalDist/ExpectationMeasure.lean
@@ -1,0 +1,82 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.EvalDist.Expectation
+public import ToMathlib.MeasureTheory.Measure.Option
+public import ToMathlib.Probability.ProbabilityMassFunction.Measure
+
+/-!
+# `expectedValue` as a Lebesgue integral
+
+`VCVio.EvalDist.Expectation` defines `expectedValue mx g` as `∑' x, Pr[= x | mx] * g x`. That
+spelling is convenient for finite cryptographic goals, but it is unreachable from Mathlib's
+convergence theory, which is stated for `∫⁻`.
+
+`expectedValue_eq_lintegral` identifies the two. The measure it integrates against is the
+denotation of `mx` read through the existing `SPMF` semantics — `evalDist` into `PMF (Option α)`,
+`PMF.toMeasure`, then `Measure.dropNone` to discard the failure mass. Nothing about
+`expectedValue` changes; the theorem is an equation, so every existing `∑'`-shaped proof stands.
+
+## What it buys
+
+Monotone convergence, Fatou and Tonelli become available for VCVio expectations by rewriting
+once. `lintegral_iSup` is recorded below as `expectedValue_iSup`, since a supremum of an
+increasing sequence of functionals is the shape a fuel-indexed or loop-indexed cost argument
+takes, and there is no `∑'` lemma for it in the library.
+
+## Generality
+
+The hypotheses are exactly those needed to identify a countable sum with an integral:
+`Countable α` and a discrete measurable structure. They are what `lintegral_countable'` asks
+for, and they hold for every cryptographic sample type.
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open scoped ENNReal
+
+universe u v
+
+namespace OracleComp.EvalDist
+
+variable {α : Type u} {m : Type u → Type v} [Monad m] [MonadLiftT m SPMF]
+  [MeasurableSpace α] [DiscreteMeasurableSpace α] [Countable α]
+
+/-- The measure denoted by `mx`, as a Mathlib `Measure` on the result type.
+
+Failure is missing mass: `evalDist` lands in `PMF (Option α)`, and `Measure.dropNone` discards
+the `none` part rather than recording it as an outcome. -/
+noncomputable def toMeasure (mx : m α) : Measure α :=
+  ((evalDist mx).toPMF.toMeasure).dropNone
+
+omit [Monad m] [Countable α] in
+@[simp]
+theorem toMeasure_apply_singleton (mx : m α) (x : α) :
+    toMeasure mx {x} = Pr[= x | mx] := by
+  rw [toMeasure, Measure.dropNone_apply_singleton,
+    PMF.toMeasure_apply_singleton _ _ MeasurableSet.of_discrete]
+  rfl
+
+omit [Monad m] in
+/-- The expected value is a Lebesgue integral against the denoted measure. -/
+theorem expectedValue_eq_lintegral (mx : m α) (g : α → ℝ≥0∞) :
+    expectedValue mx g = ∫⁻ x, g x ∂(toMeasure mx) := by
+  rw [expectedValue_def, lintegral_countable']
+  exact tsum_congr fun x => by rw [toMeasure_apply_singleton, mul_comm]
+
+omit [Monad m] in
+/-- **Monotone convergence** for VCVio expectations.
+
+There is no `∑'`-shaped counterpart to this in the library: it is `lintegral_iSup`, reachable
+only once the expectation is an integral. -/
+theorem expectedValue_iSup (mx : m α) (g : ℕ → α → ℝ≥0∞) (hg : Monotone g) :
+    expectedValue mx (fun x => ⨆ n, g n x) = ⨆ n, expectedValue mx (g n) := by
+  simp only [expectedValue_eq_lintegral]
+  exact lintegral_iSup (fun _ => Measurable.of_discrete) hg
+
+end OracleComp.EvalDist

--- a/VCVioTest/MeasureSemantics.lean
+++ b/VCVioTest/MeasureSemantics.lean
@@ -7,6 +7,7 @@ module
 
 public import VCVio.EvalDist.ResumptionMeasure
 public import VCVio.EvalDist.Divergence.KLDivergence
+public import VCVio.EvalDist.ExpectationMeasure
 public import Mathlib.Probability.Distributions.Gaussian.Real
 public import ToMathlib.MeasureTheory.DiscreteInstances
 public import Examples.OneTimePad.Basic
@@ -244,5 +245,27 @@ example : klDiv (FreeM.denote (P := gaussSpec) (FreeM.lift PUnit.unit))
     (FreeM.denote (P := gaussSpec) (FreeM.lift PUnit.unit)) = 0 := by
   rw [denote_gauss_lift]
   exact klDiv_self _
+
+/-! ## Expectation as an integral
+
+`expectedValue` keeps its `∑'` definition and every proof written against it, while the same
+quantity becomes a `∫⁻` on request. Monotone convergence is the payoff: there is no `∑'`-shaped
+counterpart to it in the library. -/
+
+open OracleComp.EvalDist in
+/-- The existing sum spelling is untouched. -/
+example (n : ℕ) (mx : ProbComp (BitVec n)) (g : BitVec n → ℝ≥0∞) :
+    expectedValue mx g = ∑' x, Pr[= x | mx] * g x := expectedValue_def mx g
+
+open OracleComp.EvalDist in
+/-- ...and is an integral against the denoted measure. -/
+example (n : ℕ) (mx : ProbComp (BitVec n)) (g : BitVec n → ℝ≥0∞) :
+    expectedValue mx g = ∫⁻ x, g x ∂(toMeasure mx) := expectedValue_eq_lintegral mx g
+
+open OracleComp.EvalDist in
+/-- **Monotone convergence** for a VCVio expectation, from `lintegral_iSup`. -/
+example (n : ℕ) (mx : ProbComp (BitVec n)) (g : ℕ → BitVec n → ℝ≥0∞) (hg : Monotone g) :
+    expectedValue mx (fun x => ⨆ k, g k x) = ⨆ k, expectedValue mx (g k) :=
+  expectedValue_iSup mx g hg
 
 end VCVioTest.MeasureSemantics

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -22,8 +22,8 @@ ToMathlib/ProbabilityTheory/OptimalCoupling.lean	11
 ToMathlib/ProbabilityTheory/SPMF.lean	69
 VCVio/CryptoFoundations/FiatShamir/Sigma.lean	2
 VCVio/CryptoFoundations/FiatShamir/Sigma/Stateful/Hops.lean	1
-VCVio/CryptoFoundations/FiatShamir/WithAbort.lean	1
 VCVio/CryptoFoundations/FiatShamir/WithAbort/ExpectedCost.lean	4
+VCVio/CryptoFoundations/FiatShamir/WithAbort.lean	1
 VCVio/CryptoFoundations/Fischlin/CostAccounting.lean	1
 VCVio/CryptoFoundations/FujisakiOkamoto/TTransform.lean	6
 VCVio/CryptoFoundations/FujisakiOkamoto/UTransform.lean	12
@@ -39,6 +39,7 @@ VCVio/EvalDist/Defs/Instances.lean	14
 VCVio/EvalDist/Defs/NeverFails.lean	6
 VCVio/EvalDist/Defs/Semantics.lean	15
 VCVio/EvalDist/Defs/Support.lean	1
+VCVio/EvalDist/ExpectationMeasure.lean	4
 VCVio/EvalDist/Instances/ErrorT.lean	22
 VCVio/EvalDist/Instances/FinRatPMF.lean	19
 VCVio/EvalDist/Instances/OptionT.lean	1


### PR DESCRIPTION
## Stack

- base: #536 (`dtumad/measure-kl-dpi`) → #535 → #531 → `main`
- roadmap: #532

## What this is

`expectedValue mx g` is defined as `∑' x, Pr[= x | mx] * g x`. That spelling suits finite
cryptographic goals, but it is unreachable from Mathlib's convergence theory, which is stated for
`∫⁻`. There is currently no `lintegral` anywhere in `VCVio/EvalDist/`.

`expectedValue_eq_lintegral` identifies the two against the measure `mx` denotes. It is an
**equation**, so nothing about `expectedValue` changes and every existing `∑'`-shaped proof
stands; the integral form is one rewrite away.

## Why bother

```lean
theorem expectedValue_iSup (mx : m α) (g : ℕ → α → ℝ≥0∞) (hg : Monotone g) :
    expectedValue mx (fun x => ⨆ n, g n x) = ⨆ n, expectedValue mx (g n)
```

Monotone convergence has no `∑'`-shaped counterpart in the library. A supremum of an increasing
sequence of functionals is the shape a fuel-indexed or loop-indexed cost argument takes, so this
is the lemma that was actually missing. Fatou and Tonelli come the same way.

Supporting `Measure.dropNone_apply_singleton` in `ToMathlib`: the success mass at `x` is the
original mass at `some x`.

## PMF baseline

`ExpectationMeasure.lean` is added to the baseline at 4. This is deliberate, and is the reviewed
exception the gate asks for rather than a way around it: the bridge routes through `PMF.toMeasure`
*precisely because* `evalDist` is still `SPMF`-valued, so the coupling is what a later retyping
removes. It sits alongside the existing bridge files `PFunctorMeasure.lean` and
`ProbabilityMassFunction/Measure.lean` for the same reason.

A gratuitous `PMF` mention in `Measure/Option.lean` was reworded instead of baselined — the
baseline should track real coupling, not prose.

## Validation

- `lake build ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets VCVioTest`
- `lake exe axiomsweep --check`
- `bash scripts/check-pmf-boundary.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)