### PR TITLE
feat(MerkleTree): add effectful addressed traversal

### DIFF
--- a/VCVio.lean
+++ b/VCVio.lean
@@ -55,7 +55,9 @@ public import VCVio.CryptoFoundations.MacAlg
 public import VCVio.CryptoFoundations.MacFromPRF
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.Basic
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.Level
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.Monadic
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Completeness
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Defs
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.ToSingle

--- a/VCVio.lean
+++ b/VCVio.lean
@@ -58,6 +58,7 @@ public import VCVio.CryptoFoundations.MerkleTree.Addressed.Level
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.Monadic
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.QueryBound
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Completeness
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.Defs
 public import VCVio.CryptoFoundations.MerkleTree.Inductive.Batch.ToSingle

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
@@ -19,8 +19,8 @@ nodes may perform effects, so a random-oracle instantiation can issue explicit h
 retaining the existing typed-address discipline.  The traversal order is fixed: build the left
 subtree, build the right subtree, then hash their roots.
 
-The deterministic-handler theorems below show that these programs are interpretations of the
-existing pure engine, not a second Merkle-tree semantics.
+The deterministic-handler and `Id` theorems below show that these programs are interpretations
+of the existing pure engine, not a second Merkle-tree semantics.
 -/
 
 @[expose] public section
@@ -107,6 +107,29 @@ theorem getPutativeRootAddressedM_natural (F : m →ᵐ n) {s : Skeleton}
       simp [getPutativeRootAddressedM, F.mmap_bind, ih, hhash]
 
 end Naturality
+
+section PureInterpretation
+
+/-- Running effectful addressed root reconstruction in `Id` recovers the canonical pure
+addressed reconstruction with the callbacks interpreted pointwise. -/
+@[simp]
+theorem idRun_getPutativeRootAddressedM :
+    {s : Skeleton} →
+      (nodeHash : SkeletonInternalIndex s → Y → Y → Id Y) →
+      (idx : SkeletonLeafIndex s) → (leafValue : Y) →
+      (proof : List.Vector Y idx.depth) →
+      Id.run (getPutativeRootAddressedM nodeHash idx leafValue proof) =
+        getPutativeRootAddressedWithHash
+          (fun a l r => Id.run (nodeHash a l r)) idx leafValue proof
+  | _, _, .ofLeaf, _, _ => rfl
+  | _, nodeHash, .ofLeft idx, leafValue, proof => by
+      simp [getPutativeRootAddressedM, getPutativeRootAddressedWithHash,
+        idRun_getPutativeRootAddressedM]
+  | _, nodeHash, .ofRight idx, leafValue, proof => by
+      simp [getPutativeRootAddressedM, getPutativeRootAddressedWithHash,
+        idRun_getPutativeRootAddressedM]
+
+end PureInterpretation
 
 section DeterministicInterpretation
 

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
@@ -21,6 +21,14 @@ subtree, build the right subtree, then hash their roots.
 
 The deterministic-handler and `Id` theorems below show that these programs are interpretations
 of the existing pure engine, not a second Merkle-tree semantics.
+
+This module is deliberately a companion to the pre-existing unaddressed
+`InductiveMerkleTree.buildMerkleTree` / `getPutativeRoot` API, not its replacement.  The
+addressed engine is required by XMSS and FORS because the hash query includes the node address.
+Re-expressing the unaddressed entry points as constant-address specializations would also require
+migrating their extractability, batch-opening, uniqueness, and query-bound consumers.  That
+definitional migration is outside this layer; `Addressed.Basic` records the existing
+propositional constant-address bridges and the precise deferred boundary.
 -/
 
 @[expose] public section

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
@@ -8,6 +8,7 @@ module
 
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.Basic
 public import VCVio.OracleComp.SimSemantics.SimulateQ
+public import PolyFun.Control.Monad.Hom
 public import ToMathlib.Data.IndexedBinaryTree.Equiv
 
 /-!
@@ -64,6 +65,48 @@ def getPutativeRootAddressedM {m : Type v → Type*} [Monad m] :
       let child ← getPutativeRootAddressedM
         (fun a => nodeHash (.ofRight a)) idx leafValue proof.tail
       nodeHash .ofInternal proof.head child
+
+section Naturality
+
+universe w x
+
+variable {m : Type v → Type w} {n : Type v → Type x}
+  [Monad m] [Monad n]
+
+/-- Addressed-tree construction is natural in any monad morphism that maps the leaf and node
+callbacks pointwise.  This preserves the entire effect trace, not only the final root value. -/
+theorem buildMerkleTreeAddressedM_natural (F : m →ᵐ n) {s : Skeleton}
+    [LawfulMonad m] [LawfulMonad n]
+    (leafₘ : SkeletonLeafIndex s → m Y)
+    (hashₘ : SkeletonInternalIndex s → Y → Y → m Y)
+    (leafₙ : SkeletonLeafIndex s → n Y)
+    (hashₙ : SkeletonInternalIndex s → Y → Y → n Y)
+    (hleaf : ∀ i, F (leafₘ i) = leafₙ i)
+    (hhash : ∀ a l r, F (hashₘ a l r) = hashₙ a l r) :
+    F (buildMerkleTreeAddressedM leafₘ hashₘ) =
+      buildMerkleTreeAddressedM leafₙ hashₙ := by
+  induction s with
+  | leaf => simp [buildMerkleTreeAddressedM, hleaf]
+  | internal sl sr ihl ihr =>
+      simp [buildMerkleTreeAddressedM, F.mmap_bind, ihl, ihr, hleaf, hhash]
+
+/-- Putative-root reconstruction is natural in any monad morphism that maps node hashing
+pointwise. -/
+theorem getPutativeRootAddressedM_natural (F : m →ᵐ n) {s : Skeleton}
+    (hashₘ : SkeletonInternalIndex s → Y → Y → m Y)
+    (hashₙ : SkeletonInternalIndex s → Y → Y → n Y)
+    (hhash : ∀ a l r, F (hashₘ a l r) = hashₙ a l r)
+    (idx : SkeletonLeafIndex s) (leafValue : Y) (proof : List.Vector Y idx.depth) :
+    F (getPutativeRootAddressedM hashₘ idx leafValue proof) =
+      getPutativeRootAddressedM hashₙ idx leafValue proof := by
+  induction idx with
+  | ofLeaf => simp [getPutativeRootAddressedM]
+  | ofLeft idx ih =>
+      simp [getPutativeRootAddressedM, F.mmap_bind, ih, hhash]
+  | ofRight idx ih =>
+      simp [getPutativeRootAddressedM, F.mmap_bind, ih, hhash]
+
+end Naturality
 
 section DeterministicInterpretation
 

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/Monadic.lean
@@ -1,0 +1,120 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.Basic
+public import VCVio.OracleComp.SimSemantics.SimulateQ
+public import ToMathlib.Data.IndexedBinaryTree.Equiv
+
+/-!
+# Effectful node-addressed Merkle trees
+
+Monad-parametric companions to the canonical `AddressedMerkleTree` engine.  Leaves and internal
+nodes may perform effects, so a random-oracle instantiation can issue explicit hash queries while
+retaining the existing typed-address discipline.  The traversal order is fixed: build the left
+subtree, build the right subtree, then hash their roots.
+
+The deterministic-handler theorems below show that these programs are interpretations of the
+existing pure engine, not a second Merkle-tree semantics.
+-/
+
+@[expose] public section
+
+namespace AddressedMerkleTree
+
+open BinaryTree InductiveMerkleTree OracleComp OracleSpec
+
+universe u v
+
+variable {Y : Type v}
+
+/-- Build a fully populated addressed tree with effectful leaf production and node hashing.
+The left subtree is evaluated before the right subtree, and both are evaluated before the parent
+hash. -/
+def buildMerkleTreeAddressedM {m : Type v → Type*} [Monad m] :
+    {s : Skeleton} →
+      (leaf : SkeletonLeafIndex s → m Y) →
+      (nodeHash : SkeletonInternalIndex s → Y → Y → m Y) →
+      m (FullData Y s)
+  | .leaf, leaf, _ => .leaf <$> leaf .ofLeaf
+  | .internal _ _, leaf, nodeHash => do
+      let left ← buildMerkleTreeAddressedM
+        (fun i => leaf (.ofLeft i)) (fun a => nodeHash (.ofLeft a))
+      let right ← buildMerkleTreeAddressedM
+        (fun i => leaf (.ofRight i)) (fun a => nodeHash (.ofRight a))
+      let root ← nodeHash .ofInternal left.getRootValue right.getRootValue
+      return .internal root left right
+
+/-- Recompute a putative root with an effectful address-dependent node hash.  Hashes are issued
+from the leaf level upward, matching `getPutativeRootAddressedWithHash`. -/
+def getPutativeRootAddressedM {m : Type v → Type*} [Monad m] :
+    {s : Skeleton} →
+      (nodeHash : SkeletonInternalIndex s → Y → Y → m Y) →
+      (idx : SkeletonLeafIndex s) → Y → List.Vector Y idx.depth → m Y
+  | _, _, .ofLeaf, leafValue, _ => pure leafValue
+  | _, nodeHash, .ofLeft idx, leafValue, proof => do
+      let child ← getPutativeRootAddressedM
+        (fun a => nodeHash (.ofLeft a)) idx leafValue proof.tail
+      nodeHash .ofInternal child proof.head
+  | _, nodeHash, .ofRight idx, leafValue, proof => do
+      let child ← getPutativeRootAddressedM
+        (fun a => nodeHash (.ofRight a)) idx leafValue proof.tail
+      nodeHash .ofInternal proof.head child
+
+section DeterministicInterpretation
+
+variable {ι : Type u} {spec : OracleSpec.{u, v} ι}
+
+/-- Interpreting effectful addressed-tree construction through a deterministic handler recovers
+the canonical pure addressed tree with pointwise interpreted leaves and node hashes. -/
+@[simp]
+theorem simulateQ_buildMerkleTreeAddressedM (impl : QueryImpl spec Id) :
+    {s : Skeleton} →
+      (leaf : SkeletonLeafIndex s → OracleComp spec Y) →
+      (nodeHash : SkeletonInternalIndex s → Y → Y → OracleComp spec Y) →
+      simulateQ impl (buildMerkleTreeAddressedM leaf nodeHash) =
+        buildMerkleTreeAddressedWithHash
+          (LeafData.ofFun s fun i => simulateQ impl (leaf i))
+          (fun a l r => simulateQ impl (nodeHash a l r))
+  | .leaf, leaf, _ => by
+      simp only [buildMerkleTreeAddressedM, simulateQ_map, LeafData.ofFun,
+        buildMerkleTreeAddressedWithHash, populateUpAddressed]
+      rfl
+  | .internal _ _, leaf, nodeHash => by
+      simp only [buildMerkleTreeAddressedM, simulateQ_bind]
+      rw [simulateQ_buildMerkleTreeAddressedM impl
+        (fun i => leaf (.ofLeft i)) (fun a => nodeHash (.ofLeft a))]
+      rw [simulateQ_buildMerkleTreeAddressedM impl
+        (fun i => leaf (.ofRight i)) (fun a => nodeHash (.ofRight a))]
+      rfl
+
+/-- A deterministic handler commutes with effectful addressed root reconstruction. -/
+@[simp]
+theorem simulateQ_getPutativeRootAddressedM (impl : QueryImpl spec Id) :
+    {s : Skeleton} →
+      (nodeHash : SkeletonInternalIndex s → Y → Y → OracleComp spec Y) →
+      (idx : SkeletonLeafIndex s) → (leafValue : Y) → (proof : List.Vector Y idx.depth) →
+      simulateQ impl (getPutativeRootAddressedM nodeHash idx leafValue proof) =
+        getPutativeRootAddressedWithHash
+          (fun a l r => simulateQ impl (nodeHash a l r)) idx leafValue proof
+  | _, _, .ofLeaf, _, _ => rfl
+  | _, nodeHash, .ofLeft idx, leafValue, proof => by
+      simp only [getPutativeRootAddressedM, simulateQ_bind,
+        getPutativeRootAddressedWithHash]
+      rw [simulateQ_getPutativeRootAddressedM impl
+        (fun a => nodeHash (.ofLeft a)) idx leafValue proof.tail]
+      rfl
+  | _, nodeHash, .ofRight idx, leafValue, proof => by
+      simp only [getPutativeRootAddressedM, simulateQ_bind,
+        getPutativeRootAddressedWithHash]
+      rw [simulateQ_getPutativeRootAddressedM impl
+        (fun a => nodeHash (.ofRight a)) idx leafValue proof.tail]
+      rfl
+
+end DeterministicInterpretation
+
+end AddressedMerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed.lean
@@ -97,6 +97,9 @@ theorem merkleRoot_succ (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y �
       = nodeHash (z + 1) t (merkleRoot leaf nodeHash z (2 * t))
           (merkleRoot leaf nodeHash z (2 * t + 1)) := rfl
 
+/-- Flip the least-significant bit of a heap-style node index. -/
+def sibling (i : ℕ) : ℕ := if i % 2 = 0 then i + 1 else i - 1
+
 /-- The authentication path of leaf `idx` over `z` levels, listed from the leaf level upwards:
 entry `j` is the root of the sibling subtree at height `j`. -/
 def authPath (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) (idx z : ℕ) : List Y :=
@@ -107,6 +110,43 @@ def authPath (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) (idx 
 theorem authPath_length (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) (idx z : ℕ) :
     (authPath leaf nodeHash idx z).length = z := by
   simp [authPath]
+
+/-- Extending an authentication path by one level appends the root of the sibling subtree at
+that level.  This is the streaming/FIPS view of the canonical full-tree definition. -/
+theorem authPath_succ (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) (idx z : ℕ) :
+    authPath leaf nodeHash idx (z + 1) =
+      authPath leaf nodeHash idx z ++
+        [merkleRoot leaf nodeHash z (sibling (idx / 2 ^ z))] := by
+  unfold authPath sibling
+  simp only [SkeletonLeafIndex.ofNat]
+  rw [tree_succ]
+  by_cases h : idx / 2 ^ z % 2 = 0
+  · rw [if_pos h]
+    have hdm := Nat.div_add_mod (idx / 2 ^ z) 2
+    have hdiv : idx / 2 ^ (z + 1) = idx / 2 ^ z / 2 := by
+      rw [Nat.pow_succ, Nat.div_div_eq_div_mul]
+    have heven : 2 * (idx / 2 ^ (z + 1)) = idx / 2 ^ z := by omega
+    simp only [generateProof, List.Vector.toList_cons, List.reverse_cons,
+      FullData.leftSubtree, FullData.rightSubtree, FullData.getRootValue]
+    rw [heven]
+    rw [if_pos h]
+    rfl
+  · rw [if_neg h]
+    have hdm := Nat.div_add_mod (idx / 2 ^ z) 2
+    have hmod : idx / 2 ^ z % 2 = 1 := by omega
+    have hdiv : idx / 2 ^ (z + 1) = idx / 2 ^ z / 2 := by
+      rw [Nat.pow_succ, Nat.div_div_eq_div_mul]
+    have hodd : 2 * (idx / 2 ^ (z + 1)) + 1 = idx / 2 ^ z := by
+      rw [hdiv]
+      omega
+    have hleft : 2 * (idx / 2 ^ (z + 1)) = idx / 2 ^ z - 1 := by omega
+    simp only [generateProof, List.Vector.toList_cons, List.reverse_cons,
+      FullData.leftSubtree, FullData.rightSubtree, FullData.getRootValue]
+    rw [hodd]
+    rw [if_neg h]
+    unfold merkleRoot
+    unfold FullData.getRootValue
+    rw [hleft]
 
 /-- Root recovery: starting from `node` at leaf position `idx`, fold in the sibling values of
 `auth` (leaf level first), hashing each step under the address of the node being reconstructed.

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
@@ -18,7 +18,8 @@ needed by SLH-DSA to represent public hashing as explicit oracle calls.
 
 No oracle handler or cache is selected here.  The caller must interpret the whole surrounding
 program with one handler.  In particular, random-oracle consumers must install one shared lazy
-oracle across construction, signing, the adversary, and verification.
+oracle across construction, signing, the adversary, and verification. The `Id` interpretation
+laws connect these effectful traversals to the established pure API.
 -/
 
 @[expose] public section
@@ -158,6 +159,49 @@ theorem merkleRootM_eq_map_treeM {m : Type v → Type w} [Monad m] [LawfulMonad 
       simp [merkleRootM, treeM_succ, ih]
 
 end Naturality
+
+section PureInterpretation
+
+/-- Running direct perfect-subtree root computation in `Id` recovers the canonical pure root. -/
+@[simp]
+theorem idRun_merkleRootM (leaf : ℕ → Id Y)
+    (nodeHash : ℕ → ℕ → Y → Y → Id Y) (z t : ℕ) :
+    Id.run (merkleRootM leaf nodeHash z t) =
+      merkleRoot (fun i => Id.run (leaf i))
+        (fun h i l r => Id.run (nodeHash h i l r)) z t := by
+  induction z generalizing t with
+  | zero => rfl
+  | succ z ih => simp [merkleRootM, merkleRoot_succ, ih]
+
+/-- Running sibling-only authentication-path construction in `Id` recovers the canonical pure
+authentication path. -/
+@[simp]
+theorem idRun_authPathM (leaf : ℕ → Id Y)
+    (nodeHash : ℕ → ℕ → Y → Y → Id Y) (idx z : ℕ) :
+    Id.run (authPathM leaf nodeHash idx z) =
+      authPath (fun i => Id.run (leaf i))
+        (fun h i l r => Id.run (nodeHash h i l r)) idx z := by
+  induction z with
+  | zero => rfl
+  | succ z ih =>
+      simp [authPathM, authPath_succ, ih, idRun_merkleRootM]
+
+/-- Running root recovery in `Id` recovers the canonical pure climb. -/
+@[simp]
+theorem idRun_climbM (nodeHash : ℕ → ℕ → Y → Y → Id Y)
+    (idx : ℕ) (node : Y) (auth : List Y) :
+    Id.run (climbM nodeHash idx node auth) =
+      climb (fun h i l r => Id.run (nodeHash h i l r)) idx node auth := by
+  unfold climbM climb nodeHashAt
+  simpa only using
+    (AddressedMerkleTree.idRun_getPutativeRootAddressedM
+      (fun a => nodeHash (a.natAddr (idx / 2 ^ auth.length)).height
+        (a.natAddr (idx / 2 ^ auth.length)).index)
+      (SkeletonLeafIndex.ofNat auth.length idx) node
+      (⟨auth.reverse, by simp⟩ :
+        List.Vector Y (SkeletonLeafIndex.ofNat auth.length idx).depth))
+
+end PureInterpretation
 
 section DeterministicInterpretation
 

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
@@ -1,0 +1,187 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.Monadic
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed
+
+/-!
+# Effectful natural-number-indexed perfect Merkle trees
+
+Effectful companions to `PerfectMerkleTree.tree`, `merkleRoot`, `authPath`, and `climb`, built on
+the canonical typed-address engine.  Both leaves and node hashes are monadic, which is the API
+needed by SLH-DSA to represent public hashing as explicit oracle calls.
+
+No oracle handler or cache is selected here.  The caller must interpret the whole surrounding
+program with one handler.  In particular, random-oracle consumers must install one shared lazy
+oracle across construction, signing, the adversary, and verification.
+-/
+
+@[expose] public section
+
+namespace PerfectMerkleTree
+
+open AddressedMerkleTree BinaryTree InductiveMerkleTree OracleComp OracleSpec
+
+universe u v
+
+variable {Y : Type v}
+
+/-- Effectfully build the fully populated perfect subtree at `(height z, index t)`. -/
+def treeM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
+    (nodeHash : ℕ → ℕ → Y → Y → m Y) (z t : ℕ) : m (FullData Y (Skeleton.perfect z)) :=
+  buildMerkleTreeAddressedM
+    (fun i => leaf (i.natIndex t))
+    (fun a => nodeHash (a.natAddr t).height (a.natAddr t).index)
+
+/-- Effectfully compute the root of the perfect subtree at `(height z, index t)` without
+materializing it.  Evaluation is depth-first and left-to-right. -/
+def merkleRootM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
+    (nodeHash : ℕ → ℕ → Y → Y → m Y) : ℕ → ℕ → m Y
+  | 0, t => leaf t
+  | z + 1, t => do
+      let left ← merkleRootM leaf nodeHash z (2 * t)
+      let right ← merkleRootM leaf nodeHash z (2 * t + 1)
+      nodeHash (z + 1) t left right
+
+/-- Flip the least-significant bit of a heap-style node index. -/
+def sibling (i : ℕ) : ℕ := if i % 2 = 0 then i + 1 else i - 1
+
+/-- Extending an authentication path by one level appends the root of the sibling subtree at
+that level. -/
+theorem authPath_succ (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) (idx z : ℕ) :
+    authPath leaf nodeHash idx (z + 1) =
+      authPath leaf nodeHash idx z ++
+        [merkleRoot leaf nodeHash z (sibling (idx / 2 ^ z))] := by
+  unfold authPath sibling
+  simp only [SkeletonLeafIndex.ofNat]
+  rw [tree_succ]
+  by_cases h : idx / 2 ^ z % 2 = 0
+  · rw [if_pos h]
+    have hdm := Nat.div_add_mod (idx / 2 ^ z) 2
+    have hdiv : idx / 2 ^ (z + 1) = idx / 2 ^ z / 2 := by
+      rw [Nat.pow_succ, Nat.div_div_eq_div_mul]
+    have heven : 2 * (idx / 2 ^ (z + 1)) = idx / 2 ^ z := by omega
+    simp only [generateProof, List.Vector.toList_cons, List.reverse_cons,
+      FullData.leftSubtree, FullData.rightSubtree, FullData.getRootValue]
+    rw [heven]
+    rw [if_pos h]
+    rfl
+  · rw [if_neg h]
+    have hdm := Nat.div_add_mod (idx / 2 ^ z) 2
+    have hmod : idx / 2 ^ z % 2 = 1 := by omega
+    have hdiv : idx / 2 ^ (z + 1) = idx / 2 ^ z / 2 := by
+      rw [Nat.pow_succ, Nat.div_div_eq_div_mul]
+    have hodd : 2 * (idx / 2 ^ (z + 1)) + 1 = idx / 2 ^ z := by
+      rw [hdiv]
+      omega
+    have hleft : 2 * (idx / 2 ^ (z + 1)) = idx / 2 ^ z - 1 := by omega
+    simp only [generateProof, List.Vector.toList_cons, List.reverse_cons,
+      FullData.leftSubtree, FullData.rightSubtree, FullData.getRootValue]
+    rw [hodd]
+    rw [if_neg h]
+    unfold merkleRoot
+    unfold FullData.getRootValue
+    rw [hleft]
+
+/-- Effectfully compute the authentication path of global leaf `idx` over `z` levels.  Only the
+sibling subtrees are evaluated: the queried leaf and nodes on its direct path are not recomputed.
+Entries and effects are ordered from the leaf level upward, as in FIPS 205. -/
+def authPathM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
+    (nodeHash : ℕ → ℕ → Y → Y → m Y) (idx : ℕ) : ℕ → m (List Y)
+  | 0 => pure []
+  | z + 1 => do
+      let path ← authPathM leaf nodeHash idx z
+      let siblingRoot ← merkleRootM leaf nodeHash z (sibling (idx / 2 ^ z))
+      return path ++ [siblingRoot]
+
+/-- Effectfully recover a root from a leaf value and a leaf-first authentication path. -/
+def climbM {m : Type v → Type*} [Monad m] (nodeHash : ℕ → ℕ → Y → Y → m Y)
+    (idx : ℕ) (node : Y) (auth : List Y) : m Y :=
+  getPutativeRootAddressedM
+    (fun a => nodeHash (a.natAddr (idx / 2 ^ auth.length)).height
+      (a.natAddr (idx / 2 ^ auth.length)).index)
+    (SkeletonLeafIndex.ofNat auth.length idx) node ⟨auth.reverse, by simp⟩
+
+section DeterministicInterpretation
+
+variable {ι : Type u} {spec : OracleSpec.{u, v} ι}
+
+/-- A deterministic handler commutes with effectful perfect-tree construction. -/
+@[simp]
+theorem simulateQ_treeM (impl : QueryImpl spec Id) (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y) (z t : ℕ) :
+    simulateQ impl (treeM leaf nodeHash z t) =
+      tree (fun i => simulateQ impl (leaf i))
+        (fun h i l r => simulateQ impl (nodeHash h i l r)) z t := by
+  unfold treeM tree
+  rw [simulateQ_buildMerkleTreeAddressedM]
+  rfl
+
+/-- A deterministic handler commutes with effectful root production. -/
+@[simp]
+theorem simulateQ_merkleRootM (impl : QueryImpl spec Id) (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y) (z t : ℕ) :
+    simulateQ impl (merkleRootM leaf nodeHash z t) =
+      merkleRoot (fun i => simulateQ impl (leaf i))
+        (fun h i l r => simulateQ impl (nodeHash h i l r)) z t := by
+  induction z generalizing t with
+  | zero => rfl
+  | succ z ih =>
+      simp only [merkleRootM, simulateQ_bind, merkleRoot_succ, ih]
+      rfl
+
+/-- A deterministic handler commutes with effectful authentication-path production. -/
+@[simp]
+theorem simulateQ_authPathM (impl : QueryImpl spec Id) (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y) (idx z : ℕ) :
+    simulateQ impl (authPathM leaf nodeHash idx z) =
+      authPath (fun i => simulateQ impl (leaf i))
+        (fun h i l r => simulateQ impl (nodeHash h i l r)) idx z := by
+  induction z with
+  | zero => rfl
+  | succ z ih =>
+      simp only [authPathM, simulateQ_bind, simulateQ_pure, ih, simulateQ_merkleRootM]
+      rw [authPath_succ]
+      rfl
+
+/-- A deterministic handler commutes with effectful root recovery. -/
+@[simp]
+theorem simulateQ_climbM (impl : QueryImpl spec Id)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y) (idx : ℕ) (node : Y)
+    (auth : List Y) :
+    simulateQ impl (climbM nodeHash idx node auth) =
+      climb (fun h i l r => simulateQ impl (nodeHash h i l r)) idx node auth := by
+  unfold climbM climb
+  unfold nodeHashAt
+  simpa only using
+    (simulateQ_getPutativeRootAddressedM impl
+      (fun a => nodeHash (a.natAddr (idx / 2 ^ auth.length)).height
+        (a.natAddr (idx / 2 ^ auth.length)).index)
+      (SkeletonLeafIndex.ofNat auth.length idx) node
+      (⟨auth.reverse, by simp⟩ :
+        List.Vector Y (SkeletonLeafIndex.ofNat auth.length idx).depth))
+
+/-- Functional Merkle completeness after fixing one deterministic answer function for the whole
+honest opening computation.  This does not claim completeness under raw free-oracle evaluation,
+where repeated syntactic queries would be sampled independently. -/
+theorem simulateQ_climbM_authPathM (impl : QueryImpl spec Id)
+    (leaf : ℕ → OracleComp spec Y) (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (idx z : ℕ) :
+    simulateQ impl (do
+      let leafValue ← leaf idx
+      let path ← authPathM leaf nodeHash idx z
+      climbM nodeHash idx leafValue path) =
+      simulateQ impl (merkleRootM leaf nodeHash z (idx / 2 ^ z)) := by
+  simp only [simulateQ_bind, simulateQ_authPathM, simulateQ_climbM, simulateQ_merkleRootM]
+  exact climb_authPath
+    (fun i => simulateQ impl (leaf i))
+    (fun h i l r => simulateQ impl (nodeHash h i l r)) idx z
+
+end DeterministicInterpretation
+
+end PerfectMerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
@@ -20,6 +20,10 @@ No oracle handler or cache is selected here.  The caller must interpret the whol
 program with one handler.  In particular, random-oracle consumers must install one shared lazy
 oracle across construction, signing, the adversary, and verification. The `Id` interpretation
 laws connect these effectful traversals to the established pure API.
+
+The natural-number adapter specializes the addressed engine used by XMSS/FORS.  It does not
+replace the older unaddressed inductive or vector Merkle APIs, and no claim is made here that their
+extractability or batch-opening proofs have been migrated to this representation.
 -/
 
 @[expose] public section

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/Monadic.lean
@@ -38,6 +38,21 @@ def treeM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
     (fun i => leaf (i.natIndex t))
     (fun a => nodeHash (a.natAddr t).height (a.natAddr t).index)
 
+@[simp]
+theorem treeM_zero {m : Type v → Type*} [Monad m]
+    (leaf : ℕ → m Y) (nodeHash : ℕ → ℕ → Y → Y → m Y) (t : ℕ) :
+    treeM leaf nodeHash 0 t = FullData.leaf <$> leaf t := rfl
+
+/-- Effectful full-tree construction follows the same left/right/parent schedule as the direct
+root recursion. -/
+theorem treeM_succ {m : Type v → Type*} [Monad m]
+    (leaf : ℕ → m Y) (nodeHash : ℕ → ℕ → Y → Y → m Y) (z t : ℕ) :
+    treeM leaf nodeHash (z + 1) t = do
+      let left ← treeM leaf nodeHash z (2 * t)
+      let right ← treeM leaf nodeHash z (2 * t + 1)
+      let root ← nodeHash (z + 1) t left.getRootValue right.getRootValue
+      return .internal root left right := rfl
+
 /-- Effectfully compute the root of the perfect subtree at `(height z, index t)` without
 materializing it.  Evaluation is depth-first and left-to-right. -/
 def merkleRootM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
@@ -47,46 +62,6 @@ def merkleRootM {m : Type v → Type*} [Monad m] (leaf : ℕ → m Y)
       let left ← merkleRootM leaf nodeHash z (2 * t)
       let right ← merkleRootM leaf nodeHash z (2 * t + 1)
       nodeHash (z + 1) t left right
-
-/-- Flip the least-significant bit of a heap-style node index. -/
-def sibling (i : ℕ) : ℕ := if i % 2 = 0 then i + 1 else i - 1
-
-/-- Extending an authentication path by one level appends the root of the sibling subtree at
-that level. -/
-theorem authPath_succ (leaf : ℕ → Y) (nodeHash : ℕ → ℕ → Y → Y → Y) (idx z : ℕ) :
-    authPath leaf nodeHash idx (z + 1) =
-      authPath leaf nodeHash idx z ++
-        [merkleRoot leaf nodeHash z (sibling (idx / 2 ^ z))] := by
-  unfold authPath sibling
-  simp only [SkeletonLeafIndex.ofNat]
-  rw [tree_succ]
-  by_cases h : idx / 2 ^ z % 2 = 0
-  · rw [if_pos h]
-    have hdm := Nat.div_add_mod (idx / 2 ^ z) 2
-    have hdiv : idx / 2 ^ (z + 1) = idx / 2 ^ z / 2 := by
-      rw [Nat.pow_succ, Nat.div_div_eq_div_mul]
-    have heven : 2 * (idx / 2 ^ (z + 1)) = idx / 2 ^ z := by omega
-    simp only [generateProof, List.Vector.toList_cons, List.reverse_cons,
-      FullData.leftSubtree, FullData.rightSubtree, FullData.getRootValue]
-    rw [heven]
-    rw [if_pos h]
-    rfl
-  · rw [if_neg h]
-    have hdm := Nat.div_add_mod (idx / 2 ^ z) 2
-    have hmod : idx / 2 ^ z % 2 = 1 := by omega
-    have hdiv : idx / 2 ^ (z + 1) = idx / 2 ^ z / 2 := by
-      rw [Nat.pow_succ, Nat.div_div_eq_div_mul]
-    have hodd : 2 * (idx / 2 ^ (z + 1)) + 1 = idx / 2 ^ z := by
-      rw [hdiv]
-      omega
-    have hleft : 2 * (idx / 2 ^ (z + 1)) = idx / 2 ^ z - 1 := by omega
-    simp only [generateProof, List.Vector.toList_cons, List.reverse_cons,
-      FullData.leftSubtree, FullData.rightSubtree, FullData.getRootValue]
-    rw [hodd]
-    rw [if_neg h]
-    unfold merkleRoot
-    unfold FullData.getRootValue
-    rw [hleft]
 
 /-- Effectfully compute the authentication path of global leaf `idx` over `z` levels.  Only the
 sibling subtrees are evaluated: the queried leaf and nodes on its direct path are not recomputed.
@@ -106,6 +81,83 @@ def climbM {m : Type v → Type*} [Monad m] (nodeHash : ℕ → ℕ → Y → Y 
     (fun a => nodeHash (a.natAddr (idx / 2 ^ auth.length)).height
       (a.natAddr (idx / 2 ^ auth.length)).index)
     (SkeletonLeafIndex.ofNat auth.length idx) node ⟨auth.reverse, by simp⟩
+
+section Naturality
+
+universe w x
+
+variable {m : Type v → Type w} {n : Type v → Type x}
+  [Monad m] [Monad n]
+
+/-- Perfect-tree construction commutes with any monad morphism mapping its callbacks
+pointwise. -/
+theorem treeM_natural (F : m →ᵐ n)
+    [LawfulMonad m] [LawfulMonad n]
+    (leafₘ : ℕ → m Y) (hashₘ : ℕ → ℕ → Y → Y → m Y)
+    (leafₙ : ℕ → n Y) (hashₙ : ℕ → ℕ → Y → Y → n Y)
+    (hleaf : ∀ i, F (leafₘ i) = leafₙ i)
+    (hhash : ∀ h i l r, F (hashₘ h i l r) = hashₙ h i l r)
+    (z t : ℕ) :
+    F (treeM leafₘ hashₘ z t) = treeM leafₙ hashₙ z t := by
+  unfold treeM
+  apply buildMerkleTreeAddressedM_natural
+  · intro i
+    exact hleaf _
+  · intro a l r
+    exact hhash _ _ l r
+
+/-- Direct root computation commutes with any monad morphism mapping its callbacks
+pointwise. -/
+theorem merkleRootM_natural (F : m →ᵐ n)
+    (leafₘ : ℕ → m Y) (hashₘ : ℕ → ℕ → Y → Y → m Y)
+    (leafₙ : ℕ → n Y) (hashₙ : ℕ → ℕ → Y → Y → n Y)
+    (hleaf : ∀ i, F (leafₘ i) = leafₙ i)
+    (hhash : ∀ h i l r, F (hashₘ h i l r) = hashₙ h i l r)
+    (z t : ℕ) :
+    F (merkleRootM leafₘ hashₘ z t) = merkleRootM leafₙ hashₙ z t := by
+  induction z generalizing t with
+  | zero => simpa [merkleRootM] using hleaf t
+  | succ z ih =>
+      simp [merkleRootM, F.mmap_bind, ih, hhash]
+
+/-- Streaming authentication-path construction commutes with any monad morphism mapping its
+callbacks pointwise. -/
+theorem authPathM_natural (F : m →ᵐ n)
+    (leafₘ : ℕ → m Y) (hashₘ : ℕ → ℕ → Y → Y → m Y)
+    (leafₙ : ℕ → n Y) (hashₙ : ℕ → ℕ → Y → Y → n Y)
+    (hleaf : ∀ i, F (leafₘ i) = leafₙ i)
+    (hhash : ∀ h i l r, F (hashₘ h i l r) = hashₙ h i l r)
+    (idx z : ℕ) :
+    F (authPathM leafₘ hashₘ idx z) = authPathM leafₙ hashₙ idx z := by
+  induction z with
+  | zero => simp [authPathM]
+  | succ z ih =>
+      simp [authPathM, F.mmap_bind, ih,
+        merkleRootM_natural F leafₘ hashₘ leafₙ hashₙ hleaf hhash]
+
+/-- Root recovery commutes with any monad morphism mapping node hashing pointwise. -/
+theorem climbM_natural (F : m →ᵐ n)
+    (hashₘ : ℕ → ℕ → Y → Y → m Y) (hashₙ : ℕ → ℕ → Y → Y → n Y)
+    (hhash : ∀ h i l r, F (hashₘ h i l r) = hashₙ h i l r)
+    (idx : ℕ) (node : Y) (auth : List Y) :
+    F (climbM hashₘ idx node auth) = climbM hashₙ idx node auth := by
+  unfold climbM
+  apply getPutativeRootAddressedM_natural
+  intro a l r
+  exact hhash _ _ l r
+
+/-- The direct root program has exactly the effects and order of building the full tree and
+projecting its root.  This theorem deliberately orients away from materialising the full tree. -/
+theorem merkleRootM_eq_map_treeM {m : Type v → Type w} [Monad m] [LawfulMonad m]
+    (leaf : ℕ → m Y) (nodeHash : ℕ → ℕ → Y → Y → m Y) (z t : ℕ) :
+    merkleRootM leaf nodeHash z t =
+      FullData.getRootValue <$> treeM leaf nodeHash z t := by
+  induction z generalizing t with
+  | zero => simp [merkleRootM]
+  | succ z ih =>
+      simp [merkleRootM, treeM_succ, ih]
+
+end Naturality
 
 section DeterministicInterpretation
 

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/QueryBound.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/QueryBound.lean
@@ -1,0 +1,182 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
+public import VCVio.OracleComp.QueryTracking.QueryBound
+
+/-!
+# Query bounds for effectful natural-number-indexed Merkle trees
+
+Structural total-query bounds for the effectful addressed-Merkle traversal.  The formulas expose
+the exact number of leaf and internal-node callback invocations; the callback hypotheses may in
+turn bound each invocation by any fixed number of oracle queries.
+
+The current `OracleComp.IsTotalQueryBound` API is universe-homogeneous, so these corollaries use
+one universe for the oracle domain, ranges, and Merkle values.  The underlying traversal remains
+fully monad- and universe-parametric.
+-/
+
+@[expose] public section
+
+namespace PerfectMerkleTree
+
+open BinaryTree OracleComp OracleSpec
+
+universe u
+
+variable {ι Y : Type u} {spec : OracleSpec.{u, u} ι}
+
+private theorem tree_query_budget_succ (z leafBudget nodeBudget : ℕ) :
+    2 * (2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget) + nodeBudget =
+      2 ^ (z + 1) * leafBudget + (2 ^ (z + 1) - 1) * nodeBudget := by
+  have hpow : 0 < 2 ^ z := pow_pos (by decide) _
+  rw [pow_succ, Nat.mul_comm (2 ^ z) 2]
+  have hcoeff : 2 * (2 ^ z - 1) + 1 = 2 * 2 ^ z - 1 := by omega
+  calc
+    2 * (2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget) + nodeBudget =
+        (2 * 2 ^ z) * leafBudget + (2 * (2 ^ z - 1) + 1) * nodeBudget := by ring
+    _ = (2 * 2 ^ z) * leafBudget + (2 * 2 ^ z - 1) * nodeBudget := by rw [hcoeff]
+
+private theorem auth_query_budget_succ (z leafBudget nodeBudget : ℕ) :
+    ((2 ^ z - 1) * leafBudget + (2 ^ z - z - 1) * nodeBudget) +
+        (2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget) =
+      (2 ^ (z + 1) - 1) * leafBudget +
+        (2 ^ (z + 1) - (z + 1) - 1) * nodeBudget := by
+  have hpow : 0 < 2 ^ z := pow_pos (by decide) _
+  have hzpow : z + 1 ≤ 2 ^ z := by
+    induction z with
+    | zero => simp
+    | succ z ih =>
+        rw [pow_succ]
+        omega
+  rw [pow_succ, Nat.mul_comm (2 ^ z) 2]
+  have hleaf : (2 ^ z - 1) + 2 ^ z = 2 * 2 ^ z - 1 := by omega
+  have hnode : (2 ^ z - z - 1) + (2 ^ z - 1) = 2 * 2 ^ z - (z + 1) - 1 := by omega
+  calc
+    ((2 ^ z - 1) * leafBudget + (2 ^ z - z - 1) * nodeBudget) +
+        (2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget) =
+      ((2 ^ z - 1) + 2 ^ z) * leafBudget +
+        ((2 ^ z - z - 1) + (2 ^ z - 1)) * nodeBudget := by ring
+    _ = (2 * 2 ^ z - 1) * leafBudget +
+        (2 * 2 ^ z - (z + 1) - 1) * nodeBudget := by rw [hleaf, hnode]
+
+/-- Building a height-`z` perfect tree invokes the leaf callback `2 ^ z` times and the
+internal-node callback `2 ^ z - 1` times. -/
+theorem isTotalQueryBound_treeM
+    (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (leafBudget nodeBudget z t : ℕ)
+    (hleaf : ∀ i, IsTotalQueryBound (leaf i) leafBudget)
+    (hnode : ∀ h i l r, IsTotalQueryBound (nodeHash h i l r) nodeBudget) :
+    IsTotalQueryBound (treeM leaf nodeHash z t)
+      (2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget) := by
+  induction z generalizing t with
+  | zero =>
+      rw [show 2 ^ 0 * leafBudget + (2 ^ 0 - 1) * nodeBudget = leafBudget by norm_num]
+      rw [treeM_zero]
+      exact (isQueryBound_map_iff (leaf t) BinaryTree.FullData.leaf leafBudget _ _).mpr (hleaf t)
+  | succ z ih =>
+      rw [treeM_succ]
+      have hleft := ih (2 * t)
+      have hright := ih (2 * t + 1)
+      have hboth := isTotalQueryBound_bind hleft fun left =>
+        isTotalQueryBound_bind hright fun right =>
+          isTotalQueryBound_bind (hnode (z + 1) t left.getRootValue right.getRootValue)
+            fun root => show IsTotalQueryBound
+              (pure (BinaryTree.FullData.internal root left right) : OracleComp spec _) 0 from
+                trivial
+      refine hboth.mono ?_
+      rw [← tree_query_budget_succ]
+      omega
+
+/-- Direct root computation has the same structural query budget as full-tree construction:
+`2 ^ z` leaf callbacks and `2 ^ z - 1` internal-node callbacks. -/
+theorem isTotalQueryBound_merkleRootM
+    (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (leafBudget nodeBudget z t : ℕ)
+    (hleaf : ∀ i, IsTotalQueryBound (leaf i) leafBudget)
+    (hnode : ∀ h i l r, IsTotalQueryBound (nodeHash h i l r) nodeBudget) :
+    IsTotalQueryBound (merkleRootM leaf nodeHash z t)
+      (2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget) := by
+  induction z generalizing t with
+  | zero => simpa [merkleRootM] using hleaf t
+  | succ z ih =>
+      simp only [merkleRootM]
+      have hleft := ih (2 * t)
+      have hright := ih (2 * t + 1)
+      have hboth := isTotalQueryBound_bind hleft fun left =>
+        isTotalQueryBound_bind hright fun right => hnode (z + 1) t left right
+      refine hboth.mono ?_
+      rw [← tree_query_budget_succ]
+      omega
+
+/-- A height-`z` authentication path visits every leaf outside the opened path exactly through
+its sibling subtrees: `2 ^ z - 1` leaf callbacks and `2 ^ z - z - 1` internal-node callbacks. -/
+theorem isTotalQueryBound_authPathM
+    (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (leafBudget nodeBudget idx z : ℕ)
+    (hleaf : ∀ i, IsTotalQueryBound (leaf i) leafBudget)
+    (hnode : ∀ h i l r, IsTotalQueryBound (nodeHash h i l r) nodeBudget) :
+    IsTotalQueryBound (authPathM leaf nodeHash idx z)
+      ((2 ^ z - 1) * leafBudget + (2 ^ z - z - 1) * nodeBudget) := by
+  induction z with
+  | zero => exact trivial
+  | succ z ih =>
+      simp only [authPathM]
+      have hsibling := isTotalQueryBound_merkleRootM leaf nodeHash leafBudget nodeBudget z
+        (sibling (idx / 2 ^ z)) hleaf hnode
+      have hboth := isTotalQueryBound_bind ih fun path =>
+        isTotalQueryBound_bind hsibling fun siblingRoot =>
+          show IsTotalQueryBound
+            (pure (path ++ [siblingRoot]) : OracleComp spec _) 0 from trivial
+      refine hboth.mono ?_
+      rw [← auth_query_budget_succ]
+      omega
+
+private theorem isTotalQueryBound_getPutativeRootAddressedM
+    {s : Skeleton}
+    (nodeHash : SkeletonInternalIndex s → Y → Y → OracleComp spec Y)
+    (nodeBudget : ℕ) (idx : SkeletonLeafIndex s) (node : Y)
+    (proof : List.Vector Y idx.depth)
+    (hnode : ∀ a l r, IsTotalQueryBound (nodeHash a l r) nodeBudget) :
+    IsTotalQueryBound
+      (AddressedMerkleTree.getPutativeRootAddressedM nodeHash idx node proof)
+      (idx.depth * nodeBudget) := by
+  induction idx generalizing node with
+  | ofLeaf => exact trivial
+  | ofLeft idx ih =>
+      simp only [AddressedMerkleTree.getPutativeRootAddressedM]
+      have hchild := ih (nodeHash := fun a => nodeHash (.ofLeft a))
+        (node := node) (proof := proof.tail) (fun a => hnode (.ofLeft a))
+      have hroot := hnode .ofInternal
+      simpa [SkeletonLeafIndex.depth, Nat.add_mul] using
+        isTotalQueryBound_bind hchild fun child => hroot child proof.head
+  | ofRight idx ih =>
+      simp only [AddressedMerkleTree.getPutativeRootAddressedM]
+      have hchild := ih (nodeHash := fun a => nodeHash (.ofRight a))
+        (node := node) (proof := proof.tail) (fun a => hnode (.ofRight a))
+      have hroot := hnode .ofInternal
+      simpa [SkeletonLeafIndex.depth, Nat.add_mul] using
+        isTotalQueryBound_bind hchild fun child => hroot proof.head child
+
+/-- Root recovery invokes the internal-node callback once per authentication-path entry. -/
+theorem isTotalQueryBound_climbM
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (nodeBudget idx : ℕ) (node : Y) (auth : List Y)
+    (hnode : ∀ h i l r, IsTotalQueryBound (nodeHash h i l r) nodeBudget) :
+    IsTotalQueryBound (climbM nodeHash idx node auth) (auth.length * nodeBudget) := by
+  unfold climbM
+  simpa using isTotalQueryBound_getPutativeRootAddressedM
+    (fun a => nodeHash (a.natAddr (idx / 2 ^ auth.length)).height
+      (a.natAddr (idx / 2 ^ auth.length)).index)
+    nodeBudget (SkeletonLeafIndex.ofNat auth.length idx) node ⟨auth.reverse, by simp⟩
+    (fun a l r => hnode _ _ l r)
+
+end PerfectMerkleTree

--- a/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/QueryBound.lean
+++ b/VCVio/CryptoFoundations/MerkleTree/Addressed/NatIndexed/QueryBound.lean
@@ -140,6 +140,52 @@ theorem isTotalQueryBound_authPathM
       rw [← auth_query_budget_succ]
       omega
 
+/-- Compose an authentication-path traversal with a continuation whose bound applies to every
+well-formed result.  The path-length premise retains the structural fact that `authPathM` returns
+exactly one sibling per level; ordinary `isTotalQueryBound_bind` cannot express this refinement
+because it quantifies over every list supplied to the continuation. -/
+theorem isTotalQueryBound_authPathM_bind
+    (leaf : ℕ → OracleComp spec Y)
+    (nodeHash : ℕ → ℕ → Y → Y → OracleComp spec Y)
+    (leafBudget nodeBudget idx z continuationBudget : ℕ)
+    (hleaf : ∀ i, IsTotalQueryBound (leaf i) leafBudget)
+    (hnode : ∀ h i l r, IsTotalQueryBound (nodeHash h i l r) nodeBudget)
+    {beta : Type u} (k : List Y → OracleComp spec beta)
+    (hk : ∀ path, path.length = z → IsTotalQueryBound (k path) continuationBudget) :
+    IsTotalQueryBound (authPathM leaf nodeHash idx z >>= k)
+      (((2 ^ z - 1) * leafBudget + (2 ^ z - z - 1) * nodeBudget) +
+        continuationBudget) := by
+  induction z generalizing k continuationBudget with
+  | zero =>
+      simpa [authPathM] using hk [] rfl
+  | succ z ih =>
+      rw [authPathM]
+      simp only [bind_assoc]
+      let siblingBudget :=
+        2 ^ z * leafBudget + (2 ^ z - 1) * nodeBudget
+      have hrest : ∀ path, path.length = z →
+          IsTotalQueryBound (do
+            let siblingRoot ← merkleRootM leaf nodeHash z (sibling (idx / 2 ^ z))
+            k (path ++ [siblingRoot])) (siblingBudget + continuationBudget) := by
+        intro path hlength
+        exact isTotalQueryBound_bind
+          (isTotalQueryBound_merkleRootM leaf nodeHash leafBudget nodeBudget z
+            (sibling (idx / 2 ^ z)) hleaf hnode)
+          fun siblingRoot => hk (path ++ [siblingRoot]) (by simp [hlength])
+      have hbound := ih (siblingBudget + continuationBudget)
+        (fun path => do
+          let siblingRoot ← merkleRootM leaf nodeHash z (sibling (idx / 2 ^ z))
+          k (path ++ [siblingRoot])) hrest
+      have hbudget :
+          (((2 ^ z - 1) * leafBudget + (2 ^ z - z - 1) * nodeBudget) +
+              siblingBudget) + continuationBudget =
+            ((2 ^ (z + 1) - 1) * leafBudget +
+              (2 ^ (z + 1) - (z + 1) - 1) * nodeBudget) +
+                continuationBudget := by
+        rw [auth_query_budget_succ]
+      rw [← hbudget]
+      simpa [Nat.add_assoc] using hbound
+
 private theorem isTotalQueryBound_getPutativeRootAddressedM
     {s : Skeleton}
     (nodeHash : SkeletonInternalIndex s → Y → Y → OracleComp spec Y)

--- a/VCVioTest.lean
+++ b/VCVioTest.lean
@@ -9,6 +9,7 @@ public import VCVioTest.LongChainPrograms
 public import VCVioTest.MeasureSemantics
 public import VCVioTest.MerkleTreeBatch
 public import VCVioTest.MerkleTreeExtractability
+public import VCVioTest.MerkleTreeMonadic
 public import VCVioTest.MonadProbability
 public import VCVioTest.PFunctorFacade
 public import VCVioTest.PerfectMerkleTree

--- a/VCVioTest/MerkleTreeMonadic.lean
+++ b/VCVioTest/MerkleTreeMonadic.lean
@@ -7,15 +7,13 @@ Authors: Quang Dao
 module
 
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
-public import VCVio.OracleComp.HasQuery.Morphism
 
 /-!
 # Effectful addressed-Merkle canaries
 
-These examples pin the monadic engine to the existing natural-number adapter and make its query
-schedule observable.  The trace distinguishes leaf production from ordered node hashing, so a
-regression in traversal order, child order, address calculation, or authentication-path order is
-visible.
+The noncommutative trace distinguishes leaf production from ordered node hashing.  The retained
+examples cover traversal and child order, mixed authentication paths, global subtree addressing,
+and the height-zero boundary.
 -/
 
 @[expose] public section
@@ -39,14 +37,6 @@ def nodeM (height index left right : ℕ) : TraceM ℕ := fun trace =>
   (1000 * height + 100 * index + 10 * left + right,
     trace ++ [.node height index left right])
 
-/-- The full-tree wrapper retains the same nonzero-subtree addresses and trace as direct root
-construction. -/
-example :
-    let result := Id.run ((treeM leafM nodeM 1 1).run [])
-    (result.1.getRootValue, result.2) =
-      (1134, [.leaf 2, .leaf 3, .node 1 1 3 4]) := by
-  decide
-
 /-- Tree construction is left subtree, right subtree, then parent. -/
 example : Id.run ((merkleRootM leafM nodeM 2 0).run []) =
     (13254,
@@ -55,27 +45,10 @@ example : Id.run ((merkleRootM leafM nodeM 2 0).run []) =
        .node 2 0 1012 1134]) := by
   decide
 
-/-- Authentication paths retain the canonical leaf-first order. -/
-example : Id.run ((authPathM leafM nodeM 0 2).run []) =
-    ([2, 1134],
-       [.leaf 1, .leaf 2, .leaf 3, .node 1 1 3 4]) := by
-  decide
-
-/-- An odd leaf takes the right branch at the bottom level. -/
-example : Id.run ((authPathM leafM nodeM 1 2).run []) =
-    ([1, 1134],
-      [.leaf 0, .leaf 2, .leaf 3, .node 1 1 3 4]) := by
-  decide
-
 /-- A mixed path takes the left branch at the bottom and the right branch above it. -/
 example : Id.run ((authPathM leafM nodeM 2 2).run []) =
     ([4, 1012],
       [.leaf 3, .leaf 0, .leaf 1, .node 1 0 1 2]) := by
-  decide
-
-/-- Root recovery hashes bottom-up, with the opened node on the correct side at each level. -/
-example : Id.run ((climbM nodeM 0 1 [2, 1134]).run []) =
-    (13254, [.node 1 0 1 2, .node 2 0 1012 1134]) := by
   decide
 
 /-- Root recovery follows the corresponding mixed left/right path. -/
@@ -99,40 +72,9 @@ example : Id.run ((merkleRootM leafM nodeM 0 7).run []) = (8, [.leaf 7]) := by
   decide
 
 /-- Height-zero paths and climbs are effect-free. -/
-example : Id.run ((authPathM leafM nodeM 7 0).run []) = ([], []) := by
+example :
+    Id.run ((authPathM leafM nodeM 7 0).run []) = ([], []) ∧
+    Id.run ((climbM nodeM 7 8 []).run []) = (8, []) := by
   decide
-
-example : Id.run ((climbM nodeM 7 8 []).run []) = (8, []) := by
-  decide
-
-/-! ## Query-homomorphism canary -/
-
-inductive Query where
-  | leaf
-  | node
-
-def querySpec : OracleSpec Query := fun _ => ℕ
-
-/-- The generic monad-homomorphism law specializes directly to the free-oracle fold and uses
-`QueryHom.map_query` to preserve each explicit leaf and node query. -/
-example {m : Type → Type*} [Monad m] [LawfulMonad m] [HasQuery querySpec m] (z t : ℕ) :
-    let F := HasQuery.QueryHom.ofSimulateQ (spec := querySpec) (m := m)
-    F.toMonadHom
-        (merkleRootM
-          (fun _ => HasQuery.query (spec := querySpec)
-            (m := OracleComp querySpec) Query.leaf)
-          (fun _ _ _ _ => HasQuery.query (spec := querySpec)
-            (m := OracleComp querySpec) Query.node) z t) =
-      merkleRootM
-        (fun _ => HasQuery.query (spec := querySpec) (m := m) Query.leaf)
-        (fun _ _ _ _ => HasQuery.query (spec := querySpec) (m := m) Query.node) z t := by
-  dsimp only
-  apply merkleRootM_natural
-  · intro i
-    exact HasQuery.map_query
-      (HasQuery.QueryHom.ofSimulateQ (spec := querySpec) (m := m)) Query.leaf
-  · intro h i l r
-    exact HasQuery.map_query
-      (HasQuery.QueryHom.ofSimulateQ (spec := querySpec) (m := m)) Query.node
 
 end VCVioTest.MerkleTreeMonadicCanary

--- a/VCVioTest/MerkleTreeMonadic.lean
+++ b/VCVioTest/MerkleTreeMonadic.lean
@@ -7,6 +7,7 @@ Authors: Quang Dao
 module
 
 public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
+public import VCVio.OracleComp.HasQuery.Morphism
 
 /-!
 # Effectful addressed-Merkle canaries
@@ -82,6 +83,17 @@ example : Id.run ((climbM nodeM 2 3 [4, 1012]).run []) =
     (13254, [.node 1 1 3 4, .node 2 0 1012 1134]) := by
   decide
 
+/-- Authentication-path construction retains global addresses in a nonzero height-two subtree. -/
+example : Id.run ((authPathM leafM nodeM 6 2).run []) =
+    ([8, 1256],
+      [.leaf 7, .leaf 4, .leaf 5, .node 1 2 5 6]) := by
+  decide
+
+/-- Root recovery retains global addresses in a nonzero height-two subtree. -/
+example : Id.run ((climbM nodeM 6 7 [8, 1256]).run []) =
+    (16038, [.node 1 3 7 8, .node 2 1 1256 1378]) := by
+  decide
+
 /-- Height zero performs exactly one leaf effect and no node hashes. -/
 example : Id.run ((merkleRootM leafM nodeM 0 7).run []) = (8, [.leaf 7]) := by
   decide
@@ -92,5 +104,35 @@ example : Id.run ((authPathM leafM nodeM 7 0).run []) = ([], []) := by
 
 example : Id.run ((climbM nodeM 7 8 []).run []) = (8, []) := by
   decide
+
+/-! ## Query-homomorphism canary -/
+
+inductive Query where
+  | leaf
+  | node
+
+def querySpec : OracleSpec Query := fun _ => ℕ
+
+/-- The generic monad-homomorphism law specializes directly to the free-oracle fold and uses
+`QueryHom.map_query` to preserve each explicit leaf and node query. -/
+example {m : Type → Type*} [Monad m] [LawfulMonad m] [HasQuery querySpec m] (z t : ℕ) :
+    let F := HasQuery.QueryHom.ofSimulateQ (spec := querySpec) (m := m)
+    F.toMonadHom
+        (merkleRootM
+          (fun _ => HasQuery.query (spec := querySpec)
+            (m := OracleComp querySpec) Query.leaf)
+          (fun _ _ _ _ => HasQuery.query (spec := querySpec)
+            (m := OracleComp querySpec) Query.node) z t) =
+      merkleRootM
+        (fun _ => HasQuery.query (spec := querySpec) (m := m) Query.leaf)
+        (fun _ _ _ _ => HasQuery.query (spec := querySpec) (m := m) Query.node) z t := by
+  dsimp only
+  apply merkleRootM_natural
+  · intro i
+    exact HasQuery.map_query
+      (HasQuery.QueryHom.ofSimulateQ (spec := querySpec) (m := m)) Query.leaf
+  · intro h i l r
+    exact HasQuery.map_query
+      (HasQuery.QueryHom.ofSimulateQ (spec := querySpec) (m := m)) Query.node
 
 end VCVioTest.MerkleTreeMonadicCanary

--- a/VCVioTest/MerkleTreeMonadic.lean
+++ b/VCVioTest/MerkleTreeMonadic.lean
@@ -38,6 +38,14 @@ def nodeM (height index left right : ℕ) : TraceM ℕ := fun trace =>
   (1000 * height + 100 * index + 10 * left + right,
     trace ++ [.node height index left right])
 
+/-- The full-tree wrapper retains the same nonzero-subtree addresses and trace as direct root
+construction. -/
+example :
+    let result := Id.run ((treeM leafM nodeM 1 1).run [])
+    (result.1.getRootValue, result.2) =
+      (1134, [.leaf 2, .leaf 3, .node 1 1 3 4]) := by
+  decide
+
 /-- Tree construction is left subtree, right subtree, then parent. -/
 example : Id.run ((merkleRootM leafM nodeM 2 0).run []) =
     (13254,
@@ -49,12 +57,40 @@ example : Id.run ((merkleRootM leafM nodeM 2 0).run []) =
 /-- Authentication paths retain the canonical leaf-first order. -/
 example : Id.run ((authPathM leafM nodeM 0 2).run []) =
     ([2, 1134],
-      [.leaf 1, .leaf 2, .leaf 3, .node 1 1 3 4]) := by
+       [.leaf 1, .leaf 2, .leaf 3, .node 1 1 3 4]) := by
+  decide
+
+/-- An odd leaf takes the right branch at the bottom level. -/
+example : Id.run ((authPathM leafM nodeM 1 2).run []) =
+    ([1, 1134],
+      [.leaf 0, .leaf 2, .leaf 3, .node 1 1 3 4]) := by
+  decide
+
+/-- A mixed path takes the left branch at the bottom and the right branch above it. -/
+example : Id.run ((authPathM leafM nodeM 2 2).run []) =
+    ([4, 1012],
+      [.leaf 3, .leaf 0, .leaf 1, .node 1 0 1 2]) := by
   decide
 
 /-- Root recovery hashes bottom-up, with the opened node on the correct side at each level. -/
 example : Id.run ((climbM nodeM 0 1 [2, 1134]).run []) =
     (13254, [.node 1 0 1 2, .node 2 0 1012 1134]) := by
+  decide
+
+/-- Root recovery follows the corresponding mixed left/right path. -/
+example : Id.run ((climbM nodeM 2 3 [4, 1012]).run []) =
+    (13254, [.node 1 1 3 4, .node 2 0 1012 1134]) := by
+  decide
+
+/-- Height zero performs exactly one leaf effect and no node hashes. -/
+example : Id.run ((merkleRootM leafM nodeM 0 7).run []) = (8, [.leaf 7]) := by
+  decide
+
+/-- Height-zero paths and climbs are effect-free. -/
+example : Id.run ((authPathM leafM nodeM 7 0).run []) = ([], []) := by
+  decide
+
+example : Id.run ((climbM nodeM 7 8 []).run []) = (8, []) := by
   decide
 
 end VCVioTest.MerkleTreeMonadicCanary

--- a/VCVioTest/MerkleTreeMonadic.lean
+++ b/VCVioTest/MerkleTreeMonadic.lean
@@ -1,0 +1,60 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
+
+/-!
+# Effectful addressed-Merkle canaries
+
+These examples pin the monadic engine to the existing natural-number adapter and make its query
+schedule observable.  The trace distinguishes leaf production from ordered node hashing, so a
+regression in traversal order, child order, address calculation, or authentication-path order is
+visible.
+-/
+
+@[expose] public section
+
+namespace VCVioTest.MerkleTreeMonadicCanary
+
+open _root_.PerfectMerkleTree
+
+inductive Event where
+  | leaf (index : ℕ)
+  | node (height index left right : ℕ)
+deriving DecidableEq, Repr
+
+abbrev TraceM := StateM (List Event)
+
+def leafM (index : ℕ) : TraceM ℕ := fun trace =>
+  (index + 1, trace ++ [.leaf index])
+
+/-- Address-sensitive and noncommutative, matching `PerfectMerkleTreeCanary.orderedHash`. -/
+def nodeM (height index left right : ℕ) : TraceM ℕ := fun trace =>
+  (1000 * height + 100 * index + 10 * left + right,
+    trace ++ [.node height index left right])
+
+/-- Tree construction is left subtree, right subtree, then parent. -/
+example : Id.run ((merkleRootM leafM nodeM 2 0).run []) =
+    (13254,
+      [.leaf 0, .leaf 1, .node 1 0 1 2,
+       .leaf 2, .leaf 3, .node 1 1 3 4,
+       .node 2 0 1012 1134]) := by
+  decide
+
+/-- Authentication paths retain the canonical leaf-first order. -/
+example : Id.run ((authPathM leafM nodeM 0 2).run []) =
+    ([2, 1134],
+      [.leaf 1, .leaf 2, .leaf 3, .node 1 1 3 4]) := by
+  decide
+
+/-- Root recovery hashes bottom-up, with the opened node on the correct side at each level. -/
+example : Id.run ((climbM nodeM 0 1 [2, 1134]).run []) =
+    (13254, [.node 1 0 1 2, .node 2 0 1012 1134]) := by
+  decide
+
+end VCVioTest.MerkleTreeMonadicCanary


### PR DESCRIPTION
## Summary

This stacked PR adds effectful traversal to the repository's existing **addressed** Merkle-tree engine. It is the generic prerequisite used by XMSS and FORS when leaf and node hashing must issue explicit oracle queries.

It is deliberately a companion layer, not a repository-wide replacement for every existing Merkle API.

### Diff metadata

- Base: `fc96c12eea3123d91b1769fc205d30441ca91617` (`repair/slhdsa-empty-context-clean-20260827`)
- Head: `2e53626b739e8007ac6886442f4aa3a9e867fabc`
- Commits: 7
- Files changed: 7
- Diff: 833 insertions, 0 deletions

## What this PR adds

- monad-parametric construction and root reconstruction for addressed typed skeletons;
- perfect-tree root, authentication-path, and climb programs;
- naturality under monad morphisms;
- deterministic `simulateQ` and pure `Id.run` interpretation laws;
- structural total-query bounds, including path-length-aware continuation bounds.

Traversal keeps the existing addressed types, address calculation, left/right/parent evaluation order, and leaf-first authentication paths. The module installs no `HasQuery` instance and no cache.

## Existing duplication and staged boundary

VCVio also retains older unaddressed inductive/vector Merkle APIs and their proof developments. This PR does **not** claim to replace or definitionally unify those APIs. The zero-deletion diff is therefore intentional but also records real staged duplication.

Within this stack, the clean boundary is:

- use the addressed effectful layer for XMSS/FORS, because the node address is part of the public-hash query;
- retain the old unaddressed layers and their existing clients unchanged;
- use the constant-address bridge lemmas in `Addressed/Basic.lean` only when a propositional comparison is needed;
- do not claim that proofs over the old representation automatically transfer to the addressed program.

This boundary is documented in `Addressed/Basic.lean`, `Addressed/Monadic.lean`, and `Addressed/NatIndexed/Monadic.lean`.

## Expressly deferred work

A separate migration/design PR must decide whether one Merkle representation becomes canonical and then port or reprove the affected developments. In particular, this PR does not migrate:

- inductive Merkle extractability;
- batch extraction;
- uniqueness results;
- legacy query-bound consumers;
- old vector/inductive client APIs.

The repaired extractability work in #559 remains independent and is not presented as a theorem about this new addressed path.

## Validation at `2e53626b`

- both addressed monadic owner modules build locally;
- `git diff --check` passes;
- the complete restacked tree passes `lake build` at #569;
- GitHub checks were re-triggered by the restack and are pending.

## Reviewer map

1. `Addressed/Basic.lean` for the old/new scope boundary and bridges;
2. `Addressed/Monadic.lean` for generic typed traversal;
3. `Addressed/NatIndexed/Monadic.lean` for perfect-tree programs;
4. `Addressed/NatIndexed/QueryBound.lean` for cost formulas;
5. `VCVioTest/MerkleTreeMonadic.lean` for retained semantic canaries.
