### PR TITLE
fix(HashSig): encode empty-context SLH-DSA external messages

### DIFF
--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -141,10 +141,19 @@ def decodeSignature (ba : ByteArray) : Signature shaPrimitives :=
     (List.range 22).map fun j => baSliceToB16 ba (2416 + 1088 + j * 16)
   (R, fors, (wots, xmssAuth))
 
-/-- Concrete verification of a decoded reference signature against `(pkSeed, pkRoot, message)`. -/
+/-- Concrete FIPS 205 external verification of a decoded signature against
+`(pkSeed, pkRoot, message)`. The empty-context domain prefix is added by `slhVerify`. -/
 def verifyBytes (pkSeed pkRoot : Bytes 16) (msg : List Byte) (sigBytes : ByteArray) : Bool :=
   letI : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
   slhVerify shaPrimitives ⟨pkSeed, pkRoot⟩ msg (decodeSignature sigBytes)
+
+/-- Verification against the internal `M'` interface. This entry point supports reference vectors
+whose message is already the exact input consumed by `H_msg`, without applying the external
+context encoding a second time. -/
+def verifyInternalBytes (pkSeed pkRoot : Bytes 16) (msg : List Byte)
+    (sigBytes : ByteArray) : Bool :=
+  letI : DecidableEq shaPrimitives.Y := inferInstanceAs (DecidableEq (Bytes 16))
+  slhVerifyInternal shaPrimitives msg (decodeSignature sigBytes) ⟨pkSeed, pkRoot⟩
 
 /-! ### Completeness transfers to the concrete bundle
 

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -130,6 +130,12 @@ theorem slhVerifyInternal_slhSignInternal (prims : Primitives p) [DecidableEq pr
 
 variable (prims : Primitives p)
 
+/-- FIPS 205 external-message encoding for the empty-context API:
+`M' = 0x00 || 0x00 || M`. Internal algorithms consume `M'`; callers of the generic
+signature API supply the raw message `M`. -/
+def emptyContextMessage (msg : List Byte) : List Byte :=
+  0x00 :: 0x00 :: msg
+
 /-- SLH-DSA key generation (FIPS 205 Algorithm 21): sample the three seeds. -/
 def slhKeygen [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
     [SampleableType prims.PkSeed] : ProbComp (PublicKey prims × SecretKey prims) := do
@@ -142,12 +148,12 @@ def slhKeygen [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
 def slhSign [SampleableType prims.Y] (sk : SecretKey prims) (msg : List Byte) :
     ProbComp (Signature prims) := do
   let addrnd ← $ᵗ prims.Y
-  return slhSignInternal prims msg sk addrnd
+  return slhSignInternal prims (emptyContextMessage msg) sk addrnd
 
 /-- SLH-DSA verification (FIPS 205 Algorithm 24, empty context). -/
 def slhVerify [DecidableEq prims.Y] (pk : PublicKey prims) (msg : List Byte)
     (sig : Signature prims) : Bool :=
-  slhVerifyInternal prims msg sig pk
+  slhVerifyInternal prims (emptyContextMessage msg) sig pk
 
 /-- SLH-DSA as a generic `SignatureAlg` in the `ProbComp` monad. -/
 def slhdsaAlg [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
@@ -194,7 +200,8 @@ theorem slhdsaAlg_perfectlyComplete [SampleableType prims.SkSeed] [SampleableTyp
     have hpk : pk = (slhKeygenInternal prims skSeed skPrf pkSeed).1 := congrArg Prod.fst hpksk
     have hsk : sk = (slhKeygenInternal prims skSeed skPrf pkSeed).2 := congrArg Prod.snd hpksk
     subst hpk; subst hsk
-    exact slhVerifyInternal_slhSignInternal prims msg skSeed skPrf pkSeed addrnd
+    exact slhVerifyInternal_slhSignInternal prims (emptyContextMessage msg)
+      skSeed skPrf pkSeed addrnd
   change Pr[= true | mx] = 1
   exact probOutput_eq_one_of_support_subset_singleton
     (NeverFail.probFailure_eq_zero (mx := mx)) huniq

--- a/HashSigTest/SLHDSA/Sha2KAT.lean
+++ b/HashSigTest/SLHDSA/Sha2KAT.lean
@@ -15,11 +15,13 @@ A deterministic reference vector produced by the SPHINCs- C reference
 `seed = 0^48`, `message = 0x00`, `opt_rand = 0^16`. The hex is
 `pk_seed(16) ‖ pk_root(16) ‖ sig(3856)`.
 
-`main` decodes it and checks that the pure-Lean concrete `verifyBytes`
-(`HashSig.SLHDSA.Concrete.Instance`) accepts the valid signature and rejects a tampered message
-— byte-exact agreement with the C reference, validating the whole verify path (SHA-256 / MGF1 /
-HMAC, `H_msg`, leaf-index split, `F`/`H`/`T_ℓ`, the 22-byte `ADRSc` layout, FORS / WOTS+ / XMSS
-reconstruction, and the FIPS 205 signature wire format). Run with `lake exe slhdsa_kat`.
+This vector predates the FIPS 205 external context wrapper, so `main` checks the pure-Lean
+internal-message entry point `verifyInternalBytes` (`HashSig.SLHDSA.Concrete.Instance`) accepts
+the valid signature and rejects a tampered message. It also checks that treating the vector's
+message as a raw external message fails, which distinguishes the two interfaces. Together these
+checks validate the whole verification path (SHA-256 / MGF1 / HMAC, `H_msg`, leaf-index split,
+`F`/`H`/`T_ℓ`, the 22-byte `ADRSc` layout, FORS / WOTS+ / XMSS reconstruction, and the FIPS 205
+signature wire format). Run with `lake exe slhdsa_kat`.
 -/
 
 public section
@@ -28,6 +30,21 @@ public section
 namespace SLHDSA.Concrete.KAT
 
 open SLHDSA SLHDSA.Concrete
+
+/-- Empty-context pure signing prefixes the raw message with the domain separator and context
+length byte required by FIPS 205 Algorithms 22 and 24. -/
+example : emptyContextMessage [1, 2] = [0, 0, 1, 2] := rfl
+
+/-- The external signing wrapper passes the encoded message to the internal algorithm. -/
+example (sk : SecretKey shaPrimitives) (msg : List Byte) :
+    slhSign shaPrimitives sk msg = (do
+      let addrnd ← $ᵗ shaPrimitives.Y
+      pure (slhSignInternal shaPrimitives (emptyContextMessage msg) sk addrnd)) := rfl
+
+/-- Concrete external verification is exactly internal verification after empty-context encoding. -/
+example (pkSeed pkRoot : Bytes 16) (msg : List Byte) (sigBytes : ByteArray) :
+    verifyBytes pkSeed pkRoot msg sigBytes =
+      verifyInternalBytes pkSeed pkRoot (emptyContextMessage msg) sigBytes := rfl
 
 /-- Reference vector `pk_seed(16) ‖ pk_root(16) ‖ sig(3856)` (hex). -/
 def vectorHex : String :=
@@ -129,18 +146,23 @@ private def parseHex (s : String) : ByteArray := Id.run do
   for i in [0:cs.size / 2] do o := o.push (hexVal cs[2 * i]! <<< 4 ||| hexVal cs[2 * i + 1]!)
   return o
 
-/-- Verify the embedded reference vector and a tampered-message rejection. -/
+/-- Verify the embedded internal-message vector, a tampered message, and separation from the
+external empty-context interface. -/
 def runKat : IO Unit := do
   let ba := parseHex vectorHex
   let pkSeed := baSliceToB16 ba 0
   let pkRoot := baSliceToB16 ba 16
   let sigBA := ba.extract 32 (32 + 3856)
-  let accepts := verifyBytes pkSeed pkRoot [0x00] sigBA
-  let rejects := verifyBytes pkSeed pkRoot [0x01] sigBA
-  if accepts && !rejects then
-    IO.println "SLH-DSA-SHA2-128-24 KAT: PASS (valid signature accepted, tampered rejected)"
+  let acceptsInternal := verifyInternalBytes pkSeed pkRoot [0x00] sigBA
+  let acceptsTamperedInternal := verifyInternalBytes pkSeed pkRoot [0x01] sigBA
+  let acceptsAsExternal := verifyBytes pkSeed pkRoot [0x00] sigBA
+  if acceptsInternal && !acceptsTamperedInternal && !acceptsAsExternal then
+    IO.println "SLH-DSA-SHA2-128-24 KAT: PASS"
   else
-    IO.eprintln s!"SLH-DSA-SHA2-128-24 KAT: FAIL (accepts={accepts} rejects={rejects})"
+    IO.eprintln "SLH-DSA-SHA2-128-24 KAT: FAIL"
+    IO.eprintln s!"acceptsInternal={acceptsInternal}"
+    IO.eprintln s!"acceptsTamperedInternal={acceptsTamperedInternal}"
+    IO.eprintln s!"acceptsAsExternal={acceptsAsExternal}"
     throw (IO.userError "SLH-DSA-SHA2-128-24 KAT failed")
 
 end SLHDSA.Concrete.KAT


### PR DESCRIPTION
## Summary

This stacked PR repairs the FIPS 205 external empty-context interface.

The generic external signing and verification APIs now encode a raw message as:

```text
M' = 0x00 || 0x00 || M
```

before calling the internal SLH-DSA algorithms. It also exposes a clearly named internal-message concrete verifier for existing reference vectors whose message is already the exact `H_msg` input.

Stack:

1. #561 — implementation-independent public-hash oracle context;
2. this PR — correct external empty-context encoding;
3. #563 / #562 and the downstream XMSS/FORS/scheme oracle stack.

### Diff metadata

- Base: `5848688e87b79ab573e6f4ba246f0284b186f896` (`repair/slhdsa-public-hash-clean-20260827`)
- Head: `5750950f332fe8e80e4cb510284de010b991dd41`
- Commits: 1
- Files changed: 3
- Diff: 53 insertions, 15 deletions

## Motivation

The internal FIPS algorithms consume `M'`, while the external empty-context API accepts raw `M`. Previously, `slhSign` and `slhVerify` passed the raw message directly to the internal algorithms, omitting the external domain-separation and zero-length-context bytes.

That behavior was internally self-consistent, so pure completeness still held, but it did not implement the external FIPS 205 interface.

## Change surface

| Area | Before | After |
|---|---|---|
| External signing | Passed raw `M` internally | Passes `00 || 00 || M` |
| External verification | Passed raw `M` internally | Passes `00 || 00 || M` |
| Internal-message vectors | Used the external wrapper accidentally | Use `verifyInternalBytes` explicitly |
| KAT boundary | Did not distinguish the interfaces | Pins internal acceptance and external rejection |

## Implementation

`emptyContextMessage` is the single owner of the external encoding:

```lean
def emptyContextMessage (msg : List Byte) : List Byte :=
  0x00 :: 0x00 :: msg
```

Both `slhSign` and `slhVerify` use it before entering `slhSignInternal` / `slhVerifyInternal`.

`Concrete.verifyBytes` remains the external FIPS API. `Concrete.verifyInternalBytes` is the explicit compatibility entry point for vectors that already provide `M'`.

## Correctness and compatibility

The deterministic internal algorithms and their correctness theorem are unchanged. The external perfect-completeness proof now instantiates that theorem with `emptyContextMessage msg`.

The embedded SHA-2 reference vector predates the external wrapper and signs the internal message `[0x00]`. The executable KAT now checks:

- internal-message verification accepts the vector;
- a tampered internal message is rejected;
- treating the same vector input as a raw external message is rejected.

That third check prevents the external/internal distinction from collapsing silently again.

## Validation completed at `5750950f`

Passed locally on the exact head:

- targeted Scheme, concrete-instance, and SHA-2 KAT builds;
- full `lake build VCVio VCVioTest HashSig HashSigTest`;
- `lake exe slhdsa_kat`;
- `lake exe slhdsa_c13_kat`;
- style lint;
- generated library/import checks;
- `git diff --check`;
- no new `sorry` or `admit`.

All seven GitHub checks pass on this head, including the project build and downstream consumer build.

## Reviewer map

Suggested review order:

1. `HashSig/SLHDSA/Scheme.lean` — external/internal message boundary;
2. `HashSig/SLHDSA/Concrete/Instance.lean` — external and internal verifier names;
3. `HashSigTest/SLHDSA/Sha2KAT.lean` — interface-separation canaries.
