### PR TITLE
feat: make parameterized semantics kernel-valued

### DIFF
--- a/ToMathlib.lean
+++ b/ToMathlib.lean
@@ -47,6 +47,7 @@ public import ToMathlib.OrderEnrichedCategory
 public import ToMathlib.Probability.Divergence.Renyi
 public import ToMathlib.Probability.Divergence.RenyiDiscrete
 public import ToMathlib.Probability.Divergence.TotalVariation
+public import ToMathlib.Probability.Kernel.Subprobability
 public import ToMathlib.Probability.NegativeHypergeometric
 public import ToMathlib.Probability.ProbabilityMassFunction.Measure
 public import ToMathlib.Probability.ProbabilityMassFunction.RadonNikodym

--- a/ToMathlib/Probability/Kernel/Subprobability.lean
+++ b/ToMathlib/Probability/Kernel/Subprobability.lean
@@ -1,0 +1,125 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import ToMathlib.MeasureTheory.Measure.Subprobability
+public import Mathlib.Probability.Kernel.Composition.Comp
+public import Mathlib.Probability.Kernel.Composition.MapComap
+public import Mathlib.Probability.Kernel.Composition.Prod
+
+/-!
+# Subprobability kernels
+
+`IsSubprobabilityKernel κ` states that every measure produced by `κ` has total mass at most one.
+It is the kernel-level mass discipline for a parameterized computation that may fail or diverge.
+
+Mathlib's `IsZeroOrMarkovKernel` is different: it allows only kernels that are identically zero or
+have mass exactly one at every input. A subprobability kernel may lose a different, nontrivial
+amount of mass at each input.
+
+The class is closed under the standard kernel operations used by probabilistic semantics. In
+particular, a subprobability kernel is finite and hence s-finite, so Mathlib's composition and
+product APIs apply without additional finiteness assumptions.
+-/
+
+@[expose] public section
+
+open MeasureTheory
+open scoped ENNReal ProbabilityTheory
+
+namespace ProbabilityTheory
+
+universe u v w
+
+variable {α : Type u} {β : Type v} {γ : Type w}
+  [MeasurableSpace α] [MeasurableSpace β] [MeasurableSpace γ]
+
+/-- A kernel whose value at every input is a subprobability measure. -/
+class IsSubprobabilityKernel (κ : Kernel α β) : Prop where
+  /-- Every kernel value has total mass at most one. -/
+  measure_univ_le' : ∀ a, κ a Set.univ ≤ 1
+
+namespace Kernel
+
+variable (κ : Kernel α β) [IsSubprobabilityKernel κ]
+
+/-- Every value of a subprobability kernel has total mass at most one. -/
+theorem measure_univ_le (a : α) : κ a Set.univ ≤ 1 :=
+  IsSubprobabilityKernel.measure_univ_le' a
+
+/-- Every measurable event has mass at most one under a subprobability kernel. -/
+theorem measure_le_one (a : α) (s : Set β) : κ a s ≤ 1 :=
+  (measure_mono (Set.subset_univ s)).trans (κ.measure_univ_le a)
+
+/-- Applying a subprobability kernel produces a subprobability measure. -/
+instance apply.instIsSubprobabilityMeasure (a : α) : IsSubprobabilityMeasure (κ a) :=
+  ⟨κ.measure_univ_le a⟩
+
+/-- A subprobability kernel is uniformly finite, with bound one. -/
+instance (priority := 100) IsSubprobabilityKernel.toIsFiniteKernel : IsFiniteKernel κ :=
+  ⟨⟨1, ENNReal.one_lt_top, κ.measure_univ_le⟩⟩
+
+end Kernel
+
+/-- Every Markov kernel is a subprobability kernel. -/
+instance (priority := 100) IsMarkovKernel.toIsSubprobabilityKernel (κ : Kernel α β)
+    [IsMarkovKernel κ] : IsSubprobabilityKernel κ :=
+  ⟨fun _ => le_of_eq measure_univ⟩
+
+instance : IsSubprobabilityKernel (0 : Kernel α β) := ⟨by simp⟩
+
+instance Kernel.const.instIsSubprobabilityKernel (μ : Measure β) [IsSubprobabilityMeasure μ] :
+    IsSubprobabilityKernel (Kernel.const α μ) :=
+  ⟨fun _ => by simpa using MeasureTheory.measure_univ_le μ⟩
+
+instance Kernel.restrict.instIsSubprobabilityKernel (κ : Kernel α β)
+    [IsSubprobabilityKernel κ] {s : Set β} (hs : MeasurableSet s) :
+    IsSubprobabilityKernel (κ.restrict hs) := ⟨fun a => by
+  rw [Kernel.restrict_apply' κ hs a MeasurableSet.univ]
+  exact (measure_mono (Set.subset_univ _)).trans (κ.measure_univ_le a)⟩
+
+instance Kernel.map.instIsSubprobabilityKernel (κ : Kernel α β)
+    [IsSubprobabilityKernel κ] (f : β → γ) :
+    IsSubprobabilityKernel (κ.map f) := ⟨fun a => by
+  by_cases hf : Measurable f
+  · rw [Kernel.map_apply' κ hf a MeasurableSet.univ, Set.preimage_univ]
+    exact κ.measure_univ_le a
+  · simp [Kernel.map_of_not_measurable κ hf]⟩
+
+instance Kernel.comap.instIsSubprobabilityKernel (κ : Kernel α β)
+    [IsSubprobabilityKernel κ] {f : γ → α} (hf : Measurable f) :
+    IsSubprobabilityKernel (κ.comap f hf) :=
+  ⟨fun a => by simpa using κ.measure_univ_le (f a)⟩
+
+instance Kernel.comp.instIsSubprobabilityKernel (η : Kernel β γ)
+    [IsSubprobabilityKernel η] (κ : Kernel α β) [IsSubprobabilityKernel κ] :
+    IsSubprobabilityKernel (η ∘ₖ κ) := ⟨fun a => by
+  rw [Kernel.comp_apply]
+  let _ : IsSubprobabilityMeasure ((κ a).bind η) :=
+    isSubprobabilityMeasure_bind η.aemeasurable
+  exact MeasureTheory.measure_univ_le ((κ a).bind η)⟩
+
+instance Kernel.prod.instIsSubprobabilityKernel (κ : Kernel α β)
+    [IsSubprobabilityKernel κ] (η : Kernel α γ) [IsSubprobabilityKernel η] :
+    IsSubprobabilityKernel (κ ×ₖ η) := ⟨fun a => by
+  rw [← Set.univ_prod_univ, Kernel.prod_apply_prod]
+  calc
+    κ a Set.univ * η a Set.univ ≤ 1 * 1 :=
+      mul_le_mul' (κ.measure_univ_le a) (η.measure_univ_le a)
+    _ = 1 := one_mul 1⟩
+
+instance Kernel.pow.instIsSubprobabilityKernel (κ : Kernel α α)
+    [IsSubprobabilityKernel κ] (n : ℕ) : IsSubprobabilityKernel (κ ^ n) := by
+  induction n with
+  | zero =>
+      change IsSubprobabilityKernel (Kernel.id : Kernel α α)
+      infer_instance
+  | succ n ih =>
+      let _ : IsSubprobabilityKernel (κ ^ n) := ih
+      rw [Kernel.pow_add κ n 1, pow_one]
+      infer_instance
+
+end ProbabilityTheory

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -97,6 +97,7 @@ public import VCVio.EvalDist.Instances.ErrorT
 public import VCVio.EvalDist.Instances.FinRatPMF
 public import VCVio.EvalDist.Instances.OptionT
 public import VCVio.EvalDist.Instances.ReaderT
+public import VCVio.EvalDist.Kernel
 public import VCVio.EvalDist.List
 public import VCVio.EvalDist.MeasureSemantics
 public import VCVio.EvalDist.MeasureTVDist

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
@@ -151,12 +151,14 @@ omit [DecidableEq M] in
     (mm : M × M) : encAlg.IND_CPA_swapLens.toFunA (.inr mm) = .inr (mm.2, mm.1) := rfl
 
 omit [DecidableEq M] in
-/-- Wrapping an IND-CPA machine with message swapping is exactly responder pullback along the
-same PolyFun lens: a one-line specialization of the generic wrap/pullback adjunction
+/-- Wrapping an IND-CPA machine with message swapping is exactly executable responder
+pullback along the same PolyFun lens: a one-line specialization of the generic
+wrap/pullback adjunction
 `OracleMachine.runAgainst_wrap`, with no protocol-specific run induction. -/
 theorem runAgainst_IND_CPA_swap (encAlg : AsymmEncAlg ProbComp M PK SK C)
     (machine : OracleMachine encAlg.IND_CPA_oracleSpec PK Bool)
-    (R : ProbResponder encAlg.IND_CPA_oracleSpec) (k : ℕ) (r : R.State)
+    (R : ProbResponder encAlg.IND_CPA_oracleSpec) [R.IsExecutable]
+    (k : ℕ) (r : R.State)
     (s : machine.State) :
     OracleMachine.runAgainst (machine.wrap encAlg.IND_CPA_swapLens) R k (r, s) =
       machine.runAgainst (R.pullback encAlg.IND_CPA_swapLens) k (r, s) :=

--- a/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
+++ b/VCVio/CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean
@@ -150,6 +150,35 @@ omit [DecidableEq M] in
 @[simp] theorem IND_CPA_swapLens_query_right (encAlg : AsymmEncAlg ProbComp M PK SK C)
     (mm : M × M) : encAlg.IND_CPA_swapLens.toFunA (.inr mm) = .inr (mm.2, mm.1) := rfl
 
+/-- Message swapping leaves response values unchanged, so pullback preserves the
+point-separating answer spaces required for executable responder coherence. -/
+instance IND_CPA_swapLens_pullback.instMeasurableSingletonClassRange
+    (encAlg : AsymmEncAlg ProbComp M PK SK C)
+    (R : ProbResponder encAlg.IND_CPA_oracleSpec) [R.IsExecutable] : ∀ t,
+    letI := (R.pullback encAlg.IND_CPA_swapLens).instMeasurableSpaceRange t
+    MeasurableSingletonClass (encAlg.IND_CPA_oracleSpec.Range t)
+  | .inl t => by
+      let hSingleton : @MeasurableSingletonClass (unifSpec.Range t)
+          (R.instMeasurableSpaceRange (.inl t)) :=
+        ProbResponder.IsExecutable.instMeasurableSingletonClassRange (R := R) (.inl t)
+      exact @MeasurableSingletonClass.mk _
+        ((R.pullback encAlg.IND_CPA_swapLens).instMeasurableSpaceRange (.inl t))
+        (fun x => by
+          change @MeasurableSet (unifSpec.Range t) (R.instMeasurableSpaceRange (.inl t))
+            (id ⁻¹' {x})
+          simpa only [Set.preimage_id] using hSingleton.measurableSet_singleton x)
+  | .inr mm => by
+      let hSingleton : @MeasurableSingletonClass C
+          (R.instMeasurableSpaceRange (.inr (mm.2, mm.1))) :=
+        ProbResponder.IsExecutable.instMeasurableSingletonClassRange
+          (R := R) (.inr (mm.2, mm.1))
+      exact @MeasurableSingletonClass.mk _
+        ((R.pullback encAlg.IND_CPA_swapLens).instMeasurableSpaceRange (.inr mm))
+        (fun x => by
+          change @MeasurableSet C (R.instMeasurableSpaceRange (.inr (mm.2, mm.1)))
+            (id ⁻¹' {x})
+          simpa only [Set.preimage_id] using hSingleton.measurableSet_singleton x)
+
 omit [DecidableEq M] in
 /-- Wrapping an IND-CPA machine with message swapping is exactly executable responder
 pullback along the same PolyFun lens: a one-line specialization of the generic

--- a/VCVio/EvalDist/Defs/Measure.lean
+++ b/VCVio/EvalDist/Defs/Measure.lean
@@ -7,6 +7,7 @@ module
 
 public import VCVio.EvalDist.Defs.Support
 public import ToMathlib.MeasureTheory.Measure.Option
+public import ToMathlib.MeasureTheory.Measure.Subprobability
 public import ToMathlib.Probability.ProbabilityMassFunction.Measure
 
 /-!
@@ -69,6 +70,11 @@ theorem evalDist_apply_univ_le_one {m : Type u → Type v} [EvalDistSemantics m]
     {α : Type u} [MeasurableSpace α] (mx : m α) : 𝒟[mx] Set.univ ≤ 1 :=
   EvalDistSemantics.apply_univ_le_one mx
 
+/-- Every computation denotation is a subprobability measure. -/
+instance evalDist.instIsSubprobabilityMeasure {m : Type u → Type v} [EvalDistSemantics m]
+    {α : Type u} [MeasurableSpace α] (mx : m α) : IsSubprobabilityMeasure 𝒟[mx] :=
+  ⟨evalDist_apply_univ_le_one mx⟩
+
 /-- A measure-valued semantics respects `pure` and measurable `bind` in the Giry monad. -/
 class LawfulEvalDistSemantics (m : Type u → Type v) [Monad m]
     [EvalDistSemantics m] : Prop where
@@ -128,6 +134,10 @@ theorem toMeasure_apply_univ_le_one (p : SPMF α) : p.toMeasure Set.univ ≤ 1 :
   exact (Measure.dropNone_apply_univ_le p.toPMF.toMeasure).trans_eq hTotal
 
 @[simp]
+theorem toMeasure_pure (x : α) : (pure x : SPMF α).toMeasure = Measure.dirac x := by
+  rw [toMeasure, SPMF.toPMF_pure, PMF.toMeasure_pure, Measure.dropNone_dirac_some]
+
+@[simp]
 theorem toMeasure_apply_singleton [MeasurableSingletonClass α] (p : SPMF α) (x : α) :
     p.toMeasure {x} = p x := by
   rw [toMeasure, Measure.dropNone_apply_singleton,
@@ -135,7 +145,7 @@ theorem toMeasure_apply_singleton [MeasurableSingletonClass α] (p : SPMF α) (x
   rfl
 
 /-- On a discrete output space, applying the successful-output measure to a set agrees with the
-corresponding event in the option-valued `PMF` backend. -/
+corresponding event in the option-valued probability-mass-function backend. -/
 theorem toMeasure_apply [DiscreteMeasurableSpace α] (p : SPMF α) (s : Set α) :
     p.toMeasure s = p.toPMF.toOuterMeasure (some '' s) := by
   rw [toMeasure, Measure.dropNone,
@@ -164,6 +174,45 @@ theorem toMeasure_injective [MeasurableSingletonClass α] :
   apply SPMF.ext
   intro x
   rw [← toMeasure_apply_singleton p x, ← toMeasure_apply_singleton q x, hpq]
+
+/-- The successful-output measure commutes with measurable maps. -/
+theorem toMeasure_map {β : Type u} [MeasurableSpace β]
+    (p : SPMF α) (f : α → β) (hf : Measurable f) :
+    (f <$> p).toMeasure = p.toMeasure.map f := by
+  have hOptionMap : Measurable (Option.map f) :=
+    Option.measurable_elim measurable_const (Option.measurable_some.comp hf)
+  ext s hs
+  rw [toMeasure, SPMF.toPMF_map]
+  change (p.toPMF.map (Option.map f)).toMeasure.dropNone s = _
+  rw [← p.toPMF.toMeasure_map (Option.map f) hOptionMap, toMeasure,
+    Measure.map_apply hf hs]
+  simp only [Measure.dropNone]
+  rw [
+    Measure.bind_apply hs Measure.measurable_dropNoneKernel.aemeasurable,
+    Measure.bind_apply (hf hs) Measure.measurable_dropNoneKernel.aemeasurable]
+  · rw [MeasureTheory.lintegral_map]
+    · apply lintegral_congr
+      intro value
+      cases value with
+      | none => simp
+      | some x =>
+          by_cases hx : f x ∈ s <;>
+            simp [Option.map, hs, hf hs, hx]
+    · exact (Measure.measurable_coe hs).comp Measure.measurable_dropNoneKernel
+    · exact hOptionMap
+
+/-- On countable discrete spaces, successful-output measures commute with `SPMF` bind. -/
+theorem toMeasure_bind {β : Type u} [Countable α] [DiscreteMeasurableSpace α]
+    [MeasurableSpace β] [Countable β] [DiscreteMeasurableSpace β]
+    (p : SPMF α) (f : α → SPMF β) :
+    (p >>= f).toMeasure = Measure.bind p.toMeasure fun x => (f x).toMeasure := by
+  apply Measure.ext_of_singleton
+  intro y
+  rw [toMeasure_apply_singleton, bind_apply_eq_tsum,
+    Measure.bind_apply MeasurableSet.of_discrete Measurable.of_discrete.aemeasurable,
+    MeasureTheory.lintegral_countable']
+  simp only [toMeasure_apply_singleton]
+  exact tsum_congr fun x => mul_comm _ _
 
 end SPMF
 

--- a/VCVio/EvalDist/Divergence/KLDivergence.lean
+++ b/VCVio/EvalDist/Divergence/KLDivergence.lean
@@ -5,6 +5,7 @@ Authors: Devon Tuma
 -/
 module
 
+public import VCVio.EvalDist.Kernel
 public import VCVio.EvalDist.PFunctorMeasure
 public import Mathlib.InformationTheory.KullbackLeibler.DataProcessing
 
@@ -57,7 +58,7 @@ variable {P : PFunctor.{uA, u}} [∀ a, MeasurableSpace (P.B a)] [P.IsMeasureSpe
 Measurability is `Measurable.of_discrete`: the *domain* is discrete, so no constraint is placed
 on the output type, which may be continuous. -/
 noncomputable def denoteKernel (f : α → FreeM P β) : Kernel α β :=
-  ⟨fun x => denote (f x), Measurable.of_discrete⟩
+  evalDistKernelOfDiscrete f
 
 omit [∀ a, DiscreteMeasurableSpace (P.B a)] in
 @[simp]

--- a/VCVio/EvalDist/Kernel.lean
+++ b/VCVio/EvalDist/Kernel.lean
@@ -1,0 +1,202 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.EvalDist.Defs.Semantics
+public import ToMathlib.Probability.Kernel.Subprobability
+
+/-!
+# Kernel-valued evaluation semantics
+
+This module bundles a measurably parameterized family of computations as a Mathlib kernel. Closed
+computations denote measures; a family `f : ρ → m α` denotes a kernel precisely when the family
+of output measures is measurable in `ρ`.
+
+The resulting kernel is automatically subprobabilistic. If the family is lossless, it is a Markov
+kernel. Monad bind is composition of the input measure with the continuation kernel.
+-/
+
+@[expose] public section
+
+open MeasureTheory ProbabilityTheory
+open scoped ProbabilityTheory
+
+universe u v w
+
+variable {m : Type u → Type v} {α β : Type u}
+
+section
+
+variable {ρ : Type w}
+
+/-- The kernel denoted by a measurably parameterized family of computations. -/
+noncomputable def evalDistKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => 𝒟[f r]) : Kernel ρ α :=
+  ⟨fun r => 𝒟[f r], hf⟩
+
+/-- On a discrete input space, every computation-valued family defines a kernel. -/
+noncomputable def evalDistKernelOfDiscrete [EvalDistSemantics m]
+    [MeasurableSpace ρ] [DiscreteMeasurableSpace ρ] [MeasurableSpace α]
+    (f : ρ → m α) : Kernel ρ α :=
+  evalDistKernel f Measurable.of_discrete
+
+@[simp]
+theorem evalDistKernel_apply [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => 𝒟[f r]) (r : ρ) :
+    evalDistKernel f hf r = 𝒟[f r] := rfl
+
+@[simp]
+theorem evalDistKernelOfDiscrete_apply [EvalDistSemantics m]
+    [MeasurableSpace ρ] [DiscreteMeasurableSpace ρ] [MeasurableSpace α]
+    (f : ρ → m α) (r : ρ) :
+    evalDistKernelOfDiscrete f r = 𝒟[f r] := rfl
+
+instance evalDistKernel.instIsSubprobabilityKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => 𝒟[f r]) :
+    IsSubprobabilityKernel (evalDistKernel f hf) :=
+  ⟨fun r => evalDist_apply_univ_le_one (f r)⟩
+
+instance evalDistKernelOfDiscrete.instIsSubprobabilityKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [DiscreteMeasurableSpace ρ] [MeasurableSpace α]
+    (f : ρ → m α) : IsSubprobabilityKernel (evalDistKernelOfDiscrete f) :=
+  ⟨fun r => evalDist_apply_univ_le_one (f r)⟩
+
+/-- A lossless computation family denotes a Markov kernel. -/
+theorem isMarkovKernel_evalDistKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => 𝒟[f r])
+    (hProbability : ∀ r, IsProbabilityMeasure 𝒟[f r]) :
+    IsMarkovKernel (evalDistKernel f hf) :=
+  ⟨hProbability⟩
+
+/-- Monad bind is composition of a measure with the continuation kernel. -/
+theorem evalDist_bind_eq_comp [Monad m] [EvalDistSemantics m] [LawfulEvalDistSemantics m]
+    [MeasurableSpace α] [MeasurableSpace β] (mx : m α) (f : α → m β)
+    (hf : Measurable fun x => 𝒟[f x]) :
+    𝒟[mx >>= f] = evalDistKernel f hf ∘ₘ 𝒟[mx] :=
+  evalDist_bind mx f hf
+
+/-- Discrete-domain specialization of `evalDist_bind_eq_comp`. -/
+theorem evalDist_bind_eq_comp_of_discrete [Monad m] [EvalDistSemantics m]
+    [LawfulEvalDistSemantics m] [MeasurableSpace α] [DiscreteMeasurableSpace α]
+    [MeasurableSpace β] (mx : m α) (f : α → m β) :
+    𝒟[mx >>= f] = evalDistKernelOfDiscrete f ∘ₘ 𝒟[mx] :=
+  evalDist_bind_of_discrete mx f
+
+namespace MeasureSemanticsVia
+
+variable [Monad m]
+
+/-- A local bundled semantics turns a measurable family of surface computations into a kernel. -/
+noncomputable def evalDistKernel (sem : MeasureSemanticsVia m)
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => sem.evalDist (f r)) : Kernel ρ α :=
+  ⟨fun r => sem.evalDist (f r), hf⟩
+
+@[simp]
+theorem evalDistKernel_apply (sem : MeasureSemanticsVia m)
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => sem.evalDist (f r)) (r : ρ) :
+    sem.evalDistKernel f hf r = sem.evalDist (f r) := rfl
+
+instance evalDistKernel.instIsSubprobabilityKernel (sem : MeasureSemanticsVia m)
+    [MeasurableSpace ρ] [MeasurableSpace α] (f : ρ → m α)
+    (hf : Measurable fun r => sem.evalDist (f r)) :
+    IsSubprobabilityKernel (sem.evalDistKernel f hf) :=
+  ⟨fun r => sem.evalDist_apply_univ_le_one (f r)⟩
+
+end MeasureSemanticsVia
+
+end
+
+namespace ReaderT
+
+variable {ρ : Type u}
+
+/-- A reader computation denotes a kernel from environments to output distributions. -/
+noncomputable def evalDistKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : ReaderT ρ m α)
+    (hMeasurable : Measurable fun environment => 𝒟[mx environment]) : Kernel ρ α :=
+  _root_.evalDistKernel mx hMeasurable
+
+/-- Discrete environments discharge the reader kernel's measurability obligation. -/
+noncomputable def evalDistKernelOfDiscrete [EvalDistSemantics m]
+    [MeasurableSpace ρ] [DiscreteMeasurableSpace ρ] [MeasurableSpace α]
+    (mx : ReaderT ρ m α) : Kernel ρ α :=
+  _root_.evalDistKernelOfDiscrete mx
+
+@[simp]
+theorem evalDistKernel_apply [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : ReaderT ρ m α)
+    (hMeasurable : Measurable fun environment => 𝒟[mx environment]) (environment : ρ) :
+    ReaderT.evalDistKernel mx hMeasurable environment = 𝒟[mx environment] := rfl
+
+instance evalDistKernel.instIsSubprobabilityKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : ReaderT ρ m α)
+    (hMeasurable : Measurable fun environment => 𝒟[mx environment]) :
+    IsSubprobabilityKernel (ReaderT.evalDistKernel mx hMeasurable) :=
+  ⟨fun environment => evalDist_apply_univ_le_one (mx environment)⟩
+
+/-- A lossless reader computation denotes a Markov kernel. -/
+theorem isMarkovKernel_evalDistKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : ReaderT ρ m α)
+    (hMeasurable : Measurable fun environment => 𝒟[mx environment])
+    (hProbability : ∀ environment, IsProbabilityMeasure 𝒟[mx environment]) :
+    IsMarkovKernel (ReaderT.evalDistKernel mx hMeasurable) :=
+  _root_.isMarkovKernel_evalDistKernel mx hMeasurable hProbability
+
+end ReaderT
+
+namespace StateT
+
+variable {ρ : Type u}
+
+/-- A state computation denotes a kernel from initial state to result and final state. -/
+noncomputable def evalDistKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : StateT ρ m α)
+    (hMeasurable : Measurable fun state => 𝒟[mx state]) : Kernel ρ (α × ρ) :=
+  _root_.evalDistKernel mx hMeasurable
+
+/-- Discrete states discharge the state kernel's measurability obligation. -/
+noncomputable def evalDistKernelOfDiscrete [EvalDistSemantics m]
+    [MeasurableSpace ρ] [DiscreteMeasurableSpace ρ] [MeasurableSpace α]
+    (mx : StateT ρ m α) : Kernel ρ (α × ρ) :=
+  _root_.evalDistKernelOfDiscrete mx
+
+@[simp]
+theorem evalDistKernel_apply [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : StateT ρ m α)
+    (hMeasurable : Measurable fun state => 𝒟[mx state]) (state : ρ) :
+    StateT.evalDistKernel mx hMeasurable state = 𝒟[mx state] := rfl
+
+instance evalDistKernel.instIsSubprobabilityKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : StateT ρ m α)
+    (hMeasurable : Measurable fun state => 𝒟[mx state]) :
+    IsSubprobabilityKernel (StateT.evalDistKernel mx hMeasurable) :=
+  ⟨fun state => evalDist_apply_univ_le_one (mx state)⟩
+
+/-- A lossless state computation denotes a Markov kernel. -/
+theorem isMarkovKernel_evalDistKernel [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α] (mx : StateT ρ m α)
+    (hMeasurable : Measurable fun state => 𝒟[mx state])
+    (hProbability : ∀ state, IsProbabilityMeasure 𝒟[mx state]) :
+    IsMarkovKernel (StateT.evalDistKernel mx hMeasurable) :=
+  _root_.isMarkovKernel_evalDistKernel mx hMeasurable hProbability
+
+/-- Discarding the final state is the first marginal of the state kernel. -/
+theorem evalDist_run'_eq_fst [Functor m] [EvalDistSemantics m]
+    [MeasurableSpace ρ] [MeasurableSpace α]
+    (mx : StateT ρ m α) (hMeasurable : Measurable fun state => 𝒟[mx state])
+    (state : ρ)
+    (hMap : 𝒟[Prod.fst <$> mx state] = (𝒟[mx state]).map Prod.fst) :
+    𝒟[mx.run' state] = (StateT.evalDistKernel mx hMeasurable).fst state := by
+  change 𝒟[Prod.fst <$> mx state] = (StateT.evalDistKernel mx hMeasurable).fst state
+  rw [hMap, Kernel.fst_apply, StateT.evalDistKernel_apply]
+
+end StateT

--- a/VCVio/EvalDist/MeasureSemantics.lean
+++ b/VCVio/EvalDist/MeasureSemantics.lean
@@ -7,14 +7,14 @@ module
 
 public import ToMathlib.MeasureTheory.MeasurableSpace.Except
 public import ToMathlib.MeasureTheory.Measure.Option
+public import VCVio.EvalDist.Kernel
 public import VCVio.EvalDist.PFunctorMeasure
 public import Mathlib.Control.Monad.Writer
-public import Mathlib.Probability.Kernel.Basic
 
 /-!
 # Measure semantics for monads and transformer stacks
 
-`MeasureSemantics m` is the small lossless denotational interface used at VCVio's boundary with
+`ProbabilitySemantics m` is the small lossless denotational interface used at VCVio's boundary with
 Mathlib. It interprets `m α` as an ordinary `Measure α` and records that the measure has total mass
 one. It intentionally does not pretend that `Measure` is a universe-polymorphic Lean monad:
 measurable spaces and measurable continuations remain visible where Mathlib requires them.
@@ -41,25 +41,24 @@ universe u v uA
 
 The output's `MeasurableSpace` is an explicit typeclass argument because it is semantic data, not
 structure carried by the Lean type itself. -/
-structure MeasureSemantics (m : Type u → Type v) where
-  /-- Interpret a computation as a Mathlib measure. -/
-  denote : {α : Type u} → [MeasurableSpace α] → m α → Measure α
+structure ProbabilitySemantics (m : Type u → Type v) extends EvalDistSemantics m where
   /-- The denotation of a total computation has mass one. -/
   isProbabilityMeasure : ∀ {α : Type u} [MeasurableSpace α] (computation : m α),
     IsProbabilityMeasure (denote computation)
 
-namespace MeasureSemantics
+namespace ProbabilitySemantics
 
 variable {m : Type u → Type v} {α ε ω ρ σ : Type u}
 
 /-- The discrete `FreeM` measure denotation packaged as a reusable semantics. -/
 noncomputable def freeM {P : PFunctor.{uA, u}} [∀ a, MeasurableSpace (P.B a)]
     [P.IsMeasureSpec] [∀ a, DiscreteMeasurableSpace (P.B a)] :
-    MeasureSemantics (PFunctor.FreeM P) where
+    ProbabilitySemantics (PFunctor.FreeM P) where
   denote := PFunctor.FreeM.denote
+  apply_univ_le_one := PFunctor.FreeM.denote_apply_univ_le_one
   isProbabilityMeasure := PFunctor.FreeM.isProbabilityMeasure_denote
 
-variable (semantics : MeasureSemantics m)
+variable (semantics : ProbabilitySemantics m)
 
 /-! ## Effect-preserving transformer denotations -/
 
@@ -144,5 +143,20 @@ instance isMarkovKernel_stateTKernel [MeasurableSpace σ] [MeasurableSpace α]
     IsMarkovKernel (semantics.stateTKernel computation hMeasurable) where
   isProbabilityMeasure state :=
     semantics.isProbabilityMeasure (computation state)
+
+end ProbabilitySemantics
+
+/-- Deprecated name for the total refinement of `EvalDistSemantics`. -/
+@[deprecated ProbabilitySemantics (since := "2026-08-26")]
+abbrev MeasureSemantics := ProbabilitySemantics
+
+namespace MeasureSemantics
+
+/-- Deprecated constructor for the total free-monad semantics. -/
+@[deprecated ProbabilitySemantics.freeM (since := "2026-08-26")]
+noncomputable abbrev freeM {P : PFunctor.{uA, u}} [∀ a, MeasurableSpace (P.B a)]
+    [P.IsMeasureSpec] [∀ a, DiscreteMeasurableSpace (P.B a)] :
+    MeasureSemantics (PFunctor.FreeM P) :=
+  ProbabilitySemantics.freeM
 
 end MeasureSemantics

--- a/VCVio/OracleComp/Coinductive/Responder.lean
+++ b/VCVio/OracleComp/Coinductive/Responder.lean
@@ -119,10 +119,31 @@ program without imposing countability on abstract state or answer types. -/
 class IsExecutable (R : ProbResponder spec) where
   /-- The executable answer-and-successor-state subdistribution. -/
   answerSPMF : R.State → (t : spec.Domain) → SPMF (spec.Range t × R.State)
+  /-- Executable states must be point-separating in the responder's measurable structure. -/
+  instMeasurableSingletonClassState :
+    letI := R.instMeasurableSpaceState
+    MeasurableSingletonClass R.State
+  /-- Executable answers must be point-separating in the responder's measurable structure. -/
+  instMeasurableSingletonClassRange : ∀ t,
+    letI := R.instMeasurableSpaceRange t
+    MeasurableSingletonClass (spec.Range t)
   /-- The executable realization denotes exactly the stored answer kernel. -/
   answerKernel_eq_toMeasure : ∀ s t,
     letI := R.instMeasurableSpaceRange t
     R.answerKernel t s = (answerSPMF s t).toMeasure
+
+/-- The authoritative kernel uniquely determines an executable realization. Point-separating
+measurable spaces are essential here: equality as measures can otherwise forget distinctions
+between individual executable outcomes. -/
+theorem IsExecutable.answerSPMF_unique (R : ProbResponder spec)
+    (E₁ E₂ : R.IsExecutable) (s : R.State) (t : spec.Domain) :
+    E₁.answerSPMF s t = E₂.answerSPMF s t := by
+  let _ := R.instMeasurableSpaceRange t
+  let _ : MeasurableSingletonClass R.State := E₁.instMeasurableSingletonClassState
+  let _ : MeasurableSingletonClass (spec.Range t) :=
+    E₁.instMeasurableSingletonClassRange t
+  apply SPMF.toMeasure_injective
+  rw [← E₁.answerKernel_eq_toMeasure s t, ← E₂.answerKernel_eq_toMeasure s t]
 
 /-- Read a kernel responder through its coherent executable `SPMF` realization.
 Kernel-valued consumers should use `answerKernel` directly. -/
@@ -149,6 +170,8 @@ it does not install blanket measurable-space instances on the underlying types. 
 instance ofSPMF.instIsExecutable {σ : Type u}
     (impl : QueryImpl spec (StateT σ SPMF)) : (ofSPMF impl).IsExecutable where
   answerSPMF s t := impl t s
+  instMeasurableSingletonClassState := inferInstance
+  instMeasurableSingletonClassRange _ := inferInstance
   answerKernel_eq_toMeasure _ _ := rfl
 
 /-- A responder as a stateful query implementation in `StateT State SPMF`: the
@@ -239,10 +262,15 @@ two readings still agree. -/
 noncomputable instance pullback.instIsExecutable {ι' : Type u}
     {spec' : OracleSpec.{u, u} ι'}
     (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
-    [R.IsExecutable] : (pullback w R).IsExecutable where
+    [R.IsExecutable]
+    [∀ t, letI := (pullback w R).instMeasurableSpaceRange t
+      MeasurableSingletonClass (spec.Range t)] : (pullback w R).IsExecutable where
   answerSPMF s t :=
     (fun q => (w.toFunB t q.1, q.2)) <$>
       IsExecutable.answerSPMF (R := R) s (w.toFunA t)
+  instMeasurableSingletonClassState :=
+    IsExecutable.instMeasurableSingletonClassState (R := R)
+  instMeasurableSingletonClassRange _ := inferInstance
   answerKernel_eq_toMeasure s t := by
     let _ := R.instMeasurableSpaceRange (w.toFunA t)
     let _ := (pullback w R).instMeasurableSpaceRange t
@@ -266,6 +294,8 @@ maps the target responder's answer back through the lens. -/
     {spec' : OracleSpec.{u, u} ι'}
     (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
     [R.IsExecutable]
+    [∀ t, letI := (pullback w R).instMeasurableSpaceRange t
+      MeasurableSingletonClass (spec.Range t)]
     (t : spec.toPFunctor.A) :
     (pullback w R).toQueryImpl t =
       (fun a => w.toFunB t a) <$> R.toQueryImpl (w.toFunA t) := by
@@ -283,6 +313,8 @@ machine-free, so run-level wrapping laws follow from it by pure congruence. -/
 theorem liftM_mapLens_pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
     (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
     [R.IsExecutable]
+    [∀ t, letI := (pullback w R).instMeasurableSpaceRange t
+      MeasurableSingletonClass (spec.Range t)]
     {γ : Type u} : ∀ oa : OracleComp spec γ,
     PFunctor.FreeM.liftM R.toQueryImpl (PFunctor.FreeM.mapLens w oa) =
       PFunctor.FreeM.liftM (pullback w R).toQueryImpl oa

--- a/VCVio/OracleComp/Coinductive/Responder.lean
+++ b/VCVio/OracleComp/Coinductive/Responder.lean
@@ -7,18 +7,19 @@ Authors: Devon Tuma
 module
 public import VCVio.OracleComp.Coinductive.DynSystem
 public import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
+public import VCVio.EvalDist.Kernel
 public import PolyFun.PFunctor.Dynamical.Game
 
 /-!
 # Probabilistic Wiring: Adversary Strategies Against Stateful Responders
 
 `ProbResponder spec` is the challenger side of an interactive game presented as a
-coalgebra: a state set together with, for each query, a *joint* subdistribution over
-the answer and the next state — a Mealy machine in the Kleisli category of `SPMF`.
-Unbundled, it is exactly a stateful handler `QueryImpl spec (StateT State SPMF)`
-(`ProbResponder.toQueryImpl` / `ofQueryImpl` are definitional inverses): the bundled
-probabilistic sibling of PolyFun's deterministic Kleisli–Mealy bridge
-`PFunctor.Responder.equivStateHandler`.
+coalgebra: a measurable state space together with, for each query, a *joint*
+subprobability kernel over the answer and the next state. It is a Mealy machine in the
+Kleisli category of subprobability kernels. An optional coherent executable
+presentation as a stateful handler `QueryImpl spec (StateT State SPMF)` remains
+available through `ProbResponder.IsExecutable`, `ProbResponder.answer`, and
+`ProbResponder.toQueryImpl`.
 
 Wiring a responder against an adversary `OracleStrategy` is not a hand-rolled
 construction: `stepAgainst` / `iterateAgainst` are PolyFun's generic eval-wired runs
@@ -75,46 +76,111 @@ variable {ι : Type u} {spec : OracleSpec.{u, u} ι} {S : Type u}
 /-! ## Probabilistic stateful responders -/
 
 /-- A probabilistic stateful responder: the challenger side of an interactive game, as
-a Mealy coalgebra in the Kleisli category of `SPMF`. From a state, each query yields a
-joint subdistribution over the answer and the successor state. The joint draw matters:
+a Mealy coalgebra in the Kleisli category of subprobability kernels. From a state, each
+query yields a joint subprobability measure over the answer and the successor state.
+The joint draw matters:
 a lazy random oracle's stored cache entry must be the very answer it returned, which no
 answer-then-state factorization expresses. -/
 structure ProbResponder {ι : Type u} (spec : OracleSpec.{u, u} ι) where
   /-- The responder's internal state (the challenger's memory). -/
   State : Type u
+  /-- The measurable structure on the responder's private state. -/
+  instMeasurableSpaceState : MeasurableSpace State
+  /-- The measurable structure on the answer to each query. -/
+  instMeasurableSpaceRange : (t : spec.Domain) → MeasurableSpace (spec.Range t)
   /-- Answer a query from a state, jointly drawing the successor state. -/
-  answer : State → (t : spec.Domain) → SPMF (spec.Range t × State)
+  answerKernel : (t : spec.Domain) →
+    letI := instMeasurableSpaceState
+    letI := instMeasurableSpaceRange t
+    ProbabilityTheory.Kernel State (spec.Range t × State)
+  /-- Each query kernel is subprobabilistic. -/
+  answerKernel_isSubprobability : ∀ t,
+    letI := instMeasurableSpaceState
+    letI := instMeasurableSpaceRange t
+    ProbabilityTheory.IsSubprobabilityKernel (answerKernel t)
+
+attribute [instance] ProbResponder.instMeasurableSpaceState
 
 namespace ProbResponder
+
+open MeasureTheory ProbabilityTheory
+
+/-- The subprobability invariant stored by a responder, exposed as an instance. -/
+instance answerKernel.instIsSubprobabilityKernel (R : ProbResponder spec)
+    (t : spec.Domain) :
+    letI := R.instMeasurableSpaceRange t
+    IsSubprobabilityKernel (R.answerKernel t) :=
+  R.answerKernel_isSubprobability t
+
+/-- A coherent executable realization of a kernel responder. This separate typeclass
+lets kernel-native responders remain genuinely measure-theoretic, while responders
+built from VCVio's SPMF/ProbComp execution layer retain their original executable
+program without imposing countability on abstract state or answer types. -/
+class IsExecutable (R : ProbResponder spec) where
+  /-- The executable answer-and-successor-state subdistribution. -/
+  answerSPMF : R.State → (t : spec.Domain) → SPMF (spec.Range t × R.State)
+  /-- The executable realization denotes exactly the stored answer kernel. -/
+  answerKernel_eq_toMeasure : ∀ s t,
+    letI := R.instMeasurableSpaceRange t
+    R.answerKernel t s = (answerSPMF s t).toMeasure
+
+/-- Read a kernel responder through its coherent executable `SPMF` realization.
+Kernel-valued consumers should use `answerKernel` directly. -/
+@[deprecated "Use `answerKernel` for kernel semantics; this is the executable SPMF bridge."
+  (since := "2026-08-26")]
+noncomputable def answer (R : ProbResponder spec) [R.IsExecutable]
+    (s : R.State) (t : spec.Domain) : SPMF (spec.Range t × R.State) :=
+  IsExecutable.answerSPMF s t
+
+/-- Build a kernel responder from an executable SPMF-valued stateful handler. The
+constructor equips the state and answers with local discrete measurable structures;
+it does not install blanket measurable-space instances on the underlying types. -/
+@[reducible] noncomputable def ofSPMF {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) : ProbResponder spec where
+  State := σ
+  instMeasurableSpaceState := ⊤
+  instMeasurableSpaceRange := fun _ => ⊤
+  answerKernel t := by
+    letI : MeasurableSpace σ := ⊤
+    letI : MeasurableSpace (spec.Range t) := ⊤
+    exact evalDistKernelOfDiscrete (fun s => impl t s)
+  answerKernel_isSubprobability t := by infer_instance
+
+instance ofSPMF.instIsExecutable {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) : (ofSPMF impl).IsExecutable where
+  answerSPMF s t := impl t s
+  answerKernel_eq_toMeasure _ _ := rfl
 
 /-- A responder as a stateful query implementation in `StateT State SPMF`: the
 bundled-to-unbundled direction of the Kleisli–Mealy identification, of which
 `PFunctor.Responder.equivStateHandler` is the deterministic (`Id`) sibling. -/
-def toQueryImpl (R : ProbResponder spec) : QueryImpl spec (StateT R.State SPMF) :=
-  fun t s => R.answer s t
+noncomputable def toQueryImpl (R : ProbResponder spec) [R.IsExecutable] :
+    QueryImpl spec (StateT R.State SPMF) :=
+  fun t s => IsExecutable.answerSPMF (R := R) s t
 
-/-- A stateful query implementation as a responder; inverse to `toQueryImpl`. -/
-@[reducible] def ofQueryImpl {σ : Type u} (impl : QueryImpl spec (StateT σ SPMF)) :
-    ProbResponder spec where
-  State := σ
-  answer s t := impl t s
+/-- Compatibility spelling for building a responder from a stateful query implementation. -/
+@[reducible]
+noncomputable def ofQueryImpl {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) : ProbResponder spec :=
+  ofSPMF impl
+
+@[simp] lemma toQueryImpl_ofSPMF {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) : (ofSPMF impl).toQueryImpl = impl := rfl
 
 @[simp] lemma toQueryImpl_ofQueryImpl {σ : Type u}
-    (impl : QueryImpl spec (StateT σ SPMF)) : (ofQueryImpl impl).toQueryImpl = impl :=
-  rfl
+    (impl : QueryImpl spec (StateT σ SPMF)) : (ofQueryImpl impl).toQueryImpl = impl := rfl
 
-@[simp] lemma ofQueryImpl_toQueryImpl (R : ProbResponder spec) :
-    ofQueryImpl R.toQueryImpl = R :=
-  rfl
+@[simp] theorem answerSPMF_ofSPMF {σ : Type u}
+    (impl : QueryImpl spec (StateT σ SPMF)) (s : σ) (t : spec.Domain) :
+    IsExecutable.answerSPMF (R := ofSPMF impl) s t = impl t s := rfl
 
 /-- A family of memoryless randomized oracles indexed by a fixed setup value, as a
 responder whose state is the setup and never changes: the per-run-sampled oracle of a
 one-shot security game (sample the setup, then answer memorylessly) is exactly this
 constant-state case. -/
 @[reducible] noncomputable def ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec) :
-    ProbResponder spec where
-  State := Γ
-  answer γ t := (fun r => (r, γ)) <$> h γ t
+    ProbResponder spec :=
+  ofSPMF fun t γ => (fun r => (r, γ)) <$> h γ t
 
 /-- A memoryless randomized oracle as a (trivially) stateful responder. -/
 @[reducible] noncomputable def ofHandler (H : ProbHandler spec) : ProbResponder spec :=
@@ -125,9 +191,8 @@ the internal hom `spec.toPFunctor ⊸ X` — as a Dirac probabilistic responder:
 and successor state it commits to, with probability one. Wiring against it recovers the
 upstream closed game (`OracleStrategy.stepAgainst_ofDet`). -/
 @[reducible] noncomputable def ofDet {σ : Type u} (C : PFunctor.Responder σ spec.toPFunctor) :
-    ProbResponder spec where
-  State := σ
-  answer s t := pure (C.answer s t, C.next s t)
+    ProbResponder spec :=
+  ofSPMF fun t s => pure (C.answer s t, C.next s t)
 
 /-- Pull a responder back along an interface lens: translate each query forward through
 the lens, ask the target responder, and pull its answer back through the lens, keeping
@@ -141,18 +206,74 @@ reducible transparency is what lets `rw`/`simp` traverse such goals. -/
     (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec') :
     ProbResponder spec where
   State := R.State
-  answer s t := (fun q => (w.toFunB t q.1, q.2)) <$> R.answer s (w.toFunA t)
+  instMeasurableSpaceState := R.instMeasurableSpaceState
+  instMeasurableSpaceRange := fun t =>
+    MeasurableSpace.map (w.toFunB t) (R.instMeasurableSpaceRange (w.toFunA t))
+  answerKernel t := by
+    letI := R.instMeasurableSpaceRange (w.toFunA t)
+    letI : MeasurableSpace (spec.Range t) :=
+      MeasurableSpace.map (w.toFunB t) (R.instMeasurableSpaceRange (w.toFunA t))
+    exact (R.answerKernel (w.toFunA t)).map fun q => (w.toFunB t q.1, q.2)
+  answerKernel_isSubprobability t := by infer_instance
 
-/-- The pulled-back responder's handler translates each query forward and maps the
-target responder's answer back through the lens: `toQueryImpl` of `pullback w R` is the
-answer-post-composition of `R.toQueryImpl` along `w`. The handler-level form of the
-interface-wrapping adjunction. -/
-@[simp] theorem toQueryImpl_pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
+/-- The answer/state map used by kernel pullback is measurable for the transported
+answer measurable space. -/
+theorem measurable_pullback_answerMap {ι' : Type u}
+    {spec' : OracleSpec.{u, u} ι'}
     (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    (t : spec.Domain) :
+    letI := R.instMeasurableSpaceRange (w.toFunA t)
+    letI := (pullback w R).instMeasurableSpaceRange t
+    Measurable fun q : spec'.Range (w.toFunA t) × R.State =>
+      (w.toFunB t q.1, q.2) := by
+  let _ := R.instMeasurableSpaceRange (w.toFunA t)
+  let _ := (pullback w R).instMeasurableSpaceRange t
+  have hw : Measurable (w.toFunB t) := by
+    rw [measurable_iff_comap_le]
+    exact MeasurableSpace.comap_map_le
+  exact (hw.comp measurable_fst).prodMk measurable_snd
+
+/-- Executability is preserved by semantic responder pullback. The executable handler
+maps the same answer/state pair as the kernel, and `SPMF.toMeasure_map` proves that the
+two readings still agree. -/
+noncomputable instance pullback.instIsExecutable {ι' : Type u}
+    {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    [R.IsExecutable] : (pullback w R).IsExecutable where
+  answerSPMF s t :=
+    (fun q => (w.toFunB t q.1, q.2)) <$>
+      IsExecutable.answerSPMF (R := R) s (w.toFunA t)
+  answerKernel_eq_toMeasure s t := by
+    let _ := R.instMeasurableSpaceRange (w.toFunA t)
+    let _ := (pullback w R).instMeasurableSpaceRange t
+    simp only [pullback]
+    rw [Kernel.map_apply _ (measurable_pullback_answerMap w R t) s]
+    rw [IsExecutable.answerKernel_eq_toMeasure]
+    exact (SPMF.toMeasure_map _ _ (measurable_pullback_answerMap w R t)).symm
+
+/-- Compatibility alias for the former executable-only pullback constructor. -/
+@[deprecated pullback (since := "2026-08-27"), reducible]
+noncomputable def pullbackSPMF {ι' : Type u}
+    {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    [R.IsExecutable] :
+    ProbResponder spec :=
+  pullback w R
+
+/-- The executable pulled-back responder's handler translates each query forward and
+maps the target responder's answer back through the lens. -/
+@[simp] theorem toQueryImpl_pullback {ι' : Type u}
+    {spec' : OracleSpec.{u, u} ι'}
+    (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    [R.IsExecutable]
     (t : spec.toPFunctor.A) :
     (pullback w R).toQueryImpl t =
       (fun a => w.toFunB t a) <$> R.toQueryImpl (w.toFunA t) := by
   funext s
+  change (fun q => (w.toFunB t q.1, q.2)) <$>
+      IsExecutable.answerSPMF (R := R) s (w.toFunA t) =
+    ((fun a => w.toFunB t a) <$> R.toQueryImpl (w.toFunA t)).run s
+  rw [StateT.run_map]
   rfl
 
 /-- **`FreeM.liftM` naturality for responder pullback**: interpreting a lens-translated
@@ -161,6 +282,7 @@ pulled-back responder. The handler-level content of the interface-wrapping adjun
 machine-free, so run-level wrapping laws follow from it by pure congruence. -/
 theorem liftM_mapLens_pullback {ι' : Type u} {spec' : OracleSpec.{u, u} ι'}
     (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor) (R : ProbResponder spec')
+    [R.IsExecutable]
     {γ : Type u} : ∀ oa : OracleComp spec γ,
     PFunctor.FreeM.liftM R.toQueryImpl (PFunctor.FreeM.mapLens w oa) =
       PFunctor.FreeM.liftM (pullback w R).toQueryImpl oa
@@ -179,9 +301,8 @@ its evaluation distribution, pointwise in the state. This is the bridge along wh
 existing stateful challengers (the lazy random oracle, cached LR encryption oracles)
 become responders. -/
 @[reducible] noncomputable def ofStateQueryImpl {ι₀ : Type} {spec₀ : OracleSpec.{0, 0} ι₀}
-    {σ : Type} (impl : QueryImpl spec₀ (StateT σ ProbComp)) : ProbResponder spec₀ where
-  State := σ
-  answer s t := 𝒮[(impl t).run s]
+    {σ : Type} (impl : QueryImpl spec₀ (StateT σ ProbComp)) : ProbResponder spec₀ :=
+  ofSPMF fun t s => 𝒮[(impl t).run s]
 
 /-- **The stateful-responder probability bridge**: running an adversary against the
 responder built from a `StateT σ ProbComp` handler (`ofStateQueryImpl impl`) is exactly
@@ -195,7 +316,7 @@ Structurally it is the naturality of `simulateQ` along the monad morphism
 `𝒮 : ProbComp →ᵐ SPMF`, transported through `StateT σ` — i.e. `𝒮 ∘ simulateQ impl =
 simulateQ (𝒮 ∘ impl)`. That is exactly `PFunctor.FreeM.run_liftM_mapHom` at the bundled
 evaluation-distribution morphism: `simulateQ` is the universal fold
-(`simulateQ_def`), `ofStateQueryImpl` post-composes each query with `𝒟` pointwise in the
+(`simulateQ_def`), `ofStateQueryImpl` post-composes each query with `𝒮` pointwise in the
 state, and `StateT.mapHom` is that post-composition as a morphism, so the whole statement
 is one instance of the generic law rather than an induction over `OracleComp`. -/
 theorem run_simulateQ_toQueryImpl_ofStateQueryImpl {ι₀ : Type}
@@ -204,7 +325,7 @@ theorem run_simulateQ_toQueryImpl_ofStateQueryImpl {ι₀ : Type}
     (simulateQ (ofStateQueryImpl impl).toQueryImpl oa).run s =
       𝒮[(simulateQ impl oa).run s] := by
   -- `exact` rather than a term-mode `:=`: matching the generic law needs the unfoldings of
-  -- `simulateQ`, `toQueryImpl`, `ofStateQueryImpl`, `StateT.mapHom`, and `𝒟`, which are
+  -- `simulateQ`, `toQueryImpl`, `ofStateQueryImpl`, `StateT.mapHom`, and `𝒮`, which are
   -- definitional but not syntactic.
   exact PFunctor.FreeM.run_liftM_mapHom (MonadHom.ofLift ProbComp SPMF) impl oa s
 
@@ -239,6 +360,8 @@ noncomputable def randomOracleResponder {ι₀ : Type} [DecidableEq ι₀]
 
 namespace OracleStrategy
 
+open MeasureTheory ProbabilityTheory
+
 /-! ## Wired runs
 
 `stepAgainst` / `iterateAgainst` are the upstream eval-wired runs
@@ -260,45 +383,173 @@ example (H : ProbHandler spec) (A : OracleStrategy S spec) (n : ℕ) (s : S) :
   | zero => rfl
   | succ n ih => exact congrArg (kleisliStep H A s >>= ·) (funext ih)
 
+/-! ## Kernel-valued wired runs -/
+
+/-- The one-round output measure obtained by wiring a strategy to a responder at a
+particular joint state. The measurability of the answer-to-next-state map is explicit;
+`stepAgainstKernel` additionally asks that this family of measures be measurable in
+the joint input state. -/
+noncomputable def stepAgainstMeasure [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (_hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (p : R.State × S) : Measure (R.State × S) := by
+  let _ := R.instMeasurableSpaceRange (A.expose p.2)
+  exact (R.answerKernel (A.expose p.2) p.1).map
+    (fun q => (q.2, A.update p.2 q.1))
+
+/-- One wired round as a subprobability kernel on the responder/strategy product
+state. The two hypotheses are precisely the local deterministic-update measurability
+and the joint-state measurability needed to promote the pointwise construction to a
+kernel. -/
+noncomputable def stepAgainstKernel [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate)) :
+    Kernel (R.State × S) (R.State × S) :=
+  ⟨stepAgainstMeasure A R hUpdate, hFamily⟩
+
+@[simp] theorem stepAgainstKernel_apply [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate))
+    (p : R.State × S) :
+    stepAgainstKernel A R hUpdate hFamily p = stepAgainstMeasure A R hUpdate p := rfl
+
+instance stepAgainstKernel.instIsSubprobabilityKernel [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate)) :
+    IsSubprobabilityKernel (stepAgainstKernel A R hUpdate hFamily) := ⟨fun p => by
+  let _ := R.instMeasurableSpaceRange (A.expose p.2)
+  rw [stepAgainstKernel_apply, stepAgainstMeasure, Measure.map_apply (hUpdate p)
+    MeasurableSet.univ, Set.preimage_univ]
+  exact (R.answerKernel (A.expose p.2)).measure_univ_le p.1⟩
+
+/-- The `n`-round kernel generated by `stepAgainstKernel`. Kernel powers provide the
+canonical iteration/composition operation and inherit the subprobability invariant. -/
+noncomputable def iterateAgainstKernel [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate)) (n : ℕ) :
+    Kernel (R.State × S) (R.State × S) :=
+  stepAgainstKernel A R hUpdate hFamily ^ n
+
+instance iterateAgainstKernel.instIsSubprobabilityKernel [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec)
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate)) (n : ℕ) :
+    IsSubprobabilityKernel (iterateAgainstKernel A R hUpdate hFamily n) := by
+  unfold iterateAgainstKernel
+  infer_instance
+
 /-- One wired round of an adversary strategy against a stateful responder: the
 responder answers the exposed query (jointly drawing its successor state), and the
 adversary advances along the answer. This is the upstream stateful-handler step
 `PFunctor.DynSystem.stepWith` at `m := SPMF`: the wiring itself is deterministic
 interface data; only the states advance stochastically. -/
-noncomputable def stepAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :=
+noncomputable def stepAgainst (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable] :
+    R.State × S → SPMF (R.State × S) :=
   PFunctor.DynSystem.stepWith R.toQueryImpl A
 
 @[simp] theorem stepAgainst_apply (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable]
     (p : R.State × S) :
     stepAgainst A R p =
-      (fun q => (q.2, A.update p.2 q.1)) <$> R.answer p.1 (A.expose p.2) := rfl
+      (fun q => (q.2, A.update p.2 q.1)) <$>
+        ProbResponder.IsExecutable.answerSPMF (R := R) p.1 (A.expose p.2) := rfl
 
 /-- The `n`-round wired run: the Markov chain on the product state space generated by
 `stepAgainst` — the upstream `PFunctor.DynSystem.iterWith` at `m := SPMF`. -/
-noncomputable def iterateAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :
+noncomputable def iterateAgainst (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable] :
     ℕ → R.State × S → SPMF (R.State × S) :=
   PFunctor.DynSystem.iterWith R.toQueryImpl A
 
 @[simp] theorem iterateAgainst_zero (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable]
     (p : R.State × S) : iterateAgainst A R 0 p = pure p := rfl
 
-theorem iterateAgainst_succ (A : OracleStrategy S spec) (R : ProbResponder spec) (n : ℕ)
+theorem iterateAgainst_succ (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable] (n : ℕ)
     (p : R.State × S) :
     iterateAgainst A R (n + 1) p = stepAgainst A R p >>= iterateAgainst A R n := rfl
+
+/-- The executable one-round run denotes exactly the kernel one-round semantics. -/
+theorem stepAgainstKernel_eq_toMeasure [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec) [R.IsExecutable]
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate))
+    (p : R.State × S) :
+    stepAgainstKernel A R hUpdate hFamily p = (stepAgainst A R p).toMeasure := by
+  let _ := R.instMeasurableSpaceRange (A.expose p.2)
+  rw [stepAgainstKernel_apply, stepAgainstMeasure, stepAgainst_apply,
+    ProbResponder.IsExecutable.answerKernel_eq_toMeasure]
+  exact (SPMF.toMeasure_map _ _ (hUpdate p)).symm
+
+/-- On countable discrete state spaces, the executable `n`-round run denotes exactly
+the corresponding power of the one-round kernel. -/
+theorem iterateAgainstKernel_eq_toMeasure [MeasurableSpace S]
+    (A : OracleStrategy S spec) (R : ProbResponder spec) [R.IsExecutable]
+    [Countable R.State] [DiscreteMeasurableSpace R.State]
+    [Countable S] [DiscreteMeasurableSpace S]
+    (hUpdate : ∀ p : R.State × S,
+      letI := R.instMeasurableSpaceRange (A.expose p.2)
+      Measurable fun q : spec.Range (A.expose p.2) × R.State =>
+        (q.2, A.update p.2 q.1))
+    (hFamily : Measurable (stepAgainstMeasure A R hUpdate))
+    (n : ℕ) (p : R.State × S) :
+    iterateAgainstKernel A R hUpdate hFamily n p =
+      (iterateAgainst A R n p).toMeasure := by
+  induction n generalizing p with
+  | zero =>
+      rw [iterateAgainstKernel, pow_zero]
+      change Measure.dirac p = (iterateAgainst A R 0 p).toMeasure
+      rw [iterateAgainst_zero]
+      rw [SPMF.toMeasure_pure]
+  | succ n ih =>
+      rw [iterateAgainstKernel, Kernel.pow_add _ n 1, pow_one, Kernel.comp_apply,
+        stepAgainstKernel_eq_toMeasure A R hUpdate hFamily,
+        iterateAgainst_succ, SPMF.toMeasure_bind]
+      apply Measure.bind_congr_right
+      exact Filter.Eventually.of_forall ih
 
 /-- The joint subdistribution over the length-`n` wired transcript and the final
 product state (responder state first, matching `stepAgainst`). `QueryLog` is VCVio
 vocabulary, so the transcript-recording run lives here rather than upstream. -/
-noncomputable def transcriptAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :
+noncomputable def transcriptAgainst (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable] :
     R.State × S → ℕ → SPMF (QueryLog spec × (R.State × S))
   | p, 0 => pure ([], p)
   | p, n + 1 => do
-      let q ← R.answer p.1 (A.expose p.2)
+      let q ← ProbResponder.IsExecutable.answerSPMF (R := R) p.1 (A.expose p.2)
       let rest ← transcriptAgainst A R (q.2, A.update p.2 q.1) n
       pure (⟨A.expose p.2, q.1⟩ :: rest.1, rest.2)
 
 /-- The subdistribution over length-`n` wired transcripts. -/
 noncomputable def transcriptDistAgainst (A : OracleStrategy S spec) (R : ProbResponder spec)
+    [R.IsExecutable]
     (p : R.State × S) (n : ℕ) : SPMF (QueryLog spec) :=
   Prod.fst <$> transcriptAgainst A R p n
 
@@ -314,7 +565,7 @@ game `PFunctor.DynSystem.closedGame`. -/
     (C : PFunctor.Responder σ spec.toPFunctor) (p : σ × S) :
     stepAgainst A (.ofDet C) p = pure ((PFunctor.DynSystem.closedGame C A).step p) := by
   obtain ⟨r, s⟩ := p
-  simp [ProbResponder.ofDet]
+  simp [ProbResponder.ofDet, ProbResponder.answerSPMF_ofSPMF]
 
 /-! ## Memoryless recovery
 
@@ -328,7 +579,8 @@ a `StateT.lift`; the same induction applies). -/
     (A : OracleStrategy S spec) (p : Γ × S) :
     stepAgainst A (ProbResponder.ofHandlerFamily h) p =
       (fun s' => (p.1, s')) <$> kleisliStep (h p.1) A p.2 := by
-  simp only [stepAgainst_apply, ProbResponder.ofHandlerFamily, kleisliStep, Functor.map_map]
+  rw [stepAgainst_apply, ProbResponder.answerSPMF_ofSPMF]
+  simp only [ProbResponder.ofHandlerFamily, kleisliStep, Functor.map_map]
 
 @[simp] theorem iterateAgainst_ofHandlerFamily {Γ : Type u} (h : Γ → ProbHandler spec)
     (A : OracleStrategy S spec) (n : ℕ) (p : Γ × S) :

--- a/VCVio/OracleComp/Coinductive/WiredRun.lean
+++ b/VCVio/OracleComp/Coinductive/WiredRun.lean
@@ -154,6 +154,8 @@ unrolled query tree, and `ProbResponder.liftM_mapLens_pullback` re-reads the
 translation through the pulled-back handler. -/
 theorem runWith_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
     (M : OracleMachine spec α β) (R : ProbResponder spec') [R.IsExecutable]
+    [∀ t, letI := (R.pullback w).instMeasurableSpaceRange t
+      MeasurableSingletonClass (spec.Range t)]
     (k : ℕ) (s : M.State) :
     (M.wrap w).runWith R.toQueryImpl k s =
       M.runWith (R.pullback w).toQueryImpl k s := by
@@ -166,6 +168,8 @@ theorem runWith_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
 level. -/
 theorem runAgainst_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
     (M : OracleMachine spec α β) (R : ProbResponder spec') [R.IsExecutable]
+    [∀ t, letI := (R.pullback w).instMeasurableSpaceRange t
+      MeasurableSingletonClass (spec.Range t)]
     (k : ℕ) (r : R.State)
     (s : M.State) :
     runAgainst (M.wrap w) R k (r, s) = M.runAgainst (R.pullback w) k (r, s) := by

--- a/VCVio/OracleComp/Coinductive/WiredRun.lean
+++ b/VCVio/OracleComp/Coinductive/WiredRun.lean
@@ -61,18 +61,19 @@ handler and run from the responder state. Input pair is responder-state-first
 state)` in `StateT.run` order. Early stopping at the first returned value is
 inherited from `runWith`. -/
 noncomputable def runAgainst (M : OracleMachine spec α β) (R : ProbResponder spec)
-    (k : ℕ) (p : R.State × M.State) : SPMF (Option β × R.State) :=
+    [R.IsExecutable] (k : ℕ) (p : R.State × M.State) : SPMF (Option β × R.State) :=
   (M.runWith R.toQueryImpl k p.2).run p.1
 
 /-- Regression canary: the wired run is definitionally the stateful `runWith` in
 `StateT.run` form. -/
 theorem runAgainst_eq_runWith_run (M : OracleMachine spec α β) (R : ProbResponder spec)
-    (k : ℕ) (r : R.State) (s : M.State) :
+    [R.IsExecutable] (k : ℕ) (r : R.State) (s : M.State) :
     M.runAgainst R k (r, s) = (M.runWith R.toQueryImpl k s).run r := rfl
 
 /-- A returned machine state's wired run is Dirac on its value and the unchanged
 responder state, at every fuel. -/
 theorem runAgainst_of_view_return (M : OracleMachine spec α β) (R : ProbResponder spec)
+    [R.IsExecutable]
     {s : M.State} {b : β} (hview : M.view s = Sum.inl b) (k : ℕ) (r : R.State) :
     M.runAgainst R k (r, s) = pure (some b, r) := by
   rw [runAgainst_eq_runWith_run, M.runWith_return R.toQueryImpl k s b hview]
@@ -81,7 +82,7 @@ theorem runAgainst_of_view_return (M : OracleMachine spec α β) (R : ProbRespon
 /-- Zero fuel cuts an unresolved query off with `none`, leaving the responder state
 unchanged. -/
 theorem runAgainst_zero_of_view_query (M : OracleMachine spec α β)
-    (R : ProbResponder spec) {s : M.State} {t : spec.Domain}
+    (R : ProbResponder spec) [R.IsExecutable] {s : M.State} {t : spec.Domain}
     {next : spec.Range t → M.State} (hview : M.view s = Sum.inr ⟨t, next⟩)
     (r : R.State) : M.runAgainst R 0 (r, s) = pure (none, r) := by
   rw [runAgainst_eq_runWith_run, M.runWith_query_zero R.toQueryImpl s t next hview]
@@ -91,11 +92,12 @@ theorem runAgainst_zero_of_view_query (M : OracleMachine spec α β)
 jointly samples the responder's answer and next state, then continues — PolyFun's
 `runWith_query_succ_stateT` read at `m := SPMF`. -/
 theorem runAgainst_succ_of_view_query (M : OracleMachine spec α β)
-    (R : ProbResponder spec) {s : M.State} {t : spec.Domain}
+    (R : ProbResponder spec) [R.IsExecutable] {s : M.State} {t : spec.Domain}
     {next : spec.Range t → M.State} (hview : M.view s = Sum.inr ⟨t, next⟩)
     (k : ℕ) (r : R.State) :
     M.runAgainst R (k + 1) (r, s) =
-      R.answer r t >>= fun q => M.runAgainst R k (q.2, next q.1) :=
+      ProbResponder.IsExecutable.answerSPMF (R := R) r t >>= fun q =>
+        M.runAgainst R k (q.2, next q.1) :=
   M.runWith_query_succ_stateT R.toQueryImpl k s t next hview r
 
 /-! ## Memoryless recovery -/
@@ -124,11 +126,13 @@ form of `OracleStrategy.iterateAgainst_ofHandlerFamily`. -/
     | inr q =>
       obtain ⟨t, next⟩ := q
       calc M.runAgainst (.ofHandlerFamily h) (k + 1) (γ, s)
-          = (ProbResponder.ofHandlerFamily h).answer γ t >>= fun p =>
+          = ProbResponder.IsExecutable.answerSPMF
+              (R := ProbResponder.ofHandlerFamily h) γ t >>= fun p =>
               M.runAgainst (.ofHandlerFamily h) k (p.2, next p.1) :=
             M.runAgainst_succ_of_view_query (.ofHandlerFamily h) hview k γ
         _ = h γ t >>= fun a =>
               (fun ob => (ob, γ)) <$> M.runWith (h γ) k (next a) := by
+            rw [ProbResponder.answerSPMF_ofSPMF]
             simp only [ProbResponder.ofHandlerFamily, bind_map_left]
             exact bind_congr fun a => ih (next a)
         _ = (fun ob => (ob, γ)) <$> M.runWith (h γ) (k + 1) s := by
@@ -149,7 +153,8 @@ pulled back along `w`. Pure factoring, no fuel induction: `unroll_wrap` translat
 unrolled query tree, and `ProbResponder.liftM_mapLens_pullback` re-reads the
 translation through the pulled-back handler. -/
 theorem runWith_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
-    (M : OracleMachine spec α β) (R : ProbResponder spec') (k : ℕ) (s : M.State) :
+    (M : OracleMachine spec α β) (R : ProbResponder spec') [R.IsExecutable]
+    (k : ℕ) (s : M.State) :
     (M.wrap w).runWith R.toQueryImpl k s =
       M.runWith (R.pullback w).toQueryImpl k s := by
   simp only [DynComputation.runWith]
@@ -160,7 +165,8 @@ theorem runWith_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
 `runWith_wrap`. This is the workhorse of same-interface reductions at the game
 level. -/
 theorem runAgainst_wrap (w : PFunctor.Lens spec.toPFunctor spec'.toPFunctor)
-    (M : OracleMachine spec α β) (R : ProbResponder spec') (k : ℕ) (r : R.State)
+    (M : OracleMachine spec α β) (R : ProbResponder spec') [R.IsExecutable]
+    (k : ℕ) (r : R.State)
     (s : M.State) :
     runAgainst (M.wrap w) R k (r, s) = M.runAgainst (R.pullback w) k (r, s) := by
   rw [runAgainst_eq_runWith_run, runAgainst_eq_runWith_run, runWith_wrap]

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -4,6 +4,7 @@ public import VCVioTest.Computability
 public import VCVioTest.ForkMeasure
 public import VCVioTest.Forking.WithoutReplacement
 public import VCVioTest.GrindFailFast
+public import VCVioTest.KernelSemantics
 public import VCVioTest.LongChainPrograms
 public import VCVioTest.MeasureSemantics
 public import VCVioTest.MerkleTreeBatch

--- a/VCVioTest/KernelSemantics.lean
+++ b/VCVioTest/KernelSemantics.lean
@@ -76,6 +76,11 @@ noncomputable example : togglingResponder.IsExecutable := by
   unfold togglingResponder
   infer_instance
 
+/-- Any two executable witnesses for one responder have the same observable program. -/
+example (E₁ E₂ : togglingResponder.IsExecutable) (state : Bool) :
+    E₁.answerSPMF state PUnit.unit = E₂.answerSPMF state PUnit.unit :=
+  ProbResponder.IsExecutable.answerSPMF_unique togglingResponder E₁ E₂ state PUnit.unit
+
 example : IsSubprobabilityKernel
     (togglingResponder.answerKernel PUnit.unit) := by
   unfold togglingResponder

--- a/VCVioTest/KernelSemantics.lean
+++ b/VCVioTest/KernelSemantics.lean
@@ -1,0 +1,175 @@
+/-
+Copyright (c) 2026 Devon Tuma. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Devon Tuma
+-/
+module
+
+public import VCVio.OracleComp.Coinductive.Responder
+public import Mathlib.MeasureTheory.Constructions.BorelSpace.Basic
+
+/-!
+# Canaries for kernel-valued semantics
+
+Checks the subprobability closure layer, the coherent executable responder bridge, and a
+kernel-native responder whose state space is genuinely continuous.
+-/
+
+public section
+
+open MeasureTheory ProbabilityTheory OracleSpec
+
+namespace VCVioTest.KernelSemantics
+
+/-! ## Subprobability computation families -/
+
+@[expose] noncomputable def lossyFamily (input : Bool) : SPMF Bool :=
+  if input then pure true else failure
+
+noncomputable def lossyKernel : Kernel Bool Bool :=
+  evalDistKernelOfDiscrete lossyFamily
+
+example : IsSubprobabilityKernel lossyKernel := by
+  unfold lossyKernel
+  infer_instance
+
+example (input : Bool) : lossyKernel input Set.univ ≤ 1 := by
+  unfold lossyKernel
+  exact Kernel.measure_univ_le (evalDistKernelOfDiscrete lossyFamily) input
+
+example : lossyKernel true = Measure.dirac true := by
+  rw [lossyKernel, evalDistKernelOfDiscrete_apply]
+  change (lossyFamily true).toMeasure = Measure.dirac true
+  rw [lossyFamily, if_pos rfl]
+  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+
+example : lossyKernel false = 0 := by
+  rw [lossyKernel, evalDistKernelOfDiscrete_apply]
+  change (lossyFamily false).toMeasure = 0
+  rw [lossyFamily, if_neg (by decide)]
+  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+
+example : lossyKernel true Set.univ = 1 := by
+  rw [show lossyKernel true = Measure.dirac true by
+    rw [lossyKernel, evalDistKernelOfDiscrete_apply]
+    change (lossyFamily true).toMeasure = Measure.dirac true
+    rw [lossyFamily, if_pos rfl]
+    simp [SPMF.toMeasure, PMF.toMeasure_pure]]
+  simp
+
+example : lossyKernel false Set.univ = 0 := by
+  rw [show lossyKernel false = 0 by
+    rw [lossyKernel, evalDistKernelOfDiscrete_apply]
+    change (lossyFamily false).toMeasure = 0
+    rw [lossyFamily, if_neg (by decide)]
+    simp [SPMF.toMeasure, PMF.toMeasure_pure]]
+  simp
+
+/-! ## Executable responders -/
+
+@[expose, reducible] def boolAnswerSpec : OracleSpec PUnit := fun _ => Bool
+
+@[reducible] noncomputable def togglingResponder : ProbResponder boolAnswerSpec :=
+  .ofSPMF fun _ state => pure (state, !state)
+
+noncomputable example : togglingResponder.IsExecutable := by
+  unfold togglingResponder
+  infer_instance
+
+example : IsSubprobabilityKernel
+    (togglingResponder.answerKernel PUnit.unit) := by
+  unfold togglingResponder
+  infer_instance
+
+example (state : Bool) :
+    togglingResponder.answerKernel PUnit.unit state =
+      (pure (state, !state) : SPMF (Bool × Bool)).toMeasure :=
+  rfl
+
+section DiscreteWiredCanaries
+
+noncomputable local instance : MeasurableSpace Bool :=
+  togglingResponder.instMeasurableSpaceRange PUnit.unit
+local instance : DiscreteMeasurableSpace Bool := ⟨fun _ => trivial⟩
+
+def echoStrategy : OracleStrategy Bool boolAnswerSpec :=
+  PFunctor.DynSystem.mk' (fun _ => PUnit.unit) fun _ answer => answer
+
+theorem echoUpdate_measurable : ∀ p : togglingResponder.State × Bool,
+    letI := togglingResponder.instMeasurableSpaceRange
+      (echoStrategy.expose p.2)
+    Measurable fun q : boolAnswerSpec.Range (echoStrategy.expose p.2) ×
+        togglingResponder.State =>
+      (q.2, echoStrategy.update p.2 q.1) :=
+  fun _ => Measurable.of_discrete
+
+theorem echoStepFamily_measurable : Measurable
+    (OracleStrategy.stepAgainstMeasure echoStrategy togglingResponder
+      echoUpdate_measurable) :=
+  Measurable.of_discrete
+
+noncomputable def togglingIterKernel (n : ℕ) : Kernel (Bool × Bool) (Bool × Bool) :=
+  OracleStrategy.iterateAgainstKernel echoStrategy togglingResponder
+    echoUpdate_measurable echoStepFamily_measurable n
+
+example (p : Bool × Bool) :
+    OracleStrategy.iterateAgainst echoStrategy togglingResponder 0 p = pure p := rfl
+
+example (p : Bool × Bool) :
+    OracleStrategy.iterateAgainst echoStrategy togglingResponder 1 p =
+      pure (!p.1, p.1) := by
+  simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply,
+    togglingResponder, echoStrategy]
+
+example (p : Bool × Bool) :
+    OracleStrategy.iterateAgainst echoStrategy togglingResponder 2 p =
+      pure (p.1, !p.1) := by
+  simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply,
+    togglingResponder, echoStrategy]
+
+example (p : Bool × Bool) : togglingIterKernel 0 p = Measure.dirac p := by
+  rw [togglingIterKernel, OracleStrategy.iterateAgainstKernel_eq_toMeasure]
+  change (pure p : SPMF (Bool × Bool)).toMeasure = Measure.dirac p
+  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+
+example (p : Bool × Bool) :
+    togglingIterKernel 1 p = Measure.dirac (!p.1, p.1) := by
+  rw [togglingIterKernel, OracleStrategy.iterateAgainstKernel_eq_toMeasure]
+  rw [show OracleStrategy.iterateAgainst echoStrategy togglingResponder 1 p =
+    pure (!p.1, p.1) by
+      simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply,
+        togglingResponder, echoStrategy]]
+  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+
+example (p : Bool × Bool) :
+    togglingIterKernel 2 p = Measure.dirac (p.1, !p.1) := by
+  rw [togglingIterKernel, OracleStrategy.iterateAgainstKernel_eq_toMeasure]
+  rw [show OracleStrategy.iterateAgainst echoStrategy togglingResponder 2 p =
+    pure (p.1, !p.1) by
+      simp [OracleStrategy.iterateAgainst_succ, OracleStrategy.stepAgainst_apply,
+        togglingResponder, echoStrategy]]
+  simp [SPMF.toMeasure, PMF.toMeasure_pure]
+
+end DiscreteWiredCanaries
+
+/-! ## A kernel-native continuous-state responder -/
+
+@[expose, reducible] def realAnswerSpec : OracleSpec PUnit := fun _ => ℝ
+
+noncomputable def realEchoResponder : ProbResponder realAnswerSpec where
+  State := ℝ
+  instMeasurableSpaceState := inferInstance
+  instMeasurableSpaceRange := fun _ => inferInstance
+  answerKernel _ := Kernel.deterministic (fun state => (state, state)) (by fun_prop)
+  answerKernel_isSubprobability _ := by infer_instance
+
+example : IsMarkovKernel (realEchoResponder.answerKernel PUnit.unit) := by
+  unfold realEchoResponder
+  infer_instance
+
+example (state : ℝ) :
+    realEchoResponder.answerKernel PUnit.unit state = Measure.dirac (state, state) := by
+  unfold realEchoResponder
+  rw [Kernel.deterministic_apply]
+
+end VCVioTest.KernelSemantics

--- a/VCVioTest/MeasureSemantics.lean
+++ b/VCVioTest/MeasureSemantics.lean
@@ -176,8 +176,8 @@ example (p q : SPMF.{0} PUnit.{1}) :
 /-! ## Transformer stacks retain their effects -/
 
 /-- The reusable total semantics for the discrete coin interface. -/
-noncomputable def coinMeasureSemantics : MeasureSemantics (FreeM coinSpec) :=
-  MeasureSemantics.freeM
+noncomputable def coinMeasureSemantics : ProbabilitySemantics (FreeM coinSpec) :=
+  ProbabilitySemantics.freeM
 
 /-- `OptionT` keeps `none` as an observable outcome until a proof explicitly discards it. -/
 example (computation : OptionT (FreeM coinSpec) Bool) :

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -35,6 +35,55 @@ round-tripping through the finite backend.
 | `support mx` | `Set α` | — | `EvalDist/Defs/Support.lean` |
 | `finSupport mx` | `Finset α` | — | `EvalDist/Defs/Support.lean` |
 
+### Kernel-valued interfaces
+
+Use a `Measure α` for a closed computation and a `Kernel ρ α` when `ρ` is a semantic input:
+an environment, initial state, public parameter, or previous protocol state. Do not encode the
+input by immediately fixing it and returning a bare measure; doing so discards the measurability
+needed for composition and data-processing theorems.
+
+| Definition | Purpose | Defined in |
+|-----------|---------|------------|
+| `IsSubprobabilityKernel κ` | Every value of `κ` has total mass at most one | `ToMathlib/Probability/Kernel/Subprobability.lean` |
+| `evalDistKernel f hf` | Measurable computation family `ρ → m α` as a kernel | `EvalDist/Kernel.lean` |
+| `evalDistKernelOfDiscrete f` | Discrete-input specialization | `EvalDist/Kernel.lean` |
+| `ReaderT.evalDistKernel` | Reader environment as kernel input | `EvalDist/Kernel.lean` |
+| `StateT.evalDistKernel` | Initial state to result/final-state kernel | `EvalDist/Kernel.lean` |
+| `ProbResponder.answerKernel` | Stateful interactive answer transition | `OracleComp/Coinductive/Responder.lean` |
+
+`IsSubprobabilityKernel` is closed under `Kernel.const`, `restrict`, `map`, `comap`, `comp`,
+`prod`, and powers. It implies `IsFiniteKernel`, so Mathlib's s-finite composition API is
+available without restating a finiteness bound. A lossless family should additionally expose an
+`IsMarkovKernel` instance or theorem.
+
+`ProbabilitySemantics` is the total/lossless semantics bundle used by transformer adapters.
+`MeasureSemantics` is a deprecated compatibility alias. The lower-level `MeasureSemanticsVia`
+continues to describe potentially lossy surface semantics.
+
+For `ProbResponder`, the kernel is authoritative. `ProbResponder.IsExecutable` optionally carries
+a coherent SPMF realization for machine execution; the deprecated `ProbResponder.answer` is just
+that bridge. This separate capability is important: abstract cryptographic caches need not be
+countable, while a kernel-native responder need not have any executable SPMF realization.
+
+#### Adoption audit
+
+| Area | Decision | Rationale / next integration point |
+|------|----------|------------------------------------|
+| Closed `evalDist`, advantages, couplings | Keep `Measure` | There is no semantic input to bundle. |
+| `ReaderT` and `StateT` observations | Use `Kernel` now | Environment/state is exactly the kernel input; use the adapters above. |
+| Stateful responders and wired rounds | Use `Kernel` now | `answerKernel`, `stepAgainstKernel`, and kernel powers model transitions compositionally. |
+| Executable `QueryImpl`, `simulateQ`, machine runs | Keep monadic/SPMF syntax | These are programs and evaluators; cross to kernels at observation boundaries. |
+| KL/data-processing continuations | Use `Kernel` now | `KLDivergence.denoteKernel` is implemented through `evalDistKernelOfDiscrete`. |
+| Query tracing, caches, costs, enforcement | Migrate observations, not handlers | Add kernel views of their `StateT` runs when a theorem composes distributions across states. |
+| Crypto functions parameterized by keys/messages/security parameter | Add kernels when composed probabilistically | A plain function remains clearer until measurability or data processing is actually used. |
+| UC/open-process runtime | Defer to an observation boundary | Structural process syntax has no canonical measurable space; bundle a kernel only for a chosen execution/observation model. |
+| Program-logic predicates and tactics | Keep computation syntax | Their job is to reason before denotation. Add kernel bridge lemmas, not kernel-valued syntax. |
+
+When introducing a new kernel, require the real measurable-space assumptions or bundle them with
+the semantic object. Do not install global `MeasurableSpace := ⊤` instances merely to discharge a
+proof. For an intentionally discrete local model, `evalDistKernelOfDiscrete` or a locally bundled
+measurable space is the explicit escape hatch.
+
 ### Measure-native interfaces
 
 | Definition | Purpose | Defined in |

--- a/docs/agents/probability.md
+++ b/docs/agents/probability.md
@@ -62,8 +62,12 @@ continues to describe potentially lossy surface semantics.
 
 For `ProbResponder`, the kernel is authoritative. `ProbResponder.IsExecutable` optionally carries
 a coherent SPMF realization for machine execution; the deprecated `ProbResponder.answer` is just
-that bridge. This separate capability is important: abstract cryptographic caches need not be
-countable, while a kernel-native responder need not have any executable SPMF realization.
+that bridge. Executable state and answer spaces must have measurable singletons, so equality with
+the authoritative kernel determines every executable point mass and therefore the entire SPMF.
+Pullback along an interface lens preserves executability only when the transported answer space
+also has measurable singletons. This separate capability is important: abstract cryptographic
+caches need not be countable, while a kernel-native responder need not have any executable SPMF
+realization.
 
 #### Adoption audit
 

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -74,7 +74,7 @@ VCVio/EvalDist/TVDist.lean	139
 VCVio/Interaction/UC/Runtime.lean	3
 VCVio/OracleComp/Coercions/SubSpec.lean	3
 VCVio/OracleComp/Coinductive/DynSystem.lean	9
-VCVio/OracleComp/Coinductive/Responder.lean	18
+VCVio/OracleComp/Coinductive/Responder.lean	19
 VCVio/OracleComp/Coinductive/WiredRun.lean	1
 VCVio/OracleComp/Constructions/GenerateSeed.lean	2
 VCVio/OracleComp/Constructions/SampleableType.lean	1

--- a/scripts/pmf_boundary_baseline.tsv
+++ b/scripts/pmf_boundary_baseline.tsv
@@ -46,7 +46,7 @@ VCVio/EvalDist/Bool.lean	4
 VCVio/EvalDist/Defs/AlternativeMonad.lean	6
 VCVio/EvalDist/Defs/Basic.lean	138
 VCVio/EvalDist/Defs/Instances.lean	29
-VCVio/EvalDist/Defs/Measure.lean	26
+VCVio/EvalDist/Defs/Measure.lean	33
 VCVio/EvalDist/Defs/NeverFails.lean	13
 VCVio/EvalDist/Defs/Semantics.lean	12
 VCVio/EvalDist/Defs/Support.lean	1
@@ -74,7 +74,7 @@ VCVio/EvalDist/TVDist.lean	139
 VCVio/Interaction/UC/Runtime.lean	3
 VCVio/OracleComp/Coercions/SubSpec.lean	3
 VCVio/OracleComp/Coinductive/DynSystem.lean	9
-VCVio/OracleComp/Coinductive/Responder.lean	8
+VCVio/OracleComp/Coinductive/Responder.lean	18
 VCVio/OracleComp/Coinductive/WiredRun.lean	1
 VCVio/OracleComp/Constructions/GenerateSeed.lean	2
 VCVio/OracleComp/Constructions/SampleableType.lean	1


### PR DESCRIPTION
## Probability campaign

Merged foundation: #530 → #531 → #535 → #536 → #537 → #538 → #540 → #544

Final stack: #548 (8/9) → **#549 (9/9)**. This PR targets the exact #548 head and is the top of the stack.

## Summary

- add subprobability-kernel infrastructure and closure under standard Mathlib kernel combinators;
- bundle parameterized computation families, ReaderT environments, and StateT transitions as kernels;
- make `ProbResponder` kernel-authoritative while retaining an optional coherent executable SPMF capability;
- add kernel-native responder pullback, wired transition kernels, and iteration through kernel powers;
- keep QueryImpl, simulateQ, and machine execution in the executable monadic layer;
- add discrete, lossy, executable, wired-iteration, and continuous-state canaries.

## Independent adversarial review and repair

The final independent review produced a concrete counterexample to the original `IsExecutable` contract: with a coarse measurable space, two different SPMFs could denote the same stored kernel, so machine execution could depend on the selected witness.

The fix makes executable coherence genuinely unique:

- executable state and answer spaces must have measurable singletons;
- `SPMF.toMeasure_injective` now works under that exact assumption;
- `IsExecutable.answerSPMF_unique` proves two witnesses agree pointwise;
- semantic pullback and wired wrapping require measurable singletons on transported answer spaces;
- the IND-CPA swap lens proves that obligation for its identity-on-answers transport;
- a committed uniqueness canary exercises the repaired contract.

The reviewer found no other correctness blocker after the earlier kernel/subprobability/bridge repairs.

## Validation

On exact head `8275c6b1` over exact #548 head `f9212fda`:

- `lake build` passed: 3,416 jobs;
- targeted responder, wired-run, kernel, and measure canaries passed;
- agent docs, Extern and Interop isolation, PMF/SPMF, and PolyFun checks passed;
- axiom fixture matrix passed;
- axiom sweep checked 14,647 declarations across 470 modules with no new axiom or sorry taint;
- `git diff --check` passed.

The remaining warnings are inherited sorry/native-backend warnings.