### PR TITLE
feat(MerkleTree): add callback-parametric perfect tree engine

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -65,6 +65,7 @@ public import VCVio.CryptoFoundations.MerkleTree.Inductive.Extractability
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.QueryBound
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Uniqueness
 public import VCVio.CryptoFoundations.MerkleTree.Perfect
+public import VCVio.CryptoFoundations.MerkleTree.Perfect.SimulateQ
 public import VCVio.CryptoFoundations.MerkleTree.Vector.Completeness
 public import VCVio.CryptoFoundations.MerkleTree.Vector.Defs
 public import VCVio.CryptoFoundations.PRF

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -64,6 +64,7 @@ public import VCVio.CryptoFoundations.MerkleTree.Inductive.Defs
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Extractability
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.QueryBound
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Uniqueness
+public import VCVio.CryptoFoundations.MerkleTree.Perfect
 public import VCVio.CryptoFoundations.MerkleTree.Vector.Completeness
 public import VCVio.CryptoFoundations.MerkleTree.Vector.Defs
 public import VCVio.CryptoFoundations.PRF

--- a/VCVio/CryptoFoundations/MerkleTree/Perfect.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Perfect.lean
@@ -191,6 +191,20 @@ theorem climbM_id (nodeHash : Address → Y → Y → Y) (base index depth : ℕ
         simp [climbM, climb, h, Id.run_bind, ih] <;> rfl
 
 @[simp]
+theorem rootAuthenticationPathM_id (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    {height : ℕ} (index : LeafIndex height) :
+    Id.run (rootAuthenticationPathM (m := Id) leaf nodeHash index) =
+      rootAuthenticationPath leaf nodeHash index := by
+  simp [rootAuthenticationPathM, rootAuthenticationPath]
+
+@[simp]
+theorem reconstructRootM_id (nodeHash : Address → Y → Y → Y) {height : ℕ}
+    (index : LeafIndex height) (leafValue : Y) (path : AuthenticationPath Y height) :
+    Id.run (reconstructRootM (m := Id) nodeHash index leafValue path) =
+      reconstructRoot nodeHash index leafValue path := by
+  simp [reconstructRootM, reconstructRoot]
+
+@[simp]
 theorem treeHash_zero (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y) (index : ℕ) :
     treeHash leaf nodeHash 0 index = leaf index := rfl
 

--- a/VCVio/CryptoFoundations/MerkleTree/Perfect.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Perfect.lean
@@ -1,0 +1,255 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import ToMathlib.General
+
+/-!
+# Callback-Parametric Perfect Merkle Trees
+
+This module implements perfect binary Merkle trees without materializing a full tree. Leaves and
+internal nodes are supplied by monadic callbacks. The internal-node callback receives the height
+and horizontal index of the node it is producing, which supports the address-dependent hashing
+used by hash-based signatures.
+
+`treeHashM` computes a subtree root in depth-first, left-to-right order. `authenticationPathM`
+computes only the sibling subtrees on one branch, and `climbM` reconstructs an ancestor from a
+length-indexed authentication path. Root-level wrappers use `Fin (2 ^ height)` for leaf indices,
+so both out-of-range leaves and wrong-length paths are excluded by their types.
+
+The monadic definitions intentionally make no consistency claim about repeated callback
+invocations. For example, a randomized or stateful callback may return different results when
+called twice at the same address. Deterministic completeness is therefore stated for the `Id`
+specialization (`climb_authenticationPath` and `reconstructRoot_authenticationPath`). A caller that
+interprets callbacks as random-oracle queries must provide the shared-oracle semantics needed to
+relate separately evaluated computations.
+-/
+
+@[expose] public section
+
+namespace PerfectMerkleTree
+
+universe u v
+
+variable {Y : Type u} {m : Type u → Type v}
+
+/-- The address of a perfect-tree node. `height = 0` denotes a leaf; internal-node callbacks are
+invoked only at addresses with positive height. -/
+structure Address where
+  height : ℕ
+  index : ℕ
+deriving DecidableEq, Repr
+
+/-- An authentication path whose length is fixed by the height it traverses. Entries are ordered
+from the queried node upward: the first entry is the node's immediate sibling. -/
+abbrev AuthenticationPath (Y : Type u) (height : ℕ) := List.Vector Y height
+
+/-- A leaf index in a perfect tree of the given height. -/
+abbrev LeafIndex (height : ℕ) := Fin (2 ^ height)
+
+/-- The sibling of a node index, obtained by flipping its least-significant bit. -/
+def sibling (index : ℕ) : ℕ :=
+  if index % 2 = 0 then index + 1 else index - 1
+
+/-- Compute the root at `(height, index)` using effectful leaf and internal-node callbacks.
+
+The computation uses stack space proportional to `height` and does not construct a `FullData`
+tree. Callback order is depth-first and left-to-right, with each internal-node callback invoked
+after both child callbacks finish. -/
+def treeHashM [Monad m] (leaf : ℕ → m Y) (nodeHash : Address → Y → Y → m Y) : ℕ → ℕ → m Y
+  | 0, index => leaf index
+  | height + 1, index => do
+      let left ← treeHashM leaf nodeHash height (2 * index)
+      let right ← treeHashM leaf nodeHash height (2 * index + 1)
+      nodeHash ⟨height + 1, index⟩ left right
+
+/-- Compute the root of a perfect tree of the given height. -/
+def rootM [Monad m] (leaf : ℕ → m Y) (nodeHash : Address → Y → Y → m Y)
+    (height : ℕ) : m Y :=
+  treeHashM leaf nodeHash height 0
+
+/-- Compute a sized authentication path for the node at `(base, index)` through `depth` levels.
+
+Only sibling subtrees are evaluated. In particular, this function neither evaluates the queried
+node nor materializes the surrounding tree. -/
+def authenticationPathM [Monad m] (leaf : ℕ → m Y) (nodeHash : Address → Y → Y → m Y)
+    (base index : ℕ) : (depth : ℕ) → m (AuthenticationPath Y depth)
+  | 0 => pure List.Vector.nil
+  | depth + 1 => do
+      let siblingRoot ← treeHashM leaf nodeHash base (sibling index)
+      let rest ← authenticationPathM leaf nodeHash (base + 1) (index / 2) depth
+      pure (List.Vector.cons siblingRoot rest)
+
+/-- Fold a sized authentication path upward, using the running node address at every step. -/
+def climbM [Monad m] (nodeHash : Address → Y → Y → m Y) (base index : ℕ) :
+    (depth : ℕ) → Y → AuthenticationPath Y depth → m Y
+  | 0, node, _ => pure node
+  | depth + 1, node, path => do
+      let parent ←
+        if index % 2 = 0 then
+          nodeHash ⟨base + 1, index / 2⟩ node path.head
+        else
+          nodeHash ⟨base + 1, index / 2⟩ path.head node
+      climbM nodeHash (base + 1) (index / 2) depth parent path.tail
+
+/-- Generate a root-level authentication path. The index and path length are statically tied to
+the tree height. -/
+def rootAuthenticationPathM [Monad m] (leaf : ℕ → m Y)
+    (nodeHash : Address → Y → Y → m Y) {height : ℕ} (index : LeafIndex height) :
+    m (AuthenticationPath Y height) :=
+  authenticationPathM leaf nodeHash 0 index.val height
+
+/-- Reconstruct a putative root from a root-level leaf opening. -/
+def reconstructRootM [Monad m] (nodeHash : Address → Y → Y → m Y) {height : ℕ}
+    (index : LeafIndex height) (leafValue : Y) (path : AuthenticationPath Y height) : m Y :=
+  climbM nodeHash 0 index.val height leafValue path
+
+/-! ## Deterministic specialization -/
+
+/-- Deterministic subtree-root computation. Its direct recursion gives pure correctness proofs
+useful definitional equations; `treeHashM_id` relates it to the production monadic engine. -/
+def treeHash (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y) : ℕ → ℕ → Y
+  | 0, index => leaf index
+  | height + 1, index =>
+      nodeHash ⟨height + 1, index⟩ (treeHash leaf nodeHash height (2 * index))
+        (treeHash leaf nodeHash height (2 * index + 1))
+
+/-- Deterministic specialization of `rootM`. -/
+def root (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y) (height : ℕ) : Y :=
+  treeHash leaf nodeHash height 0
+
+/-- Deterministic authentication-path generation. -/
+def authenticationPath (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    (base index : ℕ) : (depth : ℕ) → AuthenticationPath Y depth
+  | 0 => List.Vector.nil
+  | depth + 1 =>
+      List.Vector.cons (treeHash leaf nodeHash base (sibling index))
+        (authenticationPath leaf nodeHash (base + 1) (index / 2) depth)
+
+/-- Deterministic authentication-path folding. -/
+def climb (nodeHash : Address → Y → Y → Y) (base index : ℕ) :
+    (depth : ℕ) → Y → AuthenticationPath Y depth → Y
+  | 0, node, _ => node
+  | depth + 1, node, path =>
+      let parent :=
+        if index % 2 = 0 then
+          nodeHash ⟨base + 1, index / 2⟩ node path.head
+        else
+          nodeHash ⟨base + 1, index / 2⟩ path.head node
+      climb nodeHash (base + 1) (index / 2) depth parent path.tail
+
+/-- Deterministic root-level authentication-path generation. -/
+def rootAuthenticationPath (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    {height : ℕ} (index : LeafIndex height) : AuthenticationPath Y height :=
+  authenticationPath leaf nodeHash 0 index.val height
+
+/-- Deterministic root reconstruction. -/
+def reconstructRoot (nodeHash : Address → Y → Y → Y) {height : ℕ}
+    (index : LeafIndex height) (leafValue : Y) (path : AuthenticationPath Y height) : Y :=
+  climb nodeHash 0 index.val height leafValue path
+
+/-! The following parity lemmas justify the deterministic API as the `Id` interpretation of the
+monadic production engine. -/
+
+@[simp]
+theorem treeHashM_id (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    (height index : ℕ) :
+    Id.run (treeHashM (m := Id) leaf nodeHash height index) =
+      treeHash leaf nodeHash height index := by
+  induction height generalizing index with
+  | zero => rfl
+  | succ height ih =>
+      simp [treeHashM, treeHash, Id.run_bind, ih]
+      rfl
+
+@[simp]
+theorem rootM_id (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y) (height : ℕ) :
+    Id.run (rootM (m := Id) leaf nodeHash height) = root leaf nodeHash height := by
+  simp [rootM, root]
+
+@[simp]
+theorem authenticationPathM_id (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    (base index depth : ℕ) :
+    Id.run (authenticationPathM (m := Id) leaf nodeHash base index depth) =
+      authenticationPath leaf nodeHash base index depth := by
+  induction depth generalizing base index with
+  | zero => rfl
+  | succ depth ih => simp [authenticationPathM, authenticationPath, Id.run_bind, ih]
+
+@[simp]
+theorem climbM_id (nodeHash : Address → Y → Y → Y) (base index depth : ℕ) (node : Y)
+    (path : AuthenticationPath Y depth) :
+    Id.run (climbM (m := Id) nodeHash base index depth node path) =
+      climb nodeHash base index depth node path := by
+  induction depth generalizing base index node with
+  | zero => rfl
+  | succ depth ih =>
+      by_cases h : index % 2 = 0 <;>
+        simp [climbM, climb, h, Id.run_bind, ih] <;> rfl
+
+@[simp]
+theorem treeHash_zero (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y) (index : ℕ) :
+    treeHash leaf nodeHash 0 index = leaf index := rfl
+
+@[simp]
+theorem treeHash_succ (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    (height index : ℕ) :
+    treeHash leaf nodeHash (height + 1) index =
+      nodeHash ⟨height + 1, index⟩ (treeHash leaf nodeHash height (2 * index))
+        (treeHash leaf nodeHash height (2 * index + 1)) := rfl
+
+/-- Folding one honest sibling into its node reproduces the deterministic parent subtree root. -/
+theorem combineSibling_eq_treeHash (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y)
+    (base index : ℕ) :
+    (if index % 2 = 0 then
+      nodeHash ⟨base + 1, index / 2⟩ (treeHash leaf nodeHash base index)
+        (treeHash leaf nodeHash base (sibling index))
+    else
+      nodeHash ⟨base + 1, index / 2⟩ (treeHash leaf nodeHash base (sibling index))
+        (treeHash leaf nodeHash base index)) =
+      treeHash leaf nodeHash (base + 1) (index / 2) := by
+  have hdm := Nat.div_add_mod index 2
+  change _ = nodeHash ⟨base + 1, index / 2⟩
+    (treeHash leaf nodeHash base (2 * (index / 2)))
+    (treeHash leaf nodeHash base (2 * (index / 2) + 1))
+  by_cases h : index % 2 = 0
+  · rw [if_pos h, sibling, if_pos h]
+    have h1 : 2 * (index / 2) = index := by omega
+    rw [h1]
+  · rw [if_neg h, sibling, if_neg h]
+    have h2 : 2 * (index / 2) = index - 1 := by omega
+    have h3 : 2 * (index / 2) + 1 = index := by omega
+    rw [h3, h2]
+
+/-- Climbing the honest deterministic authentication path reconstructs the indicated ancestor. -/
+theorem climb_authenticationPath (leaf : ℕ → Y) (nodeHash : Address → Y → Y → Y) :
+    ∀ (depth base index : ℕ),
+      climb nodeHash base index depth (treeHash leaf nodeHash base index)
+          (authenticationPath leaf nodeHash base index depth) =
+        treeHash leaf nodeHash (base + depth) (index / 2 ^ depth) := by
+  intro depth
+  induction depth with
+  | zero =>
+      intro base index
+      simp [climb]
+  | succ depth ih =>
+      intro base index
+      simp only [authenticationPath, climb, List.Vector.head_cons, List.Vector.tail_cons]
+      rw [combineSibling_eq_treeHash, ih (base + 1) (index / 2)]
+      congr 1
+      · omega
+      · rw [Nat.div_div_eq_div_mul, pow_succ, Nat.mul_comm]
+
+/-- A root-level honest deterministic opening reconstructs `root`. -/
+theorem reconstructRoot_authenticationPath (leaf : ℕ → Y)
+    (nodeHash : Address → Y → Y → Y) {height : ℕ} (index : LeafIndex height) :
+    reconstructRoot nodeHash index (leaf index.val)
+        (rootAuthenticationPath leaf nodeHash index) =
+      root leaf nodeHash height := by
+  simpa [reconstructRoot, rootAuthenticationPath, root, Nat.div_eq_of_lt index.isLt] using
+    climb_authenticationPath leaf nodeHash height 0 index.val
+
+end PerfectMerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree/Perfect/SimulateQ.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Perfect/SimulateQ.lean
@@ -1,0 +1,127 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.MerkleTree.Perfect
+public import VCVio.OracleComp.SimSemantics.SimulateQ
+
+/-!
+# Deterministic Interpretations of Perfect Merkle Trees
+
+This module proves that interpreting callback-parametric perfect-Merkle computations with an
+arbitrary deterministic oracle answer function yields the corresponding pure tree. The answer
+function is fixed for the whole computation; no claim is made about raw, independently sampled
+oracle queries.
+
+The final theorem, `simulateQ_honest_reconstruct`, is functional completeness at this boundary:
+after fixing any deterministic answer function, an honestly generated leaf and sized path
+reconstruct the root computed with the same interpreted callbacks.
+-/
+
+@[expose] public section
+
+namespace PerfectMerkleTree
+
+open OracleComp
+
+universe u v
+
+variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {Y : Type v}
+
+/-- A deterministic handler commutes with subtree-root production. -/
+@[simp]
+theorem simulateQ_treeHashM (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y) (nodeHash : Address → Y → Y → OracleComp spec Y)
+    (height index : ℕ) :
+    simulateQ impl (treeHashM leaf nodeHash height index) =
+      treeHash (fun i => simulateQ impl (leaf i))
+        (fun address left right => simulateQ impl (nodeHash address left right)) height index := by
+  induction height generalizing index with
+  | zero => rfl
+  | succ height ih =>
+      simp only [treeHashM, simulateQ_bind, treeHash, ih]
+      rfl
+
+/-- A deterministic handler commutes with root production. -/
+@[simp]
+theorem simulateQ_rootM (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y) (nodeHash : Address → Y → Y → OracleComp spec Y)
+    (height : ℕ) :
+    simulateQ impl (rootM leaf nodeHash height) =
+      root (fun i => simulateQ impl (leaf i))
+        (fun address left right => simulateQ impl (nodeHash address left right)) height := by
+  simp [rootM, root]
+
+/-- A deterministic handler commutes with sized authentication-path production. -/
+@[simp]
+theorem simulateQ_authenticationPathM (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y) (nodeHash : Address → Y → Y → OracleComp spec Y)
+    (base index depth : ℕ) :
+    simulateQ impl (authenticationPathM leaf nodeHash base index depth) =
+      authenticationPath (fun i => simulateQ impl (leaf i))
+        (fun address left right => simulateQ impl (nodeHash address left right))
+        base index depth := by
+  induction depth generalizing base index with
+  | zero => rfl
+  | succ depth ih =>
+      simp only [authenticationPathM, simulateQ_bind, authenticationPath,
+        simulateQ_treeHashM, ih]
+      rfl
+
+/-- A deterministic handler commutes with folding a sized authentication path. -/
+@[simp]
+theorem simulateQ_climbM (impl : QueryImpl spec Id)
+    (nodeHash : Address → Y → Y → OracleComp spec Y) (base index depth : ℕ)
+    (node : Y) (path : AuthenticationPath Y depth) :
+    simulateQ impl (climbM nodeHash base index depth node path) =
+      climb (fun address left right => simulateQ impl (nodeHash address left right))
+        base index depth node path := by
+  induction depth generalizing base index node with
+  | zero => rfl
+  | succ depth ih =>
+      by_cases h : index % 2 = 0 <;>
+        simp [climbM, climb, h, simulateQ_bind, ih] <;> rfl
+
+/-- A deterministic handler commutes with root-level path production. -/
+@[simp]
+theorem simulateQ_rootAuthenticationPathM (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y) (nodeHash : Address → Y → Y → OracleComp spec Y)
+    {height : ℕ} (index : LeafIndex height) :
+    simulateQ impl (rootAuthenticationPathM leaf nodeHash index) =
+      rootAuthenticationPath (fun i => simulateQ impl (leaf i))
+        (fun address left right => simulateQ impl (nodeHash address left right)) index := by
+  simp [rootAuthenticationPathM, rootAuthenticationPath]
+
+/-- A deterministic handler commutes with root reconstruction. -/
+@[simp]
+theorem simulateQ_reconstructRootM (impl : QueryImpl spec Id)
+    (nodeHash : Address → Y → Y → OracleComp spec Y) {height : ℕ}
+    (index : LeafIndex height) (leafValue : Y) (path : AuthenticationPath Y height) :
+    simulateQ impl (reconstructRootM nodeHash index leafValue path) =
+      reconstructRoot (fun address left right => simulateQ impl (nodeHash address left right))
+        index leafValue path := by
+  simp [reconstructRootM, reconstructRoot]
+
+/-- Functional completeness after fixing an arbitrary deterministic oracle answer function.
+
+The statement deliberately interprets the entire honest opening computation with one `impl`.
+It does not assert completeness for raw `OracleComp` semantics, where repeated identical queries
+are sampled independently. -/
+theorem simulateQ_honest_reconstruct (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y) (nodeHash : Address → Y → Y → OracleComp spec Y)
+    {height : ℕ} (index : LeafIndex height) :
+    simulateQ impl (do
+      let leafValue ← leaf index.val
+      let path ← rootAuthenticationPathM leaf nodeHash index
+      reconstructRootM nodeHash index leafValue path) =
+      simulateQ impl (rootM leaf nodeHash height) := by
+  simp only [simulateQ_bind, simulateQ_rootAuthenticationPathM, simulateQ_reconstructRootM,
+    simulateQ_rootM]
+  exact reconstructRoot_authenticationPath
+    (fun i => simulateQ impl (leaf i))
+    (fun address left right => simulateQ impl (nodeHash address left right)) index
+
+end PerfectMerkleTree

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -6,6 +6,7 @@ public import VCVioTest.GrindFailFast
 public import VCVioTest.LongChainPrograms
 public import VCVioTest.MeasureSemantics
 public import VCVioTest.MerkleTreeBatch
+public import VCVioTest.MerkleTreePerfect
 public import VCVioTest.MonadProbability
 public import VCVioTest.PFunctorFacade
 public import VCVioTest.ProbabilityTactics

--- a/VCVioTest/MerkleTreePerfect.lean
+++ b/VCVioTest/MerkleTreePerfect.lean
@@ -1,0 +1,64 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import VCVio.CryptoFoundations.MerkleTree.Perfect
+
+/-!
+# Perfect Merkle Tree Producer Canaries
+
+Executable canaries pin left/right ordering, address production, effect order, path ordering, and
+the `Fin`/`Vector`-indexed root interface of `PerfectMerkleTree`.
+-/
+
+@[expose] public section
+
+namespace PerfectMerkleTreeTest
+
+open PerfectMerkleTree
+
+/-- A deliberately noncommutative, address-sensitive node callback. -/
+def orderedNode (address : Address) (left right : ℕ) : ℕ :=
+  1000 * address.height + 100 * address.index + 10 * left + right
+
+def orderedLeaf (index : ℕ) : ℕ := index + 1
+
+/-- The left subtree is evaluated before the right subtree, and the root address is emitted last. -/
+example : treeHash orderedLeaf orderedNode 2 0 = 13254 := rfl
+
+/-- Path entries run from the immediate sibling upward. -/
+example :
+    authenticationPath orderedLeaf orderedNode 0 0 2 =
+      (⟨[2, 1134], rfl⟩ : AuthenticationPath ℕ 2) := rfl
+
+/-- A rightmost leaf pins the opposite child orientation at both levels. -/
+example :
+    authenticationPath orderedLeaf orderedNode 0 3 2 =
+      (⟨[3, 1012], rfl⟩ : AuthenticationPath ℕ 2) := rfl
+
+example :
+    climb orderedNode 0 3 2 (orderedLeaf 3)
+        (authenticationPath orderedLeaf orderedNode 0 3 2) = 13254 := rfl
+
+/-- Root-level callers must provide an in-range leaf index, and receive a path of exactly the root
+height. -/
+example : AuthenticationPath ℕ 2 :=
+  rootAuthenticationPath orderedLeaf orderedNode (2 : LeafIndex 2)
+
+def tracedLeaf (index : ℕ) : StateM (List Address) ℕ :=
+  pure (orderedLeaf index)
+
+def tracedNode (address : Address) (left right : ℕ) : StateM (List Address) ℕ := do
+  modify (· ++ [address])
+  pure (orderedNode address left right)
+
+/-- The effectful engine invokes internal-node callbacks in left-subtree, right-subtree, root
+order, and supplies the corresponding addresses. -/
+example :
+    (treeHashM tracedLeaf tracedNode 2 0).run [] =
+      (13254, [⟨1, 0⟩, ⟨1, 1⟩, ⟨2, 0⟩]) := rfl
+
+end PerfectMerkleTreeTest

--- a/VCVioTest/MerkleTreePerfect.lean
+++ b/VCVioTest/MerkleTreePerfect.lean
@@ -48,17 +48,34 @@ height. -/
 example : AuthenticationPath ℕ 2 :=
   rootAuthenticationPath orderedLeaf orderedNode (2 : LeafIndex 2)
 
-def tracedLeaf (index : ℕ) : StateM (List Address) ℕ :=
+/-- Trace events distinguish effectful leaf production from internal-node hashing. -/
+inductive TraceEvent where
+  | leaf (index : ℕ)
+  | node (address : Address)
+deriving DecidableEq, Repr
+
+def tracedLeaf (index : ℕ) : StateM (List TraceEvent) ℕ := do
+  modify (· ++ [.leaf index])
   pure (orderedLeaf index)
 
-def tracedNode (address : Address) (left right : ℕ) : StateM (List Address) ℕ := do
-  modify (· ++ [address])
+def tracedNode (address : Address) (left right : ℕ) : StateM (List TraceEvent) ℕ := do
+  modify (· ++ [.node address])
   pure (orderedNode address left right)
 
-/-- The effectful engine invokes internal-node callbacks in left-subtree, right-subtree, root
-order, and supplies the corresponding addresses. -/
+/-- The effectful engine evaluates leaves and internal nodes in depth-first, left-to-right order,
+and supplies the corresponding node addresses. -/
 example :
     (treeHashM tracedLeaf tracedNode 2 0).run [] =
-      (13254, [⟨1, 0⟩, ⟨1, 1⟩, ⟨2, 0⟩]) := rfl
+      (13254, [.leaf 0, .leaf 1, .node ⟨1, 0⟩, .leaf 2, .leaf 3,
+        .node ⟨1, 1⟩, .node ⟨2, 0⟩]) := rfl
+
+/-- The height-zero boundary evaluates exactly one leaf and no internal node. -/
+example :
+    (rootM tracedLeaf tracedNode 0).run [] = (1, [.leaf 0]) := rfl
+
+/-- A height-zero root has exactly one valid leaf index and an empty authentication path. -/
+example :
+    rootAuthenticationPath orderedLeaf orderedNode (0 : LeafIndex 0) =
+      (List.Vector.nil : AuthenticationPath ℕ 0) := rfl
 
 end PerfectMerkleTreeTest


### PR DESCRIPTION
## Summary

- add a callback-parametric perfect binary Merkle engine with monadic leaf and node callbacks
- stream roots and authentication paths without materializing a full tree
- use `Fin (2^h)` leaf indices and length-indexed authentication paths at root-level APIs
- prove pure `Id` parity and arbitrary fixed deterministic-handler semantics for roots, authentication paths, climbing, reconstruction, and honest reconstruction
- pin ordering, addresses, effect traces, height-zero behavior, and path orientation with producer canaries

The monadic layer intentionally makes no completeness claim for arbitrary stateful handlers. Random-oracle callers must provide one shared consistency semantics. This is also not yet a bridge to `AddressedMerkleTree`-oriented binding or query-transcript extractability.

## Validation

- targeted and full `VCVio` / `VCVioTest` builds
- `lake exe lint-style VCVio`
- `lake exe mk_all --lib VCVio --module --check`
- targeted axiom sweep: no `sorryAx` or nonstandard-axiom taint
