### PR TITLE
feat(HashSig): make the d=1 hypertree oracle-parametric

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,4 +84,4 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT
+        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -1,7 +1,7 @@
 /-
 Copyright (c) 2026 Nicolas Consigny. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
-Authors: Nicolas Consigny
+Authors: Nicolas Consigny, Quang Dao
 -/
 
 module
@@ -10,14 +10,18 @@ public import HashSig.SLHDSA.Fors
 /-!
 # Hypertree (FIPS 205 §7)
 
-For the SLH-DSA-SHA2-128-24 parameter set `d = 1`, so the hypertree is a **single** XMSS tree
-and `ht_sign` / `ht_verify` (Algorithms 12–13) collapse to one XMSS layer. This module gives
-that single-layer instantiation (`htSign`, `htVerify`, `htRoot`) and the correctness lemma
-`htVerify_htSign`, derived directly from XMSS correctness (`xmssPkFromSig_xmssSign`).
+For the SLH-DSA-SHA2-128-24 parameter set `d = 1`, the hypertree is a single XMSS tree and
+Algorithms 12–13 collapse to one XMSS layer. The canonical `*M` algorithms in this file depend
+only on `CorePrimitives` and issue every public hash through `HasQuery`. The established pure API
+is defined as the literal `simulateQ` interpretation of those programs.
+
+The `*With` definitions expose the thin callback-parametric composition with XMSS. The
+`htPkFromSigM` recovery function is the computational core of verification; keeping it visible
+makes the exact extractor- and reduction-facing computation inspectable before the final Boolean
+comparison in `htVerifyM`.
 
 The general `d > 1` hypertree (each layer WOTS-signs the root of the layer below; needed by the
-C13 parameter set) is a future generalization of `HtSig` to a `d`-element layer list with a
-fold; it is intentionally out of scope here so the `d = 1` development stays fully proved.
+C13 parameter set) remains a separate generalization.
 
 ## References
 
@@ -29,41 +33,317 @@ fold; it is intentionally out of scope here so the `d = 1` development stays ful
 
 namespace SLHDSA
 
+open OracleComp
+
 variable {p : Params}
 
-/-- A hypertree signature for `d = 1`: a single XMSS signature of the FORS public key. -/
-abbrev HtSig (p : Params) (prims : Primitives p) := XmssSig p prims
+/-- A hypertree signature for `d = 1`: one XMSS signature of the FORS public key. -/
+abbrev HtSigCore (p : Params) (core : CorePrimitives p) := XmssSig p core
 
-/-- The address of the single hypertree layer (layer `0`, tree `idxTree`). -/
+/-- Source-compatible pure hypertree signature type. -/
+abbrev HtSig (p : Params) (prims : Primitives p) := HtSigCore p prims.core
+
+/-- Address of the single hypertree layer (layer `0`, tree `idxTree`). -/
 def htAdrs (adrs : Adrs) (idxTree : ℕ) : Adrs :=
   (adrs.setLayerAddress 0).setTreeAddress idxTree
 
-/-- Hypertree signing for `d = 1` (FIPS 205 Algorithm 12): XMSS-sign `msg` at the chosen leaf
-of the single tree. -/
+/-! ### Low-level callback-parametric helpers -/
+
+/-- Callback-parametric hypertree signing for `d = 1`. -/
+def htSignWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (compress : Adrs → List core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) : m (HtSigCore p core) :=
+  xmssSignWith core hash compress nodeHash msg sk pk (htAdrs adrs idxTree) idxLeaf
+
+/-- Callback-parametric hypertree root generation for `d = 1`. -/
+def htRootWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (compress : Adrs → List core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) : m core.Y :=
+  xmssRootWith core hash compress nodeHash sk pk (htAdrs adrs idxTree)
+
+/-- Callback-parametric recovery of the root authenticated by a `d = 1` hypertree signature. -/
+def htPkFromSigWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    (hash : Adrs → core.Y → m core.Y)
+    (compress : Adrs → List core.Y → m core.Y)
+    (nodeHash : Adrs → core.Y → core.Y → m core.Y)
+    (msg : core.Y) (sig : HtSigCore p core) (adrs : Adrs)
+    (idxTree idxLeaf : ℕ) : m core.Y :=
+  xmssPkFromSigWith core hash compress nodeHash idxLeaf sig msg (htAdrs adrs idxTree)
+
+/-! ### Canonical explicit-public-hash programs -/
+
+/-- Canonical explicit-public-hash hypertree signing for `d = 1`. -/
+def htSignM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m]
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) : m (HtSigCore p core) :=
+  htSignWith core (PublicHash.f core pk) (PublicHash.tl core pk)
+    (PublicHash.h core pk) msg sk pk adrs idxTree idxLeaf
+
+/-- Canonical explicit-public-hash hypertree root generation for `d = 1`. -/
+def htRootM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m]
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) : m core.Y :=
+  htRootWith core (PublicHash.f core pk) (PublicHash.tl core pk)
+    (PublicHash.h core pk) sk pk adrs idxTree
+
+/-- Canonical explicit-public-hash recovery of the root authenticated by a hypertree signature. -/
+def htPkFromSigM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m]
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) : m core.Y :=
+  htPkFromSigWith core (PublicHash.f core pk) (PublicHash.tl core pk)
+    (PublicHash.h core pk) msg sig adrs idxTree idxLeaf
+
+/-- Canonical explicit-public-hash hypertree verification. The only non-oracle step is the final
+comparison with the claimed root. -/
+def htVerifyM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) : m Bool := do
+  let recovered ← htPkFromSigM core msg sig pk adrs idxTree idxLeaf
+  return decide (recovered = pkRoot)
+
+/-! ### Naturality -/
+
+/-- Query-preserving monad morphisms commute with `d = 1` hypertree signing. -/
+theorem htSignM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    F.toMonadHom (htSignM core msg sk pk adrs idxTree idxLeaf) =
+      htSignM core msg sk pk adrs idxTree idxLeaf := by
+  exact xmssSignM_natural core F msg sk pk (htAdrs adrs idxTree) idxLeaf
+
+/-- Query-preserving monad morphisms commute with `d = 1` hypertree root generation. -/
+theorem htRootM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
+    F.toMonadHom (htRootM core sk pk adrs idxTree) =
+      htRootM core sk pk adrs idxTree := by
+  exact xmssRootM_natural core F sk pk (htAdrs adrs idxTree)
+
+/-- Query-preserving monad morphisms commute with `d = 1` hypertree root recovery. -/
+theorem htPkFromSigM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    F.toMonadHom (htPkFromSigM core msg sig pk adrs idxTree idxLeaf) =
+      htPkFromSigM core msg sig pk adrs idxTree idxLeaf := by
+  exact xmssPkFromSigM_natural core F idxLeaf sig msg pk (htAdrs adrs idxTree)
+
+/-- Query-preserving monad morphisms commute with `d = 1` hypertree verification, including
+the pure final comparison after oracle-parametric root recovery. -/
+theorem htVerifyM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n] [DecidableEq core.Y]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
+    F.toMonadHom (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot) =
+      htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot := by
+  simp [htVerifyM, htPkFromSigM_natural core F]
+
+/-! ### Structural query bounds -/
+
+/-- The single-layer hypertree root has exactly the inherited XMSS structural upper bound. -/
+theorem htRootM_isTotalQueryBound (core : CorePrimitives p)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
+    IsTotalQueryBound
+      (htRootM core sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y)
+      (xmssNodeQueryBound p p.hp) :=
+  xmssRootM_isTotalQueryBound core sk pk (htAdrs adrs idxTree)
+
+/-- Hypertree signing inherits the XMSS authentication-path and WOTS+ chain budget. -/
+theorem htSignM_isTotalQueryBound (core : CorePrimitives p)
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    IsTotalQueryBound
+      (htSignM core msg sk pk adrs idxTree idxLeaf :
+        OracleComp (publicHashSpec core) (HtSigCore p core))
+      ((∑ i : Fin p.len, chainStepsCore core msg i.val) +
+        xmssAuthPathQueryBound p p.hp) :=
+  xmssSignM_isTotalQueryBound core msg sk pk (htAdrs adrs idxTree) idxLeaf
+
+/-- Hypertree root recovery inherits the complementary WOTS+ and supplied-path budget. -/
+theorem htPkFromSigM_isTotalQueryBound (core : CorePrimitives p)
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    IsTotalQueryBound
+      (htPkFromSigM core msg sig pk adrs idxTree idxLeaf :
+        OracleComp (publicHashSpec core) core.Y)
+      ((∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) +
+        1 + sig.2.length) :=
+  xmssPkFromSigM_isTotalQueryBound core idxLeaf sig msg pk (htAdrs adrs idxTree)
+
+/-- The final Boolean comparison adds no oracle query to the inherited recovery budget. -/
+theorem htVerifyM_isTotalQueryBound (core : CorePrimitives p) [DecidableEq core.Y]
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
+    IsTotalQueryBound
+      (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+        OracleComp (publicHashSpec core) Bool)
+      ((∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) +
+        1 + sig.2.length) := by
+  have hbound := isTotalQueryBound_bind
+    (htPkFromSigM_isTotalQueryBound core msg sig pk adrs idxTree idxLeaf) fun recovered =>
+      show IsTotalQueryBound
+        (pure (decide (recovered = pkRoot)) : OracleComp (publicHashSpec core) Bool) 0 from trivial
+  simpa [htVerifyM] using hbound
+
+/-! ### Pure deterministic interpretations -/
+
+/-- Pure hypertree signing is the deterministic interpretation of `htSignM`. -/
 def htSign (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
     (adrs : Adrs) (idxTree idxLeaf : ℕ) : HtSig p prims :=
-  xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf
+  simulateQ (PublicHash.impl prims)
+    (htSignM prims.core msg sk pk adrs idxTree idxLeaf :
+      OracleComp (publicHashSpec prims.core) (HtSigCore p prims.core))
 
-/-- The hypertree root committed by key generation (`d = 1`: the single XMSS tree root). -/
+/-- Pure hypertree root generation is the deterministic interpretation of `htRootM`. -/
 def htRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree : ℕ) : prims.Y :=
-  xmssRoot prims sk pk (htAdrs adrs idxTree)
+  simulateQ (PublicHash.impl prims)
+    (htRootM prims.core sk pk adrs idxTree :
+      OracleComp (publicHashSpec prims.core) prims.Y)
 
-/-- Hypertree verification for `d = 1` (FIPS 205 Algorithm 13): recover the XMSS root from the
-signature and compare it to the public root. -/
-def htVerify (prims : Primitives p) [DecidableEq prims.Y] (msg : prims.Y) (sig : HtSig p prims)
-    (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) : Bool :=
-  decide (xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) = pkRoot)
+/-- Pure recovery is the deterministic interpretation of `htPkFromSigM`. -/
+def htPkFromSig (prims : Primitives p) (msg : prims.Y) (sig : HtSig p prims)
+    (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) : prims.Y :=
+  simulateQ (PublicHash.impl prims)
+    (htPkFromSigM prims.core msg sig pk adrs idxTree idxLeaf :
+      OracleComp (publicHashSpec prims.core) prims.Y)
 
-/-- **Hypertree correctness** for `d = 1` (FIPS 205, Algorithms 12–13): verification of an
-honest hypertree signature against the key-generation root succeeds. -/
+/-- Pure verification is the deterministic interpretation of `htVerifyM`. -/
+def htVerify (prims : Primitives p) [DecidableEq prims.Y] (msg : prims.Y)
+    (sig : HtSig p prims) (pk : prims.PkSeed) (adrs : Adrs)
+    (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) : Bool :=
+  simulateQ (PublicHash.impl prims)
+    (htVerifyM prims.core msg sig pk adrs idxTree idxLeaf pkRoot :
+      OracleComp (publicHashSpec prims.core) Bool)
+
+/-! ### Pure API equations -/
+
+@[simp]
+theorem htSign_eq_xmssSign (prims : Primitives p) (msg : prims.Y)
+    (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    htSign prims msg sk pk adrs idxTree idxLeaf =
+      xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf := by
+  rfl
+
+@[simp]
+theorem htRoot_eq_xmssRoot (prims : Primitives p) (sk : prims.SkSeed)
+    (pk : prims.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
+    htRoot prims sk pk adrs idxTree = xmssRoot prims sk pk (htAdrs adrs idxTree) := by
+  rfl
+
+@[simp]
+theorem htPkFromSig_eq_xmssPkFromSig (prims : Primitives p) (msg : prims.Y)
+    (sig : HtSig p prims) (pk : prims.PkSeed) (adrs : Adrs)
+    (idxTree idxLeaf : ℕ) :
+    htPkFromSig prims msg sig pk adrs idxTree idxLeaf =
+      xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) := by
+  rfl
+
+@[simp]
+theorem htVerify_eq_decide (prims : Primitives p) [DecidableEq prims.Y]
+    (msg : prims.Y) (sig : HtSig p prims) (pk : prims.PkSeed) (adrs : Adrs)
+    (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) :
+    htVerify prims msg sig pk adrs idxTree idxLeaf pkRoot =
+      decide (xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) = pkRoot) := by
+  unfold htVerify htVerifyM
+  simp only [simulateQ_bind, simulateQ_pure]
+  change decide
+    (simulateQ (PublicHash.impl prims)
+      (xmssPkFromSigM prims.core idxLeaf sig msg pk (htAdrs adrs idxTree)) = pkRoot) = _
+  rw [simulateQ_xmssPkFromSigM]
+
+/-! ### Deterministic interpretations -/
+
+@[simp]
+theorem simulateQ_htSignM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id)
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    simulateQ answer
+        (htSignM core msg sk pk adrs idxTree idxLeaf :
+          OracleComp (publicHashSpec core) (HtSigCore p core)) =
+      htSign (PublicHash.withPublicHash core answer) msg sk pk adrs idxTree idxLeaf := by
+  simp [htSign, PublicHash.impl_withPublicHash]
+
+@[simp]
+theorem simulateQ_htRootM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id)
+    (sk : core.SkSeed) (pk : core.PkSeed) (adrs : Adrs) (idxTree : ℕ) :
+    simulateQ answer
+        (htRootM core sk pk adrs idxTree : OracleComp (publicHashSpec core) core.Y) =
+      htRoot (PublicHash.withPublicHash core answer) sk pk adrs idxTree := by
+  simp [htRoot, PublicHash.impl_withPublicHash]
+
+@[simp]
+theorem simulateQ_htPkFromSigM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id)
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    simulateQ answer
+        (htPkFromSigM core msg sig pk adrs idxTree idxLeaf :
+          OracleComp (publicHashSpec core) core.Y) =
+      htPkFromSig (PublicHash.withPublicHash core answer) msg sig pk adrs idxTree idxLeaf := by
+  simp [htPkFromSig, PublicHash.impl_withPublicHash]
+
+@[simp]
+theorem simulateQ_htVerifyM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
+    simulateQ answer
+        (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+          OracleComp (publicHashSpec core) Bool) =
+      htVerify (PublicHash.withPublicHash core answer) msg sig pk adrs idxTree idxLeaf pkRoot := by
+  simp [htVerify, PublicHash.impl_withPublicHash]
+
+/-! ### Correctness -/
+
+/-- Hypertree correctness for `d = 1`: verification of an honest signature against the
+key-generation root succeeds. -/
 theorem htVerify_htSign (prims : Primitives p) [DecidableEq prims.Y] (msg : prims.Y)
     (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ)
     (hidx : idxLeaf < 2 ^ p.hp) :
     htVerify prims msg (htSign prims msg sk pk adrs idxTree idxLeaf) pk adrs idxTree idxLeaf
         (htRoot prims sk pk adrs idxTree) = true := by
-  unfold htVerify htSign htRoot
-  rw [xmssPkFromSig_xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf hidx]
+  rw [htVerify_eq_decide, htSign_eq_xmssSign, htRoot_eq_xmssRoot,
+    xmssPkFromSig_xmssSign prims msg sk pk (htAdrs adrs idxTree) idxLeaf hidx]
   simp
+
+/-- Fixed-answer completeness of the canonical hypertree programs. Signing, recovery, and root
+generation are interpreted by one shared deterministic public-hash answer function. This theorem
+does not install a lazy random-oracle cache; that experiment-level interpretation is separate. -/
+theorem simulateQ_htVerifyM_htSignM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (hidx : idxLeaf < 2 ^ p.hp) :
+    simulateQ answer (do
+      let sig ← htSignM core msg sk pk adrs idxTree idxLeaf
+      let root ← htRootM core sk pk adrs idxTree
+      htVerifyM core msg sig pk adrs idxTree idxLeaf root) = true := by
+  simp only [simulateQ_bind, simulateQ_htSignM_withPublicHash,
+    simulateQ_htRootM_withPublicHash, simulateQ_htVerifyM_withPublicHash]
+  exact htVerify_htSign (PublicHash.withPublicHash core answer)
+    msg sk pk adrs idxTree idxLeaf hidx
 
 end SLHDSA

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -40,9 +40,6 @@ variable {p : Params}
 /-- A hypertree signature for `d = 1`: one XMSS signature of the FORS public key. -/
 abbrev HtSigCore (p : Params) (core : CorePrimitives p) := XmssSig p core
 
-/-- Source-compatible pure hypertree signature type. -/
-abbrev HtSig (p : Params) (prims : Primitives p) := HtSigCore p prims.core
-
 /-- Address of the single hypertree layer (layer `0`, tree `idxTree`). -/
 def htAdrs (adrs : Adrs) (idxTree : ℕ) : Adrs :=
   (adrs.setLayerAddress 0).setTreeAddress idxTree
@@ -210,7 +207,7 @@ theorem htVerifyM_isTotalQueryBound (core : CorePrimitives p) [DecidableEq core.
 
 /-- Pure hypertree signing is the deterministic interpretation of `htSignM`. -/
 def htSign (prims : Primitives p) (msg : prims.Y) (sk : prims.SkSeed) (pk : prims.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) : HtSig p prims :=
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) : HtSigCore p prims.core :=
   simulateQ (PublicHash.impl prims)
     (htSignM prims.core msg sk pk adrs idxTree idxLeaf :
       OracleComp (publicHashSpec prims.core) (HtSigCore p prims.core))
@@ -223,7 +220,7 @@ def htRoot (prims : Primitives p) (sk : prims.SkSeed) (pk : prims.PkSeed) (adrs 
       OracleComp (publicHashSpec prims.core) prims.Y)
 
 /-- Pure recovery is the deterministic interpretation of `htPkFromSigM`. -/
-def htPkFromSig (prims : Primitives p) (msg : prims.Y) (sig : HtSig p prims)
+def htPkFromSig (prims : Primitives p) (msg : prims.Y) (sig : HtSigCore p prims.core)
     (pk : prims.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) : prims.Y :=
   simulateQ (PublicHash.impl prims)
     (htPkFromSigM prims.core msg sig pk adrs idxTree idxLeaf :
@@ -231,7 +228,7 @@ def htPkFromSig (prims : Primitives p) (msg : prims.Y) (sig : HtSig p prims)
 
 /-- Pure verification is the deterministic interpretation of `htVerifyM`. -/
 def htVerify (prims : Primitives p) [DecidableEq prims.Y] (msg : prims.Y)
-    (sig : HtSig p prims) (pk : prims.PkSeed) (adrs : Adrs)
+    (sig : HtSigCore p prims.core) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) : Bool :=
   simulateQ (PublicHash.impl prims)
     (htVerifyM prims.core msg sig pk adrs idxTree idxLeaf pkRoot :
@@ -254,7 +251,7 @@ theorem htRoot_eq_xmssRoot (prims : Primitives p) (sk : prims.SkSeed)
 
 @[simp]
 theorem htPkFromSig_eq_xmssPkFromSig (prims : Primitives p) (msg : prims.Y)
-    (sig : HtSig p prims) (pk : prims.PkSeed) (adrs : Adrs)
+    (sig : HtSigCore p prims.core) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) :
     htPkFromSig prims msg sig pk adrs idxTree idxLeaf =
       xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) := by
@@ -262,7 +259,7 @@ theorem htPkFromSig_eq_xmssPkFromSig (prims : Primitives p) (msg : prims.Y)
 
 @[simp]
 theorem htVerify_eq_decide (prims : Primitives p) [DecidableEq prims.Y]
-    (msg : prims.Y) (sig : HtSig p prims) (pk : prims.PkSeed) (adrs : Adrs)
+    (msg : prims.Y) (sig : HtSigCore p prims.core) (pk : prims.PkSeed) (adrs : Adrs)
     (idxTree idxLeaf : ℕ) (pkRoot : prims.Y) :
     htVerify prims msg sig pk adrs idxTree idxLeaf pkRoot =
       decide (xmssPkFromSig prims idxLeaf sig msg pk (htAdrs adrs idxTree) = pkRoot) := by

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -40,6 +40,10 @@ variable {p : Params}
 /-- A hypertree signature for `d = 1`: one XMSS signature of the FORS public key. -/
 abbrev HtSigCore (p : Params) (core : CorePrimitives p) := XmssSig p core
 
+/-- Pure hypertree signature type retained until the Scheme consumer migrates in the downstream
+scheme-integration PR. -/
+abbrev HtSig (p : Params) (prims : Primitives p) := HtSigCore p prims.core
+
 /-- Address of the single hypertree layer (layer `0`, tree `idxTree`). -/
 def htAdrs (adrs : Adrs) (idxTree : ℕ) : Adrs :=
   (adrs.setLayerAddress 0).setTreeAddress idxTree

--- a/HashSigTest/SLHDSA/Hypertree.lean
+++ b/HashSigTest/SLHDSA/Hypertree.lean
@@ -1,0 +1,97 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import HashSig.SLHDSA.Hypertree
+
+/-!
+# Oracle-parametric hypertree canaries
+
+These examples pin the `d = 1` hypertree as a transparent XMSS composition, including the
+explicit recovery computation used by verification and fixed-answer completeness under one
+shared public-hash implementation.
+-/
+
+public section
+
+namespace SLHDSA.HypertreeTest
+
+open OracleComp
+
+variable {p : Params} (core : CorePrimitives p)
+
+/-- The canonical hypertree signer is exactly the addressed XMSS signer. -/
+example (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    (htSignM core msg sk pk adrs idxTree idxLeaf :
+      OracleComp (publicHashSpec core) (HtSigCore p core)) =
+    xmssSignM core msg sk pk (htAdrs adrs idxTree) idxLeaf := by
+  rfl
+
+/-- Verification exposes recovery before the final pure comparison. -/
+example [DecidableEq core.Y] (msg : core.Y) (sig : HtSigCore p core)
+    (pk : core.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
+    (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+      OracleComp (publicHashSpec core) Bool) = (do
+        let recovered ← htPkFromSigM core msg sig pk adrs idxTree idxLeaf
+        return decide (recovered = pkRoot)) := by
+  rfl
+
+/-- Every deterministic total answer table interprets the same canonical program. -/
+example (answer : QueryImpl (publicHashSpec core) Id)
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    simulateQ answer
+        (htSignM core msg sk pk adrs idxTree idxLeaf :
+          OracleComp (publicHashSpec core) (HtSigCore p core)) =
+      htSign (PublicHash.withPublicHash core answer) msg sk pk adrs idxTree idxLeaf :=
+  simulateQ_htSignM_withPublicHash core answer msg sk pk adrs idxTree idxLeaf
+
+/-- The thin hypertree layer inherits XMSS naturality without another traversal proof. -/
+example {m : Type → Type*} [Monad m] [LawfulMonad m]
+    [HasQuery (publicHashSpec core) m]
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec core) (m := m)).toMonadHom
+        (htSignM core msg sk pk adrs idxTree idxLeaf :
+          OracleComp (publicHashSpec core) (HtSigCore p core)) =
+      (htSignM core msg sk pk adrs idxTree idxLeaf : m (HtSigCore p core)) := by
+  exact htSignM_natural core _ msg sk pk adrs idxTree idxLeaf
+
+/-- Naturality also covers the canonical verifier and its final pure comparison. -/
+example {m : Type → Type*} [Monad m] [LawfulMonad m]
+    [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
+    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
+    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec core) (m := m)).toMonadHom
+        (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+          OracleComp (publicHashSpec core) Bool) =
+      (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot : m Bool) := by
+  exact htVerifyM_natural core _ msg sig pk adrs idxTree idxLeaf pkRoot
+
+/-- The `d = 1` hypertree signer reuses the XMSS structural bound verbatim. -/
+example (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
+    IsTotalQueryBound
+      (htSignM core msg sk pk adrs idxTree idxLeaf :
+        OracleComp (publicHashSpec core) (HtSigCore p core))
+      ((∑ i : Fin p.len, chainStepsCore core msg i.val) +
+        xmssAuthPathQueryBound p p.hp) :=
+  htSignM_isTotalQueryBound core msg sk pk adrs idxTree idxLeaf
+
+/-- Signing, root generation, and verification share one answer function in the canonical
+fixed-answer completeness theorem. -/
+example (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
+    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
+    (adrs : Adrs) (idxTree idxLeaf : ℕ) (hidx : idxLeaf < 2 ^ p.hp) :
+    simulateQ answer (do
+      let sig ← htSignM core msg sk pk adrs idxTree idxLeaf
+      let root ← htRootM core sk pk adrs idxTree
+      htVerifyM core msg sig pk adrs idxTree idxLeaf root) = true :=
+  simulateQ_htVerifyM_htSignM_withPublicHash core answer msg sk pk adrs idxTree idxLeaf hidx
+
+end SLHDSA.HypertreeTest

--- a/HashSigTest/SLHDSA/Hypertree.lean
+++ b/HashSigTest/SLHDSA/Hypertree.lean
@@ -11,9 +11,8 @@ public import HashSig.SLHDSA.Hypertree
 /-!
 # Oracle-parametric hypertree canaries
 
-These examples pin the `d = 1` hypertree as a transparent XMSS composition, including the
-explicit recovery computation used by verification and fixed-answer completeness under one
-shared public-hash implementation.
+These examples cover the two observable contracts of the `d = 1` hypertree layer: signing is
+transparent XMSS composition, and verification recovers a root before its final comparison.
 -/
 
 public section
@@ -40,58 +39,5 @@ example [DecidableEq core.Y] (msg : core.Y) (sig : HtSigCore p core)
         let recovered ← htPkFromSigM core msg sig pk adrs idxTree idxLeaf
         return decide (recovered = pkRoot)) := by
   rfl
-
-/-- Every deterministic total answer table interprets the same canonical program. -/
-example (answer : QueryImpl (publicHashSpec core) Id)
-    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    simulateQ answer
-        (htSignM core msg sk pk adrs idxTree idxLeaf :
-          OracleComp (publicHashSpec core) (HtSigCore p core)) =
-      htSign (PublicHash.withPublicHash core answer) msg sk pk adrs idxTree idxLeaf :=
-  simulateQ_htSignM_withPublicHash core answer msg sk pk adrs idxTree idxLeaf
-
-/-- The thin hypertree layer inherits XMSS naturality without another traversal proof. -/
-example {m : Type → Type*} [Monad m] [LawfulMonad m]
-    [HasQuery (publicHashSpec core) m]
-    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec core) (m := m)).toMonadHom
-        (htSignM core msg sk pk adrs idxTree idxLeaf :
-          OracleComp (publicHashSpec core) (HtSigCore p core)) =
-      (htSignM core msg sk pk adrs idxTree idxLeaf : m (HtSigCore p core)) := by
-  exact htSignM_natural core _ msg sk pk adrs idxTree idxLeaf
-
-/-- Naturality also covers the canonical verifier and its final pure comparison. -/
-example {m : Type → Type*} [Monad m] [LawfulMonad m]
-    [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
-    (msg : core.Y) (sig : HtSigCore p core) (pk : core.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
-    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec core) (m := m)).toMonadHom
-        (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
-          OracleComp (publicHashSpec core) Bool) =
-      (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot : m Bool) := by
-  exact htVerifyM_natural core _ msg sig pk adrs idxTree idxLeaf pkRoot
-
-/-- The `d = 1` hypertree signer reuses the XMSS structural bound verbatim. -/
-example (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) :
-    IsTotalQueryBound
-      (htSignM core msg sk pk adrs idxTree idxLeaf :
-        OracleComp (publicHashSpec core) (HtSigCore p core))
-      ((∑ i : Fin p.len, chainStepsCore core msg i.val) +
-        xmssAuthPathQueryBound p p.hp) :=
-  htSignM_isTotalQueryBound core msg sk pk adrs idxTree idxLeaf
-
-/-- Signing, root generation, and verification share one answer function in the canonical
-fixed-answer completeness theorem. -/
-example (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
-    (msg : core.Y) (sk : core.SkSeed) (pk : core.PkSeed)
-    (adrs : Adrs) (idxTree idxLeaf : ℕ) (hidx : idxLeaf < 2 ^ p.hp) :
-    simulateQ answer (do
-      let sig ← htSignM core msg sk pk adrs idxTree idxLeaf
-      let root ← htRootM core sk pk adrs idxTree
-      htVerifyM core msg sig pk adrs idxTree idxLeaf root) = true :=
-  simulateQ_htVerifyM_htSignM_withPublicHash core answer msg sk pk adrs idxTree idxLeaf hidx
 
 end SLHDSA.HypertreeTest


### PR DESCRIPTION
## Summary

This stacked PR makes the supported `d = 1` hypertree a thin canonical explicit-public-hash composition over XMSS.

### Diff metadata

- Base: `4c715ca2cb5d5aaae6ddd88268333040f8f2da4c` (`repair/slhdsa-fors-oracle-clean-20260827`)
- Head: `8e08eceb94da1f904af3045f75faadefe9cb88c2`
- Commits: 4
- Files changed: 3
- Diff: 350 insertions, 26 deletions

## Canonical programs

- `htSignM` delegates to `xmssSignM`;
- `htRootM` delegates to `xmssRootM`;
- `htPkFromSigM` exposes authenticated-root recovery;
- `htVerifyM` performs recovery followed by a pure comparison.

The deterministic functions are literal `simulateQ (PublicHash.impl prims)` interpretations. Naturality, query bounds, and correctness are inherited from XMSS without a second tree traversal.

## Scope and API surface

This module continues to implement only the repository's `d = 1` case; unrestricted `Params` does not yet encode that invariant at the type level.

Canonical hypertree APIs use `HtSigCore p core`. The `HtSig` alias is retained at this intermediate head because the inherited Scheme consumer still uses it; #568 deletes it atomically with that consumer's migration. The tests retain only the composition/recovery canaries that distinguish hypertree behavior.

No hypertree operation owns a cache or public-hash implementation.

## Validation at `8e08eceb`

- focused Hypertree source/test builds and `lake build HashSig` pass locally;
- `git diff --check` passes;
- the complete restacked tree passes `lake build` at #569;
- GitHub checks are currently running after the restack.

## Non-goals

This PR does not implement a multi-layer hypertree, define the final random-oracle runtime, or prove aggregate SLH-DSA security.

## Reviewer map

1. `htAdrs` and `d = 1` boundary;
2. four canonical programs;
3. deterministic interpretations;
4. inherited naturality/query bounds;
5. correctness and focused composition tests.
