### PR TITLE
refactor(Responder): derive the stateful-responder bridge from fold naturality

### DIFF
--- a/VCVio/OracleComp/Coinductive/Responder.lean
+++ b/VCVio/OracleComp/Coinductive/Responder.lean
@@ -193,8 +193,8 @@ game between its `ProbComp` presentation (where probability reasoning happens) a
 
 Structurally it is the naturality of `simulateQ` along the monad morphism
 `𝒟 : ProbComp →ᵐ SPMF`, transported through `StateT σ` — i.e. `𝒟 ∘ simulateQ impl =
-simulateQ (𝒟 ∘ impl)`. That is exactly `PFunctor.FreeM.run_liftM_mapHom` at
-`φ := MonadHom.ofLift ProbComp SPMF`: `simulateQ` is the universal fold
+simulateQ (𝒟 ∘ impl)`. That is exactly `PFunctor.FreeM.run_liftM_mapHom` at the bundled
+evaluation-distribution morphism: `simulateQ` is the universal fold
 (`simulateQ_def`), `ofStateQueryImpl` post-composes each query with `𝒟` pointwise in the
 state, and `StateT.mapHom` is that post-composition as a morphism, so the whole statement
 is one instance of the generic law rather than an induction over `OracleComp`. -/
@@ -265,8 +265,7 @@ responder answers the exposed query (jointly drawing its successor state), and t
 adversary advances along the answer. This is the upstream stateful-handler step
 `PFunctor.DynSystem.stepWith` at `m := SPMF`: the wiring itself is deterministic
 interface data; only the states advance stochastically. -/
-noncomputable def stepAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :
-    R.State × S → SPMF (R.State × S) :=
+noncomputable def stepAgainst (A : OracleStrategy S spec) (R : ProbResponder spec) :=
   PFunctor.DynSystem.stepWith R.toQueryImpl A
 
 @[simp] theorem stepAgainst_apply (A : OracleStrategy S spec) (R : ProbResponder spec)

--- a/VCVio/OracleComp/Coinductive/Responder.lean
+++ b/VCVio/OracleComp/Coinductive/Responder.lean
@@ -193,32 +193,20 @@ game between its `ProbComp` presentation (where probability reasoning happens) a
 
 Structurally it is the naturality of `simulateQ` along the monad morphism
 `𝒟 : ProbComp →ᵐ SPMF`, transported through `StateT σ` — i.e. `𝒟 ∘ simulateQ impl =
-simulateQ (𝒟 ∘ impl)`. It is proved here by a bespoke `OracleComp` induction for want of a
-generic *naturality of the universal fold along a monad morphism* law: `simulateQ'` is
-already a bundled `OracleComp spec →ᵐ r`, but there is no `φ ∘ₘ simulateQ' impl =
-simulateQ' (φ ∘ impl)`, nor a `StateT`-functoriality lemma for `→ᵐ`, so this and its
-siblings (`evalDist_simulateQ_run'_eq_evalDist`, `evalDist_simulateQ_run_congr`) are each
-re-derived by hand. See the PolyFun Kleisli/handler pain-point ledger. -/
+simulateQ (𝒟 ∘ impl)`. That is exactly `PFunctor.FreeM.run_liftM_mapHom` at
+`φ := MonadHom.ofLift ProbComp SPMF`: `simulateQ` is the universal fold
+(`simulateQ_def`), `ofStateQueryImpl` post-composes each query with `𝒟` pointwise in the
+state, and `StateT.mapHom` is that post-composition as a morphism, so the whole statement
+is one instance of the generic law rather than an induction over `OracleComp`. -/
 theorem run_simulateQ_toQueryImpl_ofStateQueryImpl {ι₀ : Type}
     {spec₀ : OracleSpec.{0, 0} ι₀} {σ α : Type}
     (impl : QueryImpl spec₀ (StateT σ ProbComp)) (oa : OracleComp spec₀ α) (s : σ) :
     (simulateQ (ofStateQueryImpl impl).toQueryImpl oa).run s =
       𝒟[(simulateQ impl oa).run s] := by
-  induction oa generalizing s with
-  | pure x =>
-    change (simulateQ (ofStateQueryImpl impl).toQueryImpl (pure x)).run s =
-      𝒟[(simulateQ impl (pure x)).run s]
-    rw [simulateQ_pure, simulateQ_pure, StateT.run_pure, StateT.run_pure, evalDist_pure]
-  | queryBind t k ih =>
-    have hqb : ∀ {r : Type → Type} [Monad r] [LawfulMonad r] (impl' : QueryImpl spec₀ r),
-        simulateQ impl' (OracleComp.queryBind t k) =
-          impl' t >>= fun u => simulateQ impl' (k u) := by
-      intro r _ _ impl'
-      rw [show OracleComp.queryBind t k =
-        (liftM (spec₀.query t) : OracleComp spec₀ (spec₀.Range t)) >>= k from rfl,
-        simulateQ_bind, simulateQ_spec_query]
-    rw [hqb, hqb, StateT.run_bind, StateT.run_bind, evalDist_bind]
-    exact bind_congr fun p => ih p.1 p.2
+  -- `exact` rather than a term-mode `:=`: matching the generic law needs the unfoldings of
+  -- `simulateQ`, `toQueryImpl`, `ofStateQueryImpl`, `StateT.mapHom`, and `𝒟`, which are
+  -- definitional but not syntactic.
+  exact PFunctor.FreeM.run_liftM_mapHom (MonadHom.ofLift ProbComp SPMF) impl oa s
 
 /-- The state set of a responder built from a stateful `ProbComp` handler is that handler's
 state; a `@[simp]` `rfl` bridge so `(ofStateQueryImpl impl).State` reduces to the concrete state


### PR DESCRIPTION
## What

`ProbResponder.run_simulateQ_toQueryImpl_ofStateQueryImpl` was a bespoke 17-line `OracleComp` induction. Its own docstring said why:

> It is proved here by a bespoke `OracleComp` induction **for want of a generic *naturality of the universal fold along a monad morphism* law**: `simulateQ'` is already a bundled `OracleComp spec →ᵐ r`, but there is no `φ ∘ₘ simulateQ' impl = simulateQ' (φ ∘ impl)`, nor a `StateT`-functoriality lemma for `→ᵐ`.

That law now exists upstream. PolyFun's `FreeM.run_liftM_mapHom` is precisely it, transported through `StateT`, and every piece it needs is already present here:

| Needed | Supplied by |
|---|---|
| `simulateQ` is the universal fold | `simulateQ_def` (`rfl`) |
| `𝒟` as a bundled `ProbComp →ᵐ SPMF` | `MonadHom.ofLift ProbComp SPMF` (already used in `EvalDist/Instances/`) |
| post-composition of a stateful handler by a morphism | `StateT.mapHom` |
| `ofStateQueryImpl` post-composes each query with `𝒟` pointwise in the state | its own definition |

So the whole theorem is one application. The statement is unchanged; the docstring is rewritten to describe it intrinsically rather than to record the absence of the law.

## Two claims in the old docstring that did not survive checking

It named two siblings as "each re-derived by hand" for the same reason. I tried both:

- **`evalDist_simulateQ_run_congr`** *is* an instance of the law — but it is already a one-line `simp_all` induction, and routing it through the generic law takes ~8 lines of explicit rewriting, because `𝒟[…]` does not syntactically match `(MonadHom.ofLift …).toFun α x` and `rw` cannot find it. That is a strictly worse proof, so it is left alone. Reverted rather than shipped.
- **`evalDist_simulateQ_run'_eq_evalDist`** is **not** an instance at all. It is stated over `run'`, which discards the state and so is not a monad morphism on `StateT`, and its content is a uniformity hypothesis on the implementation (`𝒟[(so t).run' s] = OptionT.lift (PMF.uniformOfFintype …)`) rather than naturality.

So the honest score is one collapse, not three. The docstring no longer claims otherwise.

## Note on `by exact`

The proof is `by exact …` rather than a term-mode `:=`. Term mode fails with a type mismatch: matching the generic law needs the unfoldings of `simulateQ`, `toQueryImpl`, `ofStateQueryImpl`, `StateT.mapHom`, and `𝒟`, which are definitional but not syntactic. Recorded in a comment at the site.

## Validation

Full `lake build`: 0 errors. Both downstream consumers (`Responder.lean`'s `run_map_…` and `CryptoFoundations/AsymmEncAlg/INDCPA/Oracle.lean`) build unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)