### PR TITLE
fix(MerkleTree)!: repair extractability random-oracle semantics

### DIFF
--- a/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
@@ -13,10 +13,10 @@ public import ToMathlib.Data.IndexedBinaryTree.Lemmas
 /-!
 # Inductive Merkle Tree Extractability
 
-This file develops extractability for the inductive Merkle tree commitment scheme. The
-extractor reconstructs a partial tree from the committing adversary's query log and the
-opened root, and the main theorem bounds the probability that an adversary opens a leaf
-that disagrees with the extracted tree.
+This file develops the deterministic extraction kernel for the inductive Merkle tree
+commitment scheme and its random-oracle experiment. The extractor reconstructs a partial
+tree from the committing adversary's query log and the opened root. The experiment runs
+the committing, opening, and verification phases against one shared lazy random function.
 
 ## Main definitions
 
@@ -29,19 +29,18 @@ under namespace `InductiveMerkleTree`:
 * `extractor`: builds a `FullData (Option α) s` from a query log, root, and skeleton by
   walking down from the root and pulling each node's children from the unique log entry
   whose response matches.
-* `extractabilityGame`: the bundled game running a `Adversary` against the extractor
-  and verifier, recording the verifier's outcome along with the extracted tree and proof.
+* `extractabilityInner`: the oracle syntax running an `Adversary` against the extractor
+  and verifier, before choosing random-oracle semantics.
+* `extractabilityGame`: the random-oracle experiment obtained by interpreting
+  `extractabilityInner` through one shared `cachingOracle` from the empty cache.
 * `ChainInLog`: structural predicate witnessing that a query log contains the hash chain
   from `root` down to `leaf` along the path determined by `idx`.
 
 ## Main results
 
-* `extractability`: an adversary wins the extractability game with probability at most
-  `(qb + s.depth)^2 / (2|α|) + 1 / |α|`, by union-bounding collision probability against
-  the no-collision lucky-guess bound.
-
-Note that our bound is looser than the SNARGs book's bound in Lemma 18.5.1 of
-`((qb - 1) * qb) / 2 / |α| + (depth + 1) * 2 * size / |α|`.
+* `independentQuery_consistency`: a consistency bound for the non-random-function
+  semantics in which every hash query receives a fresh independent answer. This auxiliary
+  theorem is not a Merkle-tree extractability theorem in the random-oracle model.
 This is because we have simplified the proof at the expense of tightness
 (tighter, that is, in the qb >> size case)
 by analyzing collisions for the full game at once.
@@ -133,13 +132,12 @@ def extractor (s : Skeleton) (cache : (spec α).QueryLog) (root : α) : FullData
   optionPopulateDown s (extractorChildren cache) root
 
 /--
-The game for extractability.
-
-This is represented as a single `OracleComp`
-that runs the committing adversary, extractor, opening adversary, and verifier in sequence and
-returns the transcript of the execution.
+The oracle syntax underlying the extractability experiment. It runs the committing
+adversary, snapshots that phase's query log for the extractor, runs the opening adversary,
+and finally verifies the opening. Random-function consistency is supplied separately by
+`extractabilityGame`.
 -/
-def extractabilityGame {s : Skeleton} (𝒜 : Adversary α s) :
+def extractabilityInner {s : Skeleton} (𝒜 : Adversary α s) :
     OracleComp (spec α) (α × 𝒜.AuxState ×
         ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
          FullData (Option α) s × List.Vector (Option α) idx.depth × Bool)) :=
@@ -152,10 +150,10 @@ def extractabilityGame {s : Skeleton} (𝒜 : Adversary α s) :
     return (root, aux, ⟨idx, leaf, proof, extractedTree, extractedProof, verified⟩)
 
 /--
-The event that the adversary wins the extractability game:
-verification passes but the extracted leaf or proof does not match.
+The extraction-failure event on an `extractabilityInner` transcript: verification passes
+but the extracted leaf or authentication proof does not match the adversary's opening.
 -/
-def AdversaryWinsExtractabilityGame {s : Skeleton} {AuxState : Type} :
+def AdversaryWinsExtractabilityInner {s : Skeleton} {AuxState : Type} :
     α × AuxState ×
       ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
        FullData (Option α) s × List.Vector (Option α) idx.depth × Bool) → Prop
@@ -163,6 +161,22 @@ def AdversaryWinsExtractabilityGame {s : Skeleton} {AuxState : Type} :
     verified ∧
     (not (leaf = extractedTree.get idx.toNodeIndex)
     ∨ not (proof.toList.map Option.some = extractedProof.toList))
+
+/-- The Merkle-tree extractability experiment in the random-oracle model. All queries made
+by the committing adversary, opening adversary, and verifier are interpreted through one
+shared cache, so repeated equal inputs receive the same answer. -/
+def extractabilityGame {s : Skeleton} (𝒜 : Adversary α s) :
+    OracleComp (spec α) (α × 𝒜.AuxState ×
+        ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
+         FullData (Option α) s × List.Vector (Option α) idx.depth × Bool)) :=
+  Prod.fst <$> (simulateQ (spec α).cachingOracle (extractabilityInner 𝒜)).run ∅
+
+/-- The extraction-failure event for `extractabilityGame`. -/
+def AdversaryWinsExtractabilityGame {s : Skeleton} {AuxState : Type} :
+    α × AuxState ×
+      ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
+       FullData (Option α) s × List.Vector (Option α) idx.depth × Bool) → Prop :=
+  AdversaryWinsExtractabilityInner
 
 /-- If the query log's first entry with response `root` is the pair `⟨(x, y), root⟩`,
 then the extractor at an internal skeleton unfolds to that node's two children using
@@ -176,14 +190,14 @@ private lemma extractor_internal_eq_of_find?_eq
   rfl
 
 /--
-Unfold `extractabilityGame` into a nested `bind` whose outer prefix logs the committing
+Unfold `extractabilityInner` into a nested `bind` whose outer prefix logs the committing
 adversary's queries alongside the opening adversary's output, and whose continuation runs
 `verifyProof` and assembles the transcript. This is the definitional rearrangement used to
 expose the prefix as a target for query-bound reasoning.
 -/
-private lemma extractabilityGame_eq_bind_verifyProof
+private lemma extractabilityInner_eq_bind_verifyProof
     {s : Skeleton} (𝒜 : Adversary α s) :
-    extractabilityGame 𝒜 =
+    extractabilityInner 𝒜 =
       (𝒜.commit.withQueryLog >>= fun ((root, aux), queryLog) =>
         𝒜.opening aux >>= fun q => pure (((root, aux), queryLog), q)) >>=
       fun (⟨⟨root, aux⟩, queryLog⟩, ⟨idx, leaf, proof⟩) =>
@@ -193,15 +207,15 @@ private lemma extractabilityGame_eq_bind_verifyProof
                  extractor s queryLog root,
                  generateProof (extractor s queryLog root) idx,
                  verified⟩) := by
-  simp only [extractabilityGame, bind_assoc, pure_bind]
+  simp only [extractabilityInner, bind_assoc, pure_bind]
 
 omit [DecidableEq α] in
 /--
-Project the logged-prefix of `extractabilityGame` onto `Unit`: discarding both the
+Project the logged-prefix of `extractabilityInner` onto `Unit`: discarding both the
 committed root/aux and the query log of the committing adversary recovers the plain
 measurement used to express the combined query bound.
 -/
-private lemma extractabilityGame_logged_prefix_map_unit_eq
+private lemma extractabilityInner_logged_prefix_map_unit_eq
     {s : Skeleton} (𝒜 : Adversary α s) :
     (fun _ => ()) <$>
         (𝒜.commit.withQueryLog >>= fun ((root, aux), queryLog) =>
@@ -222,16 +236,28 @@ game has total query bound `qb + s.depth`.
 The extra `s.depth` accounts for the `verifyProof` step, which traverses the path from the
 queried leaf to the root, making at most `s.depth` oracle queries.
 -/
-theorem extractabilityGame_isTotalQueryBound {s : Skeleton} (𝒜 : Adversary α s) (qb : ℕ)
+theorem extractabilityInner_isTotalQueryBound {s : Skeleton} (𝒜 : Adversary α s) (qb : ℕ)
     (h : 𝒜.IsTwoPhaseTotalQueryBound qb) :
-    IsTotalQueryBound (extractabilityGame 𝒜) (qb + s.depth) := by
-  rw [extractabilityGame_eq_bind_verifyProof]
+    IsTotalQueryBound (extractabilityInner 𝒜) (qb + s.depth) := by
+  rw [extractabilityInner_eq_bind_verifyProof]
   exact isTotalQueryBound_bind (n₁ := qb) (n₂ := s.depth)
-    ((isQueryBound_iff_of_map_eq (extractabilityGame_logged_prefix_map_unit_eq 𝒜)
+    ((isQueryBound_iff_of_map_eq (extractabilityInner_logged_prefix_map_unit_eq 𝒜)
       (fun _ b => 0 < b) (fun _ b => b - 1)).mpr h)
     fun (⟨⟨root, _aux⟩, _queryLog⟩, ⟨idx, leaf, proof⟩) =>
       isTotalQueryBound_bind (n₁ := s.depth) (n₂ := 0)
         (verifyProof_isTotalQueryBound_skeleton_depth idx leaf root proof) fun _ => trivial
+
+/-- The shared-cache random-oracle experiment makes at most as many underlying fresh
+queries as `extractabilityInner`. Cache hits skip the underlying query, so the implication
+is intentionally one-way. -/
+theorem extractabilityGame_isTotalQueryBound [IsUniformSpec (spec α)]
+    {s : Skeleton} (𝒜 : Adversary α s) (qb : ℕ)
+    (h : 𝒜.IsTwoPhaseTotalQueryBound qb) :
+    IsTotalQueryBound (extractabilityGame 𝒜) (qb + s.depth) := by
+  apply (isQueryBound_map_iff _ _ (qb + s.depth) _ _).mpr
+  exact IsTotalQueryBound.simulateQ_run_withCaching _
+    (extractabilityInner_isTotalQueryBound 𝒜 qb h)
+    (fun t => (isQueryBound_query_iff t 1 _ _).mpr Nat.one_pos) ∅
 
 private lemma extractorChildren_eq_none_of_find?_eq_none
     {log_c : (spec α).QueryLog} {a : α} (hf : log_c.find? (fun ⟨_, r⟩ => r == a) = none) :
@@ -246,13 +272,13 @@ such that the proof verification step passes emitting `log_v`,
 and the extractor and proof generation steps `log_c`
 yield the same extracted tree and proof as the transcript.
 -/
-private lemma extractabilityGame_support_decompose
+private lemma extractabilityInner_support_decompose
     {s : Skeleton} (𝒜 : Adversary α s) {root : α} {aux : 𝒜.AuxState} {idx : SkeletonLeafIndex s}
     {leaf : α} {proof : List.Vector α idx.depth} {extractedTree : FullData (Option α) s}
     {extractedProof : List.Vector (Option α) idx.depth} {log : (spec α).QueryLog}
     (hsup : ((root, aux, ⟨idx, leaf, proof, extractedTree, extractedProof, true⟩),
                   log) ∈
-      support (extractabilityGame 𝒜).withQueryLog) :
+      support (extractabilityInner 𝒜).withQueryLog) :
     ∃ log_c log_v : (spec α).QueryLog,
       (true, log_v) ∈ support
           (verifyProof (m := OracleComp (spec α)) idx leaf root proof).withQueryLog ∧
@@ -260,7 +286,7 @@ private lemma extractabilityGame_support_decompose
       (∀ q, q ∈ log_c → q ∈ log) ∧
       extractedTree = extractor s log_c root ∧
       extractedProof = generateProof (extractor s log_c root) idx := by
-  unfold extractabilityGame at hsup
+  unfold extractabilityInner at hsup
   simp only [OracleComp.withQueryLog_bind, mem_support_bind_iff, support_map,
     Set.mem_image] at hsup
   obtain ⟨⟨⟨root_c, aux_c⟩, log_c⟩, h_c, ⟨_, _⟩,
@@ -515,7 +541,7 @@ theorem chainInLog_of_extractor_get_ne_none
       (ih y (fun he =>
         h_ne_none (by rw [extractor_internal_eq_of_find?_eq sl sr log root x y hf]; exact he)))
 
-private theorem extractabilityGame_not_logHasCollision_match
+private theorem extractabilityInner_not_logHasCollision_match
     [DecidableEq α]
     {s : Skeleton} (𝒜 : Adversary α s)
     {root : α} {aux : 𝒜.AuxState} {idx : SkeletonLeafIndex s} {leaf : α}
@@ -527,11 +553,11 @@ private theorem extractabilityGame_not_logHasCollision_match
     (h_ne_none : extractedTree.get idx.toNodeIndex ≠ none)
     (hsupport : ((root, aux, ⟨idx, leaf, proof, extractedTree, extractedProof, true⟩),
                   log) ∈
-      support (extractabilityGame 𝒜).withQueryLog) :
+      support (extractabilityInner 𝒜).withQueryLog) :
     extractedTree.get idx.toNodeIndex = some leaf ∧
       proof.toList.map some = extractedProof.toList := by
   obtain ⟨log_c, log_v, h_vp, h_sub_v, h_sub_c, h_tree_eq, h_proof_ext_eq⟩ :=
-    extractabilityGame_support_decompose 𝒜 hsupport
+    extractabilityInner_support_decompose 𝒜 hsupport
   obtain ⟨extLeaf, extProof, h_extLeaf_eq, h_extProof_eq, h_extChain_lc⟩ :=
     chainInLog_of_extractor_get_ne_none idx log_c root (h_tree_eq ▸ h_ne_none)
   by_cases hpair : (extLeaf, extProof) = (leaf, proof)
@@ -618,7 +644,7 @@ private lemma probEvent_verifyProof_extractor_none_le_inv_card
       (probEvent_verifyProof_eq_true_eq_inv_card_of_pos_depth h_pos leaf root proof).le
   · exact (probEvent_eq_zero fun _ _ h => h_get h.2).le.trans zero_le
 
-private theorem extractabilityGame_verified_extractor_none_le_inv_card
+private theorem extractabilityInner_verified_extractor_none_le_inv_card
     [DecidableEq α] [Fintype α] [Inhabited α]
     {s : Skeleton} (𝒜 : Adversary α s) :
     Pr[(fun x : (α × 𝒜.AuxState ×
@@ -627,7 +653,7 @@ private theorem extractabilityGame_verified_extractor_none_le_inv_card
       (spec α).QueryLog =>
         let ⟨⟨_, _, idx, _, _, extractedTree, _, verified⟩, _⟩ := x
         verified = true ∧ extractedTree.get idx.toNodeIndex = none) |
-      (extractabilityGame 𝒜).withQueryLog] ≤
+      (extractabilityInner 𝒜).withQueryLog] ≤
         (1 : ENNReal) / (Fintype.card α : ENNReal) := by
   rw [one_div]
   change Pr[((fun vals : α × 𝒜.AuxState ×
@@ -635,9 +661,9 @@ private theorem extractabilityGame_verified_extractor_none_le_inv_card
              FullData (Option α) s × List.Vector (Option α) idx.depth × Bool) =>
             let ⟨_, _, idx, _, _, extractedTree, _, verified⟩ := vals
             verified = true ∧ extractedTree.get idx.toNodeIndex = none) ∘ Prod.fst) |
-        (extractabilityGame 𝒜).withQueryLog] ≤ _
+        (extractabilityInner 𝒜).withQueryLog] ≤ _
   rw [probEvent_withQueryLog]
-  unfold extractabilityGame
+  unfold extractabilityInner
   refine probEvent_bind_le_of_forall_le fun ⟨⟨root, aux⟩, log_c⟩ _ => ?_
   refine probEvent_bind_le_of_forall_le fun ⟨idx, leaf, proof⟩ _ => ?_
   dsimp only
@@ -645,76 +671,65 @@ private theorem extractabilityGame_verified_extractor_none_le_inv_card
         Bool → OracleComp (spec α) _) = pure ∘ _ from rfl, probEvent_bind_pure_comp]
   exact probEvent_verifyProof_extractor_none_le_inv_card idx leaf root proof log_c
 
-private theorem extractabilityGame_not_logHasCollision_wins_le_inv_card
+private theorem extractabilityInner_not_logHasCollision_wins_le_inv_card
     [DecidableEq α] [Fintype α] [Inhabited α]
     {s : Skeleton} (𝒜 : Adversary α s) :
     Pr[fun (vals, log) =>
-        ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityGame vals |
-      (extractabilityGame 𝒜).withQueryLog] ≤
+        ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals |
+      (extractabilityInner 𝒜).withQueryLog] ≤
         (1 : ENNReal) / (Fintype.card α : ENNReal) := by
   refine le_trans (probEvent_mono ?_)
-    (extractabilityGame_verified_extractor_none_le_inv_card 𝒜)
+    (extractabilityInner_verified_extractor_none_le_inv_card 𝒜)
   rintro ⟨vals, log⟩ hsupport ⟨h_not_logHasCollision, h_adv_wins⟩
   obtain ⟨root, aux, idx, leaf, proof, extractedTree, extractedProof, verified⟩ := vals
   obtain ⟨rfl, h_disagree⟩ := h_adv_wins
   refine ⟨rfl, ?_⟩
   by_contra h_ne_none
-  obtain ⟨h_eq_leaf, h_map⟩ := extractabilityGame_not_logHasCollision_match 𝒜
+  obtain ⟨h_eq_leaf, h_map⟩ := extractabilityInner_not_logHasCollision_match 𝒜
     h_not_logHasCollision h_ne_none hsupport
   simp [h_map, h_eq_leaf] at h_disagree
 
-/--
-The extractability theorem for Merkle trees.
-
-Adapting from the SNARGs book Lemma 18.5.1:
-
-For any adversary `𝒜` whose committing and opening phases together obey the two-phase total
-query bound `qb`, if the game runs `𝒜.commit` and `𝒜.opening`, and the `extractor` algorithm
-is run on the resulting cache and root, then with probability at most κ does `𝒜` "win the
-extractability game", i.e. simultaneously
-
-* the merkle tree verification passes on the proof from `𝒜.opening`
-* but the extracted (leaf value, proof) pair
-  does not match the adversary's (leaf value, proof) pair
-
-Where κ is 1/|α| * ((qb + s.depth)^2 / 2 + 1).
--/
-theorem extractability [DecidableEq α] [Fintype α] [Inhabited α]
+/-- A consistency bound for the independent-response interpretation of
+`extractabilityInner`, where every hash query samples a fresh answer even when the input was
+queried before. This statement is useful only as an auxiliary fact about that semantics: it
+does not model one shared random function and therefore is not the Merkle-tree extractability
+theorem from the SNARGs book. -/
+theorem independentQuery_consistency [DecidableEq α] [Fintype α] [Inhabited α]
     {s : Skeleton} (𝒜 : Adversary α s) (qb : ℕ)
     (h_IsQueryBound_qb : 𝒜.IsTwoPhaseTotalQueryBound qb) :
-    Pr[AdversaryWinsExtractabilityGame |
-        extractabilityGame 𝒜] ≤
+    Pr[AdversaryWinsExtractabilityInner |
+        extractabilityInner 𝒜] ≤
         ((qb + s.depth) ^ 2 : ENNReal) / (2 * Fintype.card α)
         + 1 / (Fintype.card α) := by
   calc
-    _ = Pr[AdversaryWinsExtractabilityGame ∘ Prod.fst |
-          (extractabilityGame 𝒜).withQueryLog] :=
+    _ = Pr[AdversaryWinsExtractabilityInner ∘ Prod.fst |
+          (extractabilityInner 𝒜).withQueryLog] :=
       (probEvent_withQueryLog _ _).symm
     _ ≤ Pr[fun (vals, log) =>
             LogHasCollision log ∨
-            (¬ LogHasCollision log ∧ AdversaryWinsExtractabilityGame vals) |
-          (extractabilityGame 𝒜).withQueryLog] :=
+            (¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals) |
+          (extractabilityInner 𝒜).withQueryLog] :=
       probEvent_mono'' fun ⟨_, _⟩ => by tauto
     _ ≤ Pr[fun (vals, log) => LogHasCollision log |
-            (extractabilityGame 𝒜).withQueryLog] +
+            (extractabilityInner 𝒜).withQueryLog] +
         Pr[fun (vals, log) =>
-            ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityGame vals |
-          (extractabilityGame 𝒜).withQueryLog] :=
+            ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals |
+          (extractabilityInner 𝒜).withQueryLog] :=
       probEvent_or_le ..
     _ ≤ ((qb + s.depth) ^ 2 : ENNReal) / (2 * Fintype.card α) +
         Pr[fun (vals, log) =>
-            ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityGame vals |
-          (extractabilityGame 𝒜).withQueryLog] := by
+            ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals |
+          (extractabilityInner 𝒜).withQueryLog] := by
       gcongr
       convert OracleComp.probEvent_logCollision_le_birthday_total (spec := spec α)
-        (extractabilityGame 𝒜) (qb + s.depth)
-        (extractabilityGame_isTotalQueryBound 𝒜 qb h_IsQueryBound_qb)
+        (extractabilityInner 𝒜) (qb + s.depth)
+        (extractabilityInner_isTotalQueryBound 𝒜 qb h_IsQueryBound_qb)
         (fun _ => le_rfl) using 2
       · rfl
       all_goals norm_cast
     _ ≤ ((qb + s.depth) ^ 2 : ENNReal) / (2 * Fintype.card α) +
         1 / (Fintype.card α) := by
-      have h' := extractabilityGame_not_logHasCollision_wins_le_inv_card 𝒜
+      have h' := extractabilityInner_not_logHasCollision_wins_le_inv_card 𝒜
       gcongr; norm_cast
 
 end InductiveMerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
@@ -7,7 +7,7 @@ Authors: Quang Dao, Bolton Bailey
 module
 
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.QueryBound
-public import VCVio.OracleComp.QueryTracking.Birthday
+public import VCVio.OracleComp.QueryTracking.Collision
 public import ToMathlib.Data.IndexedBinaryTree.Lemmas
 
 /-!
@@ -36,15 +36,13 @@ under namespace `InductiveMerkleTree`:
 * `ChainInLog`: structural predicate witnessing that a query log contains the hash chain
   from `root` down to `leaf` along the path determined by `idx`.
 
-## Main results
+## Current proof boundary
 
-* `independentQuery_consistency`: a consistency bound for the non-random-function
-  semantics in which every hash query receives a fresh independent answer. This auxiliary
-  theorem is not a Merkle-tree extractability theorem in the random-oracle model.
-This is because we have simplified the proof at the expense of tightness
-(tighter, that is, in the qb >> size case)
-by analyzing collisions for the full game at once.
-A future improvement might be to re-structure the proof to recover the tighter bound.
+This file proves the deterministic extraction and collision lemmas and a total-query bound
+for the shared-cache experiment. It deliberately does not state a probabilistic extractability
+bound yet. Such a theorem must separately bound fresh post-commit oracle answers that hit one
+of the non-dummy labels in the commit-time partial tree; treating the verifier's last hash as
+an independent fresh query is invalid under shared random-function semantics.
 
 ## TODO
 
@@ -151,16 +149,18 @@ def extractabilityInner {s : Skeleton} (𝒜 : Adversary α s) :
 
 /--
 The extraction-failure event on an `extractabilityInner` transcript: verification passes
-but the extracted leaf or authentication proof does not match the adversary's opening.
+but the extracted leaf or authentication proof does not match the adversary's opening. This
+is the single-leaf specialization of Merkle extractability, and compares the full authentication
+path at that leaf.
 -/
 def AdversaryWinsExtractabilityInner {s : Skeleton} {AuxState : Type} :
     α × AuxState ×
       ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
        FullData (Option α) s × List.Vector (Option α) idx.depth × Bool) → Prop
   | (_, _, ⟨idx, leaf, proof, extractedTree, extractedProof, verified⟩) =>
-    verified ∧
-    (not (leaf = extractedTree.get idx.toNodeIndex)
-    ∨ not (proof.toList.map Option.some = extractedProof.toList))
+    verified = true ∧
+      (some leaf ≠ extractedTree.get idx.toNodeIndex ∨
+        proof.toList.map some ≠ extractedProof.toList)
 
 /-- The Merkle-tree extractability experiment in the random-oracle model. All queries made
 by the committing adversary, opening adversary, and verifier are interpreted through one
@@ -169,7 +169,7 @@ def extractabilityGame {s : Skeleton} (𝒜 : Adversary α s) :
     OracleComp (spec α) (α × 𝒜.AuxState ×
         ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
          FullData (Option α) s × List.Vector (Option α) idx.depth × Bool)) :=
-  Prod.fst <$> (simulateQ (spec α).cachingOracle (extractabilityInner 𝒜)).run ∅
+  (spec α).withCacheOverlay ∅ (extractabilityInner 𝒜)
 
 /-- The extraction-failure event for `extractabilityGame`. -/
 def AdversaryWinsExtractabilityGame {s : Skeleton} {AuxState : Type} :
@@ -568,168 +568,5 @@ private theorem extractabilityInner_not_logHasCollision_match
       (chainInLog_mono idx h_sub_v
         (chainInLog_of_mem_support_verifyProof idx leaf root proof log_v h_vp)))
       h_not_logHasCollision
-
-/--
-The probability that a single hash evaluates to a specific root value
-(without any prior queries)
-is the reciprocal of the range size.
--/
-private lemma probOutput_singleHash_eq_inv_card
-    [Fintype α] [Inhabited α]
-    (a b root : α) :
-    Pr[= root | (singleHash (m := OracleComp (spec α)) a b :
-                  OracleComp (spec α) α)] =
-      (Fintype.card α : ENNReal)⁻¹ := by
-  rw [show (singleHash (m := OracleComp (spec α)) a b : OracleComp (spec α) α) =
-        (liftM ((spec α).query (a, b)) : OracleComp (spec α) α) by simp [singleHash],
-    probOutput_query (spec := spec α) (a, b) root]
-
-/--
-The probability that `getPutativeRoot` evaluates to a specific root value at a positive-depth index
-(without any prior queries) is the reciprocal of the range size.
--/
-private lemma probOutput_getPutativeRoot_eq_inv_card_of_pos_depth
-    [Fintype α] [Inhabited α]
-    {s : Skeleton} {idx : SkeletonLeafIndex s} (h_pos : 0 < idx.depth)
-    (leaf : α) (proof : List.Vector α idx.depth) (root : α) :
-    Pr[= root | (getPutativeRoot (m := OracleComp (spec α)) idx leaf proof :
-                  OracleComp (spec α) α)] =
-      (Fintype.card α : ENNReal)⁻¹ := by
-  cases idx with
-  | ofLeaf => exact absurd h_pos (Nat.lt_irrefl _)
-  | @ofLeft sl sr idxLeft =>
-    rw [show getPutativeRoot (m := OracleComp (spec α)) (.ofLeft idxLeft) leaf proof =
-        getPutativeRoot idxLeft leaf proof.tail >>= (singleHash · proof.head) from rfl,
-      probOutput_bind_eq_tsum]
-    simp_rw [fun a => probOutput_singleHash_eq_inv_card a proof.head root,
-      ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
-  | @ofRight sl sr idxRight =>
-    rw [show getPutativeRoot (m := OracleComp (spec α)) (.ofRight idxRight) leaf proof =
-        getPutativeRoot idxRight leaf proof.tail >>= (singleHash proof.head ·) from rfl,
-      probOutput_bind_eq_tsum]
-    simp_rw [fun a => probOutput_singleHash_eq_inv_card proof.head a root,
-      ENNReal.tsum_mul_right, tsum_probOutput_of_liftM_PMF, one_mul]
-
-/--
-The probability that `verifyProof` evaluates to `true` at a positive-depth index
-(without any prior queries) is the reciprocal of the range size.
--/
-private lemma probEvent_verifyProof_eq_true_eq_inv_card_of_pos_depth
-    [DecidableEq α] [Fintype α] [Inhabited α]
-    {s : Skeleton} {idx : SkeletonLeafIndex s} (h_pos : 0 < idx.depth)
-    (leaf root : α) (proof : List.Vector α idx.depth) :
-    Pr[(· = true) | (verifyProof (m := OracleComp (spec α)) idx leaf root proof :
-                      OracleComp (spec α) Bool)] =
-      (Fintype.card α : ENNReal)⁻¹ := by
-  rw [show (verifyProof (m := OracleComp (spec α)) idx leaf root proof :
-              OracleComp (spec α) Bool) =
-        getPutativeRoot idx leaf proof >>= (pure ∘ (· == root)) from rfl,
-    probEvent_bind_pure_comp]
-  simp only [Function.comp_def, beq_iff_eq, probEvent_eq_eq_probOutput]
-  exact probOutput_getPutativeRoot_eq_inv_card_of_pos_depth h_pos leaf proof root
-
-private lemma probEvent_verifyProof_extractor_none_le_inv_card
-    [DecidableEq α] [Fintype α] [Inhabited α]
-    {s : Skeleton} (idx : SkeletonLeafIndex s) (leaf root : α)
-    (proof : List.Vector α idx.depth) (log_c : (spec α).QueryLog) :
-    Pr[fun verified : Bool => verified = true ∧
-         (extractor s log_c root).get idx.toNodeIndex = none |
-       (verifyProof (m := OracleComp (spec α)) idx leaf root proof :
-         OracleComp (spec α) Bool)] ≤
-      (Fintype.card α : ENNReal)⁻¹ := by
-  by_cases h_get : (extractor s log_c root).get idx.toNodeIndex = none
-  · have h_pos : 0 < idx.depth := by
-      cases idx <;> first | exact Nat.succ_pos _ | exact absurd h_get (Option.some_ne_none _)
-    exact (probEvent_mono'' (q := fun b : Bool => b = true) fun _ h => h.1).trans
-      (probEvent_verifyProof_eq_true_eq_inv_card_of_pos_depth h_pos leaf root proof).le
-  · exact (probEvent_eq_zero fun _ _ h => h_get h.2).le.trans zero_le
-
-private theorem extractabilityInner_verified_extractor_none_le_inv_card
-    [DecidableEq α] [Fintype α] [Inhabited α]
-    {s : Skeleton} (𝒜 : Adversary α s) :
-    Pr[(fun x : (α × 𝒜.AuxState ×
-        ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
-         FullData (Option α) s × List.Vector (Option α) idx.depth × Bool)) ×
-      (spec α).QueryLog =>
-        let ⟨⟨_, _, idx, _, _, extractedTree, _, verified⟩, _⟩ := x
-        verified = true ∧ extractedTree.get idx.toNodeIndex = none) |
-      (extractabilityInner 𝒜).withQueryLog] ≤
-        (1 : ENNReal) / (Fintype.card α : ENNReal) := by
-  rw [one_div]
-  change Pr[((fun vals : α × 𝒜.AuxState ×
-            ((idx : SkeletonLeafIndex s) × α × List.Vector α idx.depth ×
-             FullData (Option α) s × List.Vector (Option α) idx.depth × Bool) =>
-            let ⟨_, _, idx, _, _, extractedTree, _, verified⟩ := vals
-            verified = true ∧ extractedTree.get idx.toNodeIndex = none) ∘ Prod.fst) |
-        (extractabilityInner 𝒜).withQueryLog] ≤ _
-  rw [probEvent_withQueryLog]
-  unfold extractabilityInner
-  refine probEvent_bind_le_of_forall_le fun ⟨⟨root, aux⟩, log_c⟩ _ => ?_
-  refine probEvent_bind_le_of_forall_le fun ⟨idx, leaf, proof⟩ _ => ?_
-  dsimp only
-  rw [show (fun verified : Bool => pure (root, aux, _) :
-        Bool → OracleComp (spec α) _) = pure ∘ _ from rfl, probEvent_bind_pure_comp]
-  exact probEvent_verifyProof_extractor_none_le_inv_card idx leaf root proof log_c
-
-private theorem extractabilityInner_not_logHasCollision_wins_le_inv_card
-    [DecidableEq α] [Fintype α] [Inhabited α]
-    {s : Skeleton} (𝒜 : Adversary α s) :
-    Pr[fun (vals, log) =>
-        ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals |
-      (extractabilityInner 𝒜).withQueryLog] ≤
-        (1 : ENNReal) / (Fintype.card α : ENNReal) := by
-  refine le_trans (probEvent_mono ?_)
-    (extractabilityInner_verified_extractor_none_le_inv_card 𝒜)
-  rintro ⟨vals, log⟩ hsupport ⟨h_not_logHasCollision, h_adv_wins⟩
-  obtain ⟨root, aux, idx, leaf, proof, extractedTree, extractedProof, verified⟩ := vals
-  obtain ⟨rfl, h_disagree⟩ := h_adv_wins
-  refine ⟨rfl, ?_⟩
-  by_contra h_ne_none
-  obtain ⟨h_eq_leaf, h_map⟩ := extractabilityInner_not_logHasCollision_match 𝒜
-    h_not_logHasCollision h_ne_none hsupport
-  simp [h_map, h_eq_leaf] at h_disagree
-
-/-- A consistency bound for the independent-response interpretation of
-`extractabilityInner`, where every hash query samples a fresh answer even when the input was
-queried before. This statement is useful only as an auxiliary fact about that semantics: it
-does not model one shared random function and therefore is not the Merkle-tree extractability
-theorem from the SNARGs book. -/
-theorem independentQuery_consistency [DecidableEq α] [Fintype α] [Inhabited α]
-    {s : Skeleton} (𝒜 : Adversary α s) (qb : ℕ)
-    (h_IsQueryBound_qb : 𝒜.IsTwoPhaseTotalQueryBound qb) :
-    Pr[AdversaryWinsExtractabilityInner |
-        extractabilityInner 𝒜] ≤
-        ((qb + s.depth) ^ 2 : ENNReal) / (2 * Fintype.card α)
-        + 1 / (Fintype.card α) := by
-  calc
-    _ = Pr[AdversaryWinsExtractabilityInner ∘ Prod.fst |
-          (extractabilityInner 𝒜).withQueryLog] :=
-      (probEvent_withQueryLog _ _).symm
-    _ ≤ Pr[fun (vals, log) =>
-            LogHasCollision log ∨
-            (¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals) |
-          (extractabilityInner 𝒜).withQueryLog] :=
-      probEvent_mono'' fun ⟨_, _⟩ => by tauto
-    _ ≤ Pr[fun (vals, log) => LogHasCollision log |
-            (extractabilityInner 𝒜).withQueryLog] +
-        Pr[fun (vals, log) =>
-            ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals |
-          (extractabilityInner 𝒜).withQueryLog] :=
-      probEvent_or_le ..
-    _ ≤ ((qb + s.depth) ^ 2 : ENNReal) / (2 * Fintype.card α) +
-        Pr[fun (vals, log) =>
-            ¬ LogHasCollision log ∧ AdversaryWinsExtractabilityInner vals |
-          (extractabilityInner 𝒜).withQueryLog] := by
-      gcongr
-      convert OracleComp.probEvent_logCollision_le_birthday_total (spec := spec α)
-        (extractabilityInner 𝒜) (qb + s.depth)
-        (extractabilityInner_isTotalQueryBound 𝒜 qb h_IsQueryBound_qb)
-        (fun _ => le_rfl) using 2
-      · rfl
-      all_goals norm_cast
-    _ ≤ ((qb + s.depth) ^ 2 : ENNReal) / (2 * Fintype.card α) +
-        1 / (Fintype.card α) := by
-      have h' := extractabilityInner_not_logHasCollision_wins_le_inv_card 𝒜
-      gcongr; norm_cast
 
 end InductiveMerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean
@@ -47,7 +47,7 @@ an independent fresh query is invalid under shared random-function semantics.
 ## TODO
 
 - The lemmas here all specialize to `(m := OracleComp (spec α))` because the proofs rely
-  on `OracleComp`-specific machinery — `withQueryLog`, `support`, `probEvent`, and the
+  on `OracleComp`-specific machinery — `withQueryLog`, `simulateQ` support lemmas, and the
   `ChainInLog log` predicate over a concrete `QueryLog`. Generalizing them to an arbitrary
   monad `m` (so they apply to e.g. `SimulateQ` without re-proving) would first require a
   generic "computation-with-query-log" interface at the framework level,
@@ -66,12 +66,6 @@ namespace InductiveMerkleTree
 open List OracleSpec OracleComp BinaryTree
 
 variable {α : Type}
-
-/-- Local `IsUniformSpec` opt-in for `spec α`: the single Merkle hash oracle samples
-uniformly from `α` whenever `α` is finite and inhabited. Kept `local` so that downstream
-files outside this module do not silently pick up uniform semantics for `spec α`. -/
-noncomputable local instance instIsUniformSpec [Fintype α] [Inhabited α] :
-    IsUniformSpec (spec α) := IsUniformSpec.ofFintypeInhabited _
 
 /-! ## Adversary -/
 

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -6,6 +6,7 @@ public import VCVioTest.GrindFailFast
 public import VCVioTest.LongChainPrograms
 public import VCVioTest.MeasureSemantics
 public import VCVioTest.MerkleTreeBatch
+public import VCVioTest.MerkleTreeExtractability
 public import VCVioTest.MonadProbability
 public import VCVioTest.PFunctorFacade
 public import VCVioTest.PerfectMerkleTree

--- a/VCVioTest/MerkleTreeExtractability.lean
+++ b/VCVioTest/MerkleTreeExtractability.lean
@@ -60,6 +60,14 @@ def leftProof : List.Vector Bool leftIndex.depth :=
 
 @[simp] private lemma leftProof_head : leftProof.head = true := rfl
 
+def rightIndex : BinaryTree.SkeletonLeafIndex depthOneSkeleton :=
+  .ofRight .ofLeaf
+
+def rightProof : List.Vector Bool rightIndex.depth :=
+  ⟨[false], rfl⟩
+
+@[simp] private lemma rightProof_head : rightProof.head = false := rfl
+
 abbrev depthOneAdversary : InductiveMerkleTree.Adversary Bool depthOneSkeleton where
   AuxState := Unit
   commit := do
@@ -67,9 +75,12 @@ abbrev depthOneAdversary : InductiveMerkleTree.Adversary Bool depthOneSkeleton w
       OracleComp (InductiveMerkleTree.spec Bool) Bool)
     return (root, ())
   opening _ := do
-    let _ ← ((InductiveMerkleTree.spec Bool).query (false, true) :
+    let answer ← ((InductiveMerkleTree.spec Bool).query (false, true) :
       OracleComp (InductiveMerkleTree.spec Bool) Bool)
-    return ⟨leftIndex, false, leftProof⟩
+    if answer then
+      return ⟨rightIndex, true, rightProof⟩
+    else
+      return ⟨leftIndex, false, leftProof⟩
 
 private lemma depthOneCommit_withQueryLog_eq :
     depthOneAdversary.commit.withQueryLog =
@@ -124,15 +135,22 @@ def expectedTree (root : Bool) :
     BinaryTree.FullData (Option Bool) depthOneSkeleton :=
   .internal (some root) (.leaf (some false)) (.leaf (some true))
 
-def expectedProof : List.Vector (Option Bool) leftIndex.depth :=
+def expectedLeftProof : List.Vector (Option Bool) leftIndex.depth :=
   some true ::ᵥ List.Vector.nil
+
+def expectedRightProof : List.Vector (Option Bool) rightIndex.depth :=
+  some false ::ᵥ List.Vector.nil
 
 private lemma depthOneGame_eq :
     InductiveMerkleTree.extractabilityGame depthOneAdversary =
       (((InductiveMerkleTree.spec Bool).query (false, true) :
           OracleComp (InductiveMerkleTree.spec Bool) Bool) >>= fun root =>
-        pure (root, (), ⟨leftIndex, false, leftProof,
-          expectedTree root, expectedProof, true⟩)) := by
+        if root then
+          pure (root, (), ⟨rightIndex, true, rightProof,
+            expectedTree root, expectedRightProof, true⟩)
+        else
+          pure (root, (), ⟨leftIndex, false, leftProof,
+            expectedTree root, expectedLeftProof, true⟩)) := by
   rw [show InductiveMerkleTree.extractabilityGame depthOneAdversary =
       (InductiveMerkleTree.spec Bool).withCacheOverlay ∅
         (InductiveMerkleTree.extractabilityInner depthOneAdversary) from rfl]
@@ -145,9 +163,27 @@ private lemma depthOneGame_eq :
         return (root, aux,
           ⟨idx, leaf, proof, extractedTree, extractedProof, verified⟩) from rfl]
   rw [withCacheOverlay_bind, depthOneCommit_cached_eq]
-  simp [OracleSpec.withCacheOverlay, depthOneAdversary,
-    InductiveMerkleTree.extractor, InductiveMerkleTree.extractorChildren,
-    depthOneSkeleton, leftIndex, leftProof_head, expectedTree, expectedProof]
+  simp only [bind_assoc, pure_bind]
+  refine bind_congr (m := OracleComp (InductiveMerkleTree.spec Bool)) fun root => ?_
+  cases root <;>
+    simp [OracleSpec.withCacheOverlay,
+      InductiveMerkleTree.extractor, InductiveMerkleTree.extractorChildren,
+      depthOneSkeleton, leftIndex, rightIndex, expectedTree,
+      expectedLeftProof, expectedRightProof]
+
+/-- If the shared answer is `false`, the adversary opens the left branch. -/
+example : (false, (), ⟨leftIndex, false, leftProof,
+    expectedTree false, expectedLeftProof, true⟩) ∈
+    support (InductiveMerkleTree.extractabilityGame depthOneAdversary) := by
+  rw [depthOneGame_eq]
+  simp
+
+/-- If the shared answer is `true`, the adversary opens the right branch. -/
+example : (true, (), ⟨rightIndex, true, rightProof,
+    expectedTree true, expectedRightProof, true⟩) ∈
+    support (InductiveMerkleTree.extractabilityGame depthOneAdversary) := by
+  rw [depthOneGame_eq]
+  simp
 
 /-- Commit, opening, and verification all query `(false, true)`. The shared oracle returns
 one answer throughout, so the commit-prefix extractor recovers the opened leaf and full path. -/
@@ -161,11 +197,12 @@ example (transcript : Bool × Unit ×
   rw [depthOneGame_eq] at htranscript
   rw [mem_support_bind_iff] at htranscript
   obtain ⟨root, _, htranscript⟩ := htranscript
-  rw [mem_support_pure_iff] at htranscript
-  subst transcript
-  simp [InductiveMerkleTree.AdversaryWinsExtractabilityGame,
+  cases root <;> simp at htranscript
+  all_goals subst transcript
+  all_goals simp [InductiveMerkleTree.AdversaryWinsExtractabilityGame,
     InductiveMerkleTree.AdversaryWinsExtractabilityInner,
-    expectedTree, expectedProof, depthOneSkeleton, leftIndex, leftProof]
-  rfl
+    expectedTree, expectedLeftProof, expectedRightProof, depthOneSkeleton,
+    leftIndex, rightIndex, leftProof, rightProof]
+  all_goals rfl
 
 end VCVioTest.MerkleTreeExtractability

--- a/VCVioTest/MerkleTreeExtractability.lean
+++ b/VCVioTest/MerkleTreeExtractability.lean
@@ -46,7 +46,126 @@ example : ∀ result ∈ support
 the final implementation cache hidden from consumers. -/
 example {s : BinaryTree.Skeleton} (adversary : InductiveMerkleTree.Adversary Bool s) :
     InductiveMerkleTree.extractabilityGame adversary =
-      (Prod.fst <$> (simulateQ (InductiveMerkleTree.spec Bool).cachingOracle
-        (InductiveMerkleTree.extractabilityInner adversary)).run ∅) := rfl
+      (InductiveMerkleTree.spec Bool).withCacheOverlay ∅
+        (InductiveMerkleTree.extractabilityInner adversary) := rfl
+
+def depthOneSkeleton : BinaryTree.Skeleton :=
+  .internal .leaf .leaf
+
+def leftIndex : BinaryTree.SkeletonLeafIndex depthOneSkeleton :=
+  .ofLeft .ofLeaf
+
+def leftProof : List.Vector Bool leftIndex.depth :=
+  ⟨[true], rfl⟩
+
+@[simp] private lemma leftProof_head : leftProof.head = true := rfl
+
+abbrev depthOneAdversary : InductiveMerkleTree.Adversary Bool depthOneSkeleton where
+  AuxState := Unit
+  commit := do
+    let root ← ((InductiveMerkleTree.spec Bool).query (false, true) :
+      OracleComp (InductiveMerkleTree.spec Bool) Bool)
+    return (root, ())
+  opening _ := do
+    let _ ← ((InductiveMerkleTree.spec Bool).query (false, true) :
+      OracleComp (InductiveMerkleTree.spec Bool) Bool)
+    return ⟨leftIndex, false, leftProof⟩
+
+private lemma depthOneCommit_withQueryLog_eq :
+    depthOneAdversary.commit.withQueryLog =
+      (((InductiveMerkleTree.spec Bool).query (false, true) :
+          OracleComp (InductiveMerkleTree.spec Bool) Bool) >>= fun root =>
+        pure ((root, ()), [⟨(false, true), root⟩])) := by
+  change OracleComp.withQueryLog (((fun root => (root, ())) <$>
+      ((InductiveMerkleTree.spec Bool).query (false, true) :
+        OracleComp (InductiveMerkleTree.spec Bool) Bool))) = _
+  rw [map_eq_bind_pure_comp, OracleComp.withQueryLog_bind,
+    OracleComp.withQueryLog_query]
+  simp
+
+private lemma depthOneCommit_cached_eq :
+    (simulateQ (InductiveMerkleTree.spec Bool).cachingOracle
+      depthOneAdversary.commit.withQueryLog).run ∅ =
+      (((InductiveMerkleTree.spec Bool).query (false, true) :
+          OracleComp (InductiveMerkleTree.spec Bool) Bool) >>= fun root =>
+        pure (((root, ()), [⟨(false, true), root⟩]),
+          (∅ : (InductiveMerkleTree.spec Bool).QueryCache).cacheQuery
+            (false, true) root)) := by
+  rw [depthOneCommit_withQueryLog_eq]
+  change (simulateQ (InductiveMerkleTree.spec Bool).cachingOracle
+      (((InductiveMerkleTree.spec Bool).query (false, true) :
+          OracleComp (InductiveMerkleTree.spec Bool) Bool) >>= fun root =>
+        pure ((root, ()),
+          ([⟨(false, true), root⟩] : (InductiveMerkleTree.spec Bool).QueryLog)))).run ∅ = _
+  rw [simulateQ_bind, StateT.run_bind, cachingOracle.simulateQ_query,
+    cachingOracle.run_none (by rfl)]
+  simp
+
+/-- The commit prefix records the hash input once for the extractor, with the answer installed
+in the shared cache before the same input is repeated during opening and verification. -/
+example (z : ((Bool × Unit) × (InductiveMerkleTree.spec Bool).QueryLog) ×
+    (InductiveMerkleTree.spec Bool).QueryCache)
+    (hz : z ∈ support ((simulateQ (InductiveMerkleTree.spec Bool).cachingOracle
+      depthOneAdversary.commit.withQueryLog).run ∅)) :
+    z.1.2 = [⟨(false, true), z.1.1.1⟩] ∧
+      z.2 (false, true) = some z.1.1.1 := by
+  rw [depthOneCommit_cached_eq] at hz
+  rw [mem_support_bind_iff] at hz
+  obtain ⟨root, _, hz⟩ := hz
+  rw [mem_support_pure_iff] at hz
+  subst z
+  constructor
+  · rfl
+  · change ((∅ : (InductiveMerkleTree.spec Bool).QueryCache).cacheQuery
+      (false, true) root) (false, true) = some root
+    exact QueryCache.cacheQuery_self _ _ _
+
+def expectedTree (root : Bool) :
+    BinaryTree.FullData (Option Bool) depthOneSkeleton :=
+  .internal (some root) (.leaf (some false)) (.leaf (some true))
+
+def expectedProof : List.Vector (Option Bool) leftIndex.depth :=
+  some true ::ᵥ List.Vector.nil
+
+private lemma depthOneGame_eq :
+    InductiveMerkleTree.extractabilityGame depthOneAdversary =
+      (((InductiveMerkleTree.spec Bool).query (false, true) :
+          OracleComp (InductiveMerkleTree.spec Bool) Bool) >>= fun root =>
+        pure (root, (), ⟨leftIndex, false, leftProof,
+          expectedTree root, expectedProof, true⟩)) := by
+  rw [show InductiveMerkleTree.extractabilityGame depthOneAdversary =
+      (InductiveMerkleTree.spec Bool).withCacheOverlay ∅
+        (InductiveMerkleTree.extractabilityInner depthOneAdversary) from rfl]
+  rw [show InductiveMerkleTree.extractabilityInner depthOneAdversary =
+      depthOneAdversary.commit.withQueryLog >>= fun ((root, aux), queryLog) => do
+        let extractedTree := InductiveMerkleTree.extractor depthOneSkeleton queryLog root
+        let ⟨idx, leaf, proof⟩ ← depthOneAdversary.opening aux
+        let extractedProof := InductiveMerkleTree.generateProof extractedTree idx
+        let verified ← InductiveMerkleTree.verifyProof idx leaf root proof
+        return (root, aux,
+          ⟨idx, leaf, proof, extractedTree, extractedProof, verified⟩) from rfl]
+  rw [withCacheOverlay_bind, depthOneCommit_cached_eq]
+  simp [OracleSpec.withCacheOverlay, depthOneAdversary,
+    InductiveMerkleTree.extractor, InductiveMerkleTree.extractorChildren,
+    depthOneSkeleton, leftIndex, leftProof_head, expectedTree, expectedProof]
+
+/-- Commit, opening, and verification all query `(false, true)`. The shared oracle returns
+one answer throughout, so the commit-prefix extractor recovers the opened leaf and full path. -/
+example (transcript : Bool × Unit ×
+    ((idx : BinaryTree.SkeletonLeafIndex depthOneSkeleton) × Bool ×
+      List.Vector Bool idx.depth × BinaryTree.FullData (Option Bool) depthOneSkeleton ×
+      List.Vector (Option Bool) idx.depth × Bool))
+    (htranscript : transcript ∈ support
+      (InductiveMerkleTree.extractabilityGame depthOneAdversary)) :
+    ¬ InductiveMerkleTree.AdversaryWinsExtractabilityGame transcript := by
+  rw [depthOneGame_eq] at htranscript
+  rw [mem_support_bind_iff] at htranscript
+  obtain ⟨root, _, htranscript⟩ := htranscript
+  rw [mem_support_pure_iff] at htranscript
+  subst transcript
+  simp [InductiveMerkleTree.AdversaryWinsExtractabilityGame,
+    InductiveMerkleTree.AdversaryWinsExtractabilityInner,
+    expectedTree, expectedProof, depthOneSkeleton, leftIndex, leftProof]
+  rfl
 
 end VCVioTest.MerkleTreeExtractability

--- a/VCVioTest/MerkleTreeExtractability.lean
+++ b/VCVioTest/MerkleTreeExtractability.lean
@@ -1,0 +1,52 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Inductive.Extractability
+
+/-!
+# Inductive Merkle Extractability Canaries
+
+These examples pin the semantic boundary between raw `OracleComp` syntax, where repeated
+queries sample independently, and `extractabilityGame`, where the full experiment is run
+through one shared cache.
+-/
+
+@[expose] public section
+
+open OracleComp OracleSpec
+
+namespace VCVioTest.MerkleTreeExtractability
+
+def repeatedQuery : OracleComp (InductiveMerkleTree.spec Bool) (Bool × Bool) := do
+  let first ← ((InductiveMerkleTree.spec Bool).query (false, false) :
+    OracleComp (InductiveMerkleTree.spec Bool) Bool)
+  let second ← ((InductiveMerkleTree.spec Bool).query (false, false) :
+    OracleComp (InductiveMerkleTree.spec Bool) Bool)
+  return (first, second)
+
+/-- Raw `OracleComp` semantics permit two different answers to the same input. -/
+example : (false, true) ∈ support repeatedQuery := by
+  simp [repeatedQuery]
+
+/-- The shared cache makes the same repeated input return the same answer. -/
+example : ∀ result ∈ support
+    (Prod.fst <$> (simulateQ (InductiveMerkleTree.spec Bool).cachingOracle repeatedQuery).run ∅),
+    result.1 = result.2 := by
+  intro result hresult
+  have hcases : (false, false) = result ∨ (true, true) = result := by
+    simpa [repeatedQuery] using hresult
+  rcases hcases with rfl | rfl <;> rfl
+
+/-- `extractabilityGame` is exactly the cached interpretation of its oracle syntax, with
+the final implementation cache hidden from consumers. -/
+example {s : BinaryTree.Skeleton} (adversary : InductiveMerkleTree.Adversary Bool s) :
+    InductiveMerkleTree.extractabilityGame adversary =
+      (Prod.fst <$> (simulateQ (InductiveMerkleTree.spec Bool).cachingOracle
+        (InductiveMerkleTree.extractabilityInner adversary)).run ∅) := rfl
+
+end VCVioTest.MerkleTreeExtractability


### PR DESCRIPTION
## Summary

This PR repairs the semantic foundation of the inductive Merkle-tree extractability experiment.

It now:

- runs commitment, opening, and verification against one shared lazy random function;
- separates the raw oracle syntax (`extractabilityInner`) from its cached random-oracle interpretation (`extractabilityGame`);
- removes the invalid probabilistic `extractability` theorem instead of retaining an independent-response argument under a ROM name;
- preserves the deterministic extractor, hash-chain/collision kernel, and query accounting; and
- adds producer canaries that observe cache continuity across all three phases and distinguish both tree orientations.

This is the Phase 2a containment repair. It deliberately does **not** claim the final ROM extraction-failure probability bound; that cache-aware reduction is Phase 2b.

### Diff metadata

- Base: `46c3aade0dce87dd08f205e75941ccea60044022` (`main`)
- Head: `99ab2db745b40c78d709061acf0e9117c34eaf0d`
- Commits: 3
- Files changed: 3
- Diff: 282 insertions, 227 deletions
- Source correspondence: Chiesa–Yogev, *Building Cryptographic Proofs from Hash Functions*, Lemma 18.5.1

## Motivation

Raw `OracleComp (spec α)` semantics sample a fresh independent response for every query. In particular, two equal hash inputs may receive different answers. The previous `extractabilityGame` ran directly under those semantics while its theorem and documentation described one shared random oracle.

That mismatch made the former probability proof inapplicable to the claimed experiment: its lucky-final-hash step treated verification as a fresh independent sample even when the input could already have been queried and cached.

## Change-surface overview

| Area | Before | After |
| --- | --- | --- |
| Oracle experiment | Every query sampled independently | Commit, opening, and verification share one cache from `∅` |
| Raw syntax | Named `extractabilityGame` | Named `extractabilityInner` |
| Public game | Raw `OracleComp` syntax | `withCacheOverlay ∅ (extractabilityInner 𝒜)` |
| Probability theorem | Invalid ROM-labelled bound | Removed; no replacement claim in this PR |
| Deterministic kernel | Mixed into the probability development | Retained as extractor, chain-in-log, and collision infrastructure |
| Regression coverage | Did not observe phase-boundary cache reuse | Concrete depth-one adversary observes one cached answer across all phases and both orientations |

## Corrected experiment

`extractabilityInner` retains the algorithmic sequence:

1. run and log the committing adversary;
2. construct the partial extracted tree from that commit-prefix log;
3. run the opening adversary;
4. verify the claimed leaf and authentication path.

`extractabilityGame` interprets that entire syntax tree through a single cache overlay. Cache hits skip the underlying sampler, so repeated equal inputs receive the same response and the final cache remains hidden from the public result type.

The resource theorems are correspondingly split:

- `extractabilityInner_isTotalQueryBound` bounds raw syntactic queries;
- `extractabilityGame_isTotalQueryBound` transfers that bound to underlying cache misses, which can only decrease under caching.

## Producer canaries

The committed depth-one adversary queries ordered input `(false, true)` during commitment, opening, and verification.

- If the shared answer is `false`, opening selects the left leaf with proof `[true]`.
- If the shared answer is `true`, opening selects the right leaf with proof `[false]`.

The tests prove both branches are supported, reduce the complete experiment to exactly one underlying oracle query, pin the commit-prefix log and cache entry, and verify that neither supported transcript is an extraction failure. These examples reject fresh-cache phase boundaries, discarded opening answers, swapped hash order, wrong branch selection, and incorrect extracted paths.

## Security boundary

This PR fixes the experiment but does not finish the probabilistic theorem.

The remaining Phase 2b proof must expose and relate the commit cache, show that a collision-free extraction failure forces a fresh post-commit answer to hit a bounded set of extracted non-dummy labels, prove the corresponding multi-target bound, and combine it with the birthday term.

No theorem in this PR claims that bound already exists.

## Breaking changes

This is an intentional breaking correction:

- the false public `InductiveMerkleTree.extractability` theorem is deleted;
- `extractabilityGame` keeps its result type but now has shared-random-function semantics;
- the former raw query-bound result is available as `extractabilityInner_isTotalQueryBound`;
- `extractabilityGame_isTotalQueryBound` applies to the cached game and requires `IsUniformSpec`;
- `Extractability.lean` no longer transitively re-exports the unused birthday-bound module.

There are no in-repository consumers of the deleted theorem. The deterministic extractor, `ChainInLog`, and collision lemmas remain available.

## Commit map

- `0002b309` — share one random-oracle cache across the extractability experiment;
- `fba6653d` — remove the invalid probability bound and document the honest proof boundary;
- `99ab2db7` — make the producer canary observe repeated cached answers in both orientations.

## Validation completed at `99ab2db745b40c78d709061acf0e9117c34eaf0d`

The following passed:

- targeted no-cache build of `VCVioTest.MerkleTreeExtractability`;
- full `VCVio` and `VCVioTest` builds;
- `lake exe lint-style VCVio VCVioTest`;
- `mk_all --check` for both `VCVio` and `VCVioTest`;
- full `lake exe axiomsweep --check` with no new taint;
- PolyFun dependency-boundary check;
- forbidden `sorry`/`admit`/`stop`/`axiom`/`unsafe` and stale-name scan;
- `git diff --check`;
- two independent statement/semantics reviews, with no P0–P2 findings remaining.

The local macOS Bash 3.2 cannot execute the Bash-4 associative-array syntax in `check-pmf-boundary.sh`; the hosted Linux import job covers that repository check.

## Remaining work

Phase 2b will prove the actual cache-aware ROM extraction-failure bound. The oracle-parametric SLH-DSA work remains downstream of that theorem and will not claim aggregate security before the required game, transcript, address, and assumption bridges exist.

## Reviewer map

Suggested review order:

1. `VCVio/CryptoFoundations/MerkleTree/Inductive/Extractability.lean`: raw/cached game split, event, and query bounds.
2. `VCVioTest/MerkleTreeExtractability.lean`: cache/log installation, one-query reduction, branch/orientation canaries.
3. The removal at the end of `Extractability.lean`: invalid probability helpers and theorem.
4. `VCVioTest.lean`: producer-test registration.
