### PR TITLE
feat(HasQuery): add query-preserving morphism composition

### DIFF
--- a/VCVio/OracleComp/HasQuery/Morphism.lean
+++ b/VCVio/OracleComp/HasQuery/Morphism.lean
@@ -53,6 +53,27 @@ def PreservesProbCompLift
     (F : m →ᵐ n) : Prop :=
   ∀ {α : Type} (oa : ProbComp α), F (liftM oa : m α) = (liftM oa : n α)
 
+namespace PreservesProbCompLift
+
+/-- The identity monad morphism preserves the distinguished public-randomness lift. -/
+theorem id {m : Type → Type w} [Monad m] [MonadLiftT ProbComp m] :
+    PreservesProbCompLift (MonadHom.id m) := by
+  intro α oa
+  rfl
+
+/-- Preservation of public randomness is closed under monad-morphism composition. -/
+theorem comp {m : Type → Type w} [Monad m] [MonadLiftT ProbComp m]
+    {n : Type → Type x} [Monad n] [MonadLiftT ProbComp n]
+    {o : Type → Type y} [Monad o] [MonadLiftT ProbComp o]
+    (F : m →ᵐ n) (G : n →ᵐ o)
+    (hF : PreservesProbCompLift F) (hG : PreservesProbCompLift G) :
+    PreservesProbCompLift (G.comp F) := by
+  intro α oa
+  change G (F (liftM oa : m α)) = (liftM oa : o α)
+  rw [hF oa, hG oa]
+
+end PreservesProbCompLift
+
 @[simp]
 lemma map_query (F : QueryHom spec m n) (t : spec.Domain) :
     F.toMonadHom (HasQuery.query (spec := spec) (m := m) t) =

--- a/VCVio/OracleComp/HasQuery/Morphism.lean
+++ b/VCVio/OracleComp/HasQuery/Morphism.lean
@@ -18,13 +18,15 @@ It imports `ProbComp` and monad homomorphisms, so files that only need the
 basic query capability should import `VCVio.OracleComp.HasQuery.Basic`
 instead.
 
-Use this module for proofs that a monad morphism preserves oracle queries, or
-that it commutes with the canonical lift of public randomness.
+Use this module for proofs that a monad morphism preserves oracle queries, for composing such
+morphisms through `QueryHom.id` and `QueryHom.comp`, or for interpreting free oracle syntax through
+the ambient query capability with `QueryHom.ofSimulateQ`. The separate `PreservesProbCompLift`
+predicate records commutation with the canonical lift of public randomness.
 -/
 
 @[expose] public section
 
-universe u v w x
+universe u v w x y z
 
 namespace HasQuery
 
@@ -56,5 +58,64 @@ lemma map_query (F : QueryHom spec m n) (t : spec.Domain) :
     F.toMonadHom (HasQuery.query (spec := spec) (m := m) t) =
       HasQuery.query (spec := spec) (m := n) t :=
   F.map_query' t
+
+namespace QueryHom
+
+variable {o : Type v → Type y} [Monad o] [HasQuery spec o]
+
+/-- The identity monad morphism, bundled with its preservation of oracle queries. -/
+def id (spec : OracleSpec.{u, v} ι) (m : Type v → Type w) [Monad m] [HasQuery spec m] :
+    QueryHom spec m m where
+  toMonadHom := MonadHom.id m
+  map_query' _ := rfl
+
+@[simp]
+lemma id_toMonadHom : (id spec m).toMonadHom = MonadHom.id m := rfl
+
+@[simp, grind =]
+lemma id_apply {α : Type v} (mx : m α) : (id spec m).toMonadHom mx = mx := rfl
+
+/-- Compose query-preserving monad morphisms, applying `F` first and then `G`. -/
+protected def comp (G : QueryHom spec n o) (F : QueryHom spec m n) : QueryHom spec m o where
+  toMonadHom := G.toMonadHom.comp F.toMonadHom
+  map_query' t := by simp
+
+@[simp]
+lemma comp_toMonadHom (G : QueryHom spec n o) (F : QueryHom spec m n) :
+    (G.comp F).toMonadHom = G.toMonadHom.comp F.toMonadHom := rfl
+
+@[simp, grind =]
+lemma comp_apply {α : Type v} (G : QueryHom spec n o) (F : QueryHom spec m n) (mx : m α) :
+    (G.comp F).toMonadHom mx = G.toMonadHom (F.toMonadHom mx) := rfl
+
+@[simp, grind =]
+lemma comp_id (F : QueryHom spec m n) : F.comp (id spec m) = F := by
+  rfl
+
+@[simp, grind =]
+lemma id_comp (F : QueryHom spec m n) : (id spec n).comp F = F := by
+  rfl
+
+@[grind =]
+lemma comp_assoc {p : Type v → Type z} [Monad p] [HasQuery spec p]
+    (H : QueryHom spec o p) (G : QueryHom spec n o) (F : QueryHom spec m n) :
+    (H.comp G).comp F = H.comp (G.comp F) := by
+  rfl
+
+/-- Interpret free oracle syntax through the query capability already installed in `m`.
+
+This is the query-preserving monad morphism induced by the free-monad fold. It does not assert a
+parametricity theorem for arbitrary direct-style programs: its source is specifically
+`OracleComp spec`, and its handler is definitionally the ambient `HasQuery` operation. -/
+def ofSimulateQ [LawfulMonad m] : QueryHom spec (OracleComp spec) m where
+  toMonadHom := simulateQ' (HasQuery.toQueryImpl (spec := spec) (m := m))
+  map_query' t := by simp
+
+@[simp]
+lemma ofSimulateQ_apply [LawfulMonad m] {α : Type v} (oa : OracleComp spec α) :
+    (ofSimulateQ (spec := spec) (m := m)).toMonadHom oa =
+      simulateQ (HasQuery.toQueryImpl (spec := spec) (m := m)) oa := rfl
+
+end QueryHom
 
 end HasQuery

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -9,6 +9,7 @@ public import VCVioTest.MerkleTreeBatch
 public import VCVioTest.MonadProbability
 public import VCVioTest.PFunctorFacade
 public import VCVioTest.ProbabilityTactics
+public import VCVioTest.QueryHom
 public import VCVioTest.RoundByRound.OneRound
 public import VCVioTest.SampleableType
 public import VCVioTest.Smoke

--- a/VCVioTest/QueryHom.lean
+++ b/VCVioTest/QueryHom.lean
@@ -1,0 +1,110 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.OracleComp.HasQuery.Morphism
+
+/-!
+# Query-Preserving Monad Morphism Canaries
+
+Producer-level tests for identity, composition, and free-oracle interpretation through
+`HasQuery.QueryHom`. The reader examples distinguish composition order, while the state example
+checks that `QueryHom.ofSimulateQ` preserves a nontrivial handler's state evolution.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace VCVioTest.QueryHom
+
+universe uι uQuery uM uN uO
+
+section UniversePolymorphism
+
+variable {ι : Type uι} {spec : OracleSpec.{uι, uQuery} ι}
+  {m : Type uQuery → Type uM} [Monad m] [HasQuery spec m]
+  {n : Type uQuery → Type uN} [Monad n] [HasQuery spec n]
+  {o : Type uQuery → Type uO} [Monad o] [HasQuery spec o]
+  {α : Type uQuery}
+
+/-- `QueryHom.id` remains available when the query and target monads live in nonzero,
+independently quantified universes. -/
+example : HasQuery.QueryHom spec m m := HasQuery.QueryHom.id spec m
+
+example (mx : m α) :
+    (HasQuery.QueryHom.id spec m).toMonadHom mx = mx := by simp
+
+/-- `QueryHom.comp` has the same universe generality as its constituent morphisms. -/
+example (G : HasQuery.QueryHom spec n o) (F : HasQuery.QueryHom spec m n) :
+    HasQuery.QueryHom spec m o := G.comp F
+
+/-- Composition applies the right-hand morphism first. -/
+example (G : HasQuery.QueryHom spec n o) (F : HasQuery.QueryHom spec m n) (mx : m α) :
+    (G.comp F).toMonadHom mx = G.toMonadHom (F.toMonadHom mx) := by simp
+
+example {p : Type uQuery → Type*} [Monad p] [HasQuery spec p]
+    (H : HasQuery.QueryHom spec o p) (G : HasQuery.QueryHom spec n o)
+    (F : HasQuery.QueryHom spec m n) :
+    (H.comp G).comp F = H.comp (G.comp F) := HasQuery.QueryHom.comp_assoc H G F
+
+end UniversePolymorphism
+
+/-! ## Composition order -/
+
+abbrev ConstSpec : OracleSpec Unit := Unit →ₒ Nat
+abbrev Reader := ReaderT Nat Id
+
+instance : HasQuery ConstSpec Reader where
+  query _ := pure 0
+
+/-- Reindex a reader environment. Noncommuting reindexings distinguish composition order. -/
+def reindex (f : Nat → Nat) : Reader →ᵐ Reader where
+  toFun _ mx := fun r => mx (f r)
+  toFun_pure' _ := rfl
+  toFun_bind' _ _ := rfl
+
+def reindexQueryHom (f : Nat → Nat) : HasQuery.QueryHom ConstSpec Reader Reader where
+  toMonadHom := reindex f
+  map_query' _ := rfl
+
+def observe : Reader Nat := fun r => pure r
+
+/-- With doubling as `G` and successor as `F`, `G.comp F` observes `2 * 3 + 1 = 7`. This rejects
+a swapped implementation of `QueryHom.comp`. -/
+example : ((reindexQueryHom (fun n => n * 2)).comp
+    (reindexQueryHom (fun n => n + 1))).toMonadHom observe 3 = 7 := rfl
+
+/-- Reversing the morphisms observes `2 * (3 + 1) = 8`, so the preceding canary is not accidentally
+commutative. -/
+example : ((reindexQueryHom (fun n => n + 1)).comp
+    (reindexQueryHom (fun n => n * 2))).toMonadHom observe 3 = 8 := rfl
+
+/-! ## Stateful free-oracle interpretation -/
+
+abbrev CountSpec : OracleSpec Unit := Unit →ₒ Nat
+
+def countImpl : QueryImpl CountSpec (StateM Nat) := fun _ => do
+  let s ← get
+  set (s + 1)
+  pure s
+
+def twoQueries : OracleComp CountSpec (Nat × Nat) := do
+  let x ← HasQuery.query (spec := CountSpec) ()
+  let y ← HasQuery.query (spec := CountSpec) ()
+  pure (x, y)
+
+/-- The `ofSimulateQ` producer uses the installed query handler and threads its state across
+successive free-oracle queries. A constant, reset-per-query, or state-discarding interpreter fails
+this canary. -/
+example :
+    letI : HasQuery CountSpec (StateM Nat) := countImpl.toHasQuery
+    StateT.run ((HasQuery.QueryHom.ofSimulateQ
+      (spec := CountSpec) (m := StateM Nat)).toMonadHom twoQueries) 3 = ((3, 4), 5) := by
+  rfl
+
+end VCVioTest.QueryHom


### PR DESCRIPTION
## Summary

- add identity and composition for `HasQuery.QueryHom`
- prove the projection, identity, and associativity laws
- add `QueryHom.ofSimulateQ` for interpreting free oracle syntax through an installed query capability
- prove `PreservesProbCompLift` is closed under identity and composition, so full query-plus-public-randomness transports compose
- add universe-polymorphic, noncommutative-composition, and state-threading producer canaries

This deliberately does not claim a parametricity theorem for arbitrary direct-style `HasQuery` programs; `ofSimulateQ` starts from the free `OracleComp` syntax.

## Validation

- `lake build VCVioTest.QueryHom VCVio`
- `lake env lean VCVioTest/QueryHom.lean`
- `lake exe lint-style VCVio`
- `lake exe mk_all --lib VCVio --module --check`
- targeted axiom sweep: no `sorryAx` or nonstandard-axiom taint
