### PR TITLE
feat(CryptoFoundations): transport fork bounds to measures

### DIFF
--- a/ToMathlib/MeasureTheory/MeasurableSpace/Option.lean
+++ b/ToMathlib/MeasureTheory/MeasurableSpace/Option.lean
@@ -35,6 +35,14 @@ theorem measurable_some [MeasurableSpace α] : Measurable (@some α) :=
 theorem measurable_none [MeasurableSpace α] : Measurable (fun _ : Unit => (none : Option α)) :=
   Measurable.of_le_map inf_le_right
 
+/-- The set of present optional values is measurable. -/
+theorem measurableSet_isSome [MeasurableSpace α] :
+    MeasurableSet {value : Option α | value.isSome} := by
+  change MeasurableSet (some ⁻¹' {value : Option α | value.isSome}) ∧
+    MeasurableSet ((fun _ : Unit => (none : Option α)) ⁻¹'
+      {value : Option α | value.isSome})
+  simp
+
 /-- A function out of `Option α` is measurable when its `none` and `some` branches are. -/
 theorem measurable_elim [MeasurableSpace α] [MeasurableSpace β] {f : Option α → β}
     (hNone : Measurable (fun _ : Unit => f none))

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -33,6 +33,7 @@ public import VCVio.CryptoFoundations.Fischlin.Completeness
 public import VCVio.CryptoFoundations.Fischlin.CostAccounting
 public import VCVio.CryptoFoundations.Fischlin.Defs
 public import VCVio.CryptoFoundations.Fischlin.KnowledgeSoundness
+public import VCVio.CryptoFoundations.ForkMeasure
 public import VCVio.CryptoFoundations.FujisakiOkamoto
 public import VCVio.CryptoFoundations.FujisakiOkamoto.Composed
 public import VCVio.CryptoFoundations.FujisakiOkamoto.Defs

--- a/VCVio/CryptoFoundations/ForkMeasure.lean
+++ b/VCVio/CryptoFoundations/ForkMeasure.lean
@@ -1,0 +1,94 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+
+module
+public import ToMathlib.MeasureTheory.MeasurableSpace.Option
+public import VCVio.CryptoFoundations.ReplayFork
+public import VCVio.CryptoFoundations.SeededFork
+public import VCVio.EvalDist.PFunctorMeasure
+
+/-!
+# Measure-level forking bounds
+
+The seeded and replay forking lemmas are proved through VCVio's discrete
+probability surface. This file transports their final success bounds to the
+Mathlib measure denotation of the same oracle programs.
+
+These are compatibility corollaries rather than new forking arguments. The
+measure semantics is the canonical one induced by the existing per-query
+probability interpretation, and `PFunctor.FreeM.denote_apply_setOf` identifies its
+measurable success event with the probability used by the original theorem.
+-/
+
+@[expose] public section
+
+open MeasureTheory OracleSpec ENNReal Finset
+
+namespace OracleComp
+
+/-- The canonical measure semantics induced by an oracle specification's
+existing probability semantics. This instance is local so measure semantics
+remain an explicit opt-in outside this compatibility module. -/
+noncomputable local instance measureSpecOfProbability
+    {ι : Type} {spec : OracleSpec ι}
+    [∀ i, MeasurableSpace (spec.Range i)] [IsProbabilitySpec spec] :
+    PFunctor.IsMeasureSpec spec.toPFunctor :=
+  PFunctor.IsProbabilitySpec.toMeasureSpec spec.toPFunctor
+
+section seeded
+
+variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
+  [IsUniformSpec spec] {α : Type}
+  [∀ i, MeasurableSpace (spec.Range i)]
+  [∀ i, DiscreteMeasurableSpace (spec.Range i)]
+  [MeasurableSpace α]
+
+/-- The canonical Bellare--Neven seeded-fork bound, stated as the Mathlib
+measure of the successful-result event. -/
+theorem le_denote_isSome_seededFork_sq
+    (main : OracleComp spec α) (qb : ι → ℕ) (js : List ι) (i : ι)
+    (cf : α → Option (Fin (qb i + 1)))
+    [∀ j, SampleableType (spec.Range j)] [spec.DecidableEq]
+    [unifSpec ⊂ₒ spec] [unifSpec ˡ⊂ₒ spec] :
+    ((∑ s, Pr[= some s | cf <$> main]) ^ 2 / ((qb i + 1 : ℕ) : ℝ≥0∞)
+        - (∑ s, Pr[= some s | cf <$> main]) /
+            ((Fintype.card (spec.Range i) : ℕ) : ℝ≥0∞)) ≤
+      PFunctor.FreeM.denote (seededFork main qb js i cf)
+        {result | result.isSome} := by
+  rw [PFunctor.FreeM.denote_apply_setOf (fun _ => rfl)
+    (seededFork main qb js i cf) (fun result => result.isSome)
+    Option.measurableSet_isSome]
+  exact le_probEvent_isSome_seededFork_sq main qb js i cf
+
+end seeded
+
+section replay
+
+variable {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec] {α : Type}
+  [∀ i, MeasurableSpace (spec.Range i)]
+  [∀ i, DiscreteMeasurableSpace (spec.Range i)]
+  [MeasurableSpace α]
+
+/-- The replay/context forking bound, stated as the Mathlib measure of the
+successful-result event. -/
+theorem le_denote_isSome_contextFork
+    [spec.DecidableEq] (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1)))
+    (hreach : PathCfReachable main qb i cf) :
+    (let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
+     let h : ℝ≥0∞ := Fintype.card (spec.Range i)
+     let q := qb i + 1
+     acc * (acc / q - h⁻¹)) ≤
+      PFunctor.FreeM.denote (contextFork main qb i cf)
+        {result | result.isSome} := by
+  rw [PFunctor.FreeM.denote_apply_setOf (fun _ => rfl)
+    (contextFork main qb i cf) (fun result => result.isSome)
+    Option.measurableSet_isSome]
+  exact le_probEvent_isSome_contextFork main qb i cf hreach
+
+end replay
+
+end OracleComp

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -1,6 +1,7 @@
 module  -- shake: keep-all --deprecated_module: ignore
 
 public import VCVioTest.Computability
+public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement
 public import VCVioTest.GrindFailFast
 public import VCVioTest.LongChainPrograms

--- a/VCVioTest/ForkMeasure.lean
+++ b/VCVioTest/ForkMeasure.lean
@@ -1,0 +1,74 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.CryptoFoundations.ForkMeasure
+
+/-!
+# External canaries for the measure-level forking bounds
+
+These examples deliberately live outside the defining module. They lock the public hypotheses and
+result shapes of both compatibility corollaries, so changes to the measure bridge cannot silently
+make the wrappers unusable by downstream crypto proofs.
+-/
+
+public section
+
+open MeasureTheory OracleSpec ENNReal Finset
+
+namespace VCVioTest.ForkMeasure
+
+/-- Match the canonical discrete-to-measure interpretation used by the compatibility wrappers. -/
+noncomputable local instance measureSpecOfProbability
+    {ι : Type} {spec : OracleSpec ι}
+    [∀ i, MeasurableSpace (spec.Range i)] [IsProbabilitySpec spec] :
+    PFunctor.IsMeasureSpec spec.toPFunctor :=
+  PFunctor.IsProbabilitySpec.toMeasureSpec spec.toPFunctor
+
+section seeded
+
+variable {ι : Type} [DecidableEq ι] {spec : OracleSpec ι}
+  [IsUniformSpec spec] {α : Type}
+  [∀ i, MeasurableSpace (spec.Range i)]
+  [∀ i, DiscreteMeasurableSpace (spec.Range i)]
+  [MeasurableSpace α]
+
+/-- The seeded-fork measure wrapper remains directly consumable from another module. -/
+example (main : OracleComp spec α) (qb : ι → ℕ) (js : List ι) (i : ι)
+    (cf : α → Option (Fin (qb i + 1)))
+    [∀ j, SampleableType (spec.Range j)] [spec.DecidableEq]
+    [unifSpec ⊂ₒ spec] [unifSpec ˡ⊂ₒ spec] :
+    ((∑ s, Pr[= some s | cf <$> main]) ^ 2 / ((qb i + 1 : ℕ) : ℝ≥0∞)
+        - (∑ s, Pr[= some s | cf <$> main]) /
+            ((Fintype.card (spec.Range i) : ℕ) : ℝ≥0∞)) ≤
+      PFunctor.FreeM.denote (OracleComp.seededFork main qb js i cf)
+        {result | result.isSome} :=
+  OracleComp.le_denote_isSome_seededFork_sq main qb js i cf
+
+end seeded
+
+section replay
+
+variable {ι : Type} {spec : OracleSpec ι} [IsUniformSpec spec] {α : Type}
+  [∀ i, MeasurableSpace (spec.Range i)]
+  [∀ i, DiscreteMeasurableSpace (spec.Range i)]
+  [MeasurableSpace α]
+
+/-- The replay-fork measure wrapper retains its reachability premise and success-event bound. -/
+example [spec.DecidableEq] (main : OracleComp spec α) (qb : ι → ℕ) (i : ι)
+    (cf : α → Option (Fin (qb i + 1)))
+    (hreach : OracleComp.PathCfReachable main qb i cf) :
+    (let acc : ℝ≥0∞ := ∑ s, Pr[= some s | cf <$> main]
+     let h : ℝ≥0∞ := Fintype.card (spec.Range i)
+     let q := qb i + 1
+     acc * (acc / q - h⁻¹)) ≤
+      PFunctor.FreeM.denote (OracleComp.contextFork main qb i cf)
+        {result | result.isSome} :=
+  OracleComp.le_denote_isSome_contextFork main qb i cf hreach
+
+end replay
+
+end VCVioTest.ForkMeasure

--- a/docs/agents/crypto.md
+++ b/docs/agents/crypto.md
@@ -140,6 +140,16 @@ structure BoundedAdversary {ι : Type u} [DecidableEq ι]
 
 All return `ℝ` via `.toReal` conversion from `ℝ≥0∞`. This is essential since subtraction on `ℝ≥0∞` is truncated.
 
+### Forking bounds and measure semantics
+
+`VCVio/CryptoFoundations/SeededFork.lean` and `ReplayFork.lean` prove the
+seeded and context-fork success bounds through the established `Pr[...]`
+surface. `ForkMeasure.lean` states the same final bounds as the Mathlib measure
+of the `Option.isSome` event, using the canonical measure semantics induced by
+the oracle specification's existing per-query probability interpretation.
+These are transport corollaries; the forking arguments remain in the two
+original modules.
+
 ## Hardness Assumptions
 
 ### Discrete Log Assumptions (DLog / CDH / DDH)


### PR DESCRIPTION
## Probability campaign

Merged foundation: #530 → #531 → #535 → #536 → #537 → #538

Open stack: #540 → **#544** → #548 → #549

This is level 2 of 4 in the open stack and targets #540. Merge from left to right.

## Summary

- add `Option.measurableSet_isSome` for the coproduct measurable structure
- transport the canonical seeded-fork bound to the Mathlib measure of its success event
- transport the replay/context-fork bound in the same way
- keep the induced measure semantics local and explicit; the original forking arguments remain on the established probability surface

## Validation

- `./scripts/build-project.sh`
- `lake build ToMathlib VCVio LatticeCrypto Extern HashSig Examples VCVioWidgets`
- `./scripts/check-pmf-boundary.sh`
- `python3 scripts/check-agent-docs.py`
- `./scripts/check-extern-isolation.sh`
- `./scripts/check-interop-isolation.sh`
- `./scripts/test-axiomsweep.sh`
- `lake exe axiomsweep --check`
- `git diff --check`
