### PR TITLE
feat(HashSig): make internal SLH-DSA programs oracle-parametric

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -84,4 +84,4 @@ jobs:
       # project deliberately defines no `lint-style` exe, so it does not link the
       # FFI backends). Pass the libraries explicitly for full coverage.
       - name: Run text-based style linters
-        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT
+        run: lake exe lint-style ToMathlib VCVio Extern LatticeCrypto HashSig Examples VCVioWidgets Interop HashSigTest.SLHDSA.Oracle HashSigTest.SLHDSA.Wots HashSigTest.SLHDSA.Xmss HashSigTest.SLHDSA.Fors HashSigTest.SLHDSA.Hypertree HashSigTest.SLHDSA.Scheme HashSigTest.SLHDSA.Sha2KAT HashSigTest.SLHDSA.C13KAT

--- a/HashSig/SLHDSA/Concrete/Instance.lean
+++ b/HashSig/SLHDSA/Concrete/Instance.lean
@@ -128,7 +128,7 @@ def shaPrimitives : Primitives slhdsaSha2_128_24 where
 
 /-- Decode the 3856-byte signature `R ‖ SIG_FORS ‖ SIG_HT` (FORS: `k` trees of
 `sk(16) ‖ auth(a×16)`; HT: WOTS `len×16` then XMSS auth `h'×16`). -/
-def decodeSignature (ba : ByteArray) : Signature shaPrimitives :=
+def decodeSignature (ba : ByteArray) : SignatureCore slhdsaSha2_128_24 shaPrimitives.core :=
   let R : Bytes 16 := baSliceToB16 ba 0
   let fors : Vector (Bytes 16 × List (Bytes 16)) 6 :=
     Vector.ofFn fun i : Fin 6 =>

--- a/HashSig/SLHDSA/Fors.lean
+++ b/HashSig/SLHDSA/Fors.lean
@@ -98,10 +98,6 @@ def forsPkAdrs (adrs : Adrs) : Adrs :=
 abbrev ForsSigCore (p : Params) (core : CorePrimitives p) :=
   Vector (core.Y × List core.Y) p.k
 
-/-- Pure FORS signature type retained until the Scheme consumer migrates in the downstream
-scheme-integration PR. -/
-abbrev ForsSig (p : Params) (prims : Primitives p) := ForsSigCore p prims.core
-
 /-- Low-level callback-parametric FORS public-key generation. Roots are computed in increasing
 tree order and compressed only after every root is available. -/
 def forsPkGenWith (core : CorePrimitives p) {m : Type → Type*} [Monad m]

--- a/HashSig/SLHDSA/Hypertree.lean
+++ b/HashSig/SLHDSA/Hypertree.lean
@@ -40,10 +40,6 @@ variable {p : Params}
 /-- A hypertree signature for `d = 1`: one XMSS signature of the FORS public key. -/
 abbrev HtSigCore (p : Params) (core : CorePrimitives p) := XmssSig p core
 
-/-- Pure hypertree signature type retained until the Scheme consumer migrates in the downstream
-scheme-integration PR. -/
-abbrev HtSig (p : Params) (prims : Primitives p) := HtSigCore p prims.core
-
 /-- Address of the single hypertree layer (layer `0`, tree `idxTree`). -/
 def htAdrs (adrs : Adrs) (idxTree : ℕ) : Adrs :=
   (adrs.setLayerAddress 0).setTreeAddress idxTree

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -45,8 +45,6 @@ open OracleComp OracleSpec
 
 namespace SLHDSA
 
-universe u
-
 variable {p : Params}
 
 /-- The SLH-DSA public key over an implementation-independent context: public seed and
@@ -56,36 +54,6 @@ structure PublicKeyCore (core : CorePrimitives p) where
   pkSeed : core.PkSeed
   /-- Hypertree root `PK.root`. -/
   pkRoot : core.Y
-
-/-- Source-compatible pure public-key type. -/
-abbrev PublicKey (prims : Primitives p) := PublicKeyCore prims.core
-
-namespace PublicKey
-
-/-! Compatibility aliases for the generated API of the former `PublicKey` structure. -/
-
-abbrev mk := @PublicKeyCore.mk
-abbrev pkSeed := @PublicKeyCore.pkSeed
-abbrev pkRoot := @PublicKeyCore.pkRoot
-protected def rec {prims : Primitives p} {motive : PublicKey prims → Sort u}
-    (mk : (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
-      motive (PublicKey.mk pkSeed pkRoot)) (t : PublicKey prims) : motive t :=
-  match t with
-  | ⟨pkSeed, pkRoot⟩ => mk pkSeed pkRoot
-
-protected def recOn {prims : Primitives p} {motive : PublicKey prims → Sort u}
-    (t : PublicKey prims) (mk : (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
-      motive (PublicKey.mk pkSeed pkRoot)) : motive t :=
-  match t with
-  | ⟨pkSeed, pkRoot⟩ => mk pkSeed pkRoot
-
-protected def casesOn {prims : Primitives p} {motive : PublicKey prims → Sort u}
-    (t : PublicKey prims) (mk : (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
-      motive (PublicKey.mk pkSeed pkRoot)) : motive t :=
-  match t with
-  | ⟨pkSeed, pkRoot⟩ => mk pkSeed pkRoot
-
-end PublicKey
 
 /-- The SLH-DSA secret key over an implementation-independent context. It carries the public
 material required by signing. -/
@@ -99,51 +67,10 @@ structure SecretKeyCore (core : CorePrimitives p) where
   /-- Hypertree root `PK.root`. -/
   pkRoot : core.Y
 
-/-- Source-compatible pure secret-key type. -/
-abbrev SecretKey (prims : Primitives p) := SecretKeyCore prims.core
-
-namespace SecretKey
-
-/-! Compatibility aliases for the generated API of the former `SecretKey` structure. -/
-
-abbrev mk := @SecretKeyCore.mk
-abbrev skSeed := @SecretKeyCore.skSeed
-abbrev skPrf := @SecretKeyCore.skPrf
-abbrev pkSeed := @SecretKeyCore.pkSeed
-abbrev pkRoot := @SecretKeyCore.pkRoot
-protected def rec {prims : Primitives p} {motive : SecretKey prims → Sort u}
-    (mk : (skSeed : prims.SkSeed) → (skPrf : prims.SkPrf) →
-      (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
-      motive (SecretKey.mk skSeed skPrf pkSeed pkRoot))
-    (t : SecretKey prims) : motive t :=
-  match t with
-  | ⟨skSeed, skPrf, pkSeed, pkRoot⟩ => mk skSeed skPrf pkSeed pkRoot
-
-protected def recOn {prims : Primitives p} {motive : SecretKey prims → Sort u}
-    (t : SecretKey prims)
-    (mk : (skSeed : prims.SkSeed) → (skPrf : prims.SkPrf) →
-      (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
-      motive (SecretKey.mk skSeed skPrf pkSeed pkRoot)) : motive t :=
-  match t with
-  | ⟨skSeed, skPrf, pkSeed, pkRoot⟩ => mk skSeed skPrf pkSeed pkRoot
-
-protected def casesOn {prims : Primitives p} {motive : SecretKey prims → Sort u}
-    (t : SecretKey prims)
-    (mk : (skSeed : prims.SkSeed) → (skPrf : prims.SkPrf) →
-      (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
-      motive (SecretKey.mk skSeed skPrf pkSeed pkRoot)) : motive t :=
-  match t with
-  | ⟨skSeed, skPrf, pkSeed, pkRoot⟩ => mk skSeed skPrf pkSeed pkRoot
-
-end SecretKey
-
 /-- An SLH-DSA signature: randomizer `R`, FORS signature, and hypertree signature
 (`R ‖ SIG_FORS ‖ SIG_HT`). -/
 abbrev SignatureCore (p : Params) (core : CorePrimitives p) :=
   core.Y × ForsSigCore p core × HtSigCore p core
-
-/-- Source-compatible pure signature type. -/
-abbrev Signature (prims : Primitives p) := SignatureCore p prims.core
 
 /-! ### Message-digest split (FIPS 205 §9) -/
 
@@ -209,22 +136,23 @@ def slhVerifyInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
 /-- Pure internal key generation is the deterministic interpretation of
 `slhKeygenInternalM`. -/
 def slhKeygenInternal (prims : Primitives p) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
-    (pkSeed : prims.PkSeed) : PublicKey prims × SecretKey prims :=
+    (pkSeed : prims.PkSeed) : PublicKeyCore prims.core × SecretKeyCore prims.core :=
   simulateQ (PublicHash.impl prims)
     (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
-      OracleComp (publicHashSpec prims.core) (PublicKey prims × SecretKey prims))
+      OracleComp (publicHashSpec prims.core)
+        (PublicKeyCore prims.core × SecretKeyCore prims.core))
 
 /-- Pure internal signing is the deterministic interpretation of `slhSignInternalM`. -/
-def slhSignInternal (prims : Primitives p) (msg : List Byte) (sk : SecretKey prims)
-    (addrnd : prims.Y) : Signature prims :=
+def slhSignInternal (prims : Primitives p) (msg : List Byte) (sk : SecretKeyCore prims.core)
+    (addrnd : prims.Y) : SignatureCore p prims.core :=
   simulateQ (PublicHash.impl prims)
     (slhSignInternalM prims.core msg sk addrnd :
-      OracleComp (publicHashSpec prims.core) (Signature prims))
+      OracleComp (publicHashSpec prims.core) (SignatureCore p prims.core))
 
 /-- Pure internal verification is the deterministic interpretation of
 `slhVerifyInternalM`. -/
 def slhVerifyInternal (prims : Primitives p) [DecidableEq prims.Y] (msg : List Byte)
-    (sig : Signature prims) (pk : PublicKey prims) : Bool :=
+    (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core) : Bool :=
   simulateQ (PublicHash.impl prims)
     (slhVerifyInternalM prims.core msg sig pk : OracleComp (publicHashSpec prims.core) Bool)
 
@@ -367,7 +295,8 @@ theorem simulateQ_slhKeygenInternalM (prims : Primitives p)
     (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
     simulateQ (PublicHash.impl prims)
         (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
-          OracleComp (publicHashSpec prims.core) (PublicKey prims × SecretKey prims)) =
+          OracleComp (publicHashSpec prims.core)
+            (PublicKeyCore prims.core × SecretKeyCore prims.core)) =
       slhKeygenInternal prims skSeed skPrf pkSeed := rfl
 
 @[simp]
@@ -382,10 +311,10 @@ theorem simulateQ_slhSignInternalM_withPublicHash (core : CorePrimitives p)
 
 @[simp]
 theorem simulateQ_slhSignInternalM (prims : Primitives p)
-    (msg : List Byte) (sk : SecretKey prims) (addrnd : prims.Y) :
+    (msg : List Byte) (sk : SecretKeyCore prims.core) (addrnd : prims.Y) :
     simulateQ (PublicHash.impl prims)
         (slhSignInternalM prims.core msg sk addrnd :
-          OracleComp (publicHashSpec prims.core) (Signature prims)) =
+          OracleComp (publicHashSpec prims.core) (SignatureCore p prims.core)) =
       slhSignInternal prims msg sk addrnd := rfl
 
 @[simp]
@@ -399,7 +328,7 @@ theorem simulateQ_slhVerifyInternalM_withPublicHash (core : CorePrimitives p)
 
 @[simp]
 theorem simulateQ_slhVerifyInternalM (prims : Primitives p) [DecidableEq prims.Y]
-    (msg : List Byte) (sig : Signature prims) (pk : PublicKey prims) :
+    (msg : List Byte) (sig : SignatureCore p prims.core) (pk : PublicKeyCore prims.core) :
     simulateQ (PublicHash.impl prims)
         (slhVerifyInternalM prims.core msg sig pk :
           OracleComp (publicHashSpec prims.core) Bool) =
@@ -454,27 +383,29 @@ def emptyContextMessage (msg : List Byte) : List Byte :=
 
 /-- SLH-DSA key generation (FIPS 205 Algorithm 21): sample the three seeds. -/
 def slhKeygen [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
-    [SampleableType prims.PkSeed] : ProbComp (PublicKey prims × SecretKey prims) := do
+    [SampleableType prims.PkSeed] :
+    ProbComp (PublicKeyCore prims.core × SecretKeyCore prims.core) := do
   let skSeed ← $ᵗ prims.SkSeed
   let skPrf ← $ᵗ prims.SkPrf
   let pkSeed ← $ᵗ prims.PkSeed
   return slhKeygenInternal prims skSeed skPrf pkSeed
 
 /-- SLH-DSA signing (FIPS 205 Algorithm 22, empty context, hedged): sample `addrnd`. -/
-def slhSign [SampleableType prims.Y] (sk : SecretKey prims) (msg : List Byte) :
-    ProbComp (Signature prims) := do
+def slhSign [SampleableType prims.Y] (sk : SecretKeyCore prims.core) (msg : List Byte) :
+    ProbComp (SignatureCore p prims.core) := do
   let addrnd ← $ᵗ prims.Y
   return slhSignInternal prims (emptyContextMessage msg) sk addrnd
 
 /-- SLH-DSA verification (FIPS 205 Algorithm 24, empty context). -/
-def slhVerify [DecidableEq prims.Y] (pk : PublicKey prims) (msg : List Byte)
-    (sig : Signature prims) : Bool :=
+def slhVerify [DecidableEq prims.Y] (pk : PublicKeyCore prims.core) (msg : List Byte)
+    (sig : SignatureCore p prims.core) : Bool :=
   slhVerifyInternal prims (emptyContextMessage msg) sig pk
 
 /-- SLH-DSA as a generic `SignatureAlg` in the `ProbComp` monad. -/
 def slhdsaAlg [SampleableType prims.SkSeed] [SampleableType prims.SkPrf]
     [SampleableType prims.PkSeed] [SampleableType prims.Y] [DecidableEq prims.Y] :
-    SignatureAlg ProbComp (List Byte) (PublicKey prims) (SecretKey prims) (Signature prims) where
+    SignatureAlg ProbComp (List Byte) (PublicKeyCore prims.core) (SecretKeyCore prims.core)
+      (SignatureCore p prims.core) where
   keygen := slhKeygen prims
   sign _pk sk msg := slhSign prims sk msg
   verify pk msg σ := pure (slhVerify prims pk msg σ)

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -12,18 +12,26 @@ public import VCVio.CryptoFoundations.SignatureAlg
 # SLH-DSA Scheme (FIPS 205 §9–10)
 
 The top-level SLH-DSA signature scheme for the `d = 1` parameter set, assembled from FORS
-(`HashSig.SLHDSA.Fors`) and the single-layer hypertree (`HashSig.SLHDSA.Hypertree`):
+(`HashSig.SLHDSA.Fors`) and the single-layer hypertree (`HashSig.SLHDSA.Hypertree`). The canonical
+internal algorithms depend only on `CorePrimitives` and issue `H_msg` and every tweakable hash as
+an explicit `HasQuery` operation:
 
-- `slhKeygenInternal` / `slhSignInternal` / `slhVerifyInternal` (Algorithms 18–20),
+- `slhKeygenInternalM` / `slhSignInternalM` / `slhVerifyInternalM` (Algorithms 18–20),
+- `slhKeygenInternal` / `slhSignInternal` / `slhVerifyInternal`, the deterministic
+  `PublicHash.impl` interpretations of those programs,
 - `splitDigest`, the message-digest split into `(md, idxLeaf)` (§9; for `d = 1` the tree index
   is always `0`, so it is omitted),
 - the external probabilistic wrappers `slhKeygen` / `slhSign` / `slhVerify` (Algorithms 21–24,
   empty context), and the generic `SignatureAlg` instantiation `slhdsaAlg` in `ProbComp`.
 
+Signing follows FIPS 205 Algorithm 19 literally: after `H_msg`, it creates the FORS signature,
+recovers the FORS public key from that signature, and signs the recovered value with the
+hypertree. It does not independently regenerate the FORS public key.
+
 The headline result `slhdsaAlg_perfectlyComplete` proves **perfect completeness with no `sorry`**:
-every honestly generated signature verifies. It is a deterministic hash-tree consistency fact
-(`slhVerifyInternal_slhSignInternal`) composing WOTS+/XMSS/FORS/hypertree correctness, lifted
-across the sampling of seeds via the support characterization of `Pr[… ] = 1`.
+every honestly generated signature verifies. The deterministic kernel is also exposed for every
+fixed total public-hash answer function. This is not a cached-random-oracle theorem; a security
+experiment must choose and thread that semantics separately.
 
 ## References
 
@@ -39,27 +47,39 @@ namespace SLHDSA
 
 variable {p : Params}
 
-/-- The SLH-DSA public key: public seed and hypertree root. -/
-structure PublicKey (prims : Primitives p) where
+/-- The SLH-DSA public key over an implementation-independent context: public seed and
+hypertree root. -/
+structure PublicKeyCore (core : CorePrimitives p) where
   /-- Public seed `PK.seed`. -/
-  pkSeed : prims.PkSeed
+  pkSeed : core.PkSeed
   /-- Hypertree root `PK.root`. -/
-  pkRoot : prims.Y
+  pkRoot : core.Y
 
-/-- The SLH-DSA secret key: it carries the public material for signing. -/
-structure SecretKey (prims : Primitives p) where
+/-- Source-compatible pure public-key type. -/
+abbrev PublicKey (prims : Primitives p) := PublicKeyCore prims.core
+
+/-- The SLH-DSA secret key over an implementation-independent context. It carries the public
+material required by signing. -/
+structure SecretKeyCore (core : CorePrimitives p) where
   /-- Secret seed `SK.seed`. -/
-  skSeed : prims.SkSeed
+  skSeed : core.SkSeed
   /-- Message-PRF key `SK.prf`. -/
-  skPrf : prims.SkPrf
+  skPrf : core.SkPrf
   /-- Public seed `PK.seed`. -/
-  pkSeed : prims.PkSeed
+  pkSeed : core.PkSeed
   /-- Hypertree root `PK.root`. -/
-  pkRoot : prims.Y
+  pkRoot : core.Y
+
+/-- Source-compatible pure secret-key type. -/
+abbrev SecretKey (prims : Primitives p) := SecretKeyCore prims.core
 
 /-- An SLH-DSA signature: randomizer `R`, FORS signature, and hypertree signature
 (`R ‖ SIG_FORS ‖ SIG_HT`). -/
-abbrev Signature (prims : Primitives p) := prims.Y × ForsSig p prims × HtSig p prims
+abbrev SignatureCore (p : Params) (core : CorePrimitives p) :=
+  core.Y × ForsSigCore p core × HtSigCore p core
+
+/-- Source-compatible pure signature type. -/
+abbrev Signature (prims : Primitives p) := SignatureCore p prims.core
 
 /-! ### Message-digest split (FIPS 205 §9) -/
 
@@ -80,51 +100,283 @@ theorem splitDigest_snd_lt (p : Params) (digest : Bytes p.m) :
 def forsAdrsOf (idxLeaf : ℕ) : Adrs :=
   ((Adrs.zero.setTreeAddress 0).setTypeAndClear .forsTree).setKeyPairAddress idxLeaf
 
-/-! ### Internal algorithms (FIPS 205 §9) -/
+/-! ### Canonical internal algorithms (FIPS 205 §9) -/
 
-/-- SLH-DSA internal key generation (FIPS 205 Algorithm 18): the public root is the hypertree
-root of the single tree. -/
+/-- Canonical SLH-DSA internal key generation (FIPS 205 Algorithm 18). The public root is
+computed by the explicit-query hypertree program. -/
+def slhKeygenInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m]
+    (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
+    m (PublicKeyCore core × SecretKeyCore core) := do
+  let pkRoot ← htRootM core skSeed pkSeed Adrs.zero 0
+  return (⟨pkSeed, pkRoot⟩, ⟨skSeed, skPrf, pkSeed, pkRoot⟩)
+
+/-- Canonical SLH-DSA internal signing (FIPS 205 Algorithm 19). Its public-hash schedule is
+`H_msg`, FORS signing, recovery of the FORS public key from that signature, then hypertree
+signing. In particular, signing does not call `forsPkGenM`. -/
+def slhSignInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m]
+    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
+    m (SignatureCore p core) := do
+  let R := core.PRFmsg sk.skPrf addrnd msg
+  let digest ← PublicHash.hmsg core R sk.pkSeed sk.pkRoot msg
+  let idxLeaf := (splitDigest p digest).2
+  let md := (splitDigest p digest).1
+  let fAdrs := forsAdrsOf idxLeaf
+  let forsSig ← forsSignM core md sk.skSeed sk.pkSeed fAdrs
+  let forsPk ← forsPkFromSigM core forsSig md sk.pkSeed fAdrs
+  let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 idxLeaf
+  return (R, forsSig, htSig)
+
+/-- Canonical SLH-DSA internal verification (FIPS 205 Algorithm 20). Its public-hash schedule is
+`H_msg`, FORS public-key recovery, then hypertree recovery and comparison with `PK.root`. -/
+def slhVerifyInternalM (core : CorePrimitives p) {m : Type → Type*} [Monad m]
+    [HasQuery (publicHashSpec core) m] [DecidableEq core.Y]
+    (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) : m Bool := do
+  let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
+  let idxLeaf := (splitDigest p digest).2
+  let md := (splitDigest p digest).1
+  let fAdrs := forsAdrsOf idxLeaf
+  let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
+  htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot
+
+/-! ### Pure deterministic interpretations -/
+
+/-- Pure internal key generation is the deterministic interpretation of
+`slhKeygenInternalM`. -/
 def slhKeygenInternal (prims : Primitives p) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
     (pkSeed : prims.PkSeed) : PublicKey prims × SecretKey prims :=
-  let pkRoot := htRoot prims skSeed pkSeed Adrs.zero 0
-  (⟨pkSeed, pkRoot⟩, ⟨skSeed, skPrf, pkSeed, pkRoot⟩)
+  simulateQ (PublicHash.impl prims)
+    (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
+      OracleComp (publicHashSpec prims.core) (PublicKey prims × SecretKey prims))
 
-/-- SLH-DSA internal signing (FIPS 205 Algorithm 19): derive `R` and the digest, sign the FORS
-public key with the hypertree. -/
+/-- Pure internal signing is the deterministic interpretation of `slhSignInternalM`. -/
 def slhSignInternal (prims : Primitives p) (msg : List Byte) (sk : SecretKey prims)
     (addrnd : prims.Y) : Signature prims :=
-  let R := prims.PRFmsg sk.skPrf addrnd msg
-  let digest := prims.Hmsg R sk.pkSeed sk.pkRoot msg
-  let idxLeaf := (splitDigest p digest).2
-  let md := (splitDigest p digest).1
-  let fAdrs := forsAdrsOf idxLeaf
-  (R, forsSign prims md sk.skSeed sk.pkSeed fAdrs,
-    htSign prims (forsPkGen prims sk.skSeed sk.pkSeed fAdrs) sk.skSeed sk.pkSeed Adrs.zero 0
-      idxLeaf)
+  simulateQ (PublicHash.impl prims)
+    (slhSignInternalM prims.core msg sk addrnd :
+      OracleComp (publicHashSpec prims.core) (Signature prims))
 
-/-- SLH-DSA internal verification (FIPS 205 Algorithm 20): recompute the FORS public key and
-verify it against the hypertree. -/
+/-- Pure internal verification is the deterministic interpretation of
+`slhVerifyInternalM`. -/
 def slhVerifyInternal (prims : Primitives p) [DecidableEq prims.Y] (msg : List Byte)
     (sig : Signature prims) (pk : PublicKey prims) : Bool :=
-  let digest := prims.Hmsg sig.1 pk.pkSeed pk.pkRoot msg
-  let idxLeaf := (splitDigest p digest).2
-  let md := (splitDigest p digest).1
-  let fAdrs := forsAdrsOf idxLeaf
-  htVerify prims (forsPkFromSig prims sig.2.1 md pk.pkSeed fAdrs) sig.2.2 pk.pkSeed Adrs.zero 0
-    idxLeaf pk.pkRoot
+  simulateQ (PublicHash.impl prims)
+    (slhVerifyInternalM prims.core msg sig pk : OracleComp (publicHashSpec prims.core) Bool)
+
+/-! ### Naturality -/
+
+private theorem queryHom_hmsg (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (r : core.Y) (pkSeed : core.PkSeed) (pkRoot : core.Y) (msg : List Byte) :
+    F.toMonadHom (PublicHash.hmsg core r pkSeed pkRoot msg) =
+      PublicHash.hmsg core r pkSeed pkRoot msg := by
+  change F.toMonadHom
+      (query (spec := publicHashSpec core) (.hmsg r pkSeed pkRoot msg)) =
+    query (spec := publicHashSpec core) (.hmsg r pkSeed pkRoot msg)
+  exact HasQuery.map_query F _
+
+/-- Query-preserving monad morphisms commute with canonical internal key generation. -/
+theorem slhKeygenInternalM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
+    F.toMonadHom (slhKeygenInternalM core skSeed skPrf pkSeed) =
+      slhKeygenInternalM core skSeed skPrf pkSeed := by
+  simp [slhKeygenInternalM, htRootM_natural core F]
+
+/-- Query-preserving monad morphisms commute with canonical internal signing. -/
+theorem slhSignInternalM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
+    F.toMonadHom (slhSignInternalM core msg sk addrnd) =
+      slhSignInternalM core msg sk addrnd := by
+  simp [slhSignInternalM, queryHom_hmsg core F,
+    forsSignM_natural core F, forsPkFromSigM_natural core F, htSignM_natural core F]
+
+/-- Query-preserving monad morphisms commute with canonical internal verification. -/
+theorem slhVerifyInternalM_natural (core : CorePrimitives p)
+    {m n : Type → Type*} [Monad m] [LawfulMonad m]
+    [Monad n] [LawfulMonad n] [HasQuery (publicHashSpec core) m]
+    [HasQuery (publicHashSpec core) n] [DecidableEq core.Y]
+    (F : HasQuery.QueryHom (publicHashSpec core) m n)
+    (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
+    F.toMonadHom (slhVerifyInternalM core msg sig pk) =
+      slhVerifyInternalM core msg sig pk := by
+  simp [slhVerifyInternalM, queryHom_hmsg core F,
+    forsPkFromSigM_natural core F, htVerifyM_natural core F]
+
+/-! ### Structural query bounds -/
+
+/-- Structural public-hash budget for internal key generation. -/
+def slhKeygenInternalQueryBound (p : Params) : ℕ :=
+  xmssNodeQueryBound p p.hp
+
+/-- Structural public-hash budget for verification of the supplied signature. The FORS term
+tracks the actual authentication-path lengths. The hypertree term uses the maximum WOTS+ chain
+budget plus the supplied XMSS authentication-path length. -/
+def slhVerifyInternalQueryBound (p : Params) (core : CorePrimitives p)
+    (sig : SignatureCore p core) : ℕ :=
+  1 + ((∑ i : Fin p.k, (fun j : Fin p.k => 1 + (sig.2.1[j.val]).2.length) i) + 1) +
+    (p.len * (p.w - 1) + 1 + sig.2.2.2.length)
+
+private theorem publicHash_hmsg_isTotalQueryBound_one (core : CorePrimitives p)
+    (r : core.Y) (pkSeed : core.PkSeed) (pkRoot : core.Y) (msg : List Byte) :
+    IsTotalQueryBound
+      (PublicHash.hmsg core r pkSeed pkRoot msg :
+        OracleComp (publicHashSpec core) (Bytes p.m)) 1 := by
+  simp [PublicHash.hmsg, IsTotalQueryBound]
+
+/-- Internal key generation inherits the complete hypertree-root budget. -/
+theorem slhKeygenInternalM_isTotalQueryBound (core : CorePrimitives p)
+    (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
+    IsTotalQueryBound
+      (slhKeygenInternalM core skSeed skPrf pkSeed :
+        OracleComp (publicHashSpec core) (PublicKeyCore core × SecretKeyCore core))
+      (slhKeygenInternalQueryBound p) := by
+  simpa [slhKeygenInternalM, slhKeygenInternalQueryBound] using
+    isTotalQueryBound_bind (htRootM_isTotalQueryBound core skSeed pkSeed Adrs.zero 0)
+      (fun pkRoot => show IsTotalQueryBound
+        (pure (PublicKeyCore.mk pkSeed pkRoot,
+          SecretKeyCore.mk skSeed skPrf pkSeed pkRoot) :
+          OracleComp (publicHashSpec core) _) 0 from trivial)
+
+private theorem htVerifyM_isTotalQueryBound_coarse (core : CorePrimitives p)
+    [DecidableEq core.Y] (msg : core.Y) (sig : HtSigCore p core)
+    (pk : core.PkSeed) (adrs : Adrs) (idxTree idxLeaf : ℕ) (pkRoot : core.Y) :
+    IsTotalQueryBound
+      (htVerifyM core msg sig pk adrs idxTree idxLeaf pkRoot :
+        OracleComp (publicHashSpec core) Bool)
+      (p.len * (p.w - 1) + 1 + sig.2.length) := by
+  apply (htVerifyM_isTotalQueryBound core msg sig pk adrs idxTree idxLeaf pkRoot).mono
+  have hsum :
+      (∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) ≤
+        p.len * (p.w - 1) := by
+    calc
+      (∑ i : Fin p.len, (p.w - 1 - chainStepsCore core msg i.val)) ≤
+          ∑ _ : Fin p.len, (p.w - 1) := by
+            apply Finset.sum_le_sum
+            intro i hi
+            omega
+      _ = p.len * (p.w - 1) := by simp
+  omega
+
+/-- Verification is bounded by one `H_msg` query, FORS recovery for the supplied paths, and
+hypertree recovery with a coarse full-WOTS chain allowance. This counts free-oracle calls, not
+distinct random-oracle cache misses. -/
+theorem slhVerifyInternalM_isTotalQueryBound (core : CorePrimitives p) [DecidableEq core.Y]
+    (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
+    IsTotalQueryBound
+      (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool)
+      (slhVerifyInternalQueryBound p core sig) := by
+  have hbound := isTotalQueryBound_bind
+    (publicHash_hmsg_isTotalQueryBound_one core sig.1 pk.pkSeed pk.pkRoot msg) fun digest =>
+      isTotalQueryBound_bind
+        (forsPkFromSigM_isTotalQueryBound core sig.2.1 (splitDigest p digest).1 pk.pkSeed
+          (forsAdrsOf (splitDigest p digest).2)) fun forsPk =>
+            htVerifyM_isTotalQueryBound_coarse core forsPk sig.2.2 pk.pkSeed Adrs.zero 0
+              (splitDigest p digest).2 pk.pkRoot
+  simpa [slhVerifyInternalM, slhVerifyInternalQueryBound, Nat.add_assoc] using hbound
+
+/-! ### Deterministic interpretations -/
+
+@[simp]
+theorem simulateQ_slhKeygenInternalM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id)
+    (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
+    simulateQ answer
+        (slhKeygenInternalM core skSeed skPrf pkSeed :
+          OracleComp (publicHashSpec core) (PublicKeyCore core × SecretKeyCore core)) =
+      slhKeygenInternal (PublicHash.withPublicHash core answer) skSeed skPrf pkSeed := by
+  simp [slhKeygenInternal, PublicHash.impl_withPublicHash]
+
+@[simp]
+theorem simulateQ_slhKeygenInternalM (prims : Primitives p)
+    (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed) :
+    simulateQ (PublicHash.impl prims)
+        (slhKeygenInternalM prims.core skSeed skPrf pkSeed :
+          OracleComp (publicHashSpec prims.core) (PublicKey prims × SecretKey prims)) =
+      slhKeygenInternal prims skSeed skPrf pkSeed := rfl
+
+@[simp]
+theorem simulateQ_slhSignInternalM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id)
+    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
+    simulateQ answer
+        (slhSignInternalM core msg sk addrnd :
+          OracleComp (publicHashSpec core) (SignatureCore p core)) =
+      slhSignInternal (PublicHash.withPublicHash core answer) msg sk addrnd := by
+  simp [slhSignInternal, PublicHash.impl_withPublicHash]
+
+@[simp]
+theorem simulateQ_slhSignInternalM (prims : Primitives p)
+    (msg : List Byte) (sk : SecretKey prims) (addrnd : prims.Y) :
+    simulateQ (PublicHash.impl prims)
+        (slhSignInternalM prims.core msg sk addrnd :
+          OracleComp (publicHashSpec prims.core) (Signature prims)) =
+      slhSignInternal prims msg sk addrnd := rfl
+
+@[simp]
+theorem simulateQ_slhVerifyInternalM_withPublicHash (core : CorePrimitives p)
+    (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
+    (msg : List Byte) (sig : SignatureCore p core) (pk : PublicKeyCore core) :
+    simulateQ answer
+        (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) =
+      slhVerifyInternal (PublicHash.withPublicHash core answer) msg sig pk := by
+  simp [slhVerifyInternal, PublicHash.impl_withPublicHash]
+
+@[simp]
+theorem simulateQ_slhVerifyInternalM (prims : Primitives p) [DecidableEq prims.Y]
+    (msg : List Byte) (sig : Signature prims) (pk : PublicKey prims) :
+    simulateQ (PublicHash.impl prims)
+        (slhVerifyInternalM prims.core msg sig pk :
+          OracleComp (publicHashSpec prims.core) Bool) =
+      slhVerifyInternal prims msg sig pk := rfl
+
+/-- Fixed-answer correctness of the canonical internal programs. Key generation, signing, and
+verification use one total deterministic answer function. This theorem does not install or make
+a claim about random-oracle caching. -/
+theorem simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
+    (core : CorePrimitives p) (answer : QueryImpl (publicHashSpec core) Id)
+    [DecidableEq core.Y]
+    (msg : List Byte) (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed)
+    (addrnd : core.Y) :
+    simulateQ answer (do
+      let (pk, sk) ← slhKeygenInternalM core skSeed skPrf pkSeed
+      let sig ← slhSignInternalM core msg sk addrnd
+      slhVerifyInternalM core msg sig pk) = true := by
+  simp only [slhKeygenInternalM, slhSignInternalM, slhVerifyInternalM,
+    simulateQ_bind, simulateQ_pure,
+    simulateQ_htRootM_withPublicHash, simulateQ_forsSignM_withPublicHash,
+    simulateQ_forsPkFromSigM_withPublicHash, simulateQ_htSignM_withPublicHash,
+    simulateQ_htVerifyM_withPublicHash]
+  exact htVerify_htSign (PublicHash.withPublicHash core answer) _ skSeed pkSeed Adrs.zero 0 _
+    (splitDigest_snd_lt p _)
 
 /-- **Deterministic correctness core**: an honestly generated signature verifies, for every
-choice of seeds and randomizer. Composes FORS correctness (`forsPkFromSig_forsSign`) with
-hypertree correctness (`htVerify_htSign`). -/
+choice of seeds, randomizer, and deterministic public-hash implementation. -/
 theorem slhVerifyInternal_slhSignInternal (prims : Primitives p) [DecidableEq prims.Y]
     (msg : List Byte) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf) (pkSeed : prims.PkSeed)
     (addrnd : prims.Y) :
     slhVerifyInternal prims msg
         (slhSignInternal prims msg (slhKeygenInternal prims skSeed skPrf pkSeed).2 addrnd)
         (slhKeygenInternal prims skSeed skPrf pkSeed).1 = true := by
-  simp only [slhKeygenInternal, slhSignInternal, slhVerifyInternal]
-  rw [forsPkFromSig_forsSign]
-  exact htVerify_htSign prims _ skSeed pkSeed Adrs.zero 0 _ (splitDigest_snd_lt p _)
+  have h := simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
+    prims.core (PublicHash.impl prims) msg skSeed skPrf pkSeed addrnd
+  change ((do
+    let (pk, sk) ← slhKeygenInternal prims skSeed skPrf pkSeed
+    let sig ← slhSignInternal prims msg sk addrnd
+    slhVerifyInternal prims msg sig pk) : Id Bool) = true
+  simpa only [simulateQ_bind, simulateQ_slhKeygenInternalM,
+    simulateQ_slhSignInternalM, simulateQ_slhVerifyInternalM] using h
 
 /-! ### External algorithms and the `SignatureAlg` instance (FIPS 205 §10) -/
 

--- a/HashSig/SLHDSA/Scheme.lean
+++ b/HashSig/SLHDSA/Scheme.lean
@@ -45,6 +45,8 @@ open OracleComp OracleSpec
 
 namespace SLHDSA
 
+universe u
+
 variable {p : Params}
 
 /-- The SLH-DSA public key over an implementation-independent context: public seed and
@@ -57,6 +59,33 @@ structure PublicKeyCore (core : CorePrimitives p) where
 
 /-- Source-compatible pure public-key type. -/
 abbrev PublicKey (prims : Primitives p) := PublicKeyCore prims.core
+
+namespace PublicKey
+
+/-! Compatibility aliases for the generated API of the former `PublicKey` structure. -/
+
+abbrev mk := @PublicKeyCore.mk
+abbrev pkSeed := @PublicKeyCore.pkSeed
+abbrev pkRoot := @PublicKeyCore.pkRoot
+protected def rec {prims : Primitives p} {motive : PublicKey prims → Sort u}
+    (mk : (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
+      motive (PublicKey.mk pkSeed pkRoot)) (t : PublicKey prims) : motive t :=
+  match t with
+  | ⟨pkSeed, pkRoot⟩ => mk pkSeed pkRoot
+
+protected def recOn {prims : Primitives p} {motive : PublicKey prims → Sort u}
+    (t : PublicKey prims) (mk : (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
+      motive (PublicKey.mk pkSeed pkRoot)) : motive t :=
+  match t with
+  | ⟨pkSeed, pkRoot⟩ => mk pkSeed pkRoot
+
+protected def casesOn {prims : Primitives p} {motive : PublicKey prims → Sort u}
+    (t : PublicKey prims) (mk : (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
+      motive (PublicKey.mk pkSeed pkRoot)) : motive t :=
+  match t with
+  | ⟨pkSeed, pkRoot⟩ => mk pkSeed pkRoot
+
+end PublicKey
 
 /-- The SLH-DSA secret key over an implementation-independent context. It carries the public
 material required by signing. -/
@@ -72,6 +101,41 @@ structure SecretKeyCore (core : CorePrimitives p) where
 
 /-- Source-compatible pure secret-key type. -/
 abbrev SecretKey (prims : Primitives p) := SecretKeyCore prims.core
+
+namespace SecretKey
+
+/-! Compatibility aliases for the generated API of the former `SecretKey` structure. -/
+
+abbrev mk := @SecretKeyCore.mk
+abbrev skSeed := @SecretKeyCore.skSeed
+abbrev skPrf := @SecretKeyCore.skPrf
+abbrev pkSeed := @SecretKeyCore.pkSeed
+abbrev pkRoot := @SecretKeyCore.pkRoot
+protected def rec {prims : Primitives p} {motive : SecretKey prims → Sort u}
+    (mk : (skSeed : prims.SkSeed) → (skPrf : prims.SkPrf) →
+      (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
+      motive (SecretKey.mk skSeed skPrf pkSeed pkRoot))
+    (t : SecretKey prims) : motive t :=
+  match t with
+  | ⟨skSeed, skPrf, pkSeed, pkRoot⟩ => mk skSeed skPrf pkSeed pkRoot
+
+protected def recOn {prims : Primitives p} {motive : SecretKey prims → Sort u}
+    (t : SecretKey prims)
+    (mk : (skSeed : prims.SkSeed) → (skPrf : prims.SkPrf) →
+      (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
+      motive (SecretKey.mk skSeed skPrf pkSeed pkRoot)) : motive t :=
+  match t with
+  | ⟨skSeed, skPrf, pkSeed, pkRoot⟩ => mk skSeed skPrf pkSeed pkRoot
+
+protected def casesOn {prims : Primitives p} {motive : SecretKey prims → Sort u}
+    (t : SecretKey prims)
+    (mk : (skSeed : prims.SkSeed) → (skPrf : prims.SkPrf) →
+      (pkSeed : prims.PkSeed) → (pkRoot : prims.Y) →
+      motive (SecretKey.mk skSeed skPrf pkSeed pkRoot)) : motive t :=
+  match t with
+  | ⟨skSeed, skPrf, pkSeed, pkRoot⟩ => mk skSeed skPrf pkSeed pkRoot
+
+end SecretKey
 
 /-- An SLH-DSA signature: randomizer `R`, FORS signature, and hypertree signature
 (`R ‖ SIG_FORS ‖ SIG_HT`). -/

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -11,8 +11,8 @@ public import HashSig.SLHDSA.Scheme
 /-!
 # Oracle-parametric SLH-DSA scheme canaries
 
-These examples pin the internal FIPS 205 Algorithms 18–20 to their canonical explicit-query
-programs. In particular, signing performs `H_msg`, FORS signing, FORS recovery from that exact
+These examples cover source compatibility of the legacy key constructors and the two observable
+internal FIPS 205 schedules.  Signing performs `H_msg`, FORS signing, recovery from that exact
 signature, and hypertree signing in order; it never regenerates the FORS public key.
 -/
 
@@ -60,73 +60,5 @@ example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
       let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
       htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot) := by
   rfl
-
-/-- The established pure signer is literally the concrete public-hash interpretation of the
-canonical program. -/
-example (prims : Primitives p) (msg : List Byte) (sk : SecretKey prims)
-    (addrnd : prims.Y) :
-    slhSignInternal prims msg sk addrnd =
-      simulateQ (PublicHash.impl prims)
-        (slhSignInternalM prims.core msg sk addrnd :
-          OracleComp (publicHashSpec prims.core) (Signature prims)) := by
-  rfl
-
-/-- An arbitrary total answer function interprets the canonical signer as the induced pure
-API; no concrete hash implementation or cache is baked into the program. -/
-example (answer : QueryImpl (publicHashSpec core) Id)
-    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
-    simulateQ answer
-        (slhSignInternalM core msg sk addrnd :
-          OracleComp (publicHashSpec core) (SignatureCore p core)) =
-      slhSignInternal (PublicHash.withPublicHash core answer) msg sk addrnd :=
-  simulateQ_slhSignInternalM_withPublicHash core answer msg sk addrnd
-
-/-- Query-preserving handlers commute with the whole internal signer. -/
-example {m : Type → Type*} [Monad m] [LawfulMonad m]
-    [HasQuery (publicHashSpec core) m]
-    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
-    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec core) (m := m)).toMonadHom
-        (slhSignInternalM core msg sk addrnd :
-          OracleComp (publicHashSpec core) (SignatureCore p core)) =
-      (slhSignInternalM core msg sk addrnd : m (SignatureCore p core)) := by
-  exact slhSignInternalM_natural core _ msg sk addrnd
-
-/-- Key generation reuses the canonical hypertree root budget. -/
-example (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
-    IsTotalQueryBound
-      (slhKeygenInternalM core skSeed skPrf pkSeed :
-        OracleComp (publicHashSpec core) (PublicKeyCore core × SecretKeyCore core))
-      (slhKeygenInternalQueryBound p) :=
-  slhKeygenInternalM_isTotalQueryBound core skSeed skPrf pkSeed
-
-/-- Verification accounts for `H_msg`, the supplied FORS paths, and the supplied hypertree path;
-the bound is about structural queries rather than cache misses. -/
-example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
-    (pk : PublicKeyCore core) :
-    IsTotalQueryBound
-      (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool)
-      (slhVerifyInternalQueryBound p core sig) :=
-  slhVerifyInternalM_isTotalQueryBound core msg sig pk
-
-/-- The external hedged API retains its empty-context encoding and samples only `addrnd`; the
-canonical explicit-query program remains behind the established pure internal wrapper. -/
-example (prims : Primitives p) [SampleableType prims.Y]
-    (sk : SecretKey prims) (msg : List Byte) :
-    slhSign prims sk msg = (do
-      let addrnd ← $ᵗ prims.Y
-      return slhSignInternal prims (emptyContextMessage msg) sk addrnd) := by
-  rfl
-
-/-- One fixed total public-hash table gives end-to-end internal correctness through the canonical
-key-generation, signing, and verification programs. -/
-example (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
-    (msg : List Byte) (skSeed : core.SkSeed) (skPrf : core.SkPrf)
-    (pkSeed : core.PkSeed) (addrnd : core.Y) :
-    simulateQ answer (do
-      let (pk, sk) ← slhKeygenInternalM core skSeed skPrf pkSeed
-      let sig ← slhSignInternalM core msg sk addrnd
-      slhVerifyInternalM core msg sig pk) = true :=
-  simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
-    core answer msg skSeed skPrf pkSeed addrnd
 
 end SLHDSA.SchemeTest

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -11,9 +11,9 @@ public import HashSig.SLHDSA.Scheme
 /-!
 # Oracle-parametric SLH-DSA scheme canaries
 
-These examples cover source compatibility of the legacy key constructors and the two observable
-internal FIPS 205 schedules.  Signing performs `H_msg`, FORS signing, recovery from that exact
-signature, and hypertree signing in order; it never regenerates the FORS public key.
+These examples cover the two observable internal FIPS 205 schedules. Signing performs `H_msg`,
+FORS signing, recovery from that exact signature, and hypertree signing in order; it never
+regenerates the FORS public key.
 -/
 
 public section
@@ -23,15 +23,6 @@ namespace SLHDSA.SchemeTest
 open OracleComp
 
 variable {p : Params} (core : CorePrimitives p)
-
-/-! The legacy generated constructor and projection names remain available downstream. -/
-
-example (prims : Primitives p) (pkSeed : prims.PkSeed) (pkRoot : prims.Y) :
-    PublicKey.pkSeed (PublicKey.mk pkSeed pkRoot : PublicKey prims) = pkSeed := rfl
-
-example (prims : Primitives p) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
-    (pkSeed : prims.PkSeed) (pkRoot : prims.Y) :
-    SecretKey.skSeed (SecretKey.mk skSeed skPrf pkSeed pkRoot : SecretKey prims) = skSeed := rfl
 
 /-- FIPS 205 Algorithm 19 recovers the FORS public key from the generated signature before
 hypertree signing. Replacing that recovery with `forsPkGenM` makes this canary fail. -/

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -1,0 +1,123 @@
+/-
+Copyright (c) 2026 Quang Dao. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Quang Dao
+-/
+
+module
+
+public import HashSig.SLHDSA.Scheme
+
+/-!
+# Oracle-parametric SLH-DSA scheme canaries
+
+These examples pin the internal FIPS 205 Algorithms 18–20 to their canonical explicit-query
+programs. In particular, signing performs `H_msg`, FORS signing, FORS recovery from that exact
+signature, and hypertree signing in order; it never regenerates the FORS public key.
+-/
+
+public section
+
+namespace SLHDSA.SchemeTest
+
+open OracleComp
+
+variable {p : Params} (core : CorePrimitives p)
+
+/-- FIPS 205 Algorithm 19 recovers the FORS public key from the generated signature before
+hypertree signing. Replacing that recovery with `forsPkGenM` makes this canary fail. -/
+example (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
+    (slhSignInternalM core msg sk addrnd :
+      OracleComp (publicHashSpec core) (SignatureCore p core)) = (do
+        let R := core.PRFmsg sk.skPrf addrnd msg
+        let digest ← PublicHash.hmsg core R sk.pkSeed sk.pkRoot msg
+        let idxLeaf := (splitDigest p digest).2
+        let md := (splitDigest p digest).1
+        let fAdrs := forsAdrsOf idxLeaf
+        let forsSig ← forsSignM core md sk.skSeed sk.pkSeed fAdrs
+        let forsPk ← forsPkFromSigM core forsSig md sk.pkSeed fAdrs
+        let htSig ← htSignM core forsPk sk.skSeed sk.pkSeed Adrs.zero 0 idxLeaf
+        return (R, forsSig, htSig)) := by
+  rfl
+
+/-- Verification performs `H_msg`, FORS recovery, and hypertree recovery/comparison in order. -/
+example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
+    (pk : PublicKeyCore core) :
+    (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool) = (do
+      let digest ← PublicHash.hmsg core sig.1 pk.pkSeed pk.pkRoot msg
+      let idxLeaf := (splitDigest p digest).2
+      let md := (splitDigest p digest).1
+      let fAdrs := forsAdrsOf idxLeaf
+      let forsPk ← forsPkFromSigM core sig.2.1 md pk.pkSeed fAdrs
+      htVerifyM core forsPk sig.2.2 pk.pkSeed Adrs.zero 0 idxLeaf pk.pkRoot) := by
+  rfl
+
+/-- The established pure signer is literally the concrete public-hash interpretation of the
+canonical program. -/
+example (prims : Primitives p) (msg : List Byte) (sk : SecretKey prims)
+    (addrnd : prims.Y) :
+    slhSignInternal prims msg sk addrnd =
+      simulateQ (PublicHash.impl prims)
+        (slhSignInternalM prims.core msg sk addrnd :
+          OracleComp (publicHashSpec prims.core) (Signature prims)) := by
+  rfl
+
+/-- An arbitrary total answer function interprets the canonical signer as the induced pure
+API; no concrete hash implementation or cache is baked into the program. -/
+example (answer : QueryImpl (publicHashSpec core) Id)
+    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
+    simulateQ answer
+        (slhSignInternalM core msg sk addrnd :
+          OracleComp (publicHashSpec core) (SignatureCore p core)) =
+      slhSignInternal (PublicHash.withPublicHash core answer) msg sk addrnd :=
+  simulateQ_slhSignInternalM_withPublicHash core answer msg sk addrnd
+
+/-- Query-preserving handlers commute with the whole internal signer. -/
+example {m : Type → Type*} [Monad m] [LawfulMonad m]
+    [HasQuery (publicHashSpec core) m]
+    (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :
+    (HasQuery.QueryHom.ofSimulateQ (spec := publicHashSpec core) (m := m)).toMonadHom
+        (slhSignInternalM core msg sk addrnd :
+          OracleComp (publicHashSpec core) (SignatureCore p core)) =
+      (slhSignInternalM core msg sk addrnd : m (SignatureCore p core)) := by
+  exact slhSignInternalM_natural core _ msg sk addrnd
+
+/-- Key generation reuses the canonical hypertree root budget. -/
+example (skSeed : core.SkSeed) (skPrf : core.SkPrf) (pkSeed : core.PkSeed) :
+    IsTotalQueryBound
+      (slhKeygenInternalM core skSeed skPrf pkSeed :
+        OracleComp (publicHashSpec core) (PublicKeyCore core × SecretKeyCore core))
+      (slhKeygenInternalQueryBound p) :=
+  slhKeygenInternalM_isTotalQueryBound core skSeed skPrf pkSeed
+
+/-- Verification accounts for `H_msg`, the supplied FORS paths, and the supplied hypertree path;
+the bound is about structural queries rather than cache misses. -/
+example [DecidableEq core.Y] (msg : List Byte) (sig : SignatureCore p core)
+    (pk : PublicKeyCore core) :
+    IsTotalQueryBound
+      (slhVerifyInternalM core msg sig pk : OracleComp (publicHashSpec core) Bool)
+      (slhVerifyInternalQueryBound p core sig) :=
+  slhVerifyInternalM_isTotalQueryBound core msg sig pk
+
+/-- The external hedged API retains its empty-context encoding and samples only `addrnd`; the
+canonical explicit-query program remains behind the established pure internal wrapper. -/
+example (prims : Primitives p) [SampleableType prims.Y]
+    (sk : SecretKey prims) (msg : List Byte) :
+    slhSign prims sk msg = (do
+      let addrnd ← $ᵗ prims.Y
+      return slhSignInternal prims (emptyContextMessage msg) sk addrnd) := by
+  rfl
+
+/-- One fixed total public-hash table gives end-to-end internal correctness through the canonical
+key-generation, signing, and verification programs. -/
+example (answer : QueryImpl (publicHashSpec core) Id) [DecidableEq core.Y]
+    (msg : List Byte) (skSeed : core.SkSeed) (skPrf : core.SkPrf)
+    (pkSeed : core.PkSeed) (addrnd : core.Y) :
+    simulateQ answer (do
+      let (pk, sk) ← slhKeygenInternalM core skSeed skPrf pkSeed
+      let sig ← slhSignInternalM core msg sk addrnd
+      slhVerifyInternalM core msg sig pk) = true :=
+  simulateQ_slhVerifyInternalM_slhSignInternalM_withPublicHash
+    core answer msg skSeed skPrf pkSeed addrnd
+
+end SLHDSA.SchemeTest

--- a/HashSigTest/SLHDSA/Scheme.lean
+++ b/HashSigTest/SLHDSA/Scheme.lean
@@ -24,6 +24,15 @@ open OracleComp
 
 variable {p : Params} (core : CorePrimitives p)
 
+/-! The legacy generated constructor and projection names remain available downstream. -/
+
+example (prims : Primitives p) (pkSeed : prims.PkSeed) (pkRoot : prims.Y) :
+    PublicKey.pkSeed (PublicKey.mk pkSeed pkRoot : PublicKey prims) = pkSeed := rfl
+
+example (prims : Primitives p) (skSeed : prims.SkSeed) (skPrf : prims.SkPrf)
+    (pkSeed : prims.PkSeed) (pkRoot : prims.Y) :
+    SecretKey.skSeed (SecretKey.mk skSeed skPrf pkSeed pkRoot : SecretKey prims) = skSeed := rfl
+
 /-- FIPS 205 Algorithm 19 recovers the FORS public key from the generated signature before
 hypertree signing. Replacing that recovery with `forsPkGenM` makes this canary fail. -/
 example (msg : List Byte) (sk : SecretKeyCore core) (addrnd : core.Y) :

--- a/HashSigTest/SLHDSA/Sha2KAT.lean
+++ b/HashSigTest/SLHDSA/Sha2KAT.lean
@@ -36,7 +36,7 @@ length byte required by FIPS 205 Algorithms 22 and 24. -/
 example : emptyContextMessage [1, 2] = [0, 0, 1, 2] := rfl
 
 /-- The external signing wrapper passes the encoded message to the internal algorithm. -/
-example (sk : SecretKey shaPrimitives) (msg : List Byte) :
+example (sk : SecretKeyCore shaPrimitives.core) (msg : List Byte) :
     slhSign shaPrimitives sk msg = (do
       let addrnd ← $ᵗ shaPrimitives.Y
       pure (slhSignInternal shaPrimitives (emptyContextMessage msg) sk addrnd)) := rfl


### PR DESCRIPTION
## Summary

This stacked PR makes FIPS 205 internal Algorithms 18–20 canonical explicit-query programs over `CorePrimitives` and `HasQuery (publicHashSpec core)`.

It exposes only the implementation-independent key and signature types, derives deterministic execution by interpreting the canonical programs, proves naturality and query bounds, and establishes fixed-answer internal correctness.

### Diff metadata

- Base: `8e08eceb94da1f904af3045f75faadefe9cb88c2` (`repair/slhdsa-hypertree-oracle-clean-20260827`)
- Head: `3c3b6b940821ab81800f4fa6b424dfb0d6f1aca0`
- Commits: 5
- Files changed: 7
- Diff: 358 insertions, 64 deletions

## Canonical internal API

- `PublicKeyCore core`
- `SecretKeyCore core`
- `SignatureCore p core`
- `slhKeygenInternalM`
- `slhSignInternalM`
- `slhVerifyInternalM`

The deterministic `slh*Internal` functions are literal `simulateQ (PublicHash.impl prims)` interpretations.

The former `PublicKey`, `SecretKey`, `Signature`, `ForsSig`, and `HtSig` aliases and the hand-written constructor/projection/recursor compatibility namespaces were removed here, atomically with migration of their final inherited Scheme consumer. Focused tests now pin the FIPS signing and verification schedules rather than the deleted compatibility surface.

## FIPS schedule and correctness

Signing computes `PRF_msg` locally, queries `H_msg`, creates the FORS signature, recovers the FORS public key from that exact signature, and signs the recovered value with the hypertree. It does not regenerate the FORS public key independently.

The PR proves naturality, structural keygen/verification bounds, deterministic interpretation, and honest-signature correctness for every fixed total public-hash answer function.

## Staging boundary

At this PR boundary, the pre-existing external `ProbComp` wrappers still exist so this intermediate stack head remains buildable. #569 removes that parallel external assembly and replaces it with one canonical oracle-parametric `SignatureAlg` plus a definitional concrete specialization.

This PR does not install random-oracle state and does not prove an SLH-DSA security theorem.

## Validation at `3c3b6b94`

- `lake build HashSig HashSigTest` passes locally, including Scheme, concrete-instance, focused tests, and the SHA-2 KAT module;
- `git diff --check` passes;
- the complete restacked tree passes `lake build` at #569;
- GitHub checks were re-triggered by the restack and are pending.

## Reviewer map

1. core key/signature types;
2. three canonical internal programs;
3. FIPS signing schedule;
4. naturality and query bounds;
5. fixed-answer correctness and focused schedule tests.
