### PR TITLE
feat(HashSig): make FORS public-hash programs canonical

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,4 +84,4 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT
+        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT

--- a/HashSig/SLHDSA/Fors.lean
+++ b/HashSig/SLHDSA/Fors.lean
@@ -98,6 +98,10 @@ def forsPkAdrs (adrs : Adrs) : Adrs :=
 abbrev ForsSigCore (p : Params) (core : CorePrimitives p) :=
   Vector (core.Y × List core.Y) p.k
 
+/-- Pure FORS signature type retained until the Scheme consumer migrates in the downstream
+scheme-integration PR. -/
+abbrev ForsSig (p : Params) (prims : Primitives p) := ForsSigCore p prims.core
+
 /-- Low-level callback-parametric FORS public-key generation. Roots are computed in increasing
 tree order and compressed only after every root is available. -/
 def forsPkGenWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]

--- a/HashSig/SLHDSA/Fors.lean
+++ b/HashSig/SLHDSA/Fors.lean
@@ -6,12 +6,16 @@ Authors: Nicolas Consigny
 
 module
 public import HashSig.SLHDSA.Xmss
+public import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.Monadic
+import VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed.QueryBound
 
 /-!
 # FORS (FIPS 205 §8)
 
 The few-time forest signature: `k` Merkle trees of height `a`, with leaves `F(secret)` and the
-`k` roots compressed by `T_k`. Each tree is a `PerfectMerkleTree`
+`k` roots compressed by `T_k`. The canonical `*M` programs depend only on `CorePrimitives` and
+issue every public hash through `HasQuery`; the pure API is their literal deterministic
+`simulateQ` interpretation. Each tree is a `PerfectMerkleTree`
 (`VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed`) over global leaf indices. Provides
 `forsSkGen`/`forsLeaf`/`forsRoot` (Algorithms 14–15), `forsSign` (Algorithm 16), `forsPkFromSig`
 (Algorithm 17), and the correctness lemma `forsPkFromSig_forsSign`: recovery from an honest FORS
@@ -29,6 +33,8 @@ Because the FORS public key compresses the *whole-tree* roots (which are message
 
 
 namespace SLHDSA
+
+open OracleComp
 
 variable {p : Params}
 
@@ -53,63 +59,729 @@ theorem forsIdx_lt (p : Params) (md : List Byte) (i : ℕ) : forsIdx p md i < 2 
 def forsSkAdrs (adrs : Adrs) (t : ℕ) : Adrs :=
   ((adrs.setTypeAndClear .forsPrf).setKeyPairAddress adrs.getKeyPairAddress).setTreeIndex t
 
-/-- The FORS secret value at global leaf index `t` (FIPS 205 Algorithm 14). -/
+/-- The FORS secret value at global leaf index `t` (FIPS 205 Algorithm 14), over the
+implementation-independent context. -/
+def forsSkGenCore (core : CorePrimitives p) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (t : ℕ) : core.Y :=
+  core.PRF pk sk (forsSkAdrs adrs t)
+
+/-- Source-compatible pure wrapper for `forsSkGenCore`. -/
 def forsSkGen (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
     (t : ℕ) : prims.Y :=
-  prims.PRF pk sk (forsSkAdrs adrs t)
+  forsSkGenCore prims.core sk pk adrs t
 
 /-- Address for the FORS-tree node at `(height z, global index t)` (type `FORS_TREE`). -/
 def forsNodeAdrs (adrs : Adrs) (z t : ℕ) : Adrs :=
   let base := (adrs.setTypeAndClear .forsTree).setKeyPairAddress adrs.getKeyPairAddress
   (base.setTreeHeight z).setTreeIndex t
 
-/-- The FORS leaf value at global index `t`: `F` of the secret value. -/
-def forsLeaf (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
-    (t : ℕ) : prims.Y :=
-  prims.F pk (forsNodeAdrs adrs 0 t) (forsSkGen prims sk pk adrs t)
+/-- Low-level callback-parametric FORS leaf computation. -/
+def forsLeafWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (t : ℕ) : m core.Y :=
+  hash (forsNodeAdrs adrs 0 t) (forsSkGenCore core sk pk adrs t)
 
-/-- The FORS internal-node hash at `(height z, global index t)`. -/
-def forsNodeHash (prims : Primitives p) (pk : prims.PkSeed) (adrs : Adrs)
-    (z t : ℕ) (l r : prims.Y) : prims.Y :=
-  prims.H pk (forsNodeAdrs adrs z t) l r
+/-- Low-level addressed internal-node callback. -/
+def forsNodeHashWith {Y : Type} {m : Type → Type*}
+    (nodeHash : Adrs → Y → Y → m Y) (adrs : Adrs)
+    (z t : ℕ) (l r : Y) : m Y :=
+  nodeHash (forsNodeAdrs adrs z t) l r
 
-/-- The root of FORS tree `i` (the height-`a` node at index `i`; FIPS 205 Algorithm 15). -/
-def forsRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
-    (i : ℕ) : prims.Y :=
-  PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs) (forsNodeHash prims pk adrs) p.a i
+/-- Low-level callback-parametric root computation for FORS tree `i`. -/
+def forsRootWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (i : ℕ) : m core.Y :=
+  PerfectMerkleTree.merkleRootM (forsLeafWith core hash sk pk adrs)
+    (forsNodeHashWith nodeHash adrs) p.a i
 
 /-- Address compressing the `k` FORS roots into the FORS public key (type `FORS_ROOTS`). -/
 def forsPkAdrs (adrs : Adrs) : Adrs :=
   (adrs.setTypeAndClear .forsRoots).setKeyPairAddress adrs.getKeyPairAddress
 
-/-- The FORS public key: `T_k` of the `k` tree roots (message-independent). -/
+/-- A FORS signature over an implementation-independent context. -/
+abbrev ForsSigCore (p : Params) (core : CorePrimitives p) :=
+  Vector (core.Y × List core.Y) p.k
+
+/-- Source-compatible pure FORS signature type. -/
+abbrev ForsSig (p : Params) (prims : Primitives p) := ForsSigCore p prims.core
+
+/-- Low-level callback-parametric FORS public-key generation. Roots are computed in increasing
+tree order and compressed only after every root is available. -/
+def forsPkGenWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (compress : Adrs → List core.Y → m core.Y)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) : m core.Y := do
+  let roots ← Vector.ofFnM fun i : Fin p.k =>
+    forsRootWith core hash nodeHash sk pk adrs i.val
+  compress (forsPkAdrs adrs) roots.toList
+
+/-- Low-level callback-parametric FORS signing. `authPathM` evaluates only sibling subtrees, so
+the selected leaf is revealed but never hashed by signing. Trees are processed in increasing
+order. -/
+def forsSignWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (md : List Byte) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) : m (ForsSigCore p core) :=
+  Vector.ofFnM fun i : Fin p.k => do
+    let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+    let path ← PerfectMerkleTree.authPathM (forsLeafWith core hash sk pk adrs)
+      (forsNodeHashWith nodeHash adrs) idx p.a
+    return (forsSkGenCore core sk pk adrs idx, path)
+
+/-- Low-level callback-parametric FORS recovery. Each tree first hashes the revealed secret,
+then climbs its authentication path; recovered roots are compressed in increasing tree order. -/
+def forsPkFromSigWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (compress : Adrs → List core.Y → m core.Y)
+    (sig : ForsSigCore p core) (md : List Byte) (adrs : Adrs) : m core.Y := do
+  let roots ← Vector.ofFnM fun i : Fin p.k => do
+    let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+    let leaf ← hash (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+    PerfectMerkleTree.climbM (forsNodeHashWith nodeHash adrs) idx leaf (sig[i.val]).2
+  compress (forsPkAdrs adrs) roots.toList
+
+/-! ### Canonical oracle programs -/
+
+/-- Canonical explicit-query FORS leaf computation. -/
+def forsLeafM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (t : ℕ) : m core.Y :=
+  forsLeafWith core (PublicHash.f core pk) sk pk adrs t
+
+/-- Canonical explicit-query FORS internal-node computation. -/
+def forsNodeHashM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] (pk : core.PkSeed) (adrs : Adrs)
+    (z t : ℕ) (l r : core.Y) : m core.Y :=
+  forsNodeHashWith (PublicHash.h core pk) adrs z t l r
+
+/-- Canonical explicit-query computation of one FORS tree root. -/
+def forsRootM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (i : ℕ) : m core.Y :=
+  forsRootWith core (PublicHash.f core pk) (PublicHash.h core pk) sk pk adrs i
+
+/-- Canonical explicit-query FORS public-key generation. -/
+def forsPkGenM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) : m core.Y :=
+  forsPkGenWith core (PublicHash.f core pk) (PublicHash.h core pk)
+    (PublicHash.tl core pk) sk pk adrs
+
+/-- Canonical explicit-query FORS signing. -/
+def forsSignM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] (md : List Byte) (sk : core.SkSeed)
+    (pk : core.PkSeed) (adrs : Adrs) : m (ForsSigCore p core) :=
+  forsSignWith core (PublicHash.f core pk) (PublicHash.h core pk) md sk pk adrs
+
+/-- Canonical explicit-query FORS public-key recovery. -/
+def forsPkFromSigM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] (sig : ForsSigCore p core) (md : List Byte)
+    (pk : core.PkSeed) (adrs : Adrs) : m core.Y :=
+  forsPkFromSigWith core (PublicHash.f core pk) (PublicHash.h core pk)
+    (PublicHash.tl core pk) sig md adrs
+
+/-! ### Pure deterministic interpretations -/
+
+/-- Pure FORS leaf computation, defined as the deterministic interpretation of `forsLeafM`. -/
+def forsLeaf (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (t : ℕ) : prims.Y :=
+  simulateQ (PublicHash.impl prims)
+    (forsLeafM prims.core sk pk adrs t : OracleComp (publicHashSpec prims.core) prims.Y)
+
+/-- Pure FORS internal-node computation, defined as the interpretation of `forsNodeHashM`. -/
+def forsNodeHash (prims : Primitives p) (pk : prims.PkSeed) (adrs : Adrs)
+    (z t : ℕ) (l r : prims.Y) : prims.Y :=
+  simulateQ (PublicHash.impl prims)
+    (forsNodeHashM prims.core pk adrs z t l r :
+      OracleComp (publicHashSpec prims.core) prims.Y)
+
+/-- Pure FORS tree-root computation, defined as the interpretation of `forsRootM`. -/
+def forsRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
+    (i : ℕ) : prims.Y :=
+  simulateQ (PublicHash.impl prims)
+    (forsRootM prims.core sk pk adrs i : OracleComp (publicHashSpec prims.core) prims.Y)
+
+/-- Pure FORS public-key generation, defined as the interpretation of `forsPkGenM`. -/
 def forsPkGen (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
     prims.Y :=
-  prims.Tl pk (forsPkAdrs adrs)
-    ((List.finRange p.k).map fun i => forsRoot prims sk pk adrs i.val)
+  simulateQ (PublicHash.impl prims)
+    (forsPkGenM prims.core sk pk adrs : OracleComp (publicHashSpec prims.core) prims.Y)
 
-/-! ### Signing and recovery -/
-
-/-- A FORS signature: per tree, the revealed leaf secret and its `a`-node authentication path. -/
-abbrev ForsSig (p : Params) (prims : Primitives p) := Vector (prims.Y × List prims.Y) p.k
-
-/-- FORS signing (FIPS 205 Algorithm 16): reveal the selected leaf secret and auth path per
-tree. -/
+/-- Pure FORS signing, defined as the deterministic interpretation of `forsSignM`. -/
 def forsSign (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) : ForsSig p prims :=
-  Vector.ofFn fun i : Fin p.k =>
-    (forsSkGen prims sk pk adrs (i.val * 2 ^ p.a + forsIdx p md i.val),
-      PerfectMerkleTree.authPath (forsLeaf prims sk pk adrs) (forsNodeHash prims pk adrs)
-        (i.val * 2 ^ p.a + forsIdx p md i.val) p.a)
+  simulateQ (PublicHash.impl prims)
+    (forsSignM prims.core md sk pk adrs :
+      OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core))
 
-/-- FORS public-key recovery from a signature (FIPS 205 Algorithm 17): recompute each tree's
-leaf and climb its auth path, then compress the `k` recovered roots with `T_k`. -/
+/-- Pure FORS public-key recovery, defined as the interpretation of `forsPkFromSigM`. -/
 def forsPkFromSig (prims : Primitives p) (sig : ForsSig p prims) (md : List Byte)
     (pk : prims.PkSeed) (adrs : Adrs) : prims.Y :=
-  prims.Tl pk (forsPkAdrs adrs) ((List.finRange p.k).map fun i =>
-    PerfectMerkleTree.climb (forsNodeHash prims pk adrs) (i.val * 2 ^ p.a + forsIdx p md i.val)
-      (prims.F pk (forsNodeAdrs adrs 0 (i.val * 2 ^ p.a + forsIdx p md i.val)) (sig[i.val]).1)
-      (sig[i.val]).2)
+  simulateQ (PublicHash.impl prims)
+    (forsPkFromSigM prims.core sig md pk adrs :
+      OracleComp (publicHashSpec prims.core) prims.Y)
+
+/-! ### Naturality -/
+
+private theorem monadHom_ofFnM {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] (F : m →ᵐ n) {α : Type} {k : ℕ}
+    (fm : Fin k → m α) (fn : Fin k → n α) (h : ∀ i, F (fm i) = fn i) :
+    F (Vector.ofFnM fm) = Vector.ofFnM fn := by
+  induction k with
+  | zero => simp [F.mmap_pure]
+  | succ k ih =>
+      rw [Vector.ofFnM_succ, Vector.ofFnM_succ, F.mmap_bind]
+      rw [ih (fun i => fm i.castSucc) (fun i => fn i.castSucc) (fun i => h i.castSucc)]
+      congr 1
+      funext xs
+      rw [F.mmap_bind, h (Fin.last k)]
+      simp [F.mmap_pure]
+
+/-- A monad morphism commutes with FORS leaf production when it commutes with the leaf-hash
+callback. -/
+theorem forsLeafWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] (F : m →ᵐ n) (core : CorePrimitives p)
+    (hashm : Adrs → core.Y → m core.Y) (hashn : Adrs → core.Y → n core.Y)
+    (hhash : ∀ a y, F (hashm a y) = hashn a y)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (t : ℕ) :
+    F (forsLeafWith core hashm sk pk adrs t) = forsLeafWith core hashn sk pk adrs t := by
+  exact hhash _ _
+
+/-- A monad morphism commutes with addressed FORS node hashing when it commutes with the node
+callback. -/
+theorem forsNodeHashWith_natural {Y : Type} {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n] (F : m →ᵐ n)
+    (hashm : Adrs → Y → Y → m Y) (hashn : Adrs → Y → Y → n Y)
+    (hhash : ∀ a l r, F (hashm a l r) = hashn a l r)
+    (adrs : Adrs) (z t : ℕ) (l r : Y) :
+    F (forsNodeHashWith hashm adrs z t l r) = forsNodeHashWith hashn adrs z t l r := by
+  exact hhash _ _ _
+
+/-- A monad morphism commutes with one FORS-tree root computation when it commutes with the leaf
+and node callbacks. -/
+theorem forsRootWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] (F : m →ᵐ n) (core : CorePrimitives p)
+    (hashm : Adrs → core.Y → m core.Y) (hashn : Adrs → core.Y → n core.Y)
+    (nodeHashm : Adrs → core.Y → core.Y → m core.Y)
+    (nodeHashn : Adrs → core.Y → core.Y → n core.Y)
+    (hhash : ∀ a y, F (hashm a y) = hashn a y)
+    (hnode : ∀ a l r, F (nodeHashm a l r) = nodeHashn a l r)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (i : ℕ) :
+    F (forsRootWith core hashm nodeHashm sk pk adrs i) =
+      forsRootWith core hashn nodeHashn sk pk adrs i := by
+  exact PerfectMerkleTree.merkleRootM_natural F _ _ _ _
+    (fun t => forsLeafWith_natural F core hashm hashn hhash sk pk adrs t)
+    (fun z t l r => forsNodeHashWith_natural F nodeHashm nodeHashn hnode adrs z t l r) _ _
+
+/-- A monad morphism commutes with FORS public-key generation when it commutes with all public
+hash callbacks. -/
+theorem forsPkGenWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] (F : m →ᵐ n) (core : CorePrimitives p)
+    (hashm : Adrs → core.Y → m core.Y) (hashn : Adrs → core.Y → n core.Y)
+    (nodeHashm : Adrs → core.Y → core.Y → m core.Y)
+    (nodeHashn : Adrs → core.Y → core.Y → n core.Y)
+    (compressm : Adrs → List core.Y → m core.Y)
+    (compressn : Adrs → List core.Y → n core.Y)
+    (hhash : ∀ a y, F (hashm a y) = hashn a y)
+    (hnode : ∀ a l r, F (nodeHashm a l r) = nodeHashn a l r)
+    (hcompress : ∀ a ys, F (compressm a ys) = compressn a ys)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) :
+    F (forsPkGenWith core hashm nodeHashm compressm sk pk adrs) =
+      forsPkGenWith core hashn nodeHashn compressn sk pk adrs := by
+  simp [forsPkGenWith, F.mmap_bind,
+    monadHom_ofFnM F _ _ (fun i => forsRootWith_natural F core hashm hashn nodeHashm nodeHashn
+      hhash hnode sk pk adrs i.val), hcompress]
+
+/-- A monad morphism commutes with FORS signing when it commutes with the leaf and node
+callbacks. -/
+theorem forsSignWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] (F : m →ᵐ n) (core : CorePrimitives p)
+    (hashm : Adrs → core.Y → m core.Y) (hashn : Adrs → core.Y → n core.Y)
+    (nodeHashm : Adrs → core.Y → core.Y → m core.Y)
+    (nodeHashn : Adrs → core.Y → core.Y → n core.Y)
+    (hhash : ∀ a y, F (hashm a y) = hashn a y)
+    (hnode : ∀ a l r, F (nodeHashm a l r) = nodeHashn a l r)
+    (md : List Byte) (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) :
+    F (forsSignWith core hashm nodeHashm md sk pk adrs) =
+      forsSignWith core hashn nodeHashn md sk pk adrs := by
+  apply monadHom_ofFnM F
+  intro i
+  simp [PerfectMerkleTree.authPathM_natural F _ _ _ _
+    (fun t => forsLeafWith_natural F core hashm hashn hhash sk pk adrs t)
+    (fun z t l r => forsNodeHashWith_natural F nodeHashm nodeHashn hnode adrs z t l r)]
+
+/-- A monad morphism commutes with FORS recovery when it commutes with all public-hash
+callbacks. -/
+theorem forsPkFromSigWith_natural {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] (F : m →ᵐ n) (core : CorePrimitives p)
+    (hashm : Adrs → core.Y → m core.Y) (hashn : Adrs → core.Y → n core.Y)
+    (nodeHashm : Adrs → core.Y → core.Y → m core.Y)
+    (nodeHashn : Adrs → core.Y → core.Y → n core.Y)
+    (compressm : Adrs → List core.Y → m core.Y)
+    (compressn : Adrs → List core.Y → n core.Y)
+    (hhash : ∀ a y, F (hashm a y) = hashn a y)
+    (hnode : ∀ a l r, F (nodeHashm a l r) = nodeHashn a l r)
+    (hcompress : ∀ a ys, F (compressm a ys) = compressn a ys)
+    (sig : ForsSigCore p core) (md : List Byte) (adrs : Adrs) :
+    F (forsPkFromSigWith core hashm nodeHashm compressm sig md adrs) =
+      forsPkFromSigWith core hashn nodeHashn compressn sig md adrs := by
+  have hroots : F (Vector.ofFnM fun i : Fin p.k => do
+      let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+      let leaf ← hashm (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+      PerfectMerkleTree.climbM (forsNodeHashWith nodeHashm adrs) idx leaf (sig[i.val]).2) =
+      (Vector.ofFnM fun i : Fin p.k => do
+        let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+        let leaf ← hashn (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+        PerfectMerkleTree.climbM (forsNodeHashWith nodeHashn adrs) idx leaf (sig[i.val]).2) := by
+    apply monadHom_ofFnM F
+    intro i
+    rw [F.mmap_bind, hhash]
+    congr 1
+    funext leaf
+    exact PerfectMerkleTree.climbM_natural F _ _
+      (fun z t l r => forsNodeHashWith_natural F nodeHashm nodeHashn hnode adrs z t l r) _ _ _
+  simp [forsPkFromSigWith, F.mmap_bind, hroots, hcompress]
+
+private theorem queryHom_f (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [Monad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n) (pk : core.PkSeed) :
+    ∀ a y, F.toMonadHom (PublicHash.f core pk a y) = PublicHash.f core pk a y := by
+  intro a y
+  change F.toMonadHom
+      (query (spec := publicHashSpec core)
+        (PublicHashQuery.thash pk (core.adrsToKey a) [y])) =
+    query (spec := publicHashSpec core)
+      (PublicHashQuery.thash pk (core.adrsToKey a) [y])
+  exact HasQuery.map_query F _
+
+private theorem queryHom_h (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [Monad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n) (pk : core.PkSeed) :
+    ∀ a l r, F.toMonadHom (PublicHash.h core pk a l r) = PublicHash.h core pk a l r := by
+  intro a l r
+  change F.toMonadHom
+      (query (spec := publicHashSpec core)
+        (PublicHashQuery.thash pk (core.adrsToKey a) [l, r])) =
+    query (spec := publicHashSpec core)
+      (PublicHashQuery.thash pk (core.adrsToKey a) [l, r])
+  exact HasQuery.map_query F _
+
+private theorem queryHom_tl (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [Monad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n) (pk : core.PkSeed) :
+    ∀ a ys, F.toMonadHom (PublicHash.tl core pk a ys) = PublicHash.tl core pk a ys := by
+  intro a ys
+  change F.toMonadHom
+      (query (spec := publicHashSpec core)
+        (PublicHashQuery.thash pk (core.adrsToKey a) ys)) =
+    query (spec := publicHashSpec core)
+      (PublicHashQuery.thash pk (core.adrsToKey a) ys)
+  exact HasQuery.map_query F _
+
+/-- Query-preserving monad morphisms commute with canonical FORS leaf computation. -/
+theorem forsLeafM_natural (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [HasQuery (publicHashSpec core) m] [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (t : ℕ) :
+    F.toMonadHom (forsLeafM core sk pk adrs t) = forsLeafM core sk pk adrs t :=
+  forsLeafWith_natural F.toMonadHom core _ _ (queryHom_f core F pk) sk pk adrs t
+
+/-- Query-preserving monad morphisms commute with canonical FORS internal-node computation. -/
+theorem forsNodeHashM_natural (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [HasQuery (publicHashSpec core) m] [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (pk : core.PkSeed) (adrs : Adrs) (z t : ℕ) (l r : core.Y) :
+    F.toMonadHom (forsNodeHashM core pk adrs z t l r) =
+      forsNodeHashM core pk adrs z t l r :=
+  forsNodeHashWith_natural F.toMonadHom _ _ (queryHom_h core F pk) adrs z t l r
+
+/-- Query-preserving monad morphisms commute with one canonical FORS root computation. -/
+theorem forsRootM_natural (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [HasQuery (publicHashSpec core) m] [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (i : ℕ) :
+    F.toMonadHom (forsRootM core sk pk adrs i) = forsRootM core sk pk adrs i :=
+  forsRootWith_natural F.toMonadHom core _ _ _ _
+    (queryHom_f core F pk) (queryHom_h core F pk) sk pk adrs i
+
+/-- Query-preserving monad morphisms commute with canonical FORS public-key generation. -/
+theorem forsPkGenM_natural (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [HasQuery (publicHashSpec core) m] [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) :
+    F.toMonadHom (forsPkGenM core sk pk adrs) = forsPkGenM core sk pk adrs :=
+  forsPkGenWith_natural F.toMonadHom core _ _ _ _ _ _
+    (queryHom_f core F pk) (queryHom_h core F pk) (queryHom_tl core F pk) sk pk adrs
+
+/-- Query-preserving monad morphisms commute with canonical FORS signing. -/
+theorem forsSignM_natural (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [HasQuery (publicHashSpec core) m] [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (md : List Byte) (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) :
+    F.toMonadHom (forsSignM core md sk pk adrs) = forsSignM core md sk pk adrs :=
+  forsSignWith_natural F.toMonadHom core _ _ _ _
+    (queryHom_f core F pk) (queryHom_h core F pk) md sk pk adrs
+
+/-- Query-preserving monad morphisms commute with canonical FORS recovery. -/
+theorem forsPkFromSigM_natural (core : CorePrimitives p) {m n : Type → Type*}
+    [Monad m] [LawfulMonad m] [Monad n] [LawfulMonad n]
+    [HasQuery (publicHashSpec core) m] [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs) :
+    F.toMonadHom (forsPkFromSigM core sig md pk adrs) = forsPkFromSigM core sig md pk adrs :=
+  forsPkFromSigWith_natural F.toMonadHom core _ _ _ _ _ _
+    (queryHom_f core F pk) (queryHom_h core F pk) (queryHom_tl core F pk) sig md adrs
+
+/-! ### Structural query bounds -/
+
+private theorem isTotalQueryBound_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
+    (g : Fin k → OracleComp spec α) (budget : Fin k → ℕ)
+    (h : ∀ i, IsTotalQueryBound (g i) (budget i)) :
+    IsTotalQueryBound (Vector.ofFnM g) (∑ i, budget i) := by
+  induction k with
+  | zero =>
+      rw [Vector.ofFnM_zero]
+      trivial
+  | succ k ih =>
+      rw [Vector.ofFnM_succ, Fin.sum_univ_castSucc]
+      apply isTotalQueryBound_bind
+        (ih (fun i => g i.castSucc) (fun i => budget i.castSucc) (fun i => h i.castSucc))
+      intro xs
+      simpa using isTotalQueryBound_bind (n₂ := 0) (h (Fin.last k))
+        (fun a => show IsTotalQueryBound (pure (xs.push a) : OracleComp spec _) 0 from trivial)
+
+private theorem publicHash_f_isTotalQueryBound_one (core : CorePrimitives p)
+    (pk : core.PkSeed) (adrs : Adrs) (x : core.Y) :
+    IsTotalQueryBound
+      (PublicHash.f core pk adrs x : OracleComp (publicHashSpec core) core.Y) 1 := by
+  simp [PublicHash.f, IsTotalQueryBound]
+
+private theorem publicHash_h_isTotalQueryBound_one (core : CorePrimitives p)
+    (pk : core.PkSeed) (adrs : Adrs) (l r : core.Y) :
+    IsTotalQueryBound
+      (PublicHash.h core pk adrs l r : OracleComp (publicHashSpec core) core.Y) 1 := by
+  simp [PublicHash.h, IsTotalQueryBound]
+
+private theorem publicHash_tl_isTotalQueryBound_one (core : CorePrimitives p)
+    (pk : core.PkSeed) (adrs : Adrs) (xs : List core.Y) :
+    IsTotalQueryBound
+      (PublicHash.tl core pk adrs xs : OracleComp (publicHashSpec core) core.Y) 1 := by
+  simp [PublicHash.tl, IsTotalQueryBound]
+
+/-- A FORS leaf is one explicit `F` query. -/
+theorem forsLeafM_isTotalQueryBound (core : CorePrimitives p)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (t : ℕ) :
+    IsTotalQueryBound
+      (forsLeafM core sk pk adrs t : OracleComp (publicHashSpec core) core.Y) 1 :=
+  publicHash_f_isTotalQueryBound_one core pk _ _
+
+/-- A FORS internal node is one explicit `H` query. -/
+theorem forsNodeHashM_isTotalQueryBound (core : CorePrimitives p)
+    (pk : core.PkSeed) (adrs : Adrs) (z t : ℕ) (l r : core.Y) :
+    IsTotalQueryBound
+      (forsNodeHashM core pk adrs z t l r : OracleComp (publicHashSpec core) core.Y) 1 :=
+  publicHash_h_isTotalQueryBound_one core pk _ _ _
+
+/-- A height-`a` FORS root evaluates all `2^a` leaves and all `2^a - 1` internal nodes. -/
+theorem forsRootM_isTotalQueryBound (core : CorePrimitives p)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (i : ℕ) :
+    IsTotalQueryBound
+      (forsRootM core sk pk adrs i : OracleComp (publicHashSpec core) core.Y)
+      (2 ^ p.a + (2 ^ p.a - 1)) := by
+  simpa [forsRootM, forsRootWith] using
+    (PerfectMerkleTree.isTotalQueryBound_merkleRootM
+      (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
+      (forsNodeHashWith (PublicHash.h core pk) adrs) 1 1 p.a i
+      (fun t => publicHash_f_isTotalQueryBound_one core pk _ _)
+      (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r))
+
+/-- FORS public-key generation computes `k` complete roots, in order, and then makes one `T_k`
+query. -/
+theorem forsPkGenM_isTotalQueryBound (core : CorePrimitives p)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsPkGenM core sk pk adrs : OracleComp (publicHashSpec core) core.Y)
+      (p.k * (2 ^ p.a + (2 ^ p.a - 1)) + 1) := by
+  have hroots := isTotalQueryBound_ofFnM
+    (fun i : Fin p.k =>
+      (forsRootM core sk pk adrs i.val : OracleComp (publicHashSpec core) core.Y))
+    (fun _ => 2 ^ p.a + (2 ^ p.a - 1))
+    (fun i => forsRootM_isTotalQueryBound core sk pk adrs i.val)
+  simpa [forsPkGenM, forsPkGenWith, forsRootM] using
+    isTotalQueryBound_bind hroots fun roots =>
+      publicHash_tl_isTotalQueryBound_one core pk (forsPkAdrs adrs) roots.toList
+
+/-- FORS signing computes only sibling subtrees. Per tree this is exactly `2^a - 1` leaf
+callbacks and `2^a - a - 1` internal-node callbacks; the selected leaf is not hashed. -/
+theorem forsSignM_isTotalQueryBound (core : CorePrimitives p) (md : List Byte)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsSignM core md sk pk adrs :
+        OracleComp (publicHashSpec core) (ForsSigCore p core))
+      (p.k * ((2 ^ p.a - 1) + (2 ^ p.a - p.a - 1))) := by
+  have hpaths := isTotalQueryBound_ofFnM
+    (fun i : Fin p.k =>
+      (do
+        let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+        let path ← PerfectMerkleTree.authPathM
+          (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
+          (forsNodeHashWith (PublicHash.h core pk) adrs) idx p.a
+        return (forsSkGenCore core sk pk adrs idx, path) :
+          OracleComp (publicHashSpec core) (core.Y × List core.Y)))
+    (fun _ => (2 ^ p.a - 1) + (2 ^ p.a - p.a - 1))
+    (fun i => by
+      have hpath : IsTotalQueryBound
+          (PerfectMerkleTree.authPathM
+            (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
+            (forsNodeHashWith (PublicHash.h core pk) adrs)
+            (i.val * 2 ^ p.a + forsIdx p md i.val) p.a :
+            OracleComp (publicHashSpec core) (List core.Y))
+          ((2 ^ p.a - 1) + (2 ^ p.a - p.a - 1)) := by
+        simpa using PerfectMerkleTree.isTotalQueryBound_authPathM
+          (forsLeafWith core (PublicHash.f core pk) sk pk adrs)
+          (forsNodeHashWith (PublicHash.h core pk) adrs) 1 1
+          (i.val * 2 ^ p.a + forsIdx p md i.val) p.a
+          (fun t => publicHash_f_isTotalQueryBound_one core pk _ _)
+          (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r)
+      exact isTotalQueryBound_bind (n₂ := 0) hpath
+        (fun path => show IsTotalQueryBound
+          (pure (forsSkGenCore core sk pk adrs
+            (i.val * 2 ^ p.a + forsIdx p md i.val), path) :
+            OracleComp (publicHashSpec core) _) 0 from trivial))
+  simpa [forsSignM, forsSignWith] using hpaths
+
+/-- Recovery from an arbitrary signature performs one `F` query and one `H` query per supplied
+authentication-path entry in each tree, then one final `T_k` query. -/
+theorem forsPkFromSigM_isTotalQueryBound (core : CorePrimitives p)
+    (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsPkFromSigM core sig md pk adrs : OracleComp (publicHashSpec core) core.Y)
+      ((∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig[j.val]).2.length) i) + 1) := by
+  have hroots := isTotalQueryBound_ofFnM
+    (fun i : Fin p.k =>
+      (do
+        let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+        let leaf ← PublicHash.f core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+        PerfectMerkleTree.climbM (forsNodeHashWith (PublicHash.h core pk) adrs)
+          idx leaf (sig[i.val]).2 : OracleComp (publicHashSpec core) core.Y))
+    (fun i => 1 + (sig[i.val]).2.length)
+    (fun i => isTotalQueryBound_bind
+      (publicHash_f_isTotalQueryBound_one core pk _ _)
+      (fun leaf => by
+        simpa using PerfectMerkleTree.isTotalQueryBound_climbM
+          (forsNodeHashWith (PublicHash.h core pk) adrs) 1
+          (i.val * 2 ^ p.a + forsIdx p md i.val) leaf (sig[i.val]).2
+          (fun z t l r => publicHash_h_isTotalQueryBound_one core pk _ l r)))
+  exact isTotalQueryBound_bind hroots fun roots =>
+    publicHash_tl_isTotalQueryBound_one core pk (forsPkAdrs adrs) roots.toList
+
+/-- For a FIPS-shaped signature with `a` authentication nodes per tree, recovery has structural
+upper bound `k * (a + 1) + 1`: one `F` and `a` `H` calls per tree, then `T_k`. The constant is
+the exact callback count; `IsTotalQueryBound` exposes it through the library's upper-bound API. -/
+theorem forsPkFromSigM_isTotalQueryBound_fips (core : CorePrimitives p)
+    (sig : ForsSigCore p core) (md : List Byte) (pk : core.PkSeed) (adrs : Adrs)
+    (hlen : ∀ i : Fin p.k, (sig[i.val]).2.length = p.a) :
+    IsTotalQueryBound
+      (forsPkFromSigM core sig md pk adrs : OracleComp (publicHashSpec core) core.Y)
+      (p.k * (p.a + 1) + 1) := by
+  have h := forsPkFromSigM_isTotalQueryBound core sig md pk adrs
+  have hsum : (∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig[j.val]).2.length) i) =
+      p.k * (p.a + 1) := by
+    calc
+      (∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig[j.val]).2.length) i) =
+          ∑ _ : Fin p.k, (p.a + 1) := by
+        apply Finset.sum_congr rfl
+        intro i _
+        change 1 + (sig[i.val]).2.length = p.a + 1
+        rw [hlen i]
+        omega
+      _ = p.k * (p.a + 1) := by simp
+  simpa [hsum] using h
+
+/-! ### Pure API equations -/
+
+private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
+    (answer : QueryImpl spec Id) (g : Fin k → OracleComp spec α) :
+    simulateQ answer (Vector.ofFnM g) = Vector.ofFn fun i => simulateQ answer (g i) := by
+  calc
+    simulateQ answer (Vector.ofFnM g) =
+        Vector.ofFnM (fun i => simulateQ answer (g i)) :=
+      monadHom_ofFnM (simulateQ' answer) g _ (fun _ => rfl)
+    _ = Vector.ofFn fun i => simulateQ answer (g i) := Vector.idRun_ofFnM
+
+@[simp] theorem forsLeaf_eq_f (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
+    forsLeaf prims sk pk adrs t =
+      prims.F pk (forsNodeAdrs adrs 0 t) (forsSkGen prims sk pk adrs t) := by
+  simp [forsLeaf, forsLeafM, forsLeafWith, PublicHash.f]
+  rfl
+
+@[simp] theorem forsNodeHash_eq_h (prims : Primitives p) (pk : prims.PkSeed)
+    (adrs : Adrs) (z t : ℕ) (l r : prims.Y) :
+    forsNodeHash prims pk adrs z t l r = prims.H pk (forsNodeAdrs adrs z t) l r := by
+  simp [forsNodeHash, forsNodeHashM, forsNodeHashWith, PublicHash.h]
+  rfl
+
+@[simp] theorem forsRoot_eq_merkleRoot (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (i : ℕ) :
+    forsRoot prims sk pk adrs i =
+      PerfectMerkleTree.merkleRoot (forsLeaf prims sk pk adrs)
+        (forsNodeHash prims pk adrs) p.a i := by
+  unfold forsRoot forsRootM forsRootWith
+  rw [PerfectMerkleTree.simulateQ_merkleRootM]
+  rfl
+
+@[simp] theorem forsPkGen_eq_tl (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    forsPkGen prims sk pk adrs = prims.Tl pk (forsPkAdrs adrs)
+      (Vector.ofFn (fun i : Fin p.k => forsRoot prims sk pk adrs i.val)).toList := by
+  simp only [forsPkGen, forsPkGenM, forsPkGenWith, simulateQ_bind, simulateQ_ofFnM,
+    PublicHash.tl, simulateQ_HasQuery_query, PublicHash.impl]
+  rfl
+
+@[simp] theorem forsSign_eq_ofFn (prims : Primitives p) (md : List Byte)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    forsSign prims md sk pk adrs = Vector.ofFn fun i : Fin p.k =>
+      let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+      (forsSkGen prims sk pk adrs idx,
+        PerfectMerkleTree.authPath (forsLeaf prims sk pk adrs)
+          (forsNodeHash prims pk adrs) idx p.a) := by
+  unfold forsSign forsSignM forsSignWith
+  rw [simulateQ_ofFnM]
+  apply Vector.ext
+  intro i hi
+  simp only [Vector.getElem_ofFn, simulateQ_bind, simulateQ_pure,
+    PerfectMerkleTree.simulateQ_authPathM]
+  rfl
+
+/-- Every authentication path produced by honest FORS signing has the FIPS-prescribed length
+`a`. -/
+@[simp] theorem forsSign_authPath_length (prims : Primitives p) (md : List Byte)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (i : Fin p.k) :
+    ((forsSign prims md sk pk adrs)[i.val]).2.length = p.a := by
+  simp [forsSign_eq_ofFn, PerfectMerkleTree.authPath_length]
+
+@[simp] theorem forsPkFromSig_eq_tl (prims : Primitives p) (sig : ForsSig p prims)
+    (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
+    forsPkFromSig prims sig md pk adrs = prims.Tl pk (forsPkAdrs adrs)
+      (Vector.ofFn (fun i : Fin p.k =>
+        let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+        PerfectMerkleTree.climb (forsNodeHash prims pk adrs) idx
+          (prims.F pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1) (sig[i.val]).2)).toList := by
+  simp only [forsPkFromSig, forsPkFromSigM, forsPkFromSigWith, simulateQ_bind,
+    simulateQ_ofFnM, PublicHash.tl, PublicHash.f, simulateQ_HasQuery_query,
+    PublicHash.impl]
+  apply congrArg (prims.Thash pk (prims.adrsToKey (forsPkAdrs adrs)))
+  congr 1
+  apply Vector.ext
+  intro i hi
+  simp only [Vector.getElem_ofFn, PerfectMerkleTree.simulateQ_climbM]
+  rfl
+
+/-! ### Deterministic interpretations -/
+
+@[simp] theorem simulateQ_forsLeafM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (t : ℕ) :
+    simulateQ answer
+        (forsLeafM core sk pk adrs t : OracleComp (publicHashSpec core) core.Y) =
+      forsLeaf (PublicHash.withPublicHash core answer) sk pk adrs t := by
+  simp [forsLeaf, PublicHash.impl_withPublicHash]
+
+@[simp] theorem simulateQ_forsLeafM (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
+    simulateQ (PublicHash.impl prims)
+        (forsLeafM prims.core sk pk adrs t :
+          OracleComp (publicHashSpec prims.core) prims.Y) =
+      forsLeaf prims sk pk adrs t := rfl
+
+@[simp] theorem simulateQ_forsNodeHashM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (pk : core.PkSeed) (adrs : Adrs)
+    (z t : ℕ) (l r : core.Y) :
+    simulateQ answer
+        (forsNodeHashM core pk adrs z t l r : OracleComp (publicHashSpec core) core.Y) =
+      forsNodeHash (PublicHash.withPublicHash core answer) pk adrs z t l r := by
+  simp [forsNodeHash, PublicHash.impl_withPublicHash]
+
+@[simp] theorem simulateQ_forsNodeHashM (prims : Primitives p) (pk : prims.PkSeed)
+    (adrs : Adrs) (z t : ℕ) (l r : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (forsNodeHashM prims.core pk adrs z t l r :
+          OracleComp (publicHashSpec prims.core) prims.Y) =
+      forsNodeHash prims pk adrs z t l r := rfl
+
+@[simp] theorem simulateQ_forsRootM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (i : ℕ) :
+    simulateQ answer
+        (forsRootM core sk pk adrs i : OracleComp (publicHashSpec core) core.Y) =
+      forsRoot (PublicHash.withPublicHash core answer) sk pk adrs i := by
+  simp [forsRoot, PublicHash.impl_withPublicHash]
+
+@[simp] theorem simulateQ_forsRootM (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (i : ℕ) :
+    simulateQ (PublicHash.impl prims)
+        (forsRootM prims.core sk pk adrs i :
+          OracleComp (publicHashSpec prims.core) prims.Y) =
+      forsRoot prims sk pk adrs i := rfl
+
+@[simp] theorem simulateQ_forsPkGenM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) :
+    simulateQ answer
+        (forsPkGenM core sk pk adrs : OracleComp (publicHashSpec core) core.Y) =
+      forsPkGen (PublicHash.withPublicHash core answer) sk pk adrs := by
+  simp [forsPkGen, PublicHash.impl_withPublicHash]
+
+@[simp] theorem simulateQ_forsPkGenM (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (forsPkGenM prims.core sk pk adrs :
+          OracleComp (publicHashSpec prims.core) prims.Y) =
+      forsPkGen prims sk pk adrs := rfl
+
+@[simp] theorem simulateQ_forsSignM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (md : List Byte) (sk : core.SkSeed)
+    (pk : core.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (forsSignM core md sk pk adrs :
+          OracleComp (publicHashSpec core) (ForsSigCore p core)) =
+      forsSign (PublicHash.withPublicHash core answer) md sk pk adrs := by
+  simp [forsSign, PublicHash.impl_withPublicHash]
+
+@[simp] theorem simulateQ_forsSignM (prims : Primitives p) (md : List Byte)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (forsSignM prims.core md sk pk adrs :
+          OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) =
+      forsSign prims md sk pk adrs := rfl
+
+@[simp] theorem simulateQ_forsPkFromSigM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (sig : ForsSigCore p core)
+    (md : List Byte) (pk : core.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (forsPkFromSigM core sig md pk adrs : OracleComp (publicHashSpec core) core.Y) =
+      forsPkFromSig (PublicHash.withPublicHash core answer) sig md pk adrs := by
+  simp [forsPkFromSig, PublicHash.impl_withPublicHash]
+
+@[simp] theorem simulateQ_forsPkFromSigM (prims : Primitives p) (sig : ForsSig p prims)
+    (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ (PublicHash.impl prims)
+        (forsPkFromSigM prims.core sig md pk adrs :
+          OracleComp (publicHashSpec prims.core) prims.Y) =
+      forsPkFromSig prims sig md pk adrs := rfl
 
 /-! ### Correctness -/
 
@@ -119,15 +791,34 @@ Merkle auth-path consistency lemma. -/
 theorem forsPkFromSig_forsSign (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) :
     forsPkFromSig prims (forsSign prims md sk pk adrs) md pk adrs = forsPkGen prims sk pk adrs := by
-  unfold forsPkFromSig forsPkGen
-  refine congrArg (prims.Tl pk (forsPkAdrs adrs)) (List.map_congr_left fun i _ => ?_)
-  simp only [forsSign, Vector.getElem_ofFn]
-  have ht : (i.val * 2 ^ p.a + forsIdx p md i.val) / 2 ^ p.a = i.val := by
+  rw [forsPkFromSig_eq_tl, forsPkGen_eq_tl]
+  apply congrArg (prims.Tl pk (forsPkAdrs adrs))
+  congr 1
+  apply Vector.ext
+  intro i hi
+  simp only [forsSign_eq_ofFn, Vector.getElem_ofFn]
+  have ht : (i * 2 ^ p.a + forsIdx p md i) / 2 ^ p.a = i := by
     rw [Nat.add_comm, Nat.add_mul_div_right _ _ (by positivity : 0 < 2 ^ p.a),
-      Nat.div_eq_of_lt (forsIdx_lt p md i.val), Nat.zero_add]
+      Nat.div_eq_of_lt (forsIdx_lt p md i), Nat.zero_add]
   have key := PerfectMerkleTree.climb_authPath (forsLeaf prims sk pk adrs)
-    (forsNodeHash prims pk adrs) (i.val * 2 ^ p.a + forsIdx p md i.val) p.a
+    (forsNodeHash prims pk adrs) (i * 2 ^ p.a + forsIdx p md i) p.a
   rw [ht] at key
-  exact key
+  simpa only [forsLeaf_eq_f, forsRoot_eq_merkleRoot] using key
+
+/-- Extensional FORS completeness for every fixed total public-hash answer table.
+
+This is a stateless `QueryImpl ... Id` theorem. It deliberately fixes one answer function for
+key generation, signing, and recovery; the lazy cached-random-oracle bridge belongs to the
+security layer. -/
+theorem simulateQ_forsPkFromSigM_forsSignM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) (md : List Byte) (sk : core.SkSeed)
+    (pk : core.PkSeed) (adrs : Adrs) :
+    simulateQ answer (do
+      let sig ← forsSignM core md sk pk adrs
+      forsPkFromSigM core sig md pk adrs) =
+    simulateQ answer (forsPkGenM core sk pk adrs) := by
+  simp only [simulateQ_bind, simulateQ_forsSignM_withPublicHash,
+    simulateQ_forsPkFromSigM_withPublicHash, simulateQ_forsPkGenM_withPublicHash]
+  exact forsPkFromSig_forsSign (PublicHash.withPublicHash core answer) md sk pk adrs
 
 end SLHDSA

--- a/HashSig/SLHDSA/Fors.lean
+++ b/HashSig/SLHDSA/Fors.lean
@@ -17,7 +17,7 @@ The few-time forest signature: `k` Merkle trees of height `a`, with leaves `F(se
 issue every public hash through `HasQuery`; the pure API is their literal deterministic
 `simulateQ` interpretation. Each tree is a `PerfectMerkleTree`
 (`VCVio.CryptoFoundations.MerkleTree.Addressed.NatIndexed`) over global leaf indices. Provides
-`forsSkGen`/`forsLeaf`/`forsRoot` (Algorithms 14–15), `forsSign` (Algorithm 16), `forsPkFromSig`
+`forsSkGenCore`/`forsLeaf`/`forsRoot` (Algorithms 14–15), `forsSign` (Algorithm 16), `forsPkFromSig`
 (Algorithm 17), and the correctness lemma `forsPkFromSig_forsSign`: recovery from an honest FORS
 signature reproduces the FORS public key.
 
@@ -65,11 +65,6 @@ def forsSkGenCore (core : CorePrimitives p) (sk : core.SkSeed) (pk : core.PkSeed
     (adrs : Adrs) (t : ℕ) : core.Y :=
   core.PRF pk sk (forsSkAdrs adrs t)
 
-/-- Source-compatible pure wrapper for `forsSkGenCore`. -/
-def forsSkGen (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
-    (t : ℕ) : prims.Y :=
-  forsSkGenCore prims.core sk pk adrs t
-
 /-- Address for the FORS-tree node at `(height z, global index t)` (type `FORS_TREE`). -/
 def forsNodeAdrs (adrs : Adrs) (z t : ℕ) : Adrs :=
   let base := (adrs.setTypeAndClear .forsTree).setKeyPairAddress adrs.getKeyPairAddress
@@ -102,9 +97,6 @@ def forsPkAdrs (adrs : Adrs) : Adrs :=
 /-- A FORS signature over an implementation-independent context. -/
 abbrev ForsSigCore (p : Params) (core : CorePrimitives p) :=
   Vector (core.Y × List core.Y) p.k
-
-/-- Source-compatible pure FORS signature type. -/
-abbrev ForsSig (p : Params) (prims : Primitives p) := ForsSigCore p prims.core
 
 /-- Low-level callback-parametric FORS public-key generation. Roots are computed in increasing
 tree order and compressed only after every root is available. -/
@@ -213,13 +205,13 @@ def forsPkGen (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (ad
 
 /-- Pure FORS signing, defined as the deterministic interpretation of `forsSignM`. -/
 def forsSign (prims : Primitives p) (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed)
-    (adrs : Adrs) : ForsSig p prims :=
+    (adrs : Adrs) : ForsSigCore p prims.core :=
   simulateQ (PublicHash.impl prims)
     (forsSignM prims.core md sk pk adrs :
       OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core))
 
 /-- Pure FORS public-key recovery, defined as the interpretation of `forsPkFromSigM`. -/
-def forsPkFromSig (prims : Primitives p) (sig : ForsSig p prims) (md : List Byte)
+def forsPkFromSig (prims : Primitives p) (sig : ForsSigCore p prims.core) (md : List Byte)
     (pk : prims.PkSeed) (adrs : Adrs) : prims.Y :=
   simulateQ (PublicHash.impl prims)
     (forsPkFromSigM prims.core sig md pk adrs :
@@ -624,7 +616,7 @@ private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
 @[simp] theorem forsLeaf_eq_f (prims : Primitives p) (sk : prims.SkSeed)
     (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
     forsLeaf prims sk pk adrs t =
-      prims.F pk (forsNodeAdrs adrs 0 t) (forsSkGen prims sk pk adrs t) := by
+      prims.F pk (forsNodeAdrs adrs 0 t) (forsSkGenCore prims.core sk pk adrs t) := by
   simp [forsLeaf, forsLeafM, forsLeafWith, PublicHash.f]
   rfl
 
@@ -655,7 +647,7 @@ private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
     (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
     forsSign prims md sk pk adrs = Vector.ofFn fun i : Fin p.k =>
       let idx := i.val * 2 ^ p.a + forsIdx p md i.val
-      (forsSkGen prims sk pk adrs idx,
+      (forsSkGenCore prims.core sk pk adrs idx,
         PerfectMerkleTree.authPath (forsLeaf prims sk pk adrs)
           (forsNodeHash prims pk adrs) idx p.a) := by
   unfold forsSign forsSignM forsSignWith
@@ -673,7 +665,7 @@ private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
     ((forsSign prims md sk pk adrs)[i.val]).2.length = p.a := by
   simp [forsSign_eq_ofFn, PerfectMerkleTree.authPath_length]
 
-@[simp] theorem forsPkFromSig_eq_tl (prims : Primitives p) (sig : ForsSig p prims)
+@[simp] theorem forsPkFromSig_eq_tl (prims : Primitives p) (sig : ForsSigCore p prims.core)
     (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
     forsPkFromSig prims sig md pk adrs = prims.Tl pk (forsPkAdrs adrs)
       (Vector.ofFn (fun i : Fin p.k =>
@@ -776,7 +768,8 @@ private theorem simulateQ_ofFnM {ι α : Type} {spec : OracleSpec ι} {k : ℕ}
       forsPkFromSig (PublicHash.withPublicHash core answer) sig md pk adrs := by
   simp [forsPkFromSig, PublicHash.impl_withPublicHash]
 
-@[simp] theorem simulateQ_forsPkFromSigM (prims : Primitives p) (sig : ForsSig p prims)
+@[simp] theorem simulateQ_forsPkFromSigM (prims : Primitives p)
+    (sig : ForsSigCore p prims.core)
     (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
     simulateQ (PublicHash.impl prims)
         (forsPkFromSigM prims.core sig md pk adrs :

--- a/HashSigTest/SLHDSA/Fors.lean
+++ b/HashSigTest/SLHDSA/Fors.lean
@@ -1,0 +1,158 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import HashSig.SLHDSA.Fors
+
+/-!
+# Oracle-parametric FORS canaries
+
+These examples pin the FIPS 205 FORS query schedule: trees are traversed in increasing order,
+authentication paths evaluate sibling subtrees only, signing does not hash the selected leaf,
+root compression happens after all roots, and recovery performs `F`, the authentication-path
+climb, then the final `T_k` compression.
+-/
+
+public section
+
+namespace SLHDSA.ForsTest
+
+open OracleComp
+
+variable {p : Params} (prims : Primitives p)
+
+/-- FIPS 205 Algorithm 15: a leaf is exactly one addressed `F` query. -/
+example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
+    forsLeafM prims.core sk pk adrs t =
+      (PublicHash.f prims.core pk (forsNodeAdrs adrs 0 t)
+        (forsSkGenCore prims.core sk pk adrs t) :
+        OracleComp (publicHashSpec prims.core) prims.Y) := rfl
+
+/-- FIPS 205 Algorithm 15: root construction delegates to the oracle-agnostic Merkle traversal. -/
+example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (i : ℕ) :
+    forsRootM prims.core sk pk adrs i =
+      (PerfectMerkleTree.merkleRootM
+        (forsLeafWith prims.core (PublicHash.f prims.core pk) sk pk adrs)
+        (forsNodeHashWith (PublicHash.h prims.core pk) adrs) p.a i :
+        OracleComp (publicHashSpec prims.core) prims.Y) := rfl
+
+/-- Public-key generation computes roots in increasing `Fin k` order and compresses only after
+the complete root vector is available. -/
+example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    forsPkGenM prims.core sk pk adrs = (do
+      let roots ← Vector.ofFnM fun i : Fin p.k =>
+        forsRootM prims.core sk pk adrs i.val
+      PublicHash.tl prims.core pk (forsPkAdrs adrs) roots.toList :
+      OracleComp (publicHashSpec prims.core) prims.Y) := rfl
+
+/-- Signing processes trees in increasing order. For each selected leaf it evaluates only the
+sibling-only authentication path and returns the raw secret; there is no selected-leaf `F` call. -/
+example (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    forsSignM prims.core md sk pk adrs =
+      (Vector.ofFnM fun i : Fin p.k => do
+        let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+        let path ← PerfectMerkleTree.authPathM
+          (forsLeafWith prims.core (PublicHash.f prims.core pk) sk pk adrs)
+          (forsNodeHashWith (PublicHash.h prims.core pk) adrs) idx p.a
+        return (forsSkGenCore prims.core sk pk adrs idx, path) :
+        OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) := rfl
+
+/-- Recovery performs one `F`, then a leaf-to-root climb, per tree in increasing order, followed
+by the final `T_k` compression. -/
+example (sig : ForsSigCore p prims.core) (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs) :
+    forsPkFromSigM prims.core sig md pk adrs = (do
+      let roots ← Vector.ofFnM fun i : Fin p.k => do
+        let idx := i.val * 2 ^ p.a + forsIdx p md i.val
+        let leaf ← PublicHash.f prims.core pk (forsNodeAdrs adrs 0 idx) (sig[i.val]).1
+        PerfectMerkleTree.climbM
+          (forsNodeHashWith (PublicHash.h prims.core pk) adrs) idx leaf (sig[i.val]).2
+      PublicHash.tl prims.core pk (forsPkAdrs adrs) roots.toList :
+      OracleComp (publicHashSpec prims.core) prims.Y) := rfl
+
+/-- The sibling-only signing budget excludes the selected leaf and its direct ancestor chain. -/
+example (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsSignM prims.core md sk pk adrs :
+        OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core))
+      (p.k * ((2 ^ p.a - 1) + (2 ^ p.a - p.a - 1))) :=
+  forsSignM_isTotalQueryBound prims.core md sk pk adrs
+
+/-- Public-key generation uses one complete-tree budget per FORS tree and one final compression. -/
+example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsPkGenM prims.core sk pk adrs :
+        OracleComp (publicHashSpec prims.core) prims.Y)
+      (p.k * (2 ^ p.a + (2 ^ p.a - 1)) + 1) :=
+  forsPkGenM_isTotalQueryBound prims.core sk pk adrs
+
+/-- The height-zero edge case normalizes to no signing queries: the secret is returned directly
+and there is no sibling subtree. -/
+example (ha : p.a = 0) (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed)
+    (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsSignM prims.core md sk pk adrs :
+        OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) 0 := by
+  simpa [ha] using forsSignM_isTotalQueryBound prims.core md sk pk adrs
+
+/-- At height zero, key generation makes one leaf query per tree and one final compression. -/
+example (ha : p.a = 0) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsPkGenM prims.core sk pk adrs :
+        OracleComp (publicHashSpec prims.core) prims.Y) (p.k + 1) := by
+  simpa [ha] using forsPkGenM_isTotalQueryBound prims.core sk pk adrs
+
+/-- A FIPS-shaped signature makes one `F` and `a` climb queries per tree, then `T_k`. -/
+example (sig : ForsSigCore p prims.core) (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs)
+    (hlen : ∀ i : Fin p.k, (sig[i.val]).2.length = p.a) :
+    IsTotalQueryBound
+      (forsPkFromSigM prims.core sig md pk adrs :
+        OracleComp (publicHashSpec prims.core) prims.Y)
+      (p.k * (p.a + 1) + 1) :=
+  forsPkFromSigM_isTotalQueryBound_fips prims.core sig md pk adrs hlen
+
+/-- Honest pure signatures satisfy the FIPS-shaped recovery schedule without an extra premise. -/
+example (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    IsTotalQueryBound
+      (forsPkFromSigM prims.core (forsSign prims md sk pk adrs) md pk adrs :
+        OracleComp (publicHashSpec prims.core) prims.Y)
+      (p.k * (p.a + 1) + 1) :=
+  forsPkFromSigM_isTotalQueryBound_fips prims.core (forsSign prims md sk pk adrs) md pk adrs
+    (fun i => forsSign_authPath_length prims md sk pk adrs i)
+
+/-- Query-preserving handlers commute with canonical FORS signing. -/
+example {m : Type → Type*} [Monad m] [LawfulMonad m]
+    [HasQuery (publicHashSpec prims.core) m]
+    (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec prims.core) (m := m)).toMonadHom
+        (forsSignM prims.core md sk pk adrs :
+          OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) =
+      (forsSignM prims.core md sk pk adrs : m (ForsSigCore p prims.core)) := by
+  exact forsSignM_natural prims.core _ md sk pk adrs
+
+/-- An arbitrary fixed answer table interprets the canonical program as the induced pure API. -/
+example (answer : QueryImpl (publicHashSpec prims.core) Id)
+    (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer
+        (forsSignM prims.core md sk pk adrs :
+          OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) =
+      forsSign (PublicHash.withPublicHash prims.core answer) md sk pk adrs :=
+  simulateQ_forsSignM_withPublicHash prims.core answer md sk pk adrs
+
+/-- A fixed answer table gives extensional FORS completeness through the canonical programs. -/
+example (answer : QueryImpl (publicHashSpec prims.core) Id)
+    (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
+    simulateQ answer (do
+      let sig ← forsSignM prims.core md sk pk adrs
+      forsPkFromSigM prims.core sig md pk adrs) =
+    simulateQ answer (forsPkGenM prims.core sk pk adrs) :=
+  simulateQ_forsPkFromSigM_forsSignM_withPublicHash prims.core answer md sk pk adrs
+
+/-- The pre-oracle pure secret-generation helper remains source-compatible. -/
+example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
+    forsSkGen prims sk pk adrs t = prims.PRF pk sk (forsSkAdrs adrs t) := rfl
+
+end SLHDSA.ForsTest

--- a/HashSigTest/SLHDSA/Fors.lean
+++ b/HashSigTest/SLHDSA/Fors.lean
@@ -11,10 +11,9 @@ public import HashSig.SLHDSA.Fors
 /-!
 # Oracle-parametric FORS canaries
 
-These examples pin the FIPS 205 FORS query schedule: trees are traversed in increasing order,
-authentication paths evaluate sibling subtrees only, signing does not hash the selected leaf,
-root compression happens after all roots, and recovery performs `F`, the authentication-path
-climb, then the final `T_k` compression.
+These examples cover the three distinct top-level FORS schedules: public-key generation, signing,
+and recovery.  They pin tree order, sibling-only authentication paths, omission of a selected-leaf
+hash during signing, and final `T_k` compression.
 -/
 
 public section
@@ -24,21 +23,6 @@ namespace SLHDSA.ForsTest
 open OracleComp
 
 variable {p : Params} (prims : Primitives p)
-
-/-- FIPS 205 Algorithm 15: a leaf is exactly one addressed `F` query. -/
-example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
-    forsLeafM prims.core sk pk adrs t =
-      (PublicHash.f prims.core pk (forsNodeAdrs adrs 0 t)
-        (forsSkGenCore prims.core sk pk adrs t) :
-        OracleComp (publicHashSpec prims.core) prims.Y) := rfl
-
-/-- FIPS 205 Algorithm 15: root construction delegates to the oracle-agnostic Merkle traversal. -/
-example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (i : ℕ) :
-    forsRootM prims.core sk pk adrs i =
-      (PerfectMerkleTree.merkleRootM
-        (forsLeafWith prims.core (PublicHash.f prims.core pk) sk pk adrs)
-        (forsNodeHashWith (PublicHash.h prims.core pk) adrs) p.a i :
-        OracleComp (publicHashSpec prims.core) prims.Y) := rfl
 
 /-- Public-key generation computes roots in increasing `Fin k` order and compresses only after
 the complete root vector is available. -/
@@ -72,87 +56,5 @@ example (sig : ForsSigCore p prims.core) (md : List Byte) (pk : prims.PkSeed) (a
           (forsNodeHashWith (PublicHash.h prims.core pk) adrs) idx leaf (sig[i.val]).2
       PublicHash.tl prims.core pk (forsPkAdrs adrs) roots.toList :
       OracleComp (publicHashSpec prims.core) prims.Y) := rfl
-
-/-- The sibling-only signing budget excludes the selected leaf and its direct ancestor chain. -/
-example (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    IsTotalQueryBound
-      (forsSignM prims.core md sk pk adrs :
-        OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core))
-      (p.k * ((2 ^ p.a - 1) + (2 ^ p.a - p.a - 1))) :=
-  forsSignM_isTotalQueryBound prims.core md sk pk adrs
-
-/-- Public-key generation uses one complete-tree budget per FORS tree and one final compression. -/
-example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    IsTotalQueryBound
-      (forsPkGenM prims.core sk pk adrs :
-        OracleComp (publicHashSpec prims.core) prims.Y)
-      (p.k * (2 ^ p.a + (2 ^ p.a - 1)) + 1) :=
-  forsPkGenM_isTotalQueryBound prims.core sk pk adrs
-
-/-- The height-zero edge case normalizes to no signing queries: the secret is returned directly
-and there is no sibling subtree. -/
-example (ha : p.a = 0) (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed)
-    (adrs : Adrs) :
-    IsTotalQueryBound
-      (forsSignM prims.core md sk pk adrs :
-        OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) 0 := by
-  simpa [ha] using forsSignM_isTotalQueryBound prims.core md sk pk adrs
-
-/-- At height zero, key generation makes one leaf query per tree and one final compression. -/
-example (ha : p.a = 0) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    IsTotalQueryBound
-      (forsPkGenM prims.core sk pk adrs :
-        OracleComp (publicHashSpec prims.core) prims.Y) (p.k + 1) := by
-  simpa [ha] using forsPkGenM_isTotalQueryBound prims.core sk pk adrs
-
-/-- A FIPS-shaped signature makes one `F` and `a` climb queries per tree, then `T_k`. -/
-example (sig : ForsSigCore p prims.core) (md : List Byte) (pk : prims.PkSeed) (adrs : Adrs)
-    (hlen : ∀ i : Fin p.k, (sig[i.val]).2.length = p.a) :
-    IsTotalQueryBound
-      (forsPkFromSigM prims.core sig md pk adrs :
-        OracleComp (publicHashSpec prims.core) prims.Y)
-      (p.k * (p.a + 1) + 1) :=
-  forsPkFromSigM_isTotalQueryBound_fips prims.core sig md pk adrs hlen
-
-/-- Honest pure signatures satisfy the FIPS-shaped recovery schedule without an extra premise. -/
-example (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    IsTotalQueryBound
-      (forsPkFromSigM prims.core (forsSign prims md sk pk adrs) md pk adrs :
-        OracleComp (publicHashSpec prims.core) prims.Y)
-      (p.k * (p.a + 1) + 1) :=
-  forsPkFromSigM_isTotalQueryBound_fips prims.core (forsSign prims md sk pk adrs) md pk adrs
-    (fun i => forsSign_authPath_length prims md sk pk adrs i)
-
-/-- Query-preserving handlers commute with canonical FORS signing. -/
-example {m : Type → Type*} [Monad m] [LawfulMonad m]
-    [HasQuery (publicHashSpec prims.core) m]
-    (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec prims.core) (m := m)).toMonadHom
-        (forsSignM prims.core md sk pk adrs :
-          OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) =
-      (forsSignM prims.core md sk pk adrs : m (ForsSigCore p prims.core)) := by
-  exact forsSignM_natural prims.core _ md sk pk adrs
-
-/-- An arbitrary fixed answer table interprets the canonical program as the induced pure API. -/
-example (answer : QueryImpl (publicHashSpec prims.core) Id)
-    (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    simulateQ answer
-        (forsSignM prims.core md sk pk adrs :
-          OracleComp (publicHashSpec prims.core) (ForsSigCore p prims.core)) =
-      forsSign (PublicHash.withPublicHash prims.core answer) md sk pk adrs :=
-  simulateQ_forsSignM_withPublicHash prims.core answer md sk pk adrs
-
-/-- A fixed answer table gives extensional FORS completeness through the canonical programs. -/
-example (answer : QueryImpl (publicHashSpec prims.core) Id)
-    (md : List Byte) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) :
-    simulateQ answer (do
-      let sig ← forsSignM prims.core md sk pk adrs
-      forsPkFromSigM prims.core sig md pk adrs) =
-    simulateQ answer (forsPkGenM prims.core sk pk adrs) :=
-  simulateQ_forsPkFromSigM_forsSignM_withPublicHash prims.core answer md sk pk adrs
-
-/-- The pre-oracle pure secret-generation helper remains source-compatible. -/
-example (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (t : ℕ) :
-    forsSkGen prims sk pk adrs t = prims.PRF pk sk (forsSkAdrs adrs t) := rfl
 
 end SLHDSA.ForsTest


### PR DESCRIPTION
## Summary

This stacked PR makes FORS a canonical explicit-public-hash program over `CorePrimitives` and `HasQuery (publicHashSpec core)`. Deterministic FORS execution is obtained by interpreting the same programs with `PublicHash.impl`.

### Diff metadata

- Base: `84eb9a3431ab3b78296a1112fc599be22a530966` (`repair/slhdsa-xmss-oracle-core-clean-20260827`)
- Head: `4c715ca2cb5d5aaae6ddd88268333040f8f2da4c`
- Commits: 4
- Files changed: 3
- Diff: 795 insertions, 47 deletions

## Canonical programs

The semantic owner is the `fors*M` family: leaf hashing, node hashing, one-tree roots, public-key generation, signing, and public-key recovery. The deterministic `fors*` functions are literal `simulateQ (PublicHash.impl prims)` interpretations.

Addresses preserve the FIPS 205 global leaf index `i * 2^a + forsIdx(md, i)`. Signing hashes only sibling subtrees, and recovery processes each revealed secret/path before the final `T_k` compression.

## API surface

The unused compatibility wrapper `forsSkGen` was removed. The `ForsSig` alias is retained at this intermediate head because the inherited Scheme consumer still uses it; #568 deletes it atomically with that consumer's migration to `ForsSigCore`. Tests retain schedule, address, degenerate-parameter, and query-bound canaries while removing theorem mirrors.

## Correctness and accounting

The PR retains FORS correctness, query-preserving naturality, arbitrary deterministic interpretation, and structural/FIPS query bounds. Secret derivation via `CorePrimitives.PRF` is pure and is not counted as a public-hash query.

No FORS function installs or resets a random-oracle cache.

## Validation at `4c715ca2`

- focused FORS source/test builds and `lake build HashSig` pass locally;
- `git diff --check` passes;
- the complete restacked tree passes `lake build` at #569;
- GitHub checks are currently running after the restack.

## Non-goals

This PR does not define the top-level scheme/runtime or prove aggregate SLH-DSA security.

## Reviewer map

1. leaf/global-index and address definitions;
2. signing and recovery schedules;
3. deterministic interpretation and correctness;
4. structural/FIPS bounds;
5. retained focused tests.
