### PR TITLE
feat(HashSig): make SLH-DSA public hashing oracle-parametric

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -237,15 +237,13 @@ jobs:
         run: ./scripts/test-axiomsweep.sh
       - name: Axiom sweep
         run: lake exe axiomsweep --check
-      # Build the whole canary library rather than a hand-maintained list of
-      # `lake env lean` invocations. Every module reachable from `VCVioTest.lean` is
-      # elaborated, so a canary added in a future PR is covered the moment
-      # `./scripts/update-lib.sh` registers it. `mk_all --lib VCVioTest --module --check`
-      # above only checks that the umbrella's import list is textually complete; it does
-      # not elaborate anything. Kept out of the timed build commands on purpose: the
-      # timing report compares exactly the seven non-test libraries.
-      - name: Build the canary library
-        run: lake build VCVioTest
+      # Build both canary libraries rather than a hand-maintained list of `lake env lean`
+      # invocations. `VCVioTest` is registered through its generated umbrella; `HashSigTest`
+      # deliberately uses a submodule glob because its two KAT modules both define root-level
+      # executable entry points and cannot share an umbrella. Kept out of the timed build commands
+      # on purpose: the timing report compares exactly the seven non-test libraries.
+      - name: Build the canary libraries
+        run: lake build VCVioTest HashSigTest
       - name: Run SLH-DSA-SHA2-128-24 differential KAT
         run: lake exe slhdsa_kat
       - name: Run SLH-DSA-C13 differential KAT

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -78,4 +78,4 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto Examples VCVioWidgets Interop
+        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -16,6 +16,7 @@ public import HashSig.SLHDSA.Encoding
 public import HashSig.SLHDSA.Fors
 public import HashSig.SLHDSA.ForsOracle
 public import HashSig.SLHDSA.Hypertree
+public import HashSig.SLHDSA.MerkleParity
 public import HashSig.SLHDSA.Oracle
 public import HashSig.SLHDSA.Params
 public import HashSig.SLHDSA.Primitives

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -15,10 +15,12 @@ public import HashSig.SLHDSA.Concrete.Sha2
 public import HashSig.SLHDSA.Encoding
 public import HashSig.SLHDSA.Fors
 public import HashSig.SLHDSA.Hypertree
+public import HashSig.SLHDSA.Oracle
 public import HashSig.SLHDSA.Params
 public import HashSig.SLHDSA.Primitives
 public import HashSig.SLHDSA.Scheme
 public import HashSig.SLHDSA.Security
 public import HashSig.SLHDSA.Wots
 public import HashSig.SLHDSA.WotsChecksum
+public import HashSig.SLHDSA.WotsOracle
 public import HashSig.SLHDSA.Xmss

--- a/HashSig.lean
+++ b/HashSig.lean
@@ -14,13 +14,16 @@ public import HashSig.SLHDSA.Concrete.Keccak
 public import HashSig.SLHDSA.Concrete.Sha2
 public import HashSig.SLHDSA.Encoding
 public import HashSig.SLHDSA.Fors
+public import HashSig.SLHDSA.ForsOracle
 public import HashSig.SLHDSA.Hypertree
 public import HashSig.SLHDSA.Oracle
 public import HashSig.SLHDSA.Params
 public import HashSig.SLHDSA.Primitives
 public import HashSig.SLHDSA.Scheme
+public import HashSig.SLHDSA.SchemeOracle
 public import HashSig.SLHDSA.Security
 public import HashSig.SLHDSA.Wots
 public import HashSig.SLHDSA.WotsChecksum
 public import HashSig.SLHDSA.WotsOracle
 public import HashSig.SLHDSA.Xmss
+public import HashSig.SLHDSA.XmssOracle

--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -123,10 +123,19 @@ def decodeSignature (ba : ByteArray) : Signature shaPrimitives :=
     (List.range 22).map fun j => baSliceToB16 ba (2416 + 1088 + j * 16)
   (R, fors, (wots, xmssAuth))
 
-/-- Concrete verification of a decoded reference signature against `(pkSeed, pkRoot, message)`. -/
+/-- Concrete FIPS 205 external verification of a decoded signature against
+`(pkSeed, pkRoot, message)`.  The empty-context domain prefix is added by `slhVerify`. -/
 def verifyBytes (pkSeed pkRoot : Bytes 16) (msg : List Byte) (sigBytes : ByteArray) : Bool :=
   letI : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
   slhVerify shaPrimitives ⟨pkSeed, pkRoot⟩ msg (decodeSignature sigBytes)
+
+/-- Verification against the internal `M'` interface.  This is retained for the bundled
+SPHINCS+-style reference vector, which predates the FIPS 205 external context wrapper and already
+supplies the exact message consumed by `H_msg`. -/
+def verifyInternalBytes (pkSeed pkRoot : Bytes 16) (msg : List Byte)
+    (sigBytes : ByteArray) : Bool :=
+  letI : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
+  slhVerifyInternal shaPrimitives msg (decodeSignature sigBytes) ⟨pkSeed, pkRoot⟩
 
 /-! ### Completeness transfers to the concrete bundle
 

--- a/HashSig/SLHDSA/ForsOracle.lean
+++ b/HashSig/SLHDSA/ForsOracle.lean
@@ -165,7 +165,7 @@ theorem pkFromSig_sign (prims : Primitives p) (md : List Byte) (sk : prims.SkSee
 /-! ## Deterministic-handler structure -/
 
 @[simp]
-theorem simulateQ_leafM_with (prims : Primitives p)
+theorem simulateQ_leafM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) (index : ℕ) :
     simulateQ answer
@@ -174,7 +174,7 @@ theorem simulateQ_leafM_with (prims : Primitives p)
   simp [leafM, forsLeaf, forsSkGen, PublicHash.f, PublicHash.withPublicHash]
 
 @[simp]
-theorem simulateQ_nodeHashM_with (prims : Primitives p)
+theorem simulateQ_nodeHashM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (pk : prims.PkSeed) (adrs : Adrs)
     (address : Address) (left right : prims.Y) :
     simulateQ answer
@@ -186,7 +186,7 @@ theorem simulateQ_nodeHashM_with (prims : Primitives p)
 
 /-- One FORS root interpreted by any fixed answer function is the legacy root for the
 reinterpreted primitive bundle. -/
-theorem simulateQ_rootM_with (prims : Primitives p)
+theorem simulateQ_rootM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) (tree : Fin p.k) :
     simulateQ answer
@@ -194,7 +194,7 @@ theorem simulateQ_rootM_with (prims : Primitives p)
       forsRoot (PublicHash.withPublicHash prims answer) sk pk adrs tree.val := by
   unfold rootM forsRoot
   rw [PerfectMerkleTree.simulateQ_treeHashM]
-  simp_rw [simulateQ_leafM_with, simulateQ_nodeHashM_with]
+  simp_rw [simulateQ_leafM_withPublicHash, simulateQ_nodeHashM_withPublicHash]
   exact Merkle.treeHash_eq_merkleRoot
     (forsLeaf (PublicHash.withPublicHash prims answer) sk pk adrs)
     (forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs) p.a tree.val
@@ -206,7 +206,7 @@ private theorem indices_map_toList {n : ℕ} {α : Type} (f : Fin n → α) :
 
 /-- FORS public-key generation interpreted by any fixed answer function is legacy public-key
 generation for the reinterpreted primitive bundle. -/
-theorem simulateQ_pkGenM_with (prims : Primitives p)
+theorem simulateQ_pkGenM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) :
     simulateQ answer
@@ -214,7 +214,7 @@ theorem simulateQ_pkGenM_with (prims : Primitives p)
       forsPkGen (PublicHash.withPublicHash prims answer) sk pk adrs := by
   unfold pkGenM forsPkGen
   simp only [simulateQ_bind, PerfectMerkleTree.simulateQ_vector_mapM]
-  simp_rw [simulateQ_rootM_with]
+  simp_rw [simulateQ_rootM_withPublicHash]
   change answer (.tl pk (forsPkAdrs adrs)
       (((WotsOracle.indices p.k).map fun tree =>
         forsRoot (PublicHash.withPublicHash prims answer) sk pk adrs tree.val).toList)) =
@@ -227,20 +227,20 @@ theorem simulateQ_pkGenM_with (prims : Primitives p)
 
 /-- FORS signing interpreted by any fixed answer function is deterministic typed signing for the
 reinterpreted primitive bundle. -/
-theorem simulateQ_signM_with (prims : Primitives p)
+theorem simulateQ_signM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (md : List Byte) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) :
     simulateQ answer
         (signM prims md sk pk adrs : OracleComp (publicHashSpec prims) (Signature p prims)) =
       sign (PublicHash.withPublicHash prims answer) md sk pk adrs := by
   simp [signM, sign, PerfectMerkleTree.simulateQ_vector_mapM,
-    PerfectMerkleTree.simulateQ_authenticationPathM, simulateQ_leafM_with,
-    simulateQ_nodeHashM_with, WotsOracle.indices, PublicHash.withPublicHash]
+    PerfectMerkleTree.simulateQ_authenticationPathM, simulateQ_leafM_withPublicHash,
+    simulateQ_nodeHashM_withPublicHash, WotsOracle.indices, PublicHash.withPublicHash]
   rfl
 
 /-- FORS recovery interpreted by any fixed answer function is deterministic typed recovery for
 the reinterpreted primitive bundle. -/
-theorem simulateQ_pkFromSigM_with (prims : Primitives p)
+theorem simulateQ_pkFromSigM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (sig : Signature p prims) (md : List Byte)
     (pk : prims.PkSeed) (adrs : Adrs) :
     simulateQ answer
@@ -256,7 +256,7 @@ theorem simulateQ_pkFromSigM_with (prims : Primitives p)
         forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs
           address.height address.index) 0 index p.a
         (answer (.f pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1)) (sig[tree.val]).2 := by
-    simp [PerfectMerkleTree.simulateQ_climbM, simulateQ_nodeHashM_with, PublicHash.f]
+    simp [PerfectMerkleTree.simulateQ_climbM, simulateQ_nodeHashM_withPublicHash, PublicHash.f]
     rfl
   unfold pkFromSigM pkFromSig
   rw [simulateQ_bind, PerfectMerkleTree.simulateQ_vector_mapM]
@@ -287,7 +287,7 @@ theorem simulateQ_pkFromSigM_with (prims : Primitives p)
 
 /-- Honest FORS signing and recovery are functionally complete after fixing any deterministic
 public-hash answer function. -/
-theorem simulateQ_pkFromSigM_signM_with (prims : Primitives p)
+theorem simulateQ_pkFromSigM_signM_withPublicHash (prims : Primitives p)
     (answer : QueryImpl (publicHashSpec prims) Id) (md : List Byte) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) :
     simulateQ answer (do
@@ -301,8 +301,59 @@ theorem simulateQ_pkFromSigM_signM_with (prims : Primitives p)
       (simulateQ answer
         (signM prims md sk pk adrs : OracleComp (publicHashSpec prims) (Signature p prims)))
       md pk adrs) = _
-  rw [simulateQ_signM_with, simulateQ_pkFromSigM_with]
+  rw [simulateQ_signM_withPublicHash, simulateQ_pkFromSigM_withPublicHash]
   exact pkFromSig_sign (PublicHash.withPublicHash prims answer) md sk pk adrs
+
+/-- Canonical deterministic-handler parity for one FORS root. -/
+@[simp]
+theorem simulateQ_rootM (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (tree : Fin p.k) :
+    simulateQ (PublicHash.impl prims)
+        (rootM prims sk pk adrs tree : OracleComp (publicHashSpec prims) prims.Y) =
+      forsRoot prims sk pk adrs tree.val := by
+  convert simulateQ_rootM_withPublicHash prims (PublicHash.impl prims) sk pk adrs tree using 1
+  all_goals rfl
+
+/-- Canonical deterministic-handler parity for FORS public-key generation. -/
+@[simp]
+theorem simulateQ_pkGenM (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (pkGenM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      forsPkGen prims sk pk adrs := by
+  convert simulateQ_pkGenM_withPublicHash prims (PublicHash.impl prims) sk pk adrs using 1
+  all_goals rfl
+
+/-- Canonical deterministic-handler parity for FORS signing. -/
+@[simp]
+theorem simulateQ_signM (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (signM prims md sk pk adrs : OracleComp (publicHashSpec prims) (Signature p prims)) =
+      sign prims md sk pk adrs := by
+  convert simulateQ_signM_withPublicHash prims (PublicHash.impl prims) md sk pk adrs using 1
+  all_goals rfl
+
+/-- Canonical deterministic-handler parity for FORS public-key recovery. -/
+@[simp]
+theorem simulateQ_pkFromSigM (prims : Primitives p) (sig : Signature p prims)
+    (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (pkFromSigM prims sig md pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      pkFromSig prims sig md pk adrs := by
+  convert simulateQ_pkFromSigM_withPublicHash prims (PublicHash.impl prims) sig md pk adrs using 1
+  all_goals rfl
+
+/-- Canonical honest signing/recovery equality for FORS. -/
+theorem simulateQ_pkFromSigM_signM (prims : Primitives p) (md : List Byte)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims) (do
+      let sig ← (signM prims md sk pk adrs :
+        OracleComp (publicHashSpec prims) (Signature p prims))
+      pkFromSigM prims sig md pk adrs) = forsPkGen prims sk pk adrs := by
+  convert simulateQ_pkFromSigM_signM_withPublicHash prims (PublicHash.impl prims) md sk pk adrs
+    using 1
+  all_goals rfl
 
 @[simp]
 theorem simulateQ_leafM (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)

--- a/HashSig/SLHDSA/ForsOracle.lean
+++ b/HashSig/SLHDSA/ForsOracle.lean
@@ -75,6 +75,235 @@ def pkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
     climbM (nodeHashM prims pk adrs) 0 index p.a leaf (sig[tree.val]).2
   PublicHash.tl prims pk (forsPkAdrs adrs) roots.toList
 
+/-! ## Deterministic typed semantics -/
+
+/-- Erase the authentication-path length proofs from a typed FORS signature. -/
+def toLegacy {prims : Primitives p} (sig : Signature p prims) : ForsSig p prims :=
+  sig.map fun entry => (entry.1, entry.2.toList)
+
+/-- Deterministic typed computation of one FORS tree root. -/
+def root (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (tree : Fin p.k) : prims.Y :=
+  treeHash (forsLeaf prims sk pk adrs)
+    (fun address => forsNodeHash prims pk adrs address.height address.index) p.a tree.val
+
+/-- Deterministic FORS public-key generation through the typed perfect-tree engine. -/
+def pkGen (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    prims.Y :=
+  prims.Tl pk (forsPkAdrs adrs) ((List.finRange p.k).map fun tree =>
+    root prims sk pk adrs tree)
+
+/-- Deterministic FORS signing with exactly `a` siblings in every authentication path. -/
+def sign (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) : Signature p prims :=
+  Vector.ofFn fun tree : Fin p.k =>
+    let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+    (forsSkGen prims sk pk adrs index,
+      authenticationPath (forsLeaf prims sk pk adrs) (fun address =>
+        forsNodeHash prims pk adrs address.height address.index) 0 index p.a)
+
+/-- Deterministic FORS public-key recovery from a typed signature. -/
+def pkFromSig (prims : Primitives p) (sig : Signature p prims) (md : List Byte)
+    (pk : prims.PkSeed) (adrs : Adrs) : prims.Y :=
+  prims.Tl pk (forsPkAdrs adrs) ((List.finRange p.k).map fun tree =>
+    let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+    climb (fun address => forsNodeHash prims pk adrs address.height address.index)
+      0 index p.a (prims.F pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1)
+      (sig[tree.val]).2)
+
+/-- The deterministic typed tree root is the legacy FORS root. -/
+@[simp]
+theorem root_eq_forsRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (tree : Fin p.k) :
+    root prims sk pk adrs tree = forsRoot prims sk pk adrs tree.val := by
+  unfold root forsRoot
+  exact Merkle.treeHash_eq_merkleRoot
+    (forsLeaf prims sk pk adrs) (forsNodeHash prims pk adrs) p.a tree.val
+
+/-- Typed deterministic FORS public-key generation agrees with the legacy definition. -/
+@[simp]
+theorem pkGen_eq_forsPkGen (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    pkGen prims sk pk adrs = forsPkGen prims sk pk adrs := by
+  unfold pkGen forsPkGen
+  refine congrArg (prims.Tl pk (forsPkAdrs adrs)) (List.map_congr_left fun tree _ => ?_)
+  exact root_eq_forsRoot prims sk pk adrs tree
+
+/-- Erasing a deterministic typed signature gives the legacy FORS signature. -/
+@[simp]
+theorem toLegacy_sign (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    toLegacy (sign prims md sk pk adrs) = forsSign prims md sk pk adrs := by
+  apply Vector.ext
+  intro tree htree
+  simp only [toLegacy, sign, forsSign, Vector.getElem_map, Vector.getElem_ofFn]
+  apply Prod.ext
+  · rfl
+  · exact Merkle.authenticationPath_toList_eq_authPath
+      (forsLeaf prims sk pk adrs) (forsNodeHash prims pk adrs) p.a 0
+      (tree * 2 ^ p.a + forsIdx p md tree)
+
+/-- Typed deterministic FORS recovery agrees with legacy recovery after erasure. -/
+@[simp]
+theorem pkFromSig_eq_forsPkFromSig (prims : Primitives p) (sig : Signature p prims)
+    (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
+    pkFromSig prims sig md pk adrs = forsPkFromSig prims (toLegacy sig) md pk adrs := by
+  unfold pkFromSig forsPkFromSig
+  refine congrArg (prims.Tl pk (forsPkAdrs adrs)) (List.map_congr_left fun tree _ => ?_)
+  simp only [toLegacy, Vector.getElem_map]
+  exact Merkle.climb_eq_climb (forsNodeHash prims pk adrs) p.a 0
+    (tree.val * 2 ^ p.a + forsIdx p md tree.val) _ (sig[tree.val]).2
+
+/-- Honest deterministic typed FORS signing and recovery reconstruct the legacy public key. -/
+theorem pkFromSig_sign (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    pkFromSig prims (sign prims md sk pk adrs) md pk adrs =
+      forsPkGen prims sk pk adrs := by
+  rw [pkFromSig_eq_forsPkFromSig, toLegacy_sign]
+  exact forsPkFromSig_forsSign prims md sk pk adrs
+
+/-! ## Deterministic-handler structure -/
+
+@[simp]
+theorem simulateQ_leafM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (index : ℕ) :
+    simulateQ answer
+        (leafM prims sk pk adrs index : OracleComp (publicHashSpec prims) prims.Y) =
+      forsLeaf (PublicHash.withPublicHash prims answer) sk pk adrs index := by
+  simp [leafM, forsLeaf, forsSkGen, PublicHash.f, PublicHash.withPublicHash]
+
+@[simp]
+theorem simulateQ_nodeHashM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (pk : prims.PkSeed) (adrs : Adrs)
+    (address : Address) (left right : prims.Y) :
+    simulateQ answer
+        (nodeHashM prims pk adrs address left right :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+        address.height address.index left right := by
+  simp [nodeHashM, forsNodeHash, PublicHash.h]
+
+/-- One FORS root interpreted by any fixed answer function is the legacy root for the
+reinterpreted primitive bundle. -/
+theorem simulateQ_rootM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (tree : Fin p.k) :
+    simulateQ answer
+        (rootM prims sk pk adrs tree : OracleComp (publicHashSpec prims) prims.Y) =
+      forsRoot (PublicHash.withPublicHash prims answer) sk pk adrs tree.val := by
+  unfold rootM forsRoot
+  rw [PerfectMerkleTree.simulateQ_treeHashM]
+  simp_rw [simulateQ_leafM_with, simulateQ_nodeHashM_with]
+  exact Merkle.treeHash_eq_merkleRoot
+    (forsLeaf (PublicHash.withPublicHash prims answer) sk pk adrs)
+    (forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs) p.a tree.val
+
+private theorem indices_map_toList {n : ℕ} {α : Type} (f : Fin n → α) :
+    ((WotsOracle.indices n).map f).toList = (List.finRange n).map f := by
+  simpa [WotsOracle.indices, List.finRange, Function.comp_def] using
+    (Vector.toList_ofFn (f := f))
+
+/-- FORS public-key generation interpreted by any fixed answer function is legacy public-key
+generation for the reinterpreted primitive bundle. -/
+theorem simulateQ_pkGenM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ answer
+        (pkGenM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      forsPkGen (PublicHash.withPublicHash prims answer) sk pk adrs := by
+  unfold pkGenM forsPkGen
+  simp only [simulateQ_bind, PerfectMerkleTree.simulateQ_vector_mapM]
+  simp_rw [simulateQ_rootM_with]
+  change answer (.tl pk (forsPkAdrs adrs)
+      (((WotsOracle.indices p.k).map fun tree =>
+        forsRoot (PublicHash.withPublicHash prims answer) sk pk adrs tree.val).toList)) =
+    answer (.tl pk (forsPkAdrs adrs)
+      ((List.finRange p.k).map fun tree =>
+        forsRoot (PublicHash.withPublicHash prims answer) sk pk adrs tree.val))
+  congr 2
+  exact indices_map_toList fun tree =>
+    forsRoot (PublicHash.withPublicHash prims answer) sk pk adrs tree.val
+
+/-- FORS signing interpreted by any fixed answer function is deterministic typed signing for the
+reinterpreted primitive bundle. -/
+theorem simulateQ_signM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (md : List Byte) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (signM prims md sk pk adrs : OracleComp (publicHashSpec prims) (Signature p prims)) =
+      sign (PublicHash.withPublicHash prims answer) md sk pk adrs := by
+  simp [signM, sign, PerfectMerkleTree.simulateQ_vector_mapM,
+    PerfectMerkleTree.simulateQ_authenticationPathM, simulateQ_leafM_with,
+    simulateQ_nodeHashM_with, WotsOracle.indices, PublicHash.withPublicHash]
+  rfl
+
+/-- FORS recovery interpreted by any fixed answer function is deterministic typed recovery for
+the reinterpreted primitive bundle. -/
+theorem simulateQ_pkFromSigM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sig : Signature p prims) (md : List Byte)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (pkFromSigM prims sig md pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      pkFromSig (PublicHash.withPublicHash prims answer) sig md pk adrs := by
+  have hbody (tree : Fin p.k) :
+      simulateQ answer (do
+        let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+        let leaf ← PublicHash.f prims pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1
+        climbM (nodeHashM prims pk adrs) 0 index p.a leaf (sig[tree.val]).2) =
+      let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+      climb (fun address =>
+        forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+          address.height address.index) 0 index p.a
+        (answer (.f pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1)) (sig[tree.val]).2 := by
+    simp [PerfectMerkleTree.simulateQ_climbM, simulateQ_nodeHashM_with, PublicHash.f]
+    rfl
+  unfold pkFromSigM pkFromSig
+  rw [simulateQ_bind, PerfectMerkleTree.simulateQ_vector_mapM]
+  simp_rw [hbody]
+  change answer (.tl pk (forsPkAdrs adrs)
+      (((WotsOracle.indices p.k).map fun tree =>
+        let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+        climb (fun address =>
+          forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+            address.height address.index) 0 index p.a
+          (answer (.f pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1))
+          (sig[tree.val]).2).toList)) =
+    answer (.tl pk (forsPkAdrs adrs)
+      ((List.finRange p.k).map fun tree =>
+        let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+        climb (fun address =>
+          forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+            address.height address.index) 0 index p.a
+          (answer (.f pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1))
+          (sig[tree.val]).2))
+  congr 2
+  exact indices_map_toList fun tree =>
+    let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+    climb (fun address =>
+      forsNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+        address.height address.index) 0 index p.a
+      (answer (.f pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1)) (sig[tree.val]).2
+
+/-- Honest FORS signing and recovery are functionally complete after fixing any deterministic
+public-hash answer function. -/
+theorem simulateQ_pkFromSigM_signM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (md : List Byte) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer (do
+      let sig ← (signM prims md sk pk adrs :
+        OracleComp (publicHashSpec prims) (Signature p prims))
+      pkFromSigM prims sig md pk adrs) =
+      forsPkGen (PublicHash.withPublicHash prims answer) sk pk adrs := by
+  simp only [simulateQ_bind]
+  change simulateQ answer
+    (pkFromSigM prims
+      (simulateQ answer
+        (signM prims md sk pk adrs : OracleComp (publicHashSpec prims) (Signature p prims)))
+      md pk adrs) = _
+  rw [simulateQ_signM_with, simulateQ_pkFromSigM_with]
+  exact pkFromSig_sign (PublicHash.withPublicHash prims answer) md sk pk adrs
+
 @[simp]
 theorem simulateQ_leafM (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) (index : ℕ) :

--- a/HashSig/SLHDSA/ForsOracle.lean
+++ b/HashSig/SLHDSA/ForsOracle.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Fors
+public import HashSig.SLHDSA.XmssOracle
+
+/-!
+# Oracle-parametric FORS
+
+The FORS forest is evaluated with the callback-parametric perfect-Merkle engine.  Every public
+`F`, `H`, and `T_l` application is an explicit `PublicHash` query, while authentication paths are
+length-indexed by the FORS height `a`.  As with the XMSS layer, cache initialization is deliberately
+left to the surrounding experiment.
+-/
+
+@[expose] public section
+
+namespace SLHDSA
+
+open PerfectMerkleTree
+
+variable {p : Params}
+
+namespace ForsOracle
+
+/-- A FORS signature contains one secret value and an exactly `a`-node path per FORS tree. -/
+abbrev Signature (p : Params) (prims : Primitives p) :=
+  Vector (prims.Y × AuthenticationPath prims.Y p.a) p.k
+
+/-- Evaluate a FORS leaf with one explicit `F` query. -/
+def leafM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (index : ℕ) : m prims.Y :=
+  PublicHash.f prims pk (forsNodeAdrs adrs 0 index) (forsSkGen prims sk pk adrs index)
+
+/-- Evaluate a FORS internal node with an address-preserving `H` query. -/
+def nodeHashM (prims : Primitives p) {m : Type → Type*} [HasQuery (publicHashSpec prims) m]
+    (pk : prims.PkSeed) (adrs : Adrs) (address : Address) (left right : prims.Y) : m prims.Y :=
+  PublicHash.h prims pk (forsNodeAdrs adrs address.height address.index) left right
+
+/-- Compute one FORS tree root without allocating a full tree. -/
+def rootM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (tree : Fin p.k) : m prims.Y :=
+  treeHashM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) p.a tree.val
+
+/-- Generate the FORS public key using explicit tree and compression queries. -/
+def pkGenM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    m prims.Y := do
+  let roots ← (WotsOracle.indices p.k).mapM (rootM prims sk pk adrs)
+  PublicHash.tl prims pk (forsPkAdrs adrs) roots.toList
+
+/-- Sign a FORS digest with sized authentication paths and explicit public-hash queries. -/
+def signM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) : m (Signature p prims) :=
+  (WotsOracle.indices p.k).mapM fun tree => do
+    let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+    let path ← authenticationPathM (leafM prims sk pk adrs) (nodeHashM prims pk adrs)
+      0 index p.a
+    pure (forsSkGen prims sk pk adrs index, path)
+
+/-- Recover the FORS public key from a typed signature. -/
+def pkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sig : Signature p prims) (md : List Byte)
+    (pk : prims.PkSeed) (adrs : Adrs) : m prims.Y := do
+  let roots ← (WotsOracle.indices p.k).mapM fun tree => do
+    let index := tree.val * 2 ^ p.a + forsIdx p md tree.val
+    let leaf ← PublicHash.f prims pk (forsNodeAdrs adrs 0 index) (sig[tree.val]).1
+    climbM (nodeHashM prims pk adrs) 0 index p.a leaf (sig[tree.val]).2
+  PublicHash.tl prims pk (forsPkAdrs adrs) roots.toList
+
+@[simp]
+theorem simulateQ_leafM (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (index : ℕ) :
+    simulateQ (PublicHash.impl prims)
+        (leafM prims sk pk adrs index : OracleComp (publicHashSpec prims) prims.Y) =
+      forsLeaf prims sk pk adrs index := by
+  simp [leafM, forsLeaf]
+
+@[simp]
+theorem simulateQ_nodeHashM (prims : Primitives p) (pk : prims.PkSeed) (adrs : Adrs)
+    (address : Address) (left right : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (nodeHashM prims pk adrs address left right :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      forsNodeHash prims pk adrs address.height address.index left right := by
+  simp [nodeHashM, forsNodeHash]
+
+end ForsOracle
+
+end SLHDSA

--- a/HashSig/SLHDSA/MerkleParity.lean
+++ b/HashSig/SLHDSA/MerkleParity.lean
@@ -1,0 +1,90 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Xmss
+public import VCVio.CryptoFoundations.MerkleTree.Perfect.SimulateQ
+
+/-!
+# Perfect-Merkle Compatibility for SLH-DSA
+
+The oracle-parametric SLH-DSA layer uses `PerfectMerkleTree`, whose authentication paths are
+length-indexed vectors. The original executable specification uses `SLHDSA.Merkle` and lists.
+This module proves that their deterministic roots, path generation, and path folding agree after
+erasing the vector length proof.
+-/
+
+@[expose] public section
+
+namespace SLHDSA.Merkle
+
+open PerfectMerkleTree
+
+variable {Y : Type}
+
+/-- The perfect-tree root is the legacy SLH-DSA Merkle root under the coordinate adapter. -/
+@[simp]
+theorem treeHash_eq_merkleRoot (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y)
+    (height index : ℕ) :
+    treeHash leaf (fun address => nodeHash address.height address.index) height index =
+      merkleRoot leaf nodeHash height index := by
+  induction height generalizing index with
+  | zero => rfl
+  | succ height ih => simp [treeHash, merkleRoot, ih]
+
+/-- Erasing the sized perfect-tree authentication path gives the legacy list path. -/
+theorem authenticationPath_toList_eq_authPath
+    (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) :
+    ∀ (depth base index : ℕ),
+      (authenticationPath leaf (fun address => nodeHash address.height address.index)
+        base index depth).toList = authPath leaf nodeHash base index depth := by
+  intro depth
+  induction depth with
+  | zero =>
+      intro base index
+      rfl
+  | succ depth ih =>
+      intro base index
+      have legacyStep : authPath leaf nodeHash base index (depth + 1) =
+          merkleRoot leaf nodeHash base (Merkle.sibling index) ::
+            authPath leaf nodeHash (base + 1) (index / 2) depth := by
+        simp only [authPath, List.range_succ_eq_map, List.map_cons, List.map_map, pow_zero,
+          Nat.div_one, Nat.add_zero]
+        refine congrArg _ (List.map_congr_left fun j _ => ?_)
+        simp only [Function.comp_apply]
+        have hb : base + (j + 1) = base + 1 + j := by omega
+        have hd : index / 2 ^ (j + 1) = index / 2 / 2 ^ j := by
+          rw [Nat.div_div_eq_div_mul, pow_succ, Nat.mul_comm]
+        rw [hb, hd]
+      rw [legacyStep]
+      simp only [authenticationPath, List.Vector.toList_cons]
+      rw [treeHash_eq_merkleRoot, ih (base + 1) (index / 2)]
+      rfl
+
+/-- Folding a sized perfect-tree path agrees with folding its erased legacy list. -/
+theorem climb_eq_climb (nodeHash : ℕ → ℕ → Y → Y → Y) :
+    ∀ (depth base index : ℕ) (node : Y) (path : AuthenticationPath Y depth),
+      PerfectMerkleTree.climb (fun address => nodeHash address.height address.index)
+          base index depth node path =
+        Merkle.climb nodeHash base index node path.toList := by
+  intro depth
+  induction depth with
+  | zero =>
+      intro base index node path
+      rw [vector_eq_nil path]
+      rfl
+  | succ depth ih =>
+      intro base index node path
+      have hpath : path.toList = path.head :: path.tail.toList := by
+        calc
+          path.toList = (List.Vector.cons path.head path.tail).toList :=
+            congrArg List.Vector.toList path.cons_head_tail.symm
+          _ = path.head :: path.tail.toList := rfl
+      rw [hpath]
+      by_cases h : index % 2 = 0 <;>
+        simp [PerfectMerkleTree.climb, Merkle.climb, h, ih]
+
+end SLHDSA.Merkle

--- a/HashSig/SLHDSA/Oracle.lean
+++ b/HashSig/SLHDSA/Oracle.lean
@@ -1,0 +1,134 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Primitives
+public import VCVio.OracleComp.QueryTracking.RandomOracle.Basic
+
+/-!
+# Explicit public-hash oracle for SLH-DSA
+
+This module gives the four public SLH-DSA hash operations an explicit oracle syntax.  The query
+identity retains the function family, public seed, complete address, ordered input, and (for
+`T_l`) the full input list.  Consequently a lazy random-oracle handler cannot accidentally
+identify nodes at different addresses or calls to different hash families.
+
+`PublicHash.impl` interprets the syntax with the deterministic functions in `Primitives`.
+`PublicHash.randomOracle` instead samples each previously unseen tagged query once and caches the
+answer.  Both handlers interpret the same canonical `OracleComp` programs.
+
+The keyed operations `PRF` and `PRF_msg` are intentionally not part of this public interface:
+security games may expose this oracle to an adversary without exposing secret-key operations.
+
+## References
+
+- NIST FIPS 205, Section 4.1 (`F`, `H`, `T_l`, and `H_msg`)
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SLHDSA
+
+variable {p : Params}
+
+/-- A tagged query to one of the public SLH-DSA hash functions.  The carrier types are explicit
+parameters so the generated decidable-equality instance uses the caller's concrete instances. -/
+inductive PublicHashQuery (PkSeed Y : Type) where
+  /-- `F(PK.seed, ADRS, x)`. -/
+  | f (pkSeed : PkSeed) (adrs : Adrs) (x : Y)
+  /-- `H(PK.seed, ADRS, left, right)`.  The child order is part of the query. -/
+  | h (pkSeed : PkSeed) (adrs : Adrs) (left right : Y)
+  /-- `T_l(PK.seed, ADRS, xs)`.  Length and order are part of the query. -/
+  | tl (pkSeed : PkSeed) (adrs : Adrs) (xs : List Y)
+  /-- `H_msg(R, PK.seed, PK.root, M)`. -/
+  | hmsg (r : Y) (pkSeed : PkSeed) (pkRoot : Y) (msg : List Byte)
+deriving DecidableEq
+
+/-- The dependent public-hash specification.  Reducibility is intentional: consumers must be able
+to see that the first three constructors return nodes while `H_msg` returns a digest. -/
+@[reducible] def publicHashSpec (prims : Primitives p) :
+    OracleSpec (PublicHashQuery prims.PkSeed prims.Y)
+  | .f _ _ _ => prims.Y
+  | .h _ _ _ _ => prims.Y
+  | .tl _ _ _ => prims.Y
+  | .hmsg _ _ _ _ => Bytes p.m
+
+namespace PublicHash
+
+/-- Issue an explicit `F` query. -/
+def f (prims : Primitives p) {m : Type → Type*} [HasQuery (publicHashSpec prims) m]
+    (pkSeed : prims.PkSeed) (adrs : Adrs) (x : prims.Y) : m prims.Y :=
+  query (spec := publicHashSpec prims) (PublicHashQuery.f pkSeed adrs x)
+
+/-- Issue an explicit ordered binary-node `H` query. -/
+def h (prims : Primitives p) {m : Type → Type*} [HasQuery (publicHashSpec prims) m]
+    (pkSeed : prims.PkSeed) (adrs : Adrs) (left right : prims.Y) : m prims.Y :=
+  query (spec := publicHashSpec prims) (PublicHashQuery.h pkSeed adrs left right)
+
+/-- Issue an explicit variable-arity `T_l` query. -/
+def tl (prims : Primitives p) {m : Type → Type*} [HasQuery (publicHashSpec prims) m]
+    (pkSeed : prims.PkSeed) (adrs : Adrs) (xs : List prims.Y) : m prims.Y :=
+  query (spec := publicHashSpec prims) (PublicHashQuery.tl pkSeed adrs xs)
+
+/-- Issue an explicit `H_msg` query. -/
+def hmsg (prims : Primitives p) {m : Type → Type*} [HasQuery (publicHashSpec prims) m]
+    (r : prims.Y) (pkSeed : prims.PkSeed) (pkRoot : prims.Y) (msg : List Byte) :
+    m (Bytes p.m) :=
+  query (spec := publicHashSpec prims) (PublicHashQuery.hmsg r pkSeed pkRoot msg)
+
+/-- Deterministically interpret the public-hash syntax using the functions in `Primitives`. -/
+def impl (prims : Primitives p) : QueryImpl (publicHashSpec prims) Id
+  | .f pkSeed adrs x => prims.F pkSeed adrs x
+  | .h pkSeed adrs left right => prims.H pkSeed adrs left right
+  | .tl pkSeed adrs xs => prims.Tl pkSeed adrs xs
+  | .hmsg r pkSeed pkRoot msg => prims.Hmsg r pkSeed pkRoot msg
+
+@[simp] theorem simulateQ_f (prims : Primitives p) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (x : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (PublicHash.f prims pkSeed adrs x : OracleComp (publicHashSpec prims) prims.Y) =
+      prims.F pkSeed adrs x := by
+  simp only [f, simulateQ_HasQuery_query, impl]
+
+@[simp] theorem simulateQ_h (prims : Primitives p) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (left right : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (PublicHash.h prims pkSeed adrs left right : OracleComp (publicHashSpec prims) prims.Y) =
+      prims.H pkSeed adrs left right := by
+  simp only [h, simulateQ_HasQuery_query, impl]
+
+@[simp] theorem simulateQ_tl (prims : Primitives p) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (xs : List prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (PublicHash.tl prims pkSeed adrs xs : OracleComp (publicHashSpec prims) prims.Y) =
+      prims.Tl pkSeed adrs xs := by
+  simp only [tl, simulateQ_HasQuery_query, impl]
+
+@[simp] theorem simulateQ_hmsg (prims : Primitives p) (r : prims.Y)
+    (pkSeed : prims.PkSeed) (pkRoot : prims.Y) (msg : List Byte) :
+    simulateQ (PublicHash.impl prims)
+        (PublicHash.hmsg prims r pkSeed pkRoot msg :
+          OracleComp (publicHashSpec prims) (Bytes p.m)) =
+      prims.Hmsg r pkSeed pkRoot msg := by
+  simp only [hmsg, simulateQ_HasQuery_query, impl]
+
+/-- The cache used by the lazy public random oracle. -/
+abbrev Cache (prims : Primitives p) := (publicHashSpec prims).QueryCache
+
+/-- Lazy random-oracle interpretation of the tagged public hash syntax. -/
+def randomOracle (prims : Primitives p) [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
+    [SampleableType prims.Y] [SampleableType (Bytes p.m)] :
+    QueryImpl (publicHashSpec prims) (StateT (PublicHash.Cache prims) ProbComp) := by
+  letI : ∀ t : PublicHashQuery prims.PkSeed prims.Y,
+      SampleableType ((publicHashSpec prims).Range t) := fun t => by
+    cases t <;> exact inferInstance
+  exact (publicHashSpec prims).randomOracle
+
+end PublicHash
+
+end SLHDSA

--- a/HashSig/SLHDSA/Oracle.lean
+++ b/HashSig/SLHDSA/Oracle.lean
@@ -162,7 +162,8 @@ perfectly valid pure SLH-DSA primitive bundle. -/
 abbrev Cache (prims : Primitives p) := (publicHashSpec prims).QueryCache
 
 /-- Lazy random-oracle interpretation of the tagged public hash syntax. -/
-def randomOracle (prims : Primitives p) [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
+@[reducible] def randomOracle (prims : Primitives p)
+    [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
     [SampleableType prims.Y] [SampleableType (Bytes p.m)] :
     QueryImpl (publicHashSpec prims) (StateT (PublicHash.Cache prims) ProbComp) := by
   letI : ∀ t : PublicHashQuery prims.PkSeed prims.Y,

--- a/HashSig/SLHDSA/Oracle.lean
+++ b/HashSig/SLHDSA/Oracle.lean
@@ -23,6 +23,10 @@ answer.  Both handlers interpret the same canonical `OracleComp` programs.
 The keyed operations `PRF` and `PRF_msg` are intentionally not part of this public interface:
 security games may expose this oracle to an adversary without exposing secret-key operations.
 
+The ideal-oracle domain stores the complete structural `Adrs`.  The concrete SHA-2 instantiation
+compresses addresses to `ADRSc`; relating that encoding to this ideal model requires a separate
+reachability/injectivity argument and is not claimed here.
+
 ## References
 
 - NIST FIPS 205, Section 4.1 (`F`, `H`, `T_l`, and `H_msg`)

--- a/HashSig/SLHDSA/Oracle.lean
+++ b/HashSig/SLHDSA/Oracle.lean
@@ -129,6 +129,16 @@ def randomOracle (prims : Primitives p) [DecidableEq prims.PkSeed] [DecidableEq 
     cases t <;> exact inferInstance
   exact (publicHashSpec prims).randomOracle
 
+/-- Install the lazy random oracle as the query capability of a state transformer.  This is a
+named value rather than a global instance: a security experiment must opt into this semantics
+once, and then thread the resulting cache through key generation, the adversary, signing, and
+verification. -/
+@[instance_reducible]
+def randomOracleHasQuery (prims : Primitives p) [DecidableEq prims.PkSeed]
+    [DecidableEq prims.Y] [SampleableType prims.Y] [SampleableType (Bytes p.m)] :
+    HasQuery (publicHashSpec prims) (StateT (PublicHash.Cache prims) ProbComp) where
+  query := PublicHash.randomOracle prims
+
 end PublicHash
 
 end SLHDSA

--- a/HashSig/SLHDSA/Oracle.lean
+++ b/HashSig/SLHDSA/Oracle.lean
@@ -88,6 +88,47 @@ def impl (prims : Primitives p) : QueryImpl (publicHashSpec prims) Id
   | .tl pkSeed adrs xs => prims.Tl pkSeed adrs xs
   | .hmsg r pkSeed pkRoot msg => prims.Hmsg r pkSeed pkRoot msg
 
+/-- Reinterpret the four public hash fields of `prims` through an arbitrary deterministic answer
+function, while leaving the secret PRFs and node encoding unchanged.  This is the functional
+bridge used to prove random-oracle correctness: every total answer function defines another
+perfectly valid pure SLH-DSA primitive bundle. -/
+@[reducible] def withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) :
+    Primitives p where
+  PkSeed := prims.PkSeed
+  SkSeed := prims.SkSeed
+  SkPrf := prims.SkPrf
+  Y := prims.Y
+  F pkSeed adrs x := answer (.f pkSeed adrs x)
+  H pkSeed adrs left right := answer (.h pkSeed adrs left right)
+  Tl pkSeed adrs xs := answer (.tl pkSeed adrs xs)
+  PRF := prims.PRF
+  PRFmsg := prims.PRFmsg
+  Hmsg r pkSeed pkRoot msg := answer (.hmsg r pkSeed pkRoot msg)
+  yToBytes := prims.yToBytes
+
+@[simp] theorem withPublicHash_f (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (x : prims.Y) :
+    (withPublicHash prims answer).F pkSeed adrs x = answer (.f pkSeed adrs x) := rfl
+
+@[simp] theorem withPublicHash_h (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (left right : prims.Y) :
+    (withPublicHash prims answer).H pkSeed adrs left right =
+      answer (.h pkSeed adrs left right) := rfl
+
+@[simp] theorem withPublicHash_tl (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (xs : List prims.Y) :
+    (withPublicHash prims answer).Tl pkSeed adrs xs = answer (.tl pkSeed adrs xs) := rfl
+
+@[simp] theorem withPublicHash_hmsg (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (r : prims.Y) (pkSeed : prims.PkSeed)
+    (pkRoot : prims.Y) (msg : List Byte) :
+    (withPublicHash prims answer).Hmsg r pkSeed pkRoot msg =
+      answer (.hmsg r pkSeed pkRoot msg) := rfl
+
 @[simp] theorem simulateQ_f (prims : Primitives p) (pkSeed : prims.PkSeed) (adrs : Adrs)
     (x : prims.Y) :
     simulateQ (PublicHash.impl prims)

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -130,6 +130,12 @@ theorem slhVerifyInternal_slhSignInternal (prims : Primitives p) [DecidableEq pr
 
 variable (prims : Primitives p)
 
+/-- FIPS 205 external-message encoding for the empty-context API:
+`M' = 0x00 || toByte(0, 1) || M`.  Internal algorithms consume `M'`; callers of the generic
+signature API supply the raw message `M`. -/
+def emptyContextMessage (msg : List Byte) : List Byte :=
+  0x00 :: 0x00 :: msg
+
 /-- SLH-DSA key generation (FIPS 205 Algorithm 21): sample the three seeds. -/
 def slhKeygen [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
     [SampleableType prims.PkSeed] : ProbComp (PublicKey prims × SecretKey prims) := do
@@ -142,12 +148,12 @@ def slhKeygen [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
 def slhSign [SampleableType prims.Y] (sk : SecretKey prims) (msg : List Byte) :
     ProbComp (Signature prims) := do
   let addrnd ← $ᵗ prims.Y
-  return slhSignInternal prims msg sk addrnd
+  return slhSignInternal prims (emptyContextMessage msg) sk addrnd
 
 /-- SLH-DSA verification (FIPS 205 Algorithm 24, empty context). -/
 def slhVerify [DecidableEq prims.Y] (pk : PublicKey prims) (msg : List Byte)
     (sig : Signature prims) : Bool :=
-  slhVerifyInternal prims msg sig pk
+  slhVerifyInternal prims (emptyContextMessage msg) sig pk
 
 /-- SLH-DSA as a generic `SignatureAlg` in the `ProbComp` monad. -/
 def slhdsaAlg [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
@@ -194,7 +200,8 @@ theorem slhdsaAlg_perfectlyComplete [SampleableType prims.SkSeed] [SampleableTyp
     have hpk : pk = (slhKeygenInternal prims skSeed skPrf pkSeed).1 := congrArg Prod.fst hpksk
     have hsk : sk = (slhKeygenInternal prims skSeed skPrf pkSeed).2 := congrArg Prod.snd hpksk
     subst hpk; subst hsk
-    exact slhVerifyInternal_slhSignInternal prims msg skSeed skPrf pkSeed addrnd
+    exact slhVerifyInternal_slhSignInternal prims (emptyContextMessage msg)
+      skSeed skPrf pkSeed addrnd
   change Pr[= true | mx] = 1
   exact probOutput_eq_one_of_support_subset_singleton
     (NeverFail.probFailure_eq_zero (mx := mx)) huniq

--- a/HashSig/SLHDSA/SchemeOracle.lean
+++ b/HashSig/SLHDSA/SchemeOracle.lean
@@ -72,7 +72,7 @@ def signInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
   let index : LeafIndex p.hp := ⟨(splitDigest p digest).2, splitDigest_snd_lt p digest⟩
   let forsAddress := forsAdrsOf index.val
   let forsSig ← ForsOracle.signM prims md sk.skSeed sk.pkSeed forsAddress
-  let forsPk ← ForsOracle.pkGenM prims sk.skSeed sk.pkSeed forsAddress
+  let forsPk ← ForsOracle.pkFromSigM prims forsSig md sk.pkSeed forsAddress
   let xmssSig ←
     XmssOracle.signM prims forsPk sk.skSeed sk.pkSeed (htAdrs Adrs.zero 0) index
   pure (r, forsSig, xmssSig)

--- a/HashSig/SLHDSA/SchemeOracle.lean
+++ b/HashSig/SLHDSA/SchemeOracle.lean
@@ -153,6 +153,27 @@ noncomputable def runtime (prims : Primitives p) [DecidableEq prims.PkSeed]
     [SampleableType prims.Y] [SampleableType (Bytes p.m)] :
     runtime prims = runtimeWithCache prims ∅ := rfl
 
+/-- The cache-parametric random-oracle runtime commutes with mapping visible outputs. -/
+theorem runtimeWithCache_evalDist_map (prims : Primitives p)
+    [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
+    [SampleableType prims.Y] [SampleableType (Bytes p.m)]
+    (cache : PublicHash.Cache prims) {α β : Type} (f : α → β)
+    (mx : OracleComp (unifSpec + publicHashSpec prims) α) :
+    (runtimeWithCache prims cache).evalDist (f <$> mx) =
+      f <$> (runtimeWithCache prims cache).evalDist mx :=
+  SPMFSemantics.withStateOracle_evalDist_map ..
+
+/-- Bind-to-pure form used by the generic EUF-CMA freshness-drop game hop. -/
+theorem runtimeWithCache_evalDist_bind_pure (prims : Primitives p)
+    [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
+    [SampleableType prims.Y] [SampleableType (Bytes p.m)]
+    (cache : PublicHash.Cache prims) {α β : Type}
+    (mx : OracleComp (unifSpec + publicHashSpec prims) α) (f : α → β) :
+    (runtimeWithCache prims cache).evalDist (mx >>= fun x => pure (f x)) =
+      f <$> (runtimeWithCache prims cache).evalDist mx := by
+  rw [show (mx >>= fun x => pure (f x)) = f <$> mx from (map_eq_bind_pure_comp _ f mx).symm,
+    runtimeWithCache_evalDist_map]
+
 /-- The single-layer algorithm with the lazy random oracle installed as its explicit query
 capability.  The resulting state transformer still exposes the cache: the surrounding security
 experiment, not any scheme phase, chooses the initial cache and runs the entire game once. -/

--- a/HashSig/SLHDSA/SchemeOracle.lean
+++ b/HashSig/SLHDSA/SchemeOracle.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 module
 public import HashSig.SLHDSA.ForsOracle
 public import HashSig.SLHDSA.Scheme
+public import VCVio.OracleComp.SimSemantics.StateT.BundledSemantics
 
 /-!
 # Explicit-oracle SLH-DSA vertical slice
@@ -119,6 +120,38 @@ def alg (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbCo
   keygen := keygenM prims
   sign _ sk msg := signM prims sk msg
   verify pk msg sig := verifyInternalM prims msg sig pk
+
+/-- The scheme in free public-randomness-plus-public-hash syntax.  This is the surface expected by
+the generic `SignatureAlg` security games: the adversary sees the same public-hash queries, while a
+runtime decides whether to interpret them as a lazy random oracle, a programmed oracle, or a
+deterministic function. -/
+def oracleAlg (prims : Primitives p) [Params.IsSingleLayer p]
+    [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+    [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y] :
+    SignatureAlg (OracleComp (unifSpec + publicHashSpec prims)) (List Byte)
+      (PublicKey prims) (SecretKey prims) (Signature p prims) :=
+  alg prims
+
+/-- Runtime for the free scheme under a lazy random oracle with a caller-supplied initial cache.
+Keeping the cache parameter explicit is the hook used by programmed-oracle reductions. -/
+noncomputable def runtimeWithCache (prims : Primitives p) [DecidableEq prims.PkSeed]
+    [DecidableEq prims.Y] [SampleableType prims.Y] [SampleableType (Bytes p.m)]
+    (cache : PublicHash.Cache prims) :
+    ProbCompRuntime (OracleComp (unifSpec + publicHashSpec prims)) where
+  toSPMFSemantics := SPMFSemantics.withStateOracle (PublicHash.randomOracle prims) cache
+  toProbCompLift := ProbCompLift.ofMonadLift _
+
+/-- Standard lazy-random-oracle runtime, initialized once with an empty cache around the complete
+security experiment. -/
+noncomputable def runtime (prims : Primitives p) [DecidableEq prims.PkSeed]
+    [DecidableEq prims.Y] [SampleableType prims.Y] [SampleableType (Bytes p.m)] :
+    ProbCompRuntime (OracleComp (unifSpec + publicHashSpec prims)) :=
+  runtimeWithCache prims ∅
+
+@[simp] theorem runtime_eq_runtimeWithCache_empty (prims : Primitives p)
+    [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
+    [SampleableType prims.Y] [SampleableType (Bytes p.m)] :
+    runtime prims = runtimeWithCache prims ∅ := rfl
 
 /-- The single-layer algorithm with the lazy random oracle installed as its explicit query
 capability.  The resulting state transformer still exposes the cache: the surrounding security

--- a/HashSig/SLHDSA/SchemeOracle.lean
+++ b/HashSig/SLHDSA/SchemeOracle.lean
@@ -62,7 +62,12 @@ def keygenInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
   let pkRoot ← XmssOracle.rootM prims skSeed pkSeed (htAdrs Adrs.zero 0)
   pure (⟨pkSeed, pkRoot⟩, ⟨skSeed, skPrf, pkSeed, pkRoot⟩)
 
-/-- Internal signing for the supported `d = 1` parameter set. -/
+/-- Internal signing for the supported `d = 1` parameter set.
+
+The general hypertree algorithm recovers each intermediate XMSS root to feed the next layer.  At
+`d = 1` there is no next layer, so this slice omits that output-dead recovery query.  Consequently
+it is output-equivalent to the FIPS algorithm but intentionally does not claim literal query-trace
+equality with a mechanically specialized `d = 1` pseudocode transcription. -/
 def signInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
     [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
     (msg : List Byte) (sk : SecretKey prims)
@@ -91,6 +96,66 @@ def verifyInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
   let root ← XmssOracle.pkFromSigM prims index sig.2.2 forsPk pk.pkSeed (htAdrs Adrs.zero 0)
   pure (decide (root = pk.pkRoot))
 
+/-- Honest key generation, signing, and verification are functionally complete after fixing any
+deterministic public-hash answer function.  The same answer function interprets the whole program,
+so repeated queries—in particular the signing and verification `H_msg` calls—receive the same
+answer.  This is deliberately stronger than canonical-function parity but does not identify the
+trace of an arbitrary effectful handler. -/
+theorem simulateQ_honest_roundTrip_withPublicHash (prims : Primitives p)
+    [Params.IsSingleLayer p] [DecidableEq prims.Y]
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : List Byte)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed)
+    (addrnd : prims.Y) :
+    simulateQ answer (do
+      let (pk, sk) ← (keygenInternalM prims skSeed skPrf pkSeed :
+        OracleComp (publicHashSpec prims) (PublicKey prims × SecretKey prims))
+      let sig ← signInternalM prims msg sk addrnd
+      verifyInternalM prims msg sig pk) = true := by
+  let functionalPrims := PublicHash.withPublicHash prims answer
+  let root := XmssOracle.root functionalPrims skSeed pkSeed (htAdrs Adrs.zero 0)
+  let r := prims.PRFmsg skPrf addrnd msg
+  let digest := answer (.hmsg r pkSeed root msg)
+  let md := (splitDigest p digest).1
+  let index : LeafIndex p.hp :=
+    ⟨(splitDigest p digest).2, splitDigest_snd_lt p digest⟩
+  let forsAddress := forsAdrsOf index.val
+  simp only [keygenInternalM, signInternalM, verifyInternalM,
+    simulateQ_bind, simulateQ_pure,
+    XmssOracle.simulateQ_rootM_withPublicHash,
+    ForsOracle.simulateQ_signM_withPublicHash,
+    ForsOracle.simulateQ_pkFromSigM_withPublicHash,
+    XmssOracle.simulateQ_signM_withPublicHash,
+    XmssOracle.simulateQ_pkFromSigM_withPublicHash,
+    PublicHash.hmsg, simulateQ_HasQuery_query]
+  change decide (
+    XmssOracle.pkFromSig functionalPrims index
+      (XmssOracle.sign functionalPrims
+        (ForsOracle.pkFromSig functionalPrims
+          (ForsOracle.sign functionalPrims md skSeed pkSeed forsAddress)
+          md pkSeed forsAddress)
+        skSeed pkSeed (htAdrs Adrs.zero 0) index)
+      (ForsOracle.pkFromSig functionalPrims
+        (ForsOracle.sign functionalPrims md skSeed pkSeed forsAddress)
+        md pkSeed forsAddress)
+      pkSeed (htAdrs Adrs.zero 0) = root) = true
+  rw [ForsOracle.pkFromSig_sign, XmssOracle.pkFromSig_sign]
+  apply decide_eq_true
+  exact (XmssOracle.root_eq_xmssRoot functionalPrims skSeed pkSeed
+    (htAdrs Adrs.zero 0)).symm
+
+/-- Canonical deterministic-handler corollary of honest scheme execution. -/
+theorem simulateQ_honest_roundTrip (prims : Primitives p)
+    [Params.IsSingleLayer p] [DecidableEq prims.Y] (msg : List Byte)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed)
+    (addrnd : prims.Y) :
+    simulateQ (PublicHash.impl prims) (do
+      let (pk, sk) ← (keygenInternalM prims skSeed skPrf pkSeed :
+        OracleComp (publicHashSpec prims) (PublicKey prims × SecretKey prims))
+      let sig ← signInternalM prims msg sk addrnd
+      verifyInternalM prims msg sig pk) = true :=
+  simulateQ_honest_roundTrip_withPublicHash prims (PublicHash.impl prims) msg
+    skSeed skPrf pkSeed addrnd
+
 /-- External key generation with lifted public randomness and explicit public-hash queries. -/
 def keygenM (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbComp m]
     [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
@@ -102,13 +167,22 @@ def keygenM (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT Pr
   let pkSeed ← liftM ($ᵗ prims.PkSeed)
   keygenInternalM prims skSeed skPrf pkSeed
 
-/-- External hedged signing with lifted public randomness. -/
+/-- External empty-context hedged signing with lifted public randomness.  The raw caller message
+is encoded as FIPS 205's `M' = 0x00 || 0x00 || M` before entering Algorithm 19. -/
 def signM (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbComp m]
     [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
     [SampleableType prims.Y] (sk : SecretKey prims)
     (msg : List Byte) : m (Signature p prims) := do
   let addrnd ← liftM ($ᵗ prims.Y)
-  signInternalM prims msg sk addrnd
+  signInternalM prims (emptyContextMessage msg) sk addrnd
+
+/-- External empty-context verification.  It applies the same FIPS 205 message-domain encoding as
+`signM` before entering the internal verification algorithm. -/
+def verifyM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    [DecidableEq prims.Y] (pk : PublicKey prims) (msg : List Byte)
+    (sig : Signature p prims) : m Bool :=
+  verifyInternalM prims (emptyContextMessage msg) sig pk
 
 /-- The explicit-oracle, single-layer SLH-DSA signature algorithm. -/
 def alg (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbComp m]
@@ -119,7 +193,7 @@ def alg (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbCo
     SignatureAlg m (List Byte) (PublicKey prims) (SecretKey prims) (Signature p prims) where
   keygen := keygenM prims
   sign _ sk msg := signM prims sk msg
-  verify pk msg sig := verifyInternalM prims msg sig pk
+  verify pk msg sig := verifyM prims pk msg sig
 
 /-- The scheme in free public-randomness-plus-public-hash syntax.  This is the surface expected by
 the generic `SignatureAlg` security games: the adversary sees the same public-hash queries, while a

--- a/HashSig/SLHDSA/SchemeOracle.lean
+++ b/HashSig/SLHDSA/SchemeOracle.lean
@@ -1,0 +1,138 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.ForsOracle
+public import HashSig.SLHDSA.Scheme
+
+/-!
+# Explicit-oracle SLH-DSA vertical slice
+
+This module assembles the currently supported single-layer (`d = 1`) SLH-DSA scheme from the
+oracle-parametric WOTS+, XMSS, and FORS components.  All public `F`, `H`, `T_l`, and `H_msg`
+evaluations are explicit queries.  `PRF` and `PRF_msg` remain keyed operations on `Primitives` and
+are not exposed through the public oracle.
+
+The algorithms are monad-parametric and never allocate or reset an oracle cache.  A random-oracle
+security experiment must interpret the complete keygen/sign/adversary/verify computation once with
+`PublicHash.randomOracle`; evaluating those phases separately would create different random
+functions.  This file deliberately makes no generic completeness claim for arbitrary `HasQuery`
+handlers.
+
+The general `d > 1` hypertree remains a separate required migration before this interface can
+replace the generic FIPS 205 scheme surface.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SLHDSA
+
+open PerfectMerkleTree
+
+variable {p : Params}
+
+/-- Evidence that a parameter record really denotes the single-XMSS-layer profile implemented by
+this module.  `Params` stores `d` and `h'` independently, so checking only `d = 1` would still
+permit an inconsistent record with `h' ≠ h`. -/
+class Params.IsSingleLayer (p : Params) : Prop where
+  d_eq_one : p.d = 1
+  hp_eq_h : p.hp = p.h
+
+instance : Params.IsSingleLayer slhdsaSha2_128_24 where
+  d_eq_one := rfl
+  hp_eq_h := rfl
+
+namespace OracleScheme
+
+/-- A single-layer SLH-DSA signature with typed FORS and XMSS authentication paths. -/
+abbrev Signature (p : Params) (prims : Primitives p) :=
+  prims.Y × ForsOracle.Signature p prims × XmssOracle.Signature p prims
+
+/-- Internal key generation.  The public root is computed by the streaming XMSS engine. -/
+def keygenInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
+    (pkSeed : prims.PkSeed) : m (PublicKey prims × SecretKey prims) := do
+  let pkRoot ← XmssOracle.rootM prims skSeed pkSeed (htAdrs Adrs.zero 0)
+  pure (⟨pkSeed, pkRoot⟩, ⟨skSeed, skPrf, pkSeed, pkRoot⟩)
+
+/-- Internal signing for the supported `d = 1` parameter set. -/
+def signInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    (msg : List Byte) (sk : SecretKey prims)
+    (addrnd : prims.Y) : m (Signature p prims) := do
+  let r := prims.PRFmsg sk.skPrf addrnd msg
+  let digest ← PublicHash.hmsg prims r sk.pkSeed sk.pkRoot msg
+  let md := (splitDigest p digest).1
+  let index : LeafIndex p.hp := ⟨(splitDigest p digest).2, splitDigest_snd_lt p digest⟩
+  let forsAddress := forsAdrsOf index.val
+  let forsSig ← ForsOracle.signM prims md sk.skSeed sk.pkSeed forsAddress
+  let forsPk ← ForsOracle.pkGenM prims sk.skSeed sk.pkSeed forsAddress
+  let xmssSig ←
+    XmssOracle.signM prims forsPk sk.skSeed sk.pkSeed (htAdrs Adrs.zero 0) index
+  pure (r, forsSig, xmssSig)
+
+/-- Internal verification.  Its result is monadic because all public hashes are oracle queries. -/
+def verifyInternalM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    [DecidableEq prims.Y] (msg : List Byte)
+    (sig : Signature p prims) (pk : PublicKey prims) : m Bool := do
+  let digest ← PublicHash.hmsg prims sig.1 pk.pkSeed pk.pkRoot msg
+  let md := (splitDigest p digest).1
+  let index : LeafIndex p.hp := ⟨(splitDigest p digest).2, splitDigest_snd_lt p digest⟩
+  let forsAddress := forsAdrsOf index.val
+  let forsPk ← ForsOracle.pkFromSigM prims sig.2.1 md pk.pkSeed forsAddress
+  let root ← XmssOracle.pkFromSigM prims index sig.2.2 forsPk pk.pkSeed (htAdrs Adrs.zero 0)
+  pure (decide (root = pk.pkRoot))
+
+/-- External key generation with lifted public randomness and explicit public-hash queries. -/
+def keygenM (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbComp m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    [SampleableType prims.SkSeed]
+    [SampleableType prims.SkPrf] [SampleableType prims.PkSeed] :
+    m (PublicKey prims × SecretKey prims) := do
+  let skSeed ← liftM ($ᵗ prims.SkSeed)
+  let skPrf ← liftM ($ᵗ prims.SkPrf)
+  let pkSeed ← liftM ($ᵗ prims.PkSeed)
+  keygenInternalM prims skSeed skPrf pkSeed
+
+/-- External hedged signing with lifted public randomness. -/
+def signM (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbComp m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    [SampleableType prims.Y] (sk : SecretKey prims)
+    (msg : List Byte) : m (Signature p prims) := do
+  let addrnd ← liftM ($ᵗ prims.Y)
+  signInternalM prims msg sk addrnd
+
+/-- The explicit-oracle, single-layer SLH-DSA signature algorithm. -/
+def alg (prims : Primitives p) {m : Type → Type*} [Monad m] [MonadLiftT ProbComp m]
+    [Params.IsSingleLayer p] [HasQuery (publicHashSpec prims) m]
+    [SampleableType prims.SkSeed]
+    [SampleableType prims.SkPrf] [SampleableType prims.PkSeed] [SampleableType prims.Y]
+    [DecidableEq prims.Y] :
+    SignatureAlg m (List Byte) (PublicKey prims) (SecretKey prims) (Signature p prims) where
+  keygen := keygenM prims
+  sign _ sk msg := signM prims sk msg
+  verify pk msg sig := verifyInternalM prims msg sig pk
+
+/-- The single-layer algorithm with the lazy random oracle installed as its explicit query
+capability.  The resulting state transformer still exposes the cache: the surrounding security
+experiment, not any scheme phase, chooses the initial cache and runs the entire game once. -/
+def randomOracleAlg (prims : Primitives p) [Params.IsSingleLayer p]
+    [DecidableEq prims.PkSeed] [DecidableEq prims.Y]
+    [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
+    [SampleableType prims.PkSeed] [SampleableType prims.Y]
+    [SampleableType (Bytes p.m)] :
+    SignatureAlg (StateT (PublicHash.Cache prims) ProbComp) (List Byte)
+      (PublicKey prims) (SecretKey prims) (Signature p prims) := by
+  letI := PublicHash.randomOracleHasQuery prims
+  exact alg prims
+
+end OracleScheme
+
+end SLHDSA

--- a/HashSig/SLHDSA/WotsOracle.lean
+++ b/HashSig/SLHDSA/WotsOracle.lean
@@ -1,0 +1,101 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Oracle
+public import HashSig.SLHDSA.Wots
+
+/-!
+# Oracle-parametric WOTS+
+
+This module is the explicit-oracle counterpart of `HashSig.SLHDSA.Wots`.  Secret-value
+derivation remains the keyed `PRF` operation from `Primitives`, while every public `F` and `T_l`
+evaluation is issued through `PublicHash`.  The functions are monad-parametric and therefore do
+not choose or reset an oracle cache; a caller that wants random-oracle semantics must run the
+whole surrounding computation with one `PublicHash.randomOracle` state.
+
+`simulateQ_chainM` is the first executable bridge: the canonical oracle syntax interpreted by the
+deterministic handler is exactly the existing pure hash chain.
+-/
+
+@[expose] public section
+
+open OracleComp
+
+namespace SLHDSA
+
+variable {p : Params}
+
+namespace WotsOracle
+
+/-- Apply `F` for `s` WOTS+ chain steps, issuing one explicit query per successor step. -/
+def chainM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (pkSeed : prims.PkSeed) (adrs : Adrs) (x : prims.Y)
+    (i : ℕ) : ℕ → m prims.Y
+  | 0 => pure x
+  | s + 1 => do
+      let y ← chainM prims pkSeed adrs x i s
+      PublicHash.f prims pkSeed (adrs.setHashAddress (i + s)) y
+
+/-- The canonical vector of WOTS+ chain indices. -/
+def indices (len : ℕ) : Vector (Fin len) len :=
+  Vector.ofFn id
+
+/-- Generate every WOTS+ chain top with explicit public-hash calls. -/
+def wotsPkGenTopsM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    m (Vector prims.Y p.len) :=
+  (indices p.len).mapM fun i =>
+    chainM prims pk (wotsChainAdrs adrs i.val) (prims.PRF pk sk (wotsSkAdrs adrs i.val)) 0
+      (p.w - 1)
+
+/-- WOTS+ public-key generation with explicit `F` and `T_l` queries. -/
+def wotsPkGenM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    m prims.Y := do
+  let tops ← wotsPkGenTopsM prims sk pk adrs
+  PublicHash.tl prims pk (wotsPkAdrs adrs) tops.toList
+
+/-- WOTS+ signing with explicit `F` queries. -/
+def wotsSignM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) : m (WotsSig p prims) :=
+  (indices p.len).mapM fun i =>
+    chainM prims pk (wotsChainAdrs adrs i.val) (prims.PRF pk sk (wotsSkAdrs adrs i.val)) 0
+      (chainSteps prims msg i.val)
+
+/-- Complete every WOTS+ chain from a signature to its top using explicit `F` queries. -/
+def wotsPkFromSigTopsM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sig : WotsSig p prims) (msg : prims.Y)
+    (pk : prims.PkSeed) (adrs : Adrs) : m (Vector prims.Y p.len) :=
+  (indices p.len).mapM fun i =>
+    chainM prims pk (wotsChainAdrs adrs i.val) sig[i.val] (chainSteps prims msg i.val)
+      (p.w - 1 - chainSteps prims msg i.val)
+
+/-- Recover a WOTS+ public key from a signature with explicit `F` and `T_l` queries. -/
+def wotsPkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sig : WotsSig p prims) (msg : prims.Y)
+    (pk : prims.PkSeed) (adrs : Adrs) : m prims.Y := do
+  let tops ← wotsPkFromSigTopsM prims sig msg pk adrs
+  PublicHash.tl prims pk (wotsPkAdrs adrs) tops.toList
+
+/-- Deterministic interpretation of the explicit WOTS+ chain is the existing pure chain. -/
+@[simp]
+theorem simulateQ_chainM (prims : Primitives p) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (x : prims.Y) (i s : ℕ) :
+    simulateQ (PublicHash.impl prims)
+        (chainM prims pkSeed adrs x i s : OracleComp (publicHashSpec prims) prims.Y) =
+      chain prims pkSeed adrs x i s := by
+  induction s with
+  | zero => rfl
+  | succ s ih =>
+      simp only [chainM, simulateQ_bind, PublicHash.simulateQ_f, chain]
+      rw [ih]
+      rfl
+
+end WotsOracle
+
+end SLHDSA

--- a/HashSig/SLHDSA/WotsOracle.lean
+++ b/HashSig/SLHDSA/WotsOracle.lean
@@ -44,6 +44,30 @@ def chainM (prims : Primitives p) {m : Type → Type*} [Monad m]
 def indices (len : ℕ) : Vector (Fin len) len :=
   Vector.ofFn id
 
+private theorem simulateQ_indices_mapM {ι α : Type} {spec : OracleSpec ι} (len : ℕ)
+    (f : QueryImpl spec Id) (g : Fin len → OracleComp spec α) :
+    simulateQ f ((indices len).mapM g) = Vector.ofFn fun i => simulateQ f (g i) := by
+  have mapM_id (xs : List (Fin len)) :
+      xs.mapM (fun i => simulateQ f (g i)) = xs.map (fun i => simulateQ f (g i)) := by
+    change xs.mapM (fun i => (pure (simulateQ f (g i)) : Id α)) = _
+    simp only [List.mapM_pure]
+    exact Id.pure_run _
+  apply Vector.toArray_inj.mp
+  calc
+    _ = simulateQ f (Vector.toArray <$> (indices len).mapM g) :=
+      (simulateQ_map f ((indices len).mapM g) Vector.toArray).symm
+    _ = _ := by
+      rw [Vector.toArray_mapM, Array.mapM_eq_mapM_toList, simulateQ_map,
+        simulateQ_list_mapM]
+      rw [mapM_id]
+      simp only [indices, Vector.toArray_ofFn, Array.toList_ofFn, List.map_ofFn,
+        Function.comp_id]
+      apply Id.ext
+      rw [Id.run_map]
+      change (List.ofFn fun i => simulateQ f (g i)).toArray =
+        Array.ofFn fun i => simulateQ f (g i)
+      exact List.toArray_ofFn
+
 /-- Generate every WOTS+ chain top with explicit public-hash calls. -/
 def wotsPkGenTopsM (prims : Primitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
@@ -82,19 +106,162 @@ def wotsPkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
   let tops ← wotsPkFromSigTopsM prims sig msg pk adrs
   PublicHash.tl prims pk (wotsPkAdrs adrs) tops.toList
 
-/-- Deterministic interpretation of the explicit WOTS+ chain is the existing pure chain. -/
+/-- Interpreting the explicit WOTS+ chain by any total deterministic answer function is the pure
+chain for the functional primitive bundle induced by that answer function. -/
+@[simp]
+theorem simulateQ_chainM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (pkSeed : prims.PkSeed) (adrs : Adrs)
+    (x : prims.Y) (i s : ℕ) :
+    simulateQ answer
+        (chainM prims pkSeed adrs x i s : OracleComp (publicHashSpec prims) prims.Y) =
+      chain (PublicHash.withPublicHash prims answer) pkSeed adrs x i s := by
+  induction s with
+  | zero => rfl
+  | succ s ih =>
+      simp only [chainM, simulateQ_bind, PublicHash.f, simulateQ_HasQuery_query, chain]
+      rw [ih]
+      rfl
+
+/-- The canonical deterministic interpretation of the explicit WOTS+ chain is the legacy pure
+chain. -/
 @[simp]
 theorem simulateQ_chainM (prims : Primitives p) (pkSeed : prims.PkSeed) (adrs : Adrs)
     (x : prims.Y) (i s : ℕ) :
     simulateQ (PublicHash.impl prims)
         (chainM prims pkSeed adrs x i s : OracleComp (publicHashSpec prims) prims.Y) =
       chain prims pkSeed adrs x i s := by
-  induction s with
-  | zero => rfl
-  | succ s ih =>
-      simp only [chainM, simulateQ_bind, PublicHash.simulateQ_f, chain]
-      rw [ih]
-      rfl
+  convert
+    simulateQ_chainM_withPublicHash prims (PublicHash.impl prims) pkSeed adrs x i s using 1
+  all_goals rfl
+
+/-- Replacing only the public hashes leaves WOTS+ message digit derivation unchanged. -/
+@[simp]
+theorem chainSteps_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : prims.Y) (i : ℕ) :
+    chainSteps (PublicHash.withPublicHash prims answer) msg i = chainSteps prims msg i := rfl
+
+/-- Any deterministic public-hash answer function makes oracle WOTS+ key-generation tops agree
+with the legacy pure construction for its induced functional primitive bundle. -/
+@[simp]
+theorem simulateQ_wotsPkGenTopsM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ answer
+        (wotsPkGenTopsM prims sk pk adrs :
+          OracleComp (publicHashSpec prims) (Vector prims.Y p.len)) =
+      wotsPkGenTops (PublicHash.withPublicHash prims answer) sk pk adrs := by
+  simp only [wotsPkGenTopsM, simulateQ_indices_mapM, wotsPkGenTops,
+    simulateQ_chainM_withPublicHash]
+
+/-- Canonical deterministic-handler parity for WOTS+ key-generation tops. -/
+@[simp]
+theorem simulateQ_wotsPkGenTopsM (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (wotsPkGenTopsM prims sk pk adrs :
+          OracleComp (publicHashSpec prims) (Vector prims.Y p.len)) =
+      wotsPkGenTops prims sk pk adrs := by
+  convert
+    simulateQ_wotsPkGenTopsM_withPublicHash prims (PublicHash.impl prims) sk pk adrs using 1
+  all_goals rfl
+
+/-- Any deterministic public-hash answer function makes oracle WOTS+ public-key generation agree
+with the legacy pure construction for its induced functional primitive bundle. -/
+@[simp]
+theorem simulateQ_wotsPkGenM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ answer
+        (wotsPkGenM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      wotsPkGen (PublicHash.withPublicHash prims answer) sk pk adrs := by
+  simp only [wotsPkGenM, simulateQ_bind, simulateQ_wotsPkGenTopsM_withPublicHash,
+    PublicHash.tl, simulateQ_HasQuery_query, wotsPkGen]
+  apply Id.ext
+  rfl
+
+/-- Canonical deterministic-handler parity for WOTS+ public-key generation. -/
+@[simp]
+theorem simulateQ_wotsPkGenM (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (wotsPkGenM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      wotsPkGen prims sk pk adrs := by
+  convert simulateQ_wotsPkGenM_withPublicHash prims (PublicHash.impl prims) sk pk adrs using 1
+  all_goals rfl
+
+/-- Any deterministic public-hash answer function makes oracle WOTS+ signing agree with the
+legacy pure construction for its induced functional primitive bundle. -/
+@[simp]
+theorem simulateQ_wotsSignM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (wotsSignM prims msg sk pk adrs : OracleComp (publicHashSpec prims) (WotsSig p prims)) =
+      wotsSign (PublicHash.withPublicHash prims answer) msg sk pk adrs := by
+  simp only [wotsSignM, simulateQ_indices_mapM, wotsSign,
+    simulateQ_chainM_withPublicHash, chainSteps_withPublicHash]
+
+/-- Canonical deterministic-handler parity for WOTS+ signing. -/
+@[simp]
+theorem simulateQ_wotsSignM (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (wotsSignM prims msg sk pk adrs : OracleComp (publicHashSpec prims) (WotsSig p prims)) =
+      wotsSign prims msg sk pk adrs := by
+  convert
+    simulateQ_wotsSignM_withPublicHash prims (PublicHash.impl prims) msg sk pk adrs using 1
+  all_goals rfl
+
+/-- Any deterministic public-hash answer function makes oracle WOTS+ signature-recovery tops
+agree with the legacy pure construction for its induced functional primitive bundle. -/
+@[simp]
+theorem simulateQ_wotsPkFromSigTopsM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sig : WotsSig p prims) (msg : prims.Y)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (wotsPkFromSigTopsM prims sig msg pk adrs :
+          OracleComp (publicHashSpec prims) (Vector prims.Y p.len)) =
+      wotsPkFromSigTops (PublicHash.withPublicHash prims answer) sig msg pk adrs := by
+  simp only [wotsPkFromSigTopsM, simulateQ_indices_mapM, wotsPkFromSigTops,
+    simulateQ_chainM_withPublicHash, chainSteps_withPublicHash]
+
+/-- Canonical deterministic-handler parity for WOTS+ signature-recovery tops. -/
+@[simp]
+theorem simulateQ_wotsPkFromSigTopsM (prims : Primitives p) (sig : WotsSig p prims)
+    (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (wotsPkFromSigTopsM prims sig msg pk adrs :
+          OracleComp (publicHashSpec prims) (Vector prims.Y p.len)) =
+      wotsPkFromSigTops prims sig msg pk adrs := by
+  convert
+    simulateQ_wotsPkFromSigTopsM_withPublicHash prims (PublicHash.impl prims) sig msg pk adrs
+      using 1
+  all_goals rfl
+
+/-- Any deterministic public-hash answer function makes oracle WOTS+ public-key recovery agree
+with the legacy pure construction for its induced functional primitive bundle. -/
+@[simp]
+theorem simulateQ_wotsPkFromSigM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sig : WotsSig p prims) (msg : prims.Y)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (wotsPkFromSigM prims sig msg pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      wotsPkFromSig (PublicHash.withPublicHash prims answer) sig msg pk adrs := by
+  simp only [wotsPkFromSigM, simulateQ_bind, simulateQ_wotsPkFromSigTopsM_withPublicHash,
+    PublicHash.tl, simulateQ_HasQuery_query, wotsPkFromSig]
+  apply Id.ext
+  rfl
+
+/-- Canonical deterministic-handler parity for WOTS+ public-key recovery. -/
+@[simp]
+theorem simulateQ_wotsPkFromSigM (prims : Primitives p) (sig : WotsSig p prims)
+    (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (wotsPkFromSigM prims sig msg pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      wotsPkFromSig prims sig msg pk adrs := by
+  convert
+    simulateQ_wotsPkFromSigM_withPublicHash prims (PublicHash.impl prims) sig msg pk adrs using 1
+  all_goals rfl
 
 end WotsOracle
 

--- a/HashSig/SLHDSA/WotsOracle.lean
+++ b/HashSig/SLHDSA/WotsOracle.lean
@@ -17,8 +17,9 @@ evaluation is issued through `PublicHash`.  The functions are monad-parametric a
 not choose or reset an oracle cache; a caller that wants random-oracle semantics must run the
 whole surrounding computation with one `PublicHash.randomOracle` state.
 
-`simulateQ_chainM` is the first executable bridge: the canonical oracle syntax interpreted by the
-deterministic handler is exactly the existing pure hash chain.
+The `simulateQ_*_withPublicHash` lemmas interpret the entire layer through an arbitrary fixed
+answer function and recover the legacy pure WOTS+ construction for the induced primitive bundle.
+Canonical `PublicHash.impl` corollaries recover the original executable specification.
 -/
 
 @[expose] public section
@@ -262,6 +263,18 @@ theorem simulateQ_wotsPkFromSigM (prims : Primitives p) (sig : WotsSig p prims)
   convert
     simulateQ_wotsPkFromSigM_withPublicHash prims (PublicHash.impl prims) sig msg pk adrs using 1
   all_goals rfl
+
+/-- Functional WOTS+ completeness for every fixed deterministic public-hash answer function. -/
+theorem simulateQ_wotsPkFromSigM_wotsSignM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer (do
+      let sig ← wotsSignM prims msg sk pk adrs
+      wotsPkFromSigM prims sig msg pk adrs) =
+    simulateQ answer (wotsPkGenM prims sk pk adrs) := by
+  simp only [simulateQ_bind, simulateQ_wotsSignM_withPublicHash,
+    simulateQ_wotsPkFromSigM_withPublicHash, simulateQ_wotsPkGenM_withPublicHash]
+  exact wotsPkFromSig_wotsSign (PublicHash.withPublicHash prims answer) msg sk pk adrs
 
 end WotsOracle
 

--- a/HashSig/SLHDSA/XmssOracle.lean
+++ b/HashSig/SLHDSA/XmssOracle.lean
@@ -53,14 +53,34 @@ def rootM (prims : Primitives p) {m : Type → Type*} [Monad m]
     m prims.Y :=
   PerfectMerkleTree.rootM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) p.hp
 
+/-- Sequence authentication-path generation before WOTS+ signing and return the signature in its
+FIPS field order.  The argument order and bind order deliberately differ: FIPS 205 Algorithm 10
+computes `AUTH` first, then `SIG_WOTS`, while the result stores `SIG_WOTS || AUTH`.  Naming this
+small combinator makes the effect order independently testable. -/
+def authenticationThenSignM {m : Type → Type*} [Monad m] {Wots Path : Type}
+    (authenticationPath : m Path) (wotsSignature : m Wots) : m (Wots × Path) := do
+  let path ← authenticationPath
+  let wots ← wotsSignature
+  pure (wots, path)
+
 /-- XMSS signing with explicit public-hash calls and a statically sized authentication path. -/
 def signM (prims : Primitives p) {m : Type → Type*} [Monad m]
     [HasQuery (publicHashSpec prims) m] (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
-    (adrs : Adrs) (index : LeafIndex p.hp) : m (Signature p prims) := do
-  let wots ← WotsOracle.wotsSignM prims msg sk pk (wotsLeafAdrs adrs index.val)
-  let authenticationPath ←
-    rootAuthenticationPathM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) index
-  pure (wots, authenticationPath)
+    (adrs : Adrs) (index : LeafIndex p.hp) : m (Signature p prims) :=
+  authenticationThenSignM
+    (rootAuthenticationPathM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) index)
+    (WotsOracle.wotsSignM prims msg sk pk (wotsLeafAdrs adrs index.val))
+
+/-- Definitional guard exposing the exact effect schedule of XMSS signing. -/
+theorem signM_eq_authenticationThenSignM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (index : LeafIndex p.hp) :
+    signM prims msg sk pk adrs index =
+      authenticationThenSignM
+        (rootAuthenticationPathM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) index :
+          m (AuthenticationPath prims.Y p.hp))
+        (WotsOracle.wotsSignM prims msg sk pk (wotsLeafAdrs adrs index.val) :
+          m (WotsSig p prims)) := rfl
 
 /-- Recover the putative XMSS root from a typed signature. -/
 def pkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
@@ -174,7 +194,8 @@ theorem simulateQ_signM_structural (prims : Primitives p)
             (leafM prims sk pk adrs i : OracleComp (publicHashSpec prims) prims.Y))
           (fun address => xmssNodeHash (PublicHash.withPublicHash prims answer) pk adrs
             address.height address.index) index) := by
-  simp [signM, PerfectMerkleTree.simulateQ_rootAuthenticationPathM]
+  simp [signM, authenticationThenSignM,
+    PerfectMerkleTree.simulateQ_rootAuthenticationPathM]
   rfl
 
 /-- Structural recovery parity for any fixed deterministic public-hash answer function. -/

--- a/HashSig/SLHDSA/XmssOracle.lean
+++ b/HashSig/SLHDSA/XmssOracle.lean
@@ -6,8 +6,7 @@ Authors: Quang Dao
 
 module
 public import HashSig.SLHDSA.WotsOracle
-public import HashSig.SLHDSA.Xmss
-public import VCVio.CryptoFoundations.MerkleTree.Perfect
+public import HashSig.SLHDSA.MerkleParity
 
 /-!
 # Oracle-parametric XMSS
@@ -69,6 +68,130 @@ def pkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
     (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) : m prims.Y := do
   let leaf ← WotsOracle.wotsPkFromSigM prims sig.1 msg pk (wotsLeafAdrs adrs index.val)
   reconstructRootM (nodeHashM prims pk adrs) index leaf sig.2
+
+/-! ## Deterministic typed semantics -/
+
+/-- Erase only the authentication-path length proof, producing the legacy XMSS signature type. -/
+def toLegacy {prims : Primitives p} (sig : Signature p prims) : XmssSig p prims :=
+  (sig.1, sig.2.toList)
+
+/-- Deterministic typed XMSS root computation. -/
+def root (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    prims.Y :=
+  PerfectMerkleTree.root (xmssLeaf prims sk pk adrs)
+    (fun address => xmssNodeHash prims pk adrs address.height address.index) p.hp
+
+/-- Deterministic XMSS signing with a statically sized authentication path. -/
+def sign (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (index : LeafIndex p.hp) : Signature p prims :=
+  (wotsSign prims msg sk pk (wotsLeafAdrs adrs index.val),
+    rootAuthenticationPath (xmssLeaf prims sk pk adrs)
+      (fun address => xmssNodeHash prims pk adrs address.height address.index) index)
+
+/-- Deterministic root recovery from a typed XMSS signature. -/
+def pkFromSig (prims : Primitives p) (index : LeafIndex p.hp) (sig : Signature p prims)
+    (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) : prims.Y :=
+  reconstructRoot (fun address => xmssNodeHash prims pk adrs address.height address.index)
+    index (wotsPkFromSig prims sig.1 msg pk (wotsLeafAdrs adrs index.val)) sig.2
+
+/-- The deterministic typed root is the legacy XMSS root. -/
+@[simp]
+theorem root_eq_xmssRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    root prims sk pk adrs = xmssRoot prims sk pk adrs := by
+  unfold root xmssRoot xmssNode PerfectMerkleTree.root
+  exact Merkle.treeHash_eq_merkleRoot
+    (xmssLeaf prims sk pk adrs) (xmssNodeHash prims pk adrs) p.hp 0
+
+/-- Erasing a deterministic typed signature gives the legacy XMSS signature. -/
+@[simp]
+theorem toLegacy_sign (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    toLegacy (sign prims msg sk pk adrs index) =
+      xmssSign prims msg sk pk adrs index.val := by
+  unfold toLegacy sign xmssSign rootAuthenticationPath
+  simp only [Prod.mk.injEq, true_and]
+  exact Merkle.authenticationPath_toList_eq_authPath
+    (xmssLeaf prims sk pk adrs) (xmssNodeHash prims pk adrs) p.hp 0 index.val
+
+/-- Deterministic typed recovery agrees with legacy XMSS recovery after path erasure. -/
+@[simp]
+theorem pkFromSig_eq_xmssPkFromSig (prims : Primitives p) (index : LeafIndex p.hp)
+    (sig : Signature p prims) (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
+    pkFromSig prims index sig msg pk adrs =
+      xmssPkFromSig prims index.val (toLegacy sig) msg pk adrs := by
+  unfold pkFromSig xmssPkFromSig toLegacy reconstructRoot
+  exact Merkle.climb_eq_climb (xmssNodeHash prims pk adrs) p.hp 0 index.val _ sig.2
+
+/-- Honest deterministic typed XMSS signing and recovery reconstruct the legacy root. -/
+theorem pkFromSig_sign (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    pkFromSig prims index (sign prims msg sk pk adrs index) msg pk adrs =
+      xmssRoot prims sk pk adrs := by
+  rw [pkFromSig_eq_xmssPkFromSig, toLegacy_sign]
+  exact xmssPkFromSig_xmssSign prims msg sk pk adrs index.val index.isLt
+
+/-! ## Deterministic-handler structure -/
+
+/-- Interpreting an XMSS node query with any answer function gives the corresponding node hash
+of the reinterpreted primitive bundle. -/
+@[simp]
+theorem simulateQ_nodeHashM_with (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (pk : prims.PkSeed) (adrs : Adrs)
+    (address : Address) (left right : prims.Y) :
+    simulateQ answer
+        (nodeHashM prims pk adrs address left right :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      xmssNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+        address.height address.index left right := by
+  simp [nodeHashM, xmssNodeHash, PublicHash.h]
+
+/-- Structural root parity for any fixed deterministic public-hash answer function. -/
+theorem simulateQ_rootM_structural (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ answer
+        (rootM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      PerfectMerkleTree.root
+        (fun index => simulateQ answer
+          (leafM prims sk pk adrs index : OracleComp (publicHashSpec prims) prims.Y))
+        (fun address => xmssNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+          address.height address.index) p.hp := by
+  simp [rootM, PerfectMerkleTree.simulateQ_rootM]
+
+/-- Structural signing parity for any fixed deterministic public-hash answer function. -/
+theorem simulateQ_signM_structural (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    simulateQ answer
+        (signM prims msg sk pk adrs index :
+          OracleComp (publicHashSpec prims) (Signature p prims)) =
+      (simulateQ answer
+          (WotsOracle.wotsSignM prims msg sk pk (wotsLeafAdrs adrs index.val) :
+            OracleComp (publicHashSpec prims) (WotsSig p prims)),
+        rootAuthenticationPath
+          (fun i => simulateQ answer
+            (leafM prims sk pk adrs i : OracleComp (publicHashSpec prims) prims.Y))
+          (fun address => xmssNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+            address.height address.index) index) := by
+  simp [signM, PerfectMerkleTree.simulateQ_rootAuthenticationPathM]
+  rfl
+
+/-- Structural recovery parity for any fixed deterministic public-hash answer function. -/
+theorem simulateQ_pkFromSigM_structural (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (index : LeafIndex p.hp)
+    (sig : Signature p prims) (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (pkFromSigM prims index sig msg pk adrs :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      reconstructRoot
+        (fun address => xmssNodeHash (PublicHash.withPublicHash prims answer) pk adrs
+          address.height address.index) index
+        (simulateQ answer
+          (WotsOracle.wotsPkFromSigM prims sig.1 msg pk (wotsLeafAdrs adrs index.val) :
+            OracleComp (publicHashSpec prims) prims.Y)) sig.2 := by
+  simp [pkFromSigM, PerfectMerkleTree.simulateQ_reconstructRootM]
+  rfl
 
 /-- Deterministic interpretation of one explicit XMSS node query is the original node hash. -/
 @[simp]

--- a/HashSig/SLHDSA/XmssOracle.lean
+++ b/HashSig/SLHDSA/XmssOracle.lean
@@ -193,6 +193,120 @@ theorem simulateQ_pkFromSigM_structural (prims : Primitives p)
   simp [pkFromSigM, PerfectMerkleTree.simulateQ_reconstructRootM]
   rfl
 
+/-! ## Functional completeness -/
+
+/-- Under any fixed deterministic public-hash answer function, the oracle leaf computation is
+the legacy WOTS+ leaf for the induced functional primitive bundle. -/
+@[simp]
+theorem simulateQ_leafM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (index : ℕ) :
+    simulateQ answer
+        (leafM prims sk pk adrs index : OracleComp (publicHashSpec prims) prims.Y) =
+      xmssLeaf (PublicHash.withPublicHash prims answer) sk pk adrs index := by
+  exact WotsOracle.simulateQ_wotsPkGenM_withPublicHash prims answer sk pk
+    (wotsLeafAdrs adrs index)
+
+/-- XMSS root generation is functionally complete for every deterministic public-hash answer
+function, expressed through the typed perfect-tree semantics. -/
+theorem simulateQ_rootM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ answer
+        (rootM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      root (PublicHash.withPublicHash prims answer) sk pk adrs := by
+  rw [simulateQ_rootM_structural]
+  simp only [root, simulateQ_leafM_withPublicHash]
+
+/-- XMSS signing is functionally complete for every deterministic public-hash answer function. -/
+theorem simulateQ_signM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    simulateQ answer
+        (signM prims msg sk pk adrs index :
+          OracleComp (publicHashSpec prims) (Signature p prims)) =
+      sign (PublicHash.withPublicHash prims answer) msg sk pk adrs index := by
+  rw [simulateQ_signM_structural,
+    WotsOracle.simulateQ_wotsSignM_withPublicHash]
+  simp only [sign, simulateQ_leafM_withPublicHash]
+
+/-- XMSS root recovery is functionally complete for every deterministic public-hash answer
+function. -/
+theorem simulateQ_pkFromSigM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (index : LeafIndex p.hp)
+    (sig : Signature p prims) (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (pkFromSigM prims index sig msg pk adrs :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      pkFromSig (PublicHash.withPublicHash prims answer) index sig msg pk adrs := by
+  rw [simulateQ_pkFromSigM_structural,
+    WotsOracle.simulateQ_wotsPkFromSigM_withPublicHash]
+  rfl
+
+/-- Honest XMSS signing and recovery remain complete after fixing any deterministic public-hash
+answer function. -/
+theorem simulateQ_pkFromSigM_signM_withPublicHash (prims : Primitives p)
+    (answer : QueryImpl (publicHashSpec prims) Id) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    simulateQ answer (do
+      let sig ← (signM prims msg sk pk adrs index :
+        OracleComp (publicHashSpec prims) (Signature p prims))
+      pkFromSigM prims index sig msg pk adrs) =
+      xmssRoot (PublicHash.withPublicHash prims answer) sk pk adrs := by
+  simp only [simulateQ_bind]
+  change simulateQ answer
+    (pkFromSigM prims index
+      (simulateQ answer
+        (signM prims msg sk pk adrs index :
+          OracleComp (publicHashSpec prims) (Signature p prims)))
+      msg pk adrs) = _
+  rw [simulateQ_signM_withPublicHash, simulateQ_pkFromSigM_withPublicHash]
+  exact pkFromSig_sign (PublicHash.withPublicHash prims answer) msg sk pk adrs index
+
+/-- Canonical deterministic-handler parity for XMSS roots. -/
+@[simp]
+theorem simulateQ_rootM (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (rootM prims sk pk adrs : OracleComp (publicHashSpec prims) prims.Y) =
+      root prims sk pk adrs := by
+  convert simulateQ_rootM_withPublicHash prims (PublicHash.impl prims) sk pk adrs using 1
+  all_goals rfl
+
+/-- Canonical deterministic-handler parity for XMSS signing. -/
+@[simp]
+theorem simulateQ_signM (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    simulateQ (PublicHash.impl prims)
+        (signM prims msg sk pk adrs index :
+          OracleComp (publicHashSpec prims) (Signature p prims)) =
+      sign prims msg sk pk adrs index := by
+  convert simulateQ_signM_withPublicHash prims (PublicHash.impl prims) msg sk pk adrs index using 1
+  all_goals rfl
+
+/-- Canonical deterministic-handler parity for XMSS root recovery. -/
+@[simp]
+theorem simulateQ_pkFromSigM (prims : Primitives p) (index : LeafIndex p.hp)
+    (sig : Signature p prims) (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (pkFromSigM prims index sig msg pk adrs :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      pkFromSig prims index sig msg pk adrs := by
+  convert simulateQ_pkFromSigM_withPublicHash prims (PublicHash.impl prims) index sig msg pk adrs
+    using 1
+  all_goals rfl
+
+/-- Canonical honest signing/recovery equality for XMSS. -/
+theorem simulateQ_pkFromSigM_signM (prims : Primitives p) (msg : prims.Y)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (index : LeafIndex p.hp) :
+    simulateQ (PublicHash.impl prims) (do
+      let sig ← (signM prims msg sk pk adrs index :
+        OracleComp (publicHashSpec prims) (Signature p prims))
+      pkFromSigM prims index sig msg pk adrs) = xmssRoot prims sk pk adrs := by
+  convert simulateQ_pkFromSigM_signM_withPublicHash prims (PublicHash.impl prims) msg sk pk adrs
+    index using 1
+  all_goals rfl
+
 /-- Deterministic interpretation of one explicit XMSS node query is the original node hash. -/
 @[simp]
 theorem simulateQ_nodeHashM (prims : Primitives p) (pk : prims.PkSeed) (adrs : Adrs)

--- a/HashSig/SLHDSA/XmssOracle.lean
+++ b/HashSig/SLHDSA/XmssOracle.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.WotsOracle
+public import HashSig.SLHDSA.Xmss
+public import VCVio.CryptoFoundations.MerkleTree.Perfect
+
+/-!
+# Oracle-parametric XMSS
+
+This module connects the explicit SLH-DSA public-hash syntax to the streaming perfect-Merkle
+engine.  WOTS+ leaves are effectful, every internal node is an address-preserving `H` query, leaf
+indices are bounded by `2^h'`, and authentication paths have exactly `h'` entries.
+
+None of the definitions initializes an oracle cache.  Key generation, signing, verification, and
+an adversary can therefore be placed inside one caller-owned execution of
+`PublicHash.randomOracle`, which is the consistency boundary required by the random-oracle model.
+-/
+
+@[expose] public section
+
+namespace SLHDSA
+
+open PerfectMerkleTree
+
+variable {p : Params}
+
+namespace XmssOracle
+
+/-- An XMSS signature with its Merkle-path invariant enforced by the type. -/
+abbrev Signature (p : Params) (prims : Primitives p) :=
+  WotsSig p prims × AuthenticationPath prims.Y p.hp
+
+/-- Generate the WOTS+ public key at leaf `index` using explicit `F` and `T_l` queries. -/
+def leafM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (index : ℕ) : m prims.Y :=
+  WotsOracle.wotsPkGenM prims sk pk (wotsLeafAdrs adrs index)
+
+/-- Hash an XMSS internal node.  Both perfect-tree coordinates are embedded in the FIPS address. -/
+def nodeHashM (prims : Primitives p) {m : Type → Type*} [HasQuery (publicHashSpec prims) m]
+    (pk : prims.PkSeed) (adrs : Adrs) (address : Address) (left right : prims.Y) : m prims.Y :=
+  PublicHash.h prims pk
+    (((adrs.setTypeAndClear .tree).setTreeHeight address.height).setTreeIndex address.index)
+    left right
+
+/-- Compute an XMSS root without materializing its `2^(h'+1)-1`-node tree. -/
+def rootM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    m prims.Y :=
+  PerfectMerkleTree.rootM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) p.hp
+
+/-- XMSS signing with explicit public-hash calls and a statically sized authentication path. -/
+def signM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) (index : LeafIndex p.hp) : m (Signature p prims) := do
+  let wots ← WotsOracle.wotsSignM prims msg sk pk (wotsLeafAdrs adrs index.val)
+  let authenticationPath ←
+    rootAuthenticationPathM (leafM prims sk pk adrs) (nodeHashM prims pk adrs) index
+  pure (wots, authenticationPath)
+
+/-- Recover the putative XMSS root from a typed signature. -/
+def pkFromSigM (prims : Primitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec prims) m] (index : LeafIndex p.hp) (sig : Signature p prims)
+    (msg : prims.Y) (pk : prims.PkSeed) (adrs : Adrs) : m prims.Y := do
+  let leaf ← WotsOracle.wotsPkFromSigM prims sig.1 msg pk (wotsLeafAdrs adrs index.val)
+  reconstructRootM (nodeHashM prims pk adrs) index leaf sig.2
+
+/-- Deterministic interpretation of one explicit XMSS node query is the original node hash. -/
+@[simp]
+theorem simulateQ_nodeHashM (prims : Primitives p) (pk : prims.PkSeed) (adrs : Adrs)
+    (address : Address) (left right : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (nodeHashM prims pk adrs address left right :
+          OracleComp (publicHashSpec prims) prims.Y) =
+      xmssNodeHash prims pk adrs address.height address.index left right := by
+  simp [nodeHashM, xmssNodeHash]
+
+end XmssOracle
+
+end SLHDSA

--- a/HashSigTest/SLHDSA/Oracle.lean
+++ b/HashSigTest/SLHDSA/Oracle.lean
@@ -1,0 +1,48 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Oracle
+
+/-!
+# Producer canaries for the SLH-DSA public-hash syntax
+
+These examples pin the random-oracle query identity.  They reject implementations that erase the
+function tag, public seed, full address, or left/right ordering.
+-/
+
+public section
+
+namespace SLHDSA.PublicHashTest
+
+abbrev Q := PublicHashQuery Nat Nat
+
+example :
+    (PublicHashQuery.f 0 Adrs.zero 7 : Q) ≠ PublicHashQuery.f 1 Adrs.zero 7 := by
+  decide
+
+example :
+    (PublicHashQuery.h 0 Adrs.zero 3 5 : Q) ≠
+      PublicHashQuery.h 0 (Adrs.zero.setLayerAddress 1) 3 5 := by
+  decide
+
+example :
+    (PublicHashQuery.h 0 Adrs.zero 3 5 : Q) ≠ PublicHashQuery.h 0 Adrs.zero 5 3 := by
+  decide
+
+example :
+    (PublicHashQuery.f 0 Adrs.zero 7 : Q) ≠ PublicHashQuery.h 0 Adrs.zero 7 7 := by
+  decide
+
+example :
+    (PublicHashQuery.tl 0 Adrs.zero [3, 5] : Q) ≠ PublicHashQuery.tl 0 Adrs.zero [5, 3] := by
+  decide
+
+example :
+    (PublicHashQuery.tl 0 Adrs.zero [3] : Q) ≠ PublicHashQuery.tl 0 Adrs.zero [3, 0] := by
+  decide
+
+end SLHDSA.PublicHashTest

--- a/HashSigTest/SLHDSA/OracleConcrete.lean
+++ b/HashSigTest/SLHDSA/OracleConcrete.lean
@@ -1,0 +1,38 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.Concrete.Instance
+public import HashSig.SLHDSA.SchemeOracle
+
+/-!
+# Concrete producer canary for oracle-parametric SLH-DSA
+
+This file checks that the free public-hash syntax and its lazy-random-oracle runtime specialize to
+the repository's real SHA2-128-24 carrier bundle.  It is an elaboration canary, not a claim that
+the random oracle is the concrete SHA-2 implementation.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace SLHDSA.Concrete.OracleTest
+
+instance : DecidableEq shaPrimitives.PkSeed :=
+  inferInstanceAs (DecidableEq (Bytes 16))
+
+noncomputable example :
+    SignatureAlg (OracleComp (unifSpec + publicHashSpec shaPrimitives)) (List Byte)
+      (PublicKey shaPrimitives) (SecretKey shaPrimitives)
+      (OracleScheme.Signature slhdsaSha2_128_24 shaPrimitives) :=
+  OracleScheme.oracleAlg shaPrimitives
+
+noncomputable example :
+    ProbCompRuntime (OracleComp (unifSpec + publicHashSpec shaPrimitives)) :=
+  OracleScheme.runtime shaPrimitives
+
+end SLHDSA.Concrete.OracleTest

--- a/HashSigTest/SLHDSA/OracleScheme.lean
+++ b/HashSigTest/SLHDSA/OracleScheme.lean
@@ -100,4 +100,17 @@ noncomputable def runRoundTripRandomOracle :
     ProbComp (Bool × PublicHash.Cache toyPrimitives) :=
   roundTripRandomOracle.run ∅
 
+/-- A preloaded public-hash answer is returned without sampling or changing the shared cache. -/
+def cachedF : PublicHash.Cache toyPrimitives :=
+  OracleSpec.QueryCache.cacheQuery ∅
+    (.f (false : toyPrimitives.PkSeed) Adrs.zero (false : toyPrimitives.Y))
+    (true : toyPrimitives.Y)
+
+example :
+    (PublicHash.randomOracle toyPrimitives
+      (.f (false : toyPrimitives.PkSeed) Adrs.zero (false : toyPrimitives.Y))).run cachedF =
+      pure ((true : toyPrimitives.Y), cachedF) := by
+  apply QueryImpl.withCaching_run_some
+  exact OracleSpec.QueryCache.cacheQuery_self _ _ _
+
 end SLHDSA.OracleSchemeTest

--- a/HashSigTest/SLHDSA/OracleScheme.lean
+++ b/HashSigTest/SLHDSA/OracleScheme.lean
@@ -53,6 +53,12 @@ instance : DecidableEq toyPrimitives.Y := inferInstanceAs (DecidableEq Bool)
 instance : DecidableEq toyPrimitives.PkSeed := inferInstanceAs (DecidableEq Bool)
 noncomputable instance : SampleableType toyPrimitives.Y :=
   SampleableType.ofFintype Bool
+noncomputable instance : SampleableType toyPrimitives.SkSeed :=
+  SampleableType.ofFintype Bool
+noncomputable instance : SampleableType toyPrimitives.SkPrf :=
+  SampleableType.ofFintype Bool
+noncomputable instance : SampleableType toyPrimitives.PkSeed :=
+  SampleableType.ofFintype Bool
 
 instance : Params.IsSingleLayer toyParams where
   d_eq_one := rfl
@@ -66,6 +72,18 @@ def roundTrip : OracleComp (publicHashSpec toyPrimitives) Bool := do
 
 /-- Kernel-visible type canary for the complete explicit-oracle program. -/
 example : OracleComp (publicHashSpec toyPrimitives) Bool := roundTrip
+
+/-- The security-game surface combines public sampling and the explicit public-hash family. -/
+noncomputable example :
+    SignatureAlg (OracleComp (unifSpec + publicHashSpec toyPrimitives)) (List Byte)
+      (PublicKey toyPrimitives) (SecretKey toyPrimitives)
+      (OracleScheme.Signature toyParams toyPrimitives) :=
+  OracleScheme.oracleAlg toyPrimitives
+
+/-- Its standard semantics installs one lazy random-oracle cache around the whole game. -/
+noncomputable example :
+    ProbCompRuntime (OracleComp (unifSpec + publicHashSpec toyPrimitives)) :=
+  OracleScheme.runtime toyPrimitives
 
 /-- The same vertical slice under the concrete lazy-random-oracle capability.  Its type exposes
 the one cache that the enclosing experiment must initialize and thread through the whole run. -/

--- a/HashSigTest/SLHDSA/OracleScheme.lean
+++ b/HashSigTest/SLHDSA/OracleScheme.lean
@@ -73,6 +73,41 @@ def roundTrip : OracleComp (publicHashSpec toyPrimitives) Bool := do
 /-- Kernel-visible type canary for the complete explicit-oracle program. -/
 example : OracleComp (publicHashSpec toyPrimitives) Bool := roundTrip
 
+/-- Honest end-to-end execution succeeds under the canonical deterministic hash handler. -/
+example : simulateQ (PublicHash.impl toyPrimitives) roundTrip = true := by
+  simpa [roundTrip] using
+    OracleScheme.simulateQ_honest_roundTrip toyPrimitives [0] false false false false
+
+/-- The public empty-context API domain-separates raw messages before internal hashing. -/
+example : emptyContextMessage [1, 2] = [0, 0, 1, 2] := rfl
+
+example (pk : PublicKey toyPrimitives)
+    (sig : OracleScheme.Signature toyParams toyPrimitives) :
+    (OracleScheme.verifyM toyPrimitives pk [1, 2] sig :
+      OracleComp (publicHashSpec toyPrimitives) Bool) =
+      OracleScheme.verifyInternalM toyPrimitives [0, 0, 1, 2] sig pk := rfl
+
+/-! FIPS 205 Algorithm 10 computes the authentication path before the WOTS signature, although the
+serialized result stores WOTS first.  This stateful canary distinguishes those effect families and
+therefore catches an order reversal that deterministic `simulateQ … Id` parity would erase. -/
+
+inductive XmssSignEvent where
+  | authenticationPath
+  | wotsSignature
+deriving DecidableEq, Repr
+
+def tracedAuthenticationPath : StateM (List XmssSignEvent) ℕ := do
+  modify (· ++ [.authenticationPath])
+  pure 7
+
+def tracedWotsSignature : StateM (List XmssSignEvent) Bool := do
+  modify (· ++ [.wotsSignature])
+  pure true
+
+example :
+    (XmssOracle.authenticationThenSignM tracedAuthenticationPath tracedWotsSignature).run [] =
+      ((true, 7), [.authenticationPath, .wotsSignature]) := rfl
+
 /-- The security-game surface combines public sampling and the explicit public-hash family. -/
 noncomputable example :
     SignatureAlg (OracleComp (unifSpec + publicHashSpec toyPrimitives)) (List Byte)

--- a/HashSigTest/SLHDSA/OracleScheme.lean
+++ b/HashSigTest/SLHDSA/OracleScheme.lean
@@ -1,0 +1,85 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+public import HashSig.SLHDSA.SchemeOracle
+
+/-!
+# End-to-end canary for the explicit-oracle SLH-DSA slice
+
+This small parameter set elaborates key generation, FORS, WOTS+, XMSS signing, and verification
+through the explicit public-hash syntax.  The example is a regression canary rather than a
+security claim, an executable acceptance proof, or a FIPS-approved parameter set.
+-/
+
+@[expose] public section
+
+open OracleComp
+
+namespace SLHDSA.OracleSchemeTest
+
+/-- A tiny single-layer parameter set whose complete trees are practical to reduce in a test. -/
+def toyParams : Params where
+  n := 1
+  h := 1
+  d := 1
+  hp := 1
+  a := 1
+  k := 1
+  lgw := 1
+
+def boolByte (b : Bool) : Byte :=
+  if b then 1 else 0
+
+/-- A deliberately simple deterministic primitive bundle for exercising control flow and address
+plumbing.  It is not intended to satisfy any cryptographic property. -/
+def toyPrimitives : Primitives toyParams where
+  PkSeed := Bool
+  SkSeed := Bool
+  SkPrf := Bool
+  Y := Bool
+  F := fun pk _ x => xor pk x
+  H := fun pk _ left right => xor pk (xor left (!right))
+  Tl := fun pk _ xs => xs.foldl xor pk
+  PRF := fun pk sk _ => xor pk sk
+  PRFmsg := fun skPrf addrnd _ => xor skPrf addrnd
+  Hmsg := fun _ _ _ _ => #v[0, 0]
+  yToBytes := fun y => #v[boolByte y]
+
+instance : DecidableEq toyPrimitives.Y := inferInstanceAs (DecidableEq Bool)
+instance : DecidableEq toyPrimitives.PkSeed := inferInstanceAs (DecidableEq Bool)
+noncomputable instance : SampleableType toyPrimitives.Y :=
+  SampleableType.ofFintype Bool
+
+instance : Params.IsSingleLayer toyParams where
+  d_eq_one := rfl
+  hp_eq_h := rfl
+
+/-- The complete explicit-oracle keygen/sign/verify program. -/
+def roundTrip : OracleComp (publicHashSpec toyPrimitives) Bool := do
+  let (pk, sk) ← OracleScheme.keygenInternalM toyPrimitives false false false
+  let sig ← OracleScheme.signInternalM toyPrimitives [0] sk false
+  OracleScheme.verifyInternalM toyPrimitives [0] sig pk
+
+/-- Kernel-visible type canary for the complete explicit-oracle program. -/
+example : OracleComp (publicHashSpec toyPrimitives) Bool := roundTrip
+
+/-- The same vertical slice under the concrete lazy-random-oracle capability.  Its type exposes
+the one cache that the enclosing experiment must initialize and thread through the whole run. -/
+noncomputable def roundTripRandomOracle :
+    StateT (PublicHash.Cache toyPrimitives) ProbComp Bool := by
+  letI := PublicHash.randomOracleHasQuery toyPrimitives
+  exact do
+    let (pk, sk) ← OracleScheme.keygenInternalM toyPrimitives false false false
+    let sig ← OracleScheme.signInternalM toyPrimitives [0] sk false
+    OracleScheme.verifyInternalM toyPrimitives [0] sig pk
+
+/-- The enclosing experiment initializes the cache once, around the complete program. -/
+noncomputable def runRoundTripRandomOracle :
+    ProbComp (Bool × PublicHash.Cache toyPrimitives) :=
+  roundTripRandomOracle.run ∅
+
+end SLHDSA.OracleSchemeTest

--- a/HashSigTest/SLHDSA/Sha2KAT.lean
+++ b/HashSigTest/SLHDSA/Sha2KAT.lean
@@ -15,7 +15,8 @@ A deterministic reference vector produced by the SPHINCs- C reference
 `seed = 0^48`, `message = 0x00`, `opt_rand = 0^16`. The hex is
 `pk_seed(16) ‖ pk_root(16) ‖ sig(3856)`.
 
-`main` decodes it and checks that the pure-Lean concrete `verifyBytes`
+This vector predates the FIPS 205 external context wrapper, so `main` checks the pure-Lean
+internal-message entry point `verifyInternalBytes`
 (`HashSig.SLHDSA.Concrete.Instance`) accepts the valid signature and rejects a tampered message
 — byte-exact agreement with the C reference, validating the whole verify path (SHA-256 / MGF1 /
 HMAC, `H_msg`, leaf-index split, `F`/`H`/`T_ℓ`, the 22-byte `ADRSc` layout, FORS / WOTS+ / XMSS
@@ -135,8 +136,8 @@ def runKat : IO Unit := do
   let pkSeed := baSliceToB16 ba 0
   let pkRoot := baSliceToB16 ba 16
   let sigBA := ba.extract 32 (32 + 3856)
-  let accepts := verifyBytes pkSeed pkRoot [0x00] sigBA
-  let rejects := verifyBytes pkSeed pkRoot [0x01] sigBA
+  let accepts := verifyInternalBytes pkSeed pkRoot [0x00] sigBA
+  let rejects := verifyInternalBytes pkSeed pkRoot [0x01] sigBA
   if accepts && !rejects then
     IO.println "SLH-DSA-SHA2-128-24 KAT: PASS (valid signature accepted, tampered rejected)"
   else

--- a/VCVio/CryptoFoundations/MerkleTree/Perfect/SimulateQ.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Perfect/SimulateQ.lean
@@ -31,6 +31,23 @@ universe u v
 
 variable {ι : Type u} {spec : OracleSpec.{u, v} ι} {Y : Type v}
 
+/-- A deterministic handler commutes with `Vector.mapM` over oracle computations. -/
+@[simp]
+theorem simulateQ_vector_mapM {α β : Type v} {n : ℕ} (impl : QueryImpl spec Id)
+    (f : α → OracleComp spec β) (xs : Vector α n) :
+    simulateQ impl (xs.mapM f) = xs.map (fun x => simulateQ impl (f x)) := by
+  apply Vector.toArray_inj.mp
+  have hmap : (simulateQ impl (xs.mapM f)).toArray =
+      simulateQ impl (Vector.toArray <$> xs.mapM f) := by
+    rw [simulateQ_map]
+    rfl
+  rw [hmap, Vector.toArray_mapM, Array.mapM_eq_mapM_toList,
+    simulateQ_map, simulateQ_list_mapM]
+  change Id.run (List.toArray <$> xs.toArray.toList.mapM
+    (fun a => pure (simulateQ impl (f a)))) = xs.toArray.map (fun a => simulateQ impl (f a))
+  simp only [List.mapM_pure, map_pure, Id.run_pure]
+  rw [← List.map_toArray]
+
 /-- A deterministic handler commutes with subtree-root production. -/
 @[simp]
 theorem simulateQ_treeHashM (impl : QueryImpl spec Id)

--- a/scripts/build-project.sh
+++ b/scripts/build-project.sh
@@ -18,7 +18,7 @@ echo "# Building Project"
 # regressions, universe-polymorphism consumers). It is not a default target and is
 # not reachable from `Examples`, so build it explicitly — otherwise the local
 # workflow reproduces the CI blind spot that let two `grind` regressions through.
-lake build Examples VCVioTest
+lake build Examples VCVioTest HashSigTest
 
 if [[ "$run_ffi" == true ]]; then
   echo "# Initializing native FFI submodules"
@@ -37,5 +37,5 @@ echo "# Linting Files"
 # `lake exe lint-style` resolves to Mathlib's text-based linter; pass the project
 # libraries explicitly so it lints all of them (the default would be only the
 # `@[default_target]` `VCVio` lib).
-lake exe lint-style ToMathlib VCVio Extern LatticeCrypto Examples VCVioWidgets Interop \
+lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop \
   && echo "All files okay"


### PR DESCRIPTION
## Summary

This stacked PR repairs the SLH-DSA formalization so its public hash operations are explicit, caller-interpreted oracle queries. It builds on #552's callback-parametric perfect Merkle tree engine.

- introduces a tagged dependent oracle for `F`, `H`, `T_l`, and `H_msg`;
- keeps `PRF` and `PRF_msg` as keyed private operations;
- threads one caller-owned lazy random-oracle cache through complete security experiments;
- ports WOTS+, XMSS, FORS, and a truthfully gated `d = 1` SLH-DSA slice to the explicit oracle;
- exposes free-oracle and cache-parametric runtimes for generic signature games;
- proves arbitrary deterministic-handler parity and honest end-to-end functional completeness;
- preserves FIPS-observable XMSS order (`AUTH` before WOTS signing) and restores the empty-context external message prefix;
- adds concrete SHA-2 specialization, cache, trace-order, and end-to-end canaries;
- makes HashSig library/tests part of normal CI.

## Model boundary

The ideal oracle is indexed by the full structural `Adrs`. The concrete SHA-2 implementation hashes compressed `ADRSc`; this PR does not claim their equivalence without a separate reachability/injectivity argument. The implementation is currently restricted to consistent `d = 1` profiles; general hypertree/C13 migration remains follow-up work.

The `d = 1` signer omits the output-dead intermediate XMSS recovery that would only feed a next hypertree layer. It is output-equivalent but does not claim literal trace equality with mechanically specialized pseudocode.

Follow-ups are tracked in #554 (general hypertree/C13), #555 (full-`Adrs` to SHA-2 `ADRSc` bridge), and #550 (security-assumption repair).

## Validation

- `lake -Kjobs=2 build VCVio HashSig VCVioTest HashSigTest`
- style lint for `VCVio` and `HashSig`
- targeted axiom sweep over the new oracle/Merkle/SLH-DSA modules: no `sorryAx` or nonstandard axiom taint
- `lake exe slhdsa_kat`
- `git diff --check`

The final full validation and independent audit are being rerun on the pushed head.
