### PR TITLE
feat(ToMathlib): Renyi MGF for measures, its data processing inequality, and the discrete theory as a corollary

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -41,8 +41,11 @@ public import ToMathlib.MeasureTheory.Measure.Monotone
 public import ToMathlib.MeasureTheory.Measure.Option
 public import ToMathlib.MeasureTheory.Measure.Subprobability
 public import ToMathlib.OrderEnrichedCategory
+public import ToMathlib.Probability.Divergence.Renyi
+public import ToMathlib.Probability.Divergence.RenyiDiscrete
 public import ToMathlib.Probability.NegativeHypergeometric
 public import ToMathlib.Probability.ProbabilityMassFunction.Measure
+public import ToMathlib.Probability.ProbabilityMassFunction.RadonNikodym
 public import ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence
 public import ToMathlib.Probability.ProbabilityMassFunction.TailSums
 public import ToMathlib.Probability.ProbabilityMassFunction.TotalVariation

--- a/ToMathlib/Probability/Divergence/Renyi.lean
+++ b/ToMathlib/Probability/Divergence/Renyi.lean
@@ -1,0 +1,71 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+public import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
+
+/-!
+# The Renyi moment generating function of a pair of measures
+
+Mathlib states Kullback-Leibler for measures (`InformationTheory.klDiv`) but has no Renyi
+divergence at all, so this is local development rather than a wrapper. It follows `klDiv`'s shape
+deliberately: `ℝ≥0∞`-valued, defined by an integral of a function of `Measure.rnDeriv`, and
+guarded by absolute continuity.
+
+## Why the guard
+
+`∫⁻ x, (∂μ/∂ν x) ^ a ∂ν` integrates against `ν`, so it cannot see a set where `ν` vanishes and
+`μ` does not — it would report a finite value for a pair at infinite divergence. The `μ ≪ ν`
+guard restores that, and it is what makes `renyiMGF_toMeasure` below an equality rather than an
+inequality. Mathlib's `klDiv` carries the same guard for the same reason.
+
+## The discrete theory
+
+`ToMathlib.Probability.Divergence.RenyiDiscrete` identifies this with the countably supported
+formula, so that development becomes a corollary of this one rather than a parallel copy. This
+module is deliberately free of any dependence on that layer.
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace InformationTheory
+
+variable {α : Type*} [MeasurableSpace α]
+
+open scoped Classical in
+/-- The Renyi moment generating function of order `a`, also called the Hellinger integral.
+
+For `a > 1` this is `∑' x, p x ^ a * q x ^ (1 - a)` in the countably supported case; see
+`ToMathlib.Probability.Divergence.RenyiDiscrete`. -/
+noncomputable def renyiMGF (a : ℝ) (μ ν : Measure α) : ℝ≥0∞ :=
+  if μ ≪ ν then ∫⁻ x, (μ.rnDeriv ν x) ^ a ∂ν else ⊤
+
+open scoped Classical in
+theorem renyiMGF_of_ac {a : ℝ} {μ ν : Measure α} (h : μ ≪ ν) :
+    renyiMGF a μ ν = ∫⁻ x, (μ.rnDeriv ν x) ^ a ∂ν := if_pos h
+
+open scoped Classical in
+@[simp]
+theorem renyiMGF_of_not_ac {a : ℝ} {μ ν : Measure α} (h : ¬ μ ≪ ν) :
+    renyiMGF a μ ν = ⊤ := if_neg h
+
+/-- A measure has Renyi MGF one against itself. -/
+@[simp]
+theorem renyiMGF_self (a : ℝ) (μ : Measure α) [IsProbabilityMeasure μ] :
+    renyiMGF a μ μ = 1 := by
+  rw [renyiMGF_of_ac (Measure.AbsolutelyContinuous.refl μ)]
+  have h : ∫⁻ x, (μ.rnDeriv μ x) ^ a ∂μ = ∫⁻ _, 1 ∂μ := by
+    refine lintegral_congr_ae ?_
+    filter_upwards [μ.rnDeriv_self] with x hx
+    simp [hx]
+  rw [h]
+  simp
+
+end InformationTheory

--- a/ToMathlib/Probability/Divergence/Renyi.lean
+++ b/ToMathlib/Probability/Divergence/Renyi.lean
@@ -6,6 +6,8 @@ Authors: Devon Tuma
 module
 
 public import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+public import Mathlib.InformationTheory.KullbackLeibler.DataProcessing
+public import Mathlib.Analysis.Convex.SpecificFunctions.Basic
 public import Mathlib.Analysis.SpecialFunctions.Pow.NNReal
 
 /-!
@@ -67,5 +69,99 @@ theorem renyiMGF_self (a : ℝ) (μ : Measure α) [IsProbabilityMeasure μ] :
     simp [hx]
   rw [h]
   simp
+
+/-! ### Data processing
+
+The inequality is Mathlib's, not ours. `ConvexOn.comp_rnDeriv_map_le` bounds `f` of the pushed
+derivative by the conditional expectation of `f` of the original, for *any* convex `f`; taking
+`f = (· ^ a)` and integrating is the whole argument. What remains is bookkeeping between the
+`ℝ≥0∞` integral this file is stated in and the Bochner integral that scaffolding is stated in.
+
+Both degenerate cases are genuinely trivial rather than swept aside: without absolute continuity,
+and without integrability, the right-hand side is already `⊤`. -/
+
+section DataProcessing
+
+variable {β : Type*} [MeasurableSpace β]
+
+/-- The Radon-Nikodym derivative is `ν`-almost everywhere finite, so raising it to a power
+commutes with passing through `ℝ`. -/
+theorem ofReal_toReal_rnDeriv_rpow (a : ℝ) (ha : 0 ≤ a) (μ ν : Measure α) [SigmaFinite μ] :
+    (fun x => ENNReal.ofReal ((μ.rnDeriv ν x).toReal ^ a)) =ᵐ[ν]
+      fun x => (μ.rnDeriv ν x) ^ a := by
+  filter_upwards [μ.rnDeriv_lt_top ν] with x hx
+  rw [← ENNReal.ofReal_rpow_of_nonneg ENNReal.toReal_nonneg ha,
+    ENNReal.ofReal_toReal hx.ne]
+
+theorem aestronglyMeasurable_toReal_rnDeriv_rpow (a : ℝ) (μ ν : Measure α) :
+    AEStronglyMeasurable (fun x => (μ.rnDeriv ν x).toReal ^ a) ν :=
+  ((Measure.measurable_rnDeriv μ ν).ennreal_toReal.pow_const a).aestronglyMeasurable
+
+/-- A finite Renyi MGF is exactly integrability of the real-valued integrand. -/
+theorem integrable_toReal_rnDeriv_rpow (a : ℝ) (ha : 0 ≤ a) (μ ν : Measure α) [SigmaFinite μ]
+    (h : ∫⁻ x, (μ.rnDeriv ν x) ^ a ∂ν ≠ ⊤) :
+    Integrable (fun x => (μ.rnDeriv ν x).toReal ^ a) ν := by
+  refine ⟨aestronglyMeasurable_toReal_rnDeriv_rpow a μ ν, ?_⟩
+  rw [hasFiniteIntegral_iff_ofReal (.of_forall fun x => Real.rpow_nonneg ENNReal.toReal_nonneg a),
+    lintegral_congr_ae (ofReal_toReal_rnDeriv_rpow a ha μ ν)]
+  exact h.lt_top
+
+/-- The `ℝ≥0∞` integral of this file and the Bochner integral Mathlib's convexity scaffolding is
+stated in are the same number. -/
+theorem lintegral_rnDeriv_rpow_eq_ofReal (a : ℝ) (ha : 0 ≤ a) (μ ν : Measure α) [SigmaFinite μ]
+    (h_int : Integrable (fun x => (μ.rnDeriv ν x).toReal ^ a) ν) :
+    ∫⁻ x, (μ.rnDeriv ν x) ^ a ∂ν
+      = ENNReal.ofReal (∫ x, (μ.rnDeriv ν x).toReal ^ a ∂ν) := by
+  rw [ofReal_integral_eq_lintegral_ofReal h_int
+      (.of_forall fun x => Real.rpow_nonneg ENNReal.toReal_nonneg a),
+    lintegral_congr_ae (ofReal_toReal_rnDeriv_rpow a ha μ ν)]
+
+/-- **Data processing inequality for the Renyi MGF**, in Bochner form. -/
+theorem integral_toReal_rnDeriv_rpow_map_le (a : ℝ) (ha : 1 < a) (μ ν : Measure α)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] {g : α → β} (hg : Measurable g) (hac : μ ≪ ν)
+    (h_int : Integrable (fun x => (μ.rnDeriv ν x).toReal ^ a) ν) :
+    ∫ y, ((μ.map g).rnDeriv (ν.map g) y).toReal ^ a ∂(ν.map g)
+      ≤ ∫ x, (μ.rnDeriv ν x).toReal ^ a ∂ν := by
+  have hf : StronglyMeasurable (fun t : ℝ => t ^ a) := by fun_prop
+  have hf_cvx : ConvexOn ℝ (Set.Ici (0 : ℝ)) (fun t : ℝ => t ^ a) := convexOn_rpow ha.le
+  have hf_cont : ContinuousWithinAt (fun t : ℝ => t ^ a) (Set.Ici 0) 0 :=
+    (Real.continuousAt_rpow_const 0 a (Or.inr (by linarith))).continuousWithinAt
+  have hsm : StronglyMeasurable (fun y => ((μ.map g).rnDeriv (ν.map g) y).toReal ^ a) :=
+    hf.comp_measurable (Measure.measurable_rnDeriv _ _).ennreal_toReal
+  have hLint := hf_cvx.integrable_comp_rnDeriv_map hac hg hf hf_cont h_int
+  calc ∫ y, ((μ.map g).rnDeriv (ν.map g) y).toReal ^ a ∂(ν.map g)
+      = ∫ x, ((μ.map g).rnDeriv (ν.map g) (g x)).toReal ^ a ∂ν :=
+        integral_map hg.aemeasurable hsm.aestronglyMeasurable
+    _ ≤ ∫ x, (ν[fun x => (μ.rnDeriv ν x).toReal ^ a | ‹MeasurableSpace β›.comap g]) x ∂ν := by
+        refine integral_mono_ae ?_ integrable_condExp ?_
+        · exact (integrable_map_measure hsm.aestronglyMeasurable hg.aemeasurable).mp hLint
+        · exact hf_cvx.comp_rnDeriv_map_le hac hg hf hf_cont h_int
+    _ = ∫ x, (μ.rnDeriv ν x).toReal ^ a ∂ν := integral_condExp hg.comap_le
+
+/-- **Data processing inequality for the Renyi MGF.**
+
+Post-processing by a measurable function cannot increase it. Compare the hand-rolled discrete
+proof in `ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence`, which does the fibrewise
+Holder argument by hand; here the convexity is Mathlib's and the argument is one `calc`. -/
+theorem renyiMGF_map_le (a : ℝ) (ha : 1 < a) (μ ν : Measure α)
+    [IsFiniteMeasure μ] [IsFiniteMeasure ν] {g : α → β} (hg : Measurable g) :
+    renyiMGF a (μ.map g) (ν.map g) ≤ renyiMGF a μ ν := by
+  have ha0 : (0 : ℝ) ≤ a := by linarith
+  by_cases hac : μ ≪ ν
+  swap; · simp [renyiMGF_of_not_ac hac]
+  by_cases htop : renyiMGF a μ ν = ⊤
+  · simp [htop]
+  rw [renyiMGF_of_ac hac] at htop ⊢
+  have h_int := integrable_toReal_rnDeriv_rpow a ha0 μ ν htop
+  have h_int_map : Integrable
+      (fun y => ((μ.map g).rnDeriv (ν.map g) y).toReal ^ a) (ν.map g) :=
+    (convexOn_rpow ha.le).integrable_comp_rnDeriv_map hac hg (by fun_prop)
+      ((Real.continuousAt_rpow_const 0 a (Or.inr ha0)).continuousWithinAt) h_int
+  rw [renyiMGF_of_ac (hac.map hg), lintegral_rnDeriv_rpow_eq_ofReal a ha0 _ _ h_int_map,
+    lintegral_rnDeriv_rpow_eq_ofReal a ha0 _ _ h_int]
+  exact ENNReal.ofReal_le_ofReal
+    (integral_toReal_rnDeriv_rpow_map_le a ha μ ν hg hac h_int)
+
+end DataProcessing
 
 end InformationTheory

--- a/ToMathlib/Probability/Divergence/RenyiDiscrete.lean
+++ b/ToMathlib/Probability/Divergence/RenyiDiscrete.lean
@@ -1,0 +1,81 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import ToMathlib.Probability.Divergence.Renyi
+public import ToMathlib.Probability.ProbabilityMassFunction.RadonNikodym
+public import ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence
+
+/-!
+# The discrete Renyi MGF as a corollary of the measure-level one
+
+`ToMathlib.Probability.Divergence.Renyi` defines `InformationTheory.renyiMGF` for a pair of
+measures. `renyiMGF_toMeasure` below identifies it with `PMF.renyiMGF` on a countable discrete
+space, so a result proved once at the measure level can be read back as the `tsum` formula the
+existing development is stated in.
+
+That is what keeps the migration cheap: the discrete theory does not have to be reproved, and
+downstream users of `PMF.renyiMGF` are untouched.
+
+This module exists only to connect the two layers, and is the only place in the Renyi development
+that mentions `PMF` at all. It is expected to disappear once the discrete layer is retired.
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open scoped ENNReal
+
+namespace InformationTheory
+
+variable {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α] [Countable α]
+
+
+/-- **The measure-level Renyi MGF agrees with the `PMF` one.**
+
+Every lemma proved about `renyiMGF` therefore transports to `PMF.renyiMGF`, and conversely. -/
+theorem renyiMGF_toMeasure (a : ℝ) (ha : 1 < a) (p q : PMF α) :
+    renyiMGF a p.toMeasure q.toMeasure = PMF.renyiMGF a p q := by
+  have ha0 : 0 < a := lt_trans one_pos ha
+  by_cases hac : p.toMeasure ≪ q.toMeasure
+  · have hsupp := (PMF.absolutelyContinuous_toMeasure_iff p q).mp hac
+    rw [renyiMGF_of_ac hac]
+    have hcongr : ∫⁻ x, (p.toMeasure.rnDeriv q.toMeasure x) ^ a ∂q.toMeasure
+        = ∫⁻ x, (p x / q x) ^ a ∂q.toMeasure := by
+      refine lintegral_congr_ae ?_
+      filter_upwards [PMF.rnDeriv_toMeasure p q] with x hx
+      rw [hx]
+    rw [hcongr, lintegral_countable']
+    refine tsum_congr fun x => ?_
+    rw [PMF.toMeasure_apply_singleton _ _ (MeasurableSet.singleton x)]
+    by_cases hq : q x = 0
+    · rw [hq, hsupp x hq]
+      simp [ENNReal.zero_rpow_of_pos ha0]
+    · rw [ENNReal.div_rpow_of_nonneg _ _ ha0.le,
+        ENNReal.rpow_sub _ _ hq (PMF.apply_ne_top q x), ENNReal.rpow_one]
+      simp only [div_eq_mul_inv]
+      ring
+  · rw [renyiMGF_of_not_ac hac]
+    obtain ⟨x, hq, hp⟩ : ∃ x, q x = 0 ∧ p x ≠ 0 := by
+      by_contra hcon
+      exact hac ((PMF.absolutelyContinuous_toMeasure_iff p q).mpr
+        fun x hx => by_contra fun h => hcon ⟨x, hx, h⟩)
+    refine (ENNReal.tsum_eq_top_of_eq_top ⟨x, ?_⟩).symm
+    rw [hq, ENNReal.zero_rpow_of_neg (by linarith)]
+    exact ENNReal.mul_top (by
+      simp only [ne_eq, ENNReal.rpow_eq_zero_iff, hp, false_and, false_or, not_and, not_lt]
+      exact fun _ => ha0.le)
+
+/-! ### The discrete theory as a corollary
+
+`PMF.renyiMGF_self` is proved directly in
+`ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence`. Here it falls out of the
+measure-level statement and `renyiMGF_toMeasure`, with no `tsum` manipulation — which is the
+shape every discrete corollary of a measure-level divergence result will take. -/
+example (a : ℝ) (ha : 1 < a) (p : PMF α) : PMF.renyiMGF a p p = 1 := by
+  rw [← renyiMGF_toMeasure a ha p p, renyiMGF_self]
+
+end InformationTheory

--- a/ToMathlib/Probability/Divergence/RenyiDiscrete.lean
+++ b/ToMathlib/Probability/Divergence/RenyiDiscrete.lean
@@ -29,9 +29,11 @@ that mentions `PMF` at all. It is expected to disappear once the discrete layer 
 open MeasureTheory
 open scoped ENNReal
 
+universe u
+
 namespace InformationTheory
 
-variable {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α] [Countable α]
+variable {α : Type u} [MeasurableSpace α] [MeasurableSingletonClass α] [Countable α]
 
 
 /-- **The measure-level Renyi MGF agrees with the `PMF` one.**
@@ -77,5 +79,26 @@ measure-level statement and `renyiMGF_toMeasure`, with no `tsum` manipulation �
 shape every discrete corollary of a measure-level divergence result will take. -/
 example (a : ℝ) (ha : 1 < a) (p : PMF α) : PMF.renyiMGF a p p = 1 := by
   rw [← renyiMGF_toMeasure a ha p p, renyiMGF_self]
+
+/-- **The discrete data processing inequality, as a corollary of the measure-level one.**
+
+`PMF.renyiMGF_map_le` is proved directly in
+`ToMathlib.Probability.ProbabilityMassFunction.RenyiDivergence` by a fibrewise Holder argument
+spanning roughly a hundred and twenty lines. Here it is four rewrites and the measure-level
+statement, whose own proof defers the convexity to Mathlib.
+
+That is the concrete form of the payoff: the discrete result is not reproved, and it is not a
+weaker statement — it is the same inequality. -/
+theorem renyiMGF_map_le_of_pmf (a : ℝ) (ha : 1 ≤ a) {β : Type u} [MeasurableSpace β]
+    [MeasurableSingletonClass β] [Countable β] (f : α → β) (p q : PMF α) :
+    PMF.renyiMGF a (f <$> p) (f <$> q) ≤ PMF.renyiMGF a p q := by
+  rcases eq_or_lt_of_le ha with rfl | ha
+  · simp only [PMF.renyiMGF, sub_self, ENNReal.rpow_zero, mul_one, ENNReal.rpow_one]
+    rw [(f <$> p).tsum_coe, p.tsum_coe]
+  have hf : Measurable f := measurable_of_countable f
+  change PMF.renyiMGF a (PMF.map f p) (PMF.map f q) ≤ PMF.renyiMGF a p q
+  rw [← renyiMGF_toMeasure a ha, ← renyiMGF_toMeasure a ha,
+    ← PMF.toMeasure_map f p hf, ← PMF.toMeasure_map f q hf]
+  exact renyiMGF_map_le a ha _ _ hf
 
 end InformationTheory

--- a/ToMathlib/Probability/ProbabilityMassFunction/RadonNikodym.lean
+++ b/ToMathlib/Probability/ProbabilityMassFunction/RadonNikodym.lean
@@ -1,0 +1,91 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import Mathlib.Probability.ProbabilityMassFunction.Basic
+public import Mathlib.MeasureTheory.Measure.Decomposition.RadonNikodym
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Countable
+
+/-!
+# Radon-Nikodym derivatives of `PMF.toMeasure`
+
+Mathlib's divergences are stated through `Measure.rnDeriv`, while VCVio's are stated as sums of
+pointwise masses. `PMF.rnDeriv_toMeasure` is the equation between the two: on a countable
+discrete space the derivative of one `PMF`'s measure against another's is the pointwise ratio.
+
+It is what lets a measure-level divergence result be read back as the `tsum` formula an existing
+`PMF` proof is stated in, and conversely.
+
+## Route
+
+`p.toMeasure` is the counting measure carrying `p` as a density, so its derivative against
+`Measure.count` is `p` itself (`Measure.rnDeriv_withDensity`). Both measures are absolutely
+continuous with respect to counting measure, so `Measure.rnDeriv_eq_div` turns the derivative of
+one against the other into the ratio of those densities.
+
+The `=ᵐ` is not incidental. Where `q x = 0` the ratio is not determined by the derivative, and
+the almost-everywhere qualifier is exactly what excludes those points — which is also why a
+divergence defined by an integral against `q` must carry an absolute-continuity guard to see
+them at all.
+-/
+
+@[expose] public section
+
+open MeasureTheory
+
+namespace PMF
+
+variable {α : Type*} [MeasurableSpace α] [MeasurableSingletonClass α]
+
+/-- A `PMF`'s measure is the counting measure with the mass function as its density. -/
+theorem toMeasure_eq_withDensity_count (p : PMF α) :
+    p.toMeasure = Measure.count.withDensity p := by
+  ext s hs
+  rw [PMF.toMeasure_apply_eq_tsum, withDensity_apply _ hs, ← lintegral_indicator hs,
+    lintegral_count]
+
+omit [MeasurableSingletonClass α] in
+/-- Only the empty set is null for counting measure, so every `PMF` measure is dominated by it. -/
+theorem absolutelyContinuous_count (p : PMF α) : p.toMeasure ≪ Measure.count :=
+  Measure.AbsolutelyContinuous.mk fun s _ h => by
+    simp [Measure.count_eq_zero_iff.mp h]
+
+variable [Countable α]
+
+/-- The density of a `PMF` measure against counting measure is the mass function. -/
+theorem rnDeriv_toMeasure_count (p : PMF α) :
+    p.toMeasure.rnDeriv Measure.count =ᵐ[Measure.count] p := by
+  rw [toMeasure_eq_withDensity_count]
+  exact Measure.rnDeriv_withDensity _ (measurable_of_countable _)
+
+/-- **The pointwise Radon-Nikodym derivative of one `PMF` against another.**
+
+This is the bridge between a measure-level divergence and its `tsum` formula. -/
+theorem rnDeriv_toMeasure (p q : PMF α) :
+    p.toMeasure.rnDeriv q.toMeasure =ᵐ[q.toMeasure] fun x => p x / q x := by
+  filter_upwards [Measure.rnDeriv_eq_div (absolutelyContinuous_count p)
+      (absolutelyContinuous_count q),
+    absolutelyContinuous_count q (rnDeriv_toMeasure_count p),
+    absolutelyContinuous_count q (rnDeriv_toMeasure_count q)] with x h1 h2 h3
+  rw [h1, h2, h3]
+
+omit [Countable α] in
+/-- Absolute continuity of `PMF` measures is inclusion of supports. -/
+theorem absolutelyContinuous_toMeasure_iff (p q : PMF α) :
+    p.toMeasure ≪ q.toMeasure ↔ ∀ x, q x = 0 → p x = 0 := by
+  constructor
+  · intro h x hx
+    have : q.toMeasure {x} = 0 := by
+      rw [PMF.toMeasure_apply_singleton _ _ (MeasurableSet.singleton x)]; exact hx
+    have := h this
+    rwa [PMF.toMeasure_apply_singleton _ _ (MeasurableSet.singleton x)] at this
+  · intro h
+    refine Measure.AbsolutelyContinuous.mk fun s hs hzero => ?_
+    rw [PMF.toMeasure_apply_eq_zero_iff _ hs] at hzero ⊢
+    exact Set.disjoint_left.mpr fun x hxp hxs =>
+      Set.disjoint_left.mp hzero (fun hq => hxp (h x hq)) hxs
+
+end PMF

--- a/VCVioTest/MeasureSemantics.lean
+++ b/VCVioTest/MeasureSemantics.lean
@@ -278,6 +278,15 @@ discrete development is therefore a corollary rather than a parallel copy. -/
 /-- Renyi between two continuous laws — no `PMF` counterpart exists. -/
 example (a : ℝ) : renyiMGF a (gaussianReal 0 1) (gaussianReal 0 1) = 1 := renyiMGF_self a _
 
+/-- The discrete data processing inequality, obtained from the measure-level one.
+
+This is the *same statement* as the hand-rolled `PMF.renyiMGF_map_le`, whose direct proof is a
+fibrewise Holder argument of roughly a hundred and twenty lines; here it follows from Mathlib's
+convexity scaffolding through the agreement theorem. -/
+example (n m : ℕ) (a : ℝ) (ha : 1 ≤ a) (f : BitVec n → BitVec m) (p q : PMF (BitVec n)) :
+    (f <$> p).renyiMGF a (f <$> q) ≤ p.renyiMGF a q :=
+  renyiMGF_map_le_of_pmf a ha f p q
+
 /-- ...and it is the existing discrete formula on a finite sample type. -/
 example (n : ℕ) (a : ℝ) (ha : 1 < a) (p q : PMF (BitVec n)) :
     renyiMGF a p.toMeasure q.toMeasure = PMF.renyiMGF a p q := renyiMGF_toMeasure a ha p q

--- a/VCVioTest/MeasureSemantics.lean
+++ b/VCVioTest/MeasureSemantics.lean
@@ -8,6 +8,7 @@ module
 public import VCVio.EvalDist.ResumptionMeasure
 public import VCVio.EvalDist.Divergence.KLDivergence
 public import VCVio.EvalDist.ExpectationMeasure
+public import ToMathlib.Probability.Divergence.RenyiDiscrete
 public import Mathlib.Probability.Distributions.Gaussian.Real
 public import ToMathlib.MeasureTheory.DiscreteInstances
 public import Examples.OneTimePad.Basic
@@ -267,5 +268,18 @@ open OracleComp.EvalDist in
 example (n : ℕ) (mx : ProbComp (BitVec n)) (g : ℕ → BitVec n → ℝ≥0∞) (hg : Monotone g) :
     expectedValue mx (fun x => ⨆ k, g k x) = ⨆ k, expectedValue mx (g k) :=
   expectedValue_iSup mx g hg
+
+/-! ## Renyi divergence, at both ends of the boundary
+
+The measure-level Renyi MGF is stated for arbitrary measures, so it covers laws no `PMF` can
+carry, and it agrees exactly with the countably supported formula where both are defined. The
+discrete development is therefore a corollary rather than a parallel copy. -/
+
+/-- Renyi between two continuous laws — no `PMF` counterpart exists. -/
+example (a : ℝ) : renyiMGF a (gaussianReal 0 1) (gaussianReal 0 1) = 1 := renyiMGF_self a _
+
+/-- ...and it is the existing discrete formula on a finite sample type. -/
+example (n : ℕ) (a : ℝ) (ha : 1 < a) (p q : PMF (BitVec n)) :
+    renyiMGF a p.toMeasure q.toMeasure = PMF.renyiMGF a p q := renyiMGF_toMeasure a ha p q
 
 end VCVioTest.MeasureSemantics

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -12,7 +12,7 @@ ToMathlib/Control/Monad/Commutative.lean	5
 ToMathlib/Data/ENNReal/AbsDiff.lean	1
 ToMathlib/Data/ENNReal/TsumDistrib.lean	1
 ToMathlib/General.lean	29
-ToMathlib/Probability/Divergence/RenyiDiscrete.lean	15
+ToMathlib/Probability/Divergence/RenyiDiscrete.lean	26
 ToMathlib/Probability/ProbabilityMassFunction/Measure.lean	17
 ToMathlib/Probability/ProbabilityMassFunction/RadonNikodym.lean	20
 ToMathlib/Probability/ProbabilityMassFunction/RenyiDivergence.lean	76

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -12,7 +12,9 @@ ToMathlib/Control/Monad/Commutative.lean	5
 ToMathlib/Data/ENNReal/AbsDiff.lean	1
 ToMathlib/Data/ENNReal/TsumDistrib.lean	1
 ToMathlib/General.lean	29
+ToMathlib/Probability/Divergence/RenyiDiscrete.lean	15
 ToMathlib/Probability/ProbabilityMassFunction/Measure.lean	17
+ToMathlib/Probability/ProbabilityMassFunction/RadonNikodym.lean	20
 ToMathlib/Probability/ProbabilityMassFunction/RenyiDivergence.lean	76
 ToMathlib/Probability/ProbabilityMassFunction/TailSums.lean	7
 ToMathlib/Probability/ProbabilityMassFunction/TotalVariation.lean	75


### PR DESCRIPTION
## Stack

- base: #537 (`dtumad/measure-expectation`) → #536 → #535 → #531 → `main`
- roadmap: #532

Top of the stack, and the one that tests whether the migration actually pays.

## The definition

Mathlib states Kullback-Leibler for measures but has **no** Rényi divergence at all, so this is
local development rather than a wrapper. It follows `klDiv`'s shape deliberately: `ℝ≥0∞`-valued,
an integral of a function of `Measure.rnDeriv`, guarded by absolute continuity.

The guard is not decoration. Integrating against `ν` cannot see a set where `ν` vanishes and `μ`
does not, so without it the definition would report a finite value for a pair at infinite
divergence — and `renyiMGF_toMeasure` below would be an inequality instead of an equation.

## The load-bearing lemma

`PMF.rnDeriv_toMeasure`: on a countable discrete space the Radon-Nikodym derivative of one `PMF`'s
measure against another's is the pointwise ratio. It routes through the counting measure, for
which a `PMF`'s measure is exactly the density, and it is what connects Mathlib's `rnDeriv`-shaped
divergence theory to VCVio's `tsum`-shaped one.

`renyiMGF_toMeasure` is then an **equality**, so the existing `PMF` development becomes a
corollary rather than a parallel copy.

## Data processing, and what it cost

`ConvexOn.comp_rnDeriv_map_le` bounds `f` of a pushed-forward derivative by the conditional
expectation of `f` of the original, for *any* convex `f`. Taking `f = (· ^ a)` and integrating is
the entire argument.

| | non-blank lines |
|---|---|
| hand-rolled `PMF.renyiMGF_map_le` (fibrewise Hölder) | **120** |
| core convexity argument over measures | **20** |
| `ℝ≥0∞`-to-Bochner plumbing (3 reusable helpers) | 61 |
| discrete corollary from the measure version | **11** |

The 61 lines are the honest caveat: Mathlib's scaffolding is Bochner-`∫`/`Integrable`-shaped while
these divergences are `ℝ≥0∞`/`lintegral`-shaped. That plumbing is about `rnDeriv` and `rpow`
rather than about data processing, so it is a fixed cost reusable by any other f-divergence stated
this way, not a per-divergence one.

`renyiMGF_map_le_of_pmf` has the *same statement* as the hand-rolled lemma, `1 ≤ a` hypothesis
included. The canary records it as a direct term for that lemma's own spelling, so the two are
interchangeable.

Both degenerate cases are genuinely trivial rather than swept aside: without absolute continuity,
and without integrability, the right-hand side is already `⊤`.

## Layering

`Divergence/Renyi.lean` has **zero** bare-`PMF` occurrences. All coupling is isolated in
`Divergence/RenyiDiscrete.lean` and `ProbabilityMassFunction/RadonNikodym.lean`, which exist only
to connect the two layers and are expected to disappear when the discrete layer is retired. The
split is deliberate: it keeps the boundary gate measuring something real.

## Not done here

`PMF.etvDist_sq_le_of_renyiDiv` (the Rényi → TV bound) is still `sorry`. Its proof strategy checks
out — TV² ≤ 1 − BC² by Cauchy-Schwarz, then BC² ≥ `renyiDiv`⁻¹ by log-convexity of the MGF — and
the crux `ENNReal` identity is proved here, but the Hellinger-affinity development it needs is a
separate piece of work. Total variation over measures is likewise not started.

## Validation

- `lake build ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets VCVioTest`
- `lake exe axiomsweep --check` — no new taint
- `bash scripts/check-pmf-boundary.sh`

🤖 Generated with [Claude Code](https://claude.com/claude-code)